### PR TITLE
test(weave): densify tests/scorers suite

### DIFF
--- a/tests/scorers/test_hallucination_scorer.py
+++ b/tests/scorers/test_hallucination_scorer.py
@@ -66,6 +66,7 @@ async def test_hallucination_scorer_score(hallucination_scorer):
 
 @pytest.mark.asyncio
 async def test_hallucination_scorer_eval(hallucination_scorer):
+    """Covers eval with the default `context` column and with a column_map remap."""
     dataset = [
         {"context": "John likes various types of cheese."},
         {"context": "Pepe likes various types of cheese."},
@@ -75,21 +76,14 @@ async def test_hallucination_scorer_eval(hallucination_scorer):
     def model():
         return "John's favorite cheese is cheddar."
 
-    evaluation = weave.Evaluation(
-        dataset=dataset,
-        scorers=[hallucination_scorer],
-    )
+    evaluation = weave.Evaluation(dataset=dataset, scorers=[hallucination_scorer])
     result = await evaluation.evaluate(model)
     assert result["HallucinationFreeScorer"]["has_hallucination"]["true_count"] == 2
     assert (
         result["HallucinationFreeScorer"]["has_hallucination"]["true_fraction"] == 1.0
     )
 
-
-@pytest.mark.asyncio
-async def test_hallucination_scorer_eval2(hallucination_scorer):
-    """Test that the hallucination scorer can be used with a column map in an evaluation."""
-    dataset = [
+    mapped_dataset = [
         {
             "input": "John likes various types of cheese.",
             "other_col": "John's favorite cheese is cheddar.",
@@ -101,17 +95,19 @@ async def test_hallucination_scorer_eval2(hallucination_scorer):
     ]
 
     @weave.op
-    def model(input):
+    def mapped_model(input):
         return "The person's favorite cheese is cheddar."
 
     hallucination_scorer.column_map = {"context": "input"}
 
-    evaluation = weave.Evaluation(
-        dataset=dataset,
-        scorers=[hallucination_scorer],
+    mapped_evaluation = weave.Evaluation(
+        dataset=mapped_dataset, scorers=[hallucination_scorer]
     )
-    result = await evaluation.evaluate(model)
-    assert result["HallucinationFreeScorer"]["has_hallucination"]["true_count"] == 2
+    mapped_result = await mapped_evaluation.evaluate(mapped_model)
     assert (
-        result["HallucinationFreeScorer"]["has_hallucination"]["true_fraction"] == 1.0
+        mapped_result["HallucinationFreeScorer"]["has_hallucination"]["true_count"] == 2
+    )
+    assert (
+        mapped_result["HallucinationFreeScorer"]["has_hallucination"]["true_fraction"]
+        == 1.0
     )

--- a/tests/scorers/test_remote_scorer.py
+++ b/tests/scorers/test_remote_scorer.py
@@ -52,65 +52,66 @@ def test_remote_scorer_record_excludes_op_methods() -> None:
     assert "summarize" in plain_record.__dict__
 
 
-def test_remote_scorer_oauth_auth_config_serializes_and_deserializes() -> None:
+@pytest.mark.parametrize(
+    ("auth_config", "expected_cls"),
+    [
+        (
+            {
+                "mode": "oauth_client_credentials",
+                "token_endpoint_url": "https://idp.example.com/oauth2/token",
+                "client_id": "weave-remote-scorer",
+                "client_secret_name": "REMOTE_SCORER_CLIENT_SECRET",
+                "scope": "remote-score",
+            },
+            OAuthClientCredentialsConfig,
+        ),
+        (
+            {
+                "mode": "static_bearer",
+                "bearer_secret_name": "REMOTE_SCORER_BEARER_TOKEN",
+            },
+            StaticBearerAuthConfig,
+        ),
+    ],
+)
+def test_remote_scorer_auth_config_serializes_and_deserializes(
+    auth_config: dict[str, str],
+    expected_cls: type,
+) -> None:
     rs = RemoteScorer(
         name="policy_remote",
         endpoint_url="https://scoring.example.com/v1/score",
-        auth_config={
-            "mode": "oauth_client_credentials",
-            "token_endpoint_url": "https://idp.example.com/oauth2/token",
-            "client_id": "weave-remote-scorer",
-            "client_secret_name": "REMOTE_SCORER_CLIENT_SECRET",
-            "scope": "remote-score",
-        },
+        auth_config=auth_config,
     )
 
-    assert isinstance(rs.auth_config, OAuthClientCredentialsConfig)
+    assert isinstance(rs.auth_config, expected_cls)
     dumped = rs.model_dump()
-    assert dumped["auth_config"] == {
-        "mode": "oauth_client_credentials",
-        "token_endpoint_url": "https://idp.example.com/oauth2/token",
-        "client_id": "weave-remote-scorer",
-        "client_secret_name": "REMOTE_SCORER_CLIENT_SECRET",
-        "scope": "remote-score",
-    }
+    assert dumped["auth_config"] == auth_config
 
     round_tripped = RemoteScorer.model_validate(dumped)
-    assert isinstance(round_tripped.auth_config, OAuthClientCredentialsConfig)
-    assert round_tripped.auth_config == rs.auth_config
-
-
-def test_remote_scorer_static_bearer_auth_config_serializes_and_deserializes() -> None:
-    rs = RemoteScorer(
-        endpoint_url="https://scoring.example.com/v1/score",
-        auth_config={
-            "mode": "static_bearer",
-            "bearer_secret_name": "REMOTE_SCORER_BEARER_TOKEN",
-        },
-    )
-
-    assert isinstance(rs.auth_config, StaticBearerAuthConfig)
-    dumped = rs.model_dump()
-    assert dumped["auth_config"] == {
-        "mode": "static_bearer",
-        "bearer_secret_name": "REMOTE_SCORER_BEARER_TOKEN",
-    }
-
-    round_tripped = RemoteScorer.model_validate(dumped)
-    assert isinstance(round_tripped.auth_config, StaticBearerAuthConfig)
+    assert isinstance(round_tripped.auth_config, expected_cls)
     assert round_tripped.auth_config == rs.auth_config
 
 
 @pytest.mark.parametrize(
-    "token_endpoint_url",
+    ("token_endpoint_url", "expected"),
     [
-        "https://idp.example.com/oauth2/token",
-        "http://127.0.0.1:8000/token",
-        "http://localhost:3000/token",
+        (
+            "https://idp.example.com/oauth2/token",
+            "https://idp.example.com/oauth2/token",
+        ),
+        ("http://127.0.0.1:8000/token", "http://127.0.0.1:8000/token"),
+        ("http://localhost:3000/token", "http://localhost:3000/token"),
+        # Leading/trailing whitespace is stripped.
+        (
+            "  https://idp.example.com/oauth2/token\n",
+            "https://idp.example.com/oauth2/token",
+        ),
     ],
 )
 def test_oauth_token_endpoint_url_accepts_http_s_with_host(
     token_endpoint_url: str,
+    expected: str,
 ) -> None:
     rs = RemoteScorer(
         endpoint_url="https://scoring.example.com/v1/score",
@@ -122,7 +123,7 @@ def test_oauth_token_endpoint_url_accepts_http_s_with_host(
         },
     )
     assert isinstance(rs.auth_config, OAuthClientCredentialsConfig)
-    assert rs.auth_config.token_endpoint_url == token_endpoint_url
+    assert rs.auth_config.token_endpoint_url == expected
 
 
 @pytest.mark.parametrize(
@@ -133,10 +134,12 @@ def test_oauth_token_endpoint_url_accepts_http_s_with_host(
         ("http://", "include a host"),
         ("ftp://idp.example.com/token", "http or https"),
         ("not-a-url", "http or https"),
+        # Non-string input bypasses whitespace-stripping and fails string coercion.
+        (12345, None),
     ],
 )
 def test_oauth_token_endpoint_url_rejects_malformed(
-    token_endpoint_url: str, match_substr: str
+    token_endpoint_url: object, match_substr: str | None
 ) -> None:
     with pytest.raises(ValidationError, match=match_substr):
         RemoteScorer(
@@ -144,35 +147,6 @@ def test_oauth_token_endpoint_url_rejects_malformed(
             auth_config={
                 "mode": "oauth_client_credentials",
                 "token_endpoint_url": token_endpoint_url,
-                "client_id": "weave-remote-scorer",
-                "client_secret_name": "REMOTE_SCORER_CLIENT_SECRET",
-            },
-        )
-
-
-def test_oauth_token_endpoint_url_strips_whitespace() -> None:
-    rs = RemoteScorer(
-        endpoint_url="https://scoring.example.com/v1/score",
-        auth_config={
-            "mode": "oauth_client_credentials",
-            "token_endpoint_url": "  https://idp.example.com/oauth2/token\n",
-            "client_id": "weave-remote-scorer",
-            "client_secret_name": "REMOTE_SCORER_CLIENT_SECRET",
-        },
-    )
-    assert isinstance(rs.auth_config, OAuthClientCredentialsConfig)
-    assert rs.auth_config.token_endpoint_url == "https://idp.example.com/oauth2/token"
-
-
-def test_oauth_token_endpoint_url_non_string_input_rejected() -> None:
-    # Non-string inputs bypass the whitespace-stripping branch and then fail
-    # the URL-shape validator with a string-coercion error from pydantic.
-    with pytest.raises(ValidationError):
-        RemoteScorer(
-            endpoint_url="https://scoring.example.com/v1/score",
-            auth_config={
-                "mode": "oauth_client_credentials",
-                "token_endpoint_url": 12345,
                 "client_id": "weave-remote-scorer",
                 "client_secret_name": "REMOTE_SCORER_CLIENT_SECRET",
             },
@@ -294,27 +268,22 @@ def test_remote_scorer_auth_config_rejects_raw_secret_fields(
     assert "client_secret" not in OAuthClientCredentialsConfig.model_fields
 
 
-def test_remote_scorer_endpoint_url_allows_http_for_local_dev() -> None:
-    for url in (
-        "http://127.0.0.1:8000/v1/score",
-        "http://localhost:3000/score",
-    ):
-        rs = RemoteScorer(endpoint_url=url)
-        assert rs.endpoint_url == url
-
-
-def test_remote_scorer_endpoint_url_strips_whitespace() -> None:
-    rs = RemoteScorer(
-        endpoint_url="  https://scoring.example.com/v1  ",
-    )
-    assert rs.endpoint_url == "https://scoring.example.com/v1"
-
-
-def test_remote_scorer_endpoint_url_strips_leading_trailing_newlines_and_tabs() -> None:
-    rs = RemoteScorer(
-        endpoint_url="\thttps://scoring.example.com/v1\n",
-    )
-    assert rs.endpoint_url == "https://scoring.example.com/v1"
+@pytest.mark.parametrize(
+    ("endpoint_url", "expected"),
+    [
+        # http is allowed for local dev.
+        ("http://127.0.0.1:8000/v1/score", "http://127.0.0.1:8000/v1/score"),
+        ("http://localhost:3000/score", "http://localhost:3000/score"),
+        # Surrounding whitespace, newlines, and tabs are stripped.
+        ("  https://scoring.example.com/v1  ", "https://scoring.example.com/v1"),
+        ("\thttps://scoring.example.com/v1\n", "https://scoring.example.com/v1"),
+    ],
+)
+def test_remote_scorer_endpoint_url_normalizes(
+    endpoint_url: str, expected: str
+) -> None:
+    rs = RemoteScorer(endpoint_url=endpoint_url)
+    assert rs.endpoint_url == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/scorers/test_similarity_scorer.py
+++ b/tests/scorers/test_similarity_scorer.py
@@ -37,35 +37,31 @@ def similarity_scorer(mock_aembedding):
 
 
 @pytest.mark.asyncio
-async def test_similarity_scorer_score(similarity_scorer):
+@pytest.mark.parametrize(
+    ("threshold", "expected_is_similar"),
+    [(0.0, True), (0.99, False)],
+)
+async def test_similarity_scorer_score(
+    similarity_scorer, threshold, expected_is_similar
+):
     output = "John's favorite cheese is cheddar."
     target = "John likes various types of cheese."
-    similarity_scorer.threshold = 0.0
+    similarity_scorer.threshold = threshold
     result = await similarity_scorer.score(output=output, target=target)
     # TypedDict ensures type safety
     assert isinstance(result, dict)
     assert isinstance(result["similarity_score"], float)
     assert isinstance(result["is_similar"], bool)
-    assert result["similarity_score"] > 0.0
-    assert result["is_similar"] is True
-
-
-@pytest.mark.asyncio
-async def test_similarity_scorer_not_similar(similarity_scorer):
-    output = "John's favorite cheese is cheddar."
-    target = "John likes various types of cheese."
-    similarity_scorer.threshold = 0.99
-    result = await similarity_scorer.score(output=output, target=target)
-    # TypedDict ensures type safety
-    assert isinstance(result, dict)
-    assert isinstance(result["similarity_score"], float)
-    assert isinstance(result["is_similar"], bool)
-    assert result["similarity_score"] < 0.99
-    assert result["is_similar"] is False
+    if expected_is_similar:
+        assert result["similarity_score"] > threshold
+    else:
+        assert result["similarity_score"] < threshold
+    assert result["is_similar"] is expected_is_similar
 
 
 @pytest.mark.asyncio
 async def test_similarity_scorer_eval(similarity_scorer):
+    """Covers both the default `target` column and a remapped column via column_map."""
     dataset = [
         {"target": "John likes various types of cheese."},
         {"target": "Pepe likes various types of cheese."},
@@ -75,19 +71,13 @@ async def test_similarity_scorer_eval(similarity_scorer):
     def model():
         return "John's favorite cheese is cheddar."
 
-    evaluation = weave.Evaluation(
-        dataset=dataset,
-        scorers=[similarity_scorer],
-    )
+    evaluation = weave.Evaluation(dataset=dataset, scorers=[similarity_scorer])
     result = await evaluation.evaluate(model)
     assert result["EmbeddingSimilarityScorer"]["similarity_score"]["mean"] > 0.0
     assert result["EmbeddingSimilarityScorer"]["is_similar"]["true_count"] == 2
     assert result["EmbeddingSimilarityScorer"]["is_similar"]["true_fraction"] == 1.0
 
-
-@pytest.mark.asyncio
-async def test_similarity_scorer_eval2(similarity_scorer):
-    dataset = [
+    mapped_dataset = [
         {
             "input": "John likes various types of cheese.",
             "other_col": "John's favorite cheese is cheddar.",
@@ -99,16 +89,17 @@ async def test_similarity_scorer_eval2(similarity_scorer):
     ]
 
     @weave.op
-    def model(input):
+    def mapped_model(input):
         return "The person's favorite cheese is cheddar."
 
     similarity_scorer.column_map = {"target": "other_col"}
 
-    evaluation = weave.Evaluation(
-        dataset=dataset,
-        scorers=[similarity_scorer],
+    mapped_evaluation = weave.Evaluation(
+        dataset=mapped_dataset, scorers=[similarity_scorer]
     )
-    result = await evaluation.evaluate(model)
-    assert result["EmbeddingSimilarityScorer"]["similarity_score"]["mean"] > 0.0
-    assert result["EmbeddingSimilarityScorer"]["is_similar"]["true_count"] == 2
-    assert result["EmbeddingSimilarityScorer"]["is_similar"]["true_fraction"] == 1.0
+    mapped_result = await mapped_evaluation.evaluate(mapped_model)
+    assert mapped_result["EmbeddingSimilarityScorer"]["similarity_score"]["mean"] > 0.0
+    assert mapped_result["EmbeddingSimilarityScorer"]["is_similar"]["true_count"] == 2
+    assert (
+        mapped_result["EmbeddingSimilarityScorer"]["is_similar"]["true_fraction"] == 1.0
+    )

--- a/tests/scorers/test_summarization_scorer.py
+++ b/tests/scorers/test_summarization_scorer.py
@@ -47,48 +47,39 @@ def summarization_scorer(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_summarization_scorer_evaluate_summary(summarization_scorer):
-    input_text = "This is the original text."
-    summary_text = "This is the summary."
-    result = await summarization_scorer._evaluate_summary(
-        input=input_text, summary=summary_text
-    )
-    assert isinstance(result, SummarizationEvaluationResponse)
-    assert result.summarization_evaluation == "excellent"
-    assert result.think_step_by_step == "This is some reasoning."
-
-
-@pytest.mark.asyncio
-async def test_summarization_scorer_score(summarization_scorer):
-    input_text = "This is the original text."
-    output_text = "This is the summary."
-    result = await summarization_scorer.score(input=input_text, output=output_text)
-    assert isinstance(result, dict)
-    assert "summarization_eval_score" in result
-    assert result["summarization_eval_score"] == 1.0  # "excellent" maps to 1.0
-    assert "llm_eval_reasoning" in result
-    assert result["llm_eval_reasoning"] == "This is some reasoning."
-    assert "is_entity_dense" in result
-    assert isinstance(result["is_entity_dense"], bool)
-    assert "entity_density" in result
-    assert isinstance(result["entity_density"], float)
-
-
-def test_summarization_scorer_initialization(summarization_scorer):
+async def test_summarization_scorer_init_and_methods(summarization_scorer):
     assert isinstance(summarization_scorer, SummarizationScorer)
     assert summarization_scorer.model_id == "gpt-4o"
     assert summarization_scorer.temperature == 0.7
     assert summarization_scorer.max_tokens == 1024
 
+    eval_result = await summarization_scorer._evaluate_summary(
+        input="This is the original text.", summary="This is the summary."
+    )
+    assert isinstance(eval_result, SummarizationEvaluationResponse)
+    assert eval_result.summarization_evaluation == "excellent"
+    assert eval_result.think_step_by_step == "This is some reasoning."
 
-@pytest.mark.asyncio
-async def test_summarization_scorer_extract_entities(summarization_scorer):
-    text = "This is a sample text with entities."
-    entities = await summarization_scorer._extract_entities(text)
+    entities = await summarization_scorer._extract_entities(
+        "This is a sample text with entities."
+    )
     assert isinstance(entities, list)
     assert len(entities) == 2
     assert "entity1" in entities
     assert "entity2" in entities
+
+    score = await summarization_scorer.score(
+        input="This is the original text.", output="This is the summary."
+    )
+    assert isinstance(score, dict)
+    assert "summarization_eval_score" in score
+    assert score["summarization_eval_score"] == 1.0  # "excellent" maps to 1.0
+    assert "llm_eval_reasoning" in score
+    assert score["llm_eval_reasoning"] == "This is some reasoning."
+    assert "is_entity_dense" in score
+    assert isinstance(score["is_entity_dense"], bool)
+    assert "entity_density" in score
+    assert isinstance(score["entity_density"], float)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Split from #7235. Densify `tests/scorers` tests into fewer, denser parametrized / multi-assert functions: 4 files, +123/-176.

## Testing
per-file coverage-superset gate (each touched file's executed weave/ lines+branches after >= before); tests/scorers dir run shows no new failures vs master.