### PR TITLE
test(weave): densify tests/flow suite

### DIFF
--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -507,7 +507,9 @@ async def test_various_input_forms(client, evaluation_logger_kwargs, scorer, sco
     assert len(calls) == expected_num_calls * 2
 
 
-def test_passing_dict_requires_name_with_scorer(weave_active):
+@pytest.mark.disable_logging_error_check
+def test_passing_dict_requires_name(weave_active):
+    """A dict scorer or dict model must carry a `name`; with one it is accepted."""
     ev = weave.EvaluationLogger()
     pred = ev.log_prediction(inputs={}, output=None)
     with pytest.raises(ValueError, match="Your dict must contain a `name` key."):
@@ -516,11 +518,8 @@ def test_passing_dict_requires_name_with_scorer(weave_active):
     pred.log_score(scorer={"name": "my_scorer"}, score=0.5)
     ev.finish()
 
-
-@pytest.mark.disable_logging_error_check
-def test_passing_dict_requires_name_with_model(weave_active):
     with pytest.raises(ValueError, match="Your dict must contain a `name` key."):
-        ev = weave.EvaluationLogger(model={"something": "else"})
+        weave.EvaluationLogger(model={"something": "else"})
 
     ev2 = weave.EvaluationLogger(model={"name": "my_model"})
     ev2.finish()
@@ -709,8 +708,8 @@ def test_evaluation_logger_uses_passed_output_not_model_predict(client):
 
 
 @pytest.mark.parametrize("model_name", ["for", "42", "a-b-c", "!"])
-def test_evaluation_invalid_model_name_fixable(model_name):
-    # Should not raise
+def test_evaluation_invalid_model_name_fixable(weave_active, model_name):
+    # Should not raise: names are sanitized into a valid class name.
     weave.EvaluationLogger(model=model_name)
 
 
@@ -1061,34 +1060,39 @@ def test_log_score_context_manager_with_nested_ops(client):
     assert predict_and_score_call.output["scores"]["length_check"] is True
 
 
-def test_log_example_basic(client):
-    """Test basic functionality of log_example method."""
+@pytest.mark.parametrize(
+    ("inputs", "output", "scores", "finalize"),
+    [
+        (
+            {"question": "What is 2+2?"},
+            "4",
+            {"correctness": 1.0, "fluency": 0.9},
+            "summary",
+        ),
+        ({"input": "test"}, "result", {}, "finish"),
+    ],
+)
+def test_log_example_basic(client, inputs, output, scores, finalize):
+    """A single log_example records inputs/output/scores, including empty scores."""
     ev = EvaluationLogger()
+    ev.log_example(inputs=inputs, output=output, scores=scores)
 
-    # Log a complete example with inputs, output, and scores
-    ev.log_example(
-        inputs={"question": "What is 2+2?"},
-        output="4",
-        scores={"correctness": 1.0, "fluency": 0.9},
-    )
-
-    ev.log_summary({"avg_score": 0.95})
+    if finalize == "summary":
+        ev.log_summary({"avg_score": 0.95})
+    elif finalize == "finish":
+        ev.finish()
+    else:
+        raise ValueError(f"unhandled finalize: {finalize}")
     client.flush()
 
-    calls = client.get_calls()
-
-    # Find the predict_and_score call
-    predict_and_score_call = None
-    for call in calls:
-        if op_name_from_call(call) == "Evaluation.predict_and_score":
-            predict_and_score_call = call
-            break
-
-    assert predict_and_score_call is not None
-    assert predict_and_score_call.inputs["example"] == {"question": "What is 2+2?"}
-    assert predict_and_score_call.output["output"] == "4"
-    assert predict_and_score_call.output["scores"]["correctness"] == 1.0
-    assert predict_and_score_call.output["scores"]["fluency"] == 0.9
+    predict_and_score_call = next(
+        c
+        for c in client.get_calls()
+        if op_name_from_call(c) == "Evaluation.predict_and_score"
+    )
+    assert predict_and_score_call.inputs["example"] == inputs
+    assert predict_and_score_call.output["output"] == output
+    assert predict_and_score_call.output["scores"] == scores
 
 
 def test_log_example_multiple_examples(client):
@@ -1125,75 +1129,24 @@ def test_log_example_multiple_examples(client):
             assert call.output["scores"][scorer_name] == score_value
 
 
-def test_log_example_with_empty_scores(client):
-    """Test log_example with empty scores dictionary."""
+@pytest.mark.parametrize("finalize", ["finish", "log_summary"])
+def test_log_example_after_finalization_raises_error(weave_active, finalize):
+    """log_example after either finalization path (finish/log_summary) raises."""
     ev = EvaluationLogger()
 
-    # Log example with no scores
-    ev.log_example(
-        inputs={"input": "test"},
-        output="result",
-        scores={},
-    )
-
-    ev.finish()
-    client.flush()
-
-    calls = client.get_calls()
-    predict_and_score_call = None
-    for call in calls:
-        if op_name_from_call(call) == "Evaluation.predict_and_score":
-            predict_and_score_call = call
-            break
-
-    assert predict_and_score_call is not None
-    assert predict_and_score_call.inputs["example"] == {"input": "test"}
-    assert predict_and_score_call.output["output"] == "result"
-    # Scores should be empty
-    assert predict_and_score_call.output["scores"] == {}
-
-
-def test_log_example_after_finalization_raises_error(weave_active):
-    """Test that log_example raises ValueError when called after finalization."""
-    ev = EvaluationLogger()
-
-    # Log one example successfully
     ev.log_example(
         inputs={"q": "test"},
         output="answer",
         scores={"score": 1.0},
     )
 
-    # Finalize the evaluation
-    ev.finish()
+    if finalize == "finish":
+        ev.finish()
+    elif finalize == "log_summary":
+        ev.log_summary({"total": 1})
+    else:
+        raise ValueError(f"unhandled finalize: {finalize}")
 
-    # Attempting to log another example should raise an error
-    with pytest.raises(
-        ValueError,
-        match="Cannot log example after evaluation has been finalized",
-    ):
-        ev.log_example(
-            inputs={"q": "another test"},
-            output="another answer",
-            scores={"score": 0.5},
-        )
-
-
-def test_log_example_after_log_summary_raises_error(weave_active):
-    """Test that log_example raises ValueError when called after log_summary."""
-    ev = EvaluationLogger()
-
-    # Log one example successfully
-    ev.log_example(
-        inputs={"q": "test"},
-        output="answer",
-        scores={"score": 1.0},
-    )
-
-    # Call log_summary (which also finalizes)
-    ev.log_summary({"total": 1})
-
-    # Attempting to log another example should raise an error
     with pytest.raises(
         ValueError,
         match="Cannot log example after evaluation has been finalized",

--- a/tests/flow/test_prompt.py
+++ b/tests/flow/test_prompt.py
@@ -11,85 +11,84 @@ def test_stringprompt_format():
     )
 
 
-def test_messagesprompt_format():
-    prompt = MessagesPrompt(
-        [
-            {"role": "system", "content": "You are a pirate."},
-            {"role": "user", "content": "Tell us your thoughts on {topic}."},
-        ]
-    )
-    assert prompt.format(topic="airplanes") == [
-        {"role": "system", "content": "You are a pirate."},
-        {"role": "user", "content": "Tell us your thoughts on airplanes."},
-    ]
-
-
-def test_messagesprompt_nesteddict_format():
-    prompt = MessagesPrompt(
-        [
-            {"role": "system", "content": "You are a pirate."},
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": "Tell us your thoughts on {topic}.",
-                    }
-                ],
-            },
-        ]
-    )
-    assert prompt.format(topic="airplanes") == [
-        {"role": "system", "content": "You are a pirate."},
-        {
-            "role": "user",
-            "content": [
-                {
-                    "type": "text",
-                    "text": "Tell us your thoughts on airplanes.",
-                }
+@pytest.mark.parametrize(
+    ("messages", "expected"),
+    [
+        (
+            [
+                {"role": "system", "content": "You are a pirate."},
+                {"role": "user", "content": "Tell us your thoughts on {topic}."},
             ],
-        },
-    ]
+            [
+                {"role": "system", "content": "You are a pirate."},
+                {"role": "user", "content": "Tell us your thoughts on airplanes."},
+            ],
+        ),
+        (
+            [
+                {"role": "system", "content": "You are a pirate."},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Tell us your thoughts on {topic}."}
+                    ],
+                },
+            ],
+            [
+                {"role": "system", "content": "You are a pirate."},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Tell us your thoughts on airplanes."}
+                    ],
+                },
+            ],
+        ),
+    ],
+)
+def test_messagesprompt_format(messages, expected):
+    assert MessagesPrompt(messages).format(topic="airplanes") == expected
 
 
-def test_messagesprompt_format_missing_var_raises_error():
-    """Test that missing template variables raise IncorrectPromptVarError with helpful message."""
-    prompt = MessagesPrompt(
-        [
-            {"role": "system", "content": "You are a {role_type} assistant."},
-            {"role": "user", "content": "Evaluate {output} against {expected}."},
-        ]
-    )
-
-    # Only provide 'output', missing 'role_type' and 'expected'
+@pytest.mark.parametrize(
+    ("messages", "format_kwargs", "any_of", "all_of"),
+    [
+        (
+            [
+                {"role": "system", "content": "You are a {role_type} assistant."},
+                {"role": "user", "content": "Evaluate {output} against {expected}."},
+            ],
+            {"output": "test"},
+            ("role_type", "expected"),
+            ("output",),
+        ),
+        (
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Hello {name}, please evaluate {item}.",
+                        }
+                    ],
+                },
+            ],
+            {"name": "Alice"},
+            (),
+            ("item", "name"),
+        ),
+    ],
+)
+def test_messagesprompt_format_missing_var_raises_error(
+    messages, format_kwargs, any_of, all_of
+):
+    """Missing template variables raise IncorrectPromptVarError listing missing + available vars."""
+    prompt = MessagesPrompt(messages)
     with pytest.raises(IncorrectPromptVarError) as exc_info:
-        prompt.format(output="test")
-
+        prompt.format(**format_kwargs)
     error_msg = str(exc_info.value)
-    # Should mention one of the missing vars
-    assert "role_type" in error_msg or "expected" in error_msg
-    # Should show available vars
-    assert "output" in error_msg
-
-
-def test_messagesprompt_nesteddict_format_missing_var_raises_error():
-    """Test that missing template variables in nested content raise IncorrectPromptVarError."""
-    prompt = MessagesPrompt(
-        [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "Hello {name}, please evaluate {item}."}
-                ],
-            },
-        ]
-    )
-
-    # Only provide 'name', missing 'item'
-    with pytest.raises(IncorrectPromptVarError) as exc_info:
-        prompt.format(name="Alice")
-
-    error_msg = str(exc_info.value)
-    assert "item" in error_msg
-    assert "name" in error_msg
+    if any_of:
+        assert any(substring in error_msg for substring in any_of)
+    for substring in all_of:
+        assert substring in error_msg

--- a/tests/flow/test_prompt_easy.py
+++ b/tests/flow/test_prompt_easy.py
@@ -5,39 +5,35 @@ import pytest
 from weave import EasyPrompt
 
 
-def iter_equal(items1, items2):
-    """`True` if iterators `items1` and `items2` contain equal items."""
-    return (items1 is items2) or all(
-        a == b for a, b in itertools.zip_longest(items1, items2, fillvalue=object())
-    )
-
-
-def test_prompt_message_constructor_str():
-    prompt = EasyPrompt("What's 23 * 42")
-    assert prompt() == [{"role": "user", "content": "What's 23 * 42"}]
-
-
-def test_prompt_message_constructor_prefix_str():
-    prompt = EasyPrompt("system: you are a pirate")
-    assert prompt() == [{"role": "system", "content": "you are a pirate"}]
-
-
-def test_prompt_message_constructor_role_arg():
-    prompt = EasyPrompt("You're a calculator.", role="system")
-    assert prompt() == [{"role": "system", "content": "You're a calculator."}]
-
-
-def test_prompt_message_constructor_array():
-    prompt = EasyPrompt(
-        [
-            {"role": "system", "content": "You're a calculator."},
-            {"role": "user", "content": "What's 23 * 42"},
-        ]
-    )
-    assert prompt() == [
-        {"role": "system", "content": "You're a calculator."},
-        {"role": "user", "content": "What's 23 * 42"},
-    ]
+@pytest.mark.parametrize(
+    ("args", "kwargs", "expected"),
+    [
+        ("What's 23 * 42", {}, [{"role": "user", "content": "What's 23 * 42"}]),
+        (
+            "system: you are a pirate",
+            {},
+            [{"role": "system", "content": "you are a pirate"}],
+        ),
+        (
+            "You're a calculator.",
+            {"role": "system"},
+            [{"role": "system", "content": "You're a calculator."}],
+        ),
+        (
+            [
+                {"role": "system", "content": "You're a calculator."},
+                {"role": "user", "content": "What's 23 * 42"},
+            ],
+            {},
+            [
+                {"role": "system", "content": "You're a calculator."},
+                {"role": "user", "content": "What's 23 * 42"},
+            ],
+        ),
+    ],
+)
+def test_prompt_message_constructor(args, kwargs, expected):
+    assert EasyPrompt(args, **kwargs)() == expected
 
 
 def test_prompt_message_constructor_obj():
@@ -92,11 +88,9 @@ def test_prompt_append() -> None:
         {"role": "user", "content": "What's the capital of Brazil?"},
     ]
 
-
-def test_prompt_append_with_role() -> None:
-    prompt = EasyPrompt()
-    prompt.append("system: who knows a lot about geography", role="asdf")
-    assert prompt() == [
+    explicit_role = EasyPrompt()
+    explicit_role.append("system: who knows a lot about geography", role="asdf")
+    assert explicit_role() == [
         {"role": "asdf", "content": "system: who knows a lot about geography"},
     ]
 
@@ -138,23 +132,35 @@ def test_prompt_parameter_default() -> None:
     assert list(prompt()) == [{"role": "user", "content": "23 * 42"}]
 
 
-def test_prompt_parameter_validation_int() -> None:
-    prompt = EasyPrompt("{A} + {B}")
-    prompt.require("A", min=10, max=100)
-    with pytest.raises(ValueError, match="is less than min") as e:
-        prompt.bind(A=0)
-    assert str(e.value) == "A (0) is less than min (10)"
-
-
-def test_prompt_parameter_validation_oneof() -> None:
-    prompt = EasyPrompt("{flavor}")
-    prompt.require("flavor", oneof=("vanilla", "strawberry", "chocolate"))
-    with pytest.raises(ValueError, match="must be one of") as e:
-        prompt.bind(flavor="mint chip")
-    assert (
-        str(e.value)
-        == "flavor (mint chip) must be one of vanilla, strawberry, chocolate"
-    )
+@pytest.mark.parametrize(
+    ("template", "name", "require_kwargs", "bind_kwargs", "match", "message"),
+    [
+        (
+            "{A} + {B}",
+            "A",
+            {"min": 10, "max": 100},
+            {"A": 0},
+            "is less than min",
+            "A (0) is less than min (10)",
+        ),
+        (
+            "{flavor}",
+            "flavor",
+            {"oneof": ("vanilla", "strawberry", "chocolate")},
+            {"flavor": "mint chip"},
+            "must be one of",
+            "flavor (mint chip) must be one of vanilla, strawberry, chocolate",
+        ),
+    ],
+)
+def test_prompt_parameter_validation(
+    template, name, require_kwargs, bind_kwargs, match, message
+):
+    prompt = EasyPrompt(template)
+    prompt.require(name, **require_kwargs)
+    with pytest.raises(ValueError, match=match) as e:
+        prompt.bind(**bind_kwargs)
+    assert str(e.value) == message
 
 
 def test_prompt_bind_iteration() -> None:
@@ -218,25 +224,6 @@ def test_prompt_as_dict():
             },
         ],
     }
-
-
-def test_prompt_as_pydantic_dict():
-    prompt = EasyPrompt(
-        model="gpt-4o",
-        messages=[
-            {
-                "role": "system",
-                "content": "You will be provided with text, and your task is to translate it into emojis. Do not use any regular text. Do your best with emojis only.",
-            },
-            {
-                "role": "user",
-                "content": "Artificial intelligence is a technology with great promise.",
-            },
-        ],
-        temperature=0.8,
-        max_tokens=64,
-        top_p=1,
-    )
     assert prompt.as_pydantic_dict() == {
         "name": None,
         "description": None,
@@ -259,3 +246,10 @@ def test_prompt_as_pydantic_dict():
         ],
         "requirements": {},
     }
+
+
+def iter_equal(items1, items2):
+    """`True` if iterators `items1` and `items2` contain equal items."""
+    return (items1 is items2) or all(
+        a == b for a, b in itertools.zip_longest(items1, items2, fillvalue=object())
+    )

--- a/tests/flow/test_weaveflow.py
+++ b/tests/flow/test_weaveflow.py
@@ -7,25 +7,29 @@ from pydantic import Field
 import weave
 
 
-def test_weaveflow_op_wandb(weave_active):
+def test_weaveflow_basic_ops(weave_active):
+    """Plain ops, list-returning ops, and nested op composition."""
+
     @weave.op
     def custom_adder(a: int, b: int) -> int:
         return a + b
 
-    res = custom_adder(1, 2)
-    assert res == 3
-
-
-def test_weaveflow_op_wandb_return_list(weave_active):
     @weave.op
-    def custom_adder(a: int, b: int) -> list[int]:
+    def custom_adder_list(a: int, b: int) -> list[int]:
         return [a + b]
 
-    res = custom_adder(1, 2)
-    assert res == [3]
+    @weave.op
+    def double_adder(a: int, b: int) -> int:
+        return custom_adder(a, a) + custom_adder(b, b)
+
+    assert custom_adder(1, 2) == 3
+    assert custom_adder_list(1, 2) == [3]
+    assert double_adder(1, 2) == 6
 
 
-def test_weaveflow_object_wandb_with_opmethod(weave_active):
+def test_weaveflow_op_methods(weave_active):
+    """Op methods on weave.Object: call result and qualified op name."""
+
     class ATestObj(weave.Object):
         a: int
 
@@ -34,21 +38,11 @@ def test_weaveflow_object_wandb_with_opmethod(weave_active):
             return self.a + b
 
     x = ATestObj(a=1)
-    res = x.a_test_add(2)
-    assert res == 3
+    assert x.a_test_add(2) == 3
 
-
-def test_weaveflow_nested_op(weave_active):
-    @weave.op
-    def adder(a: int, b: int) -> int:
-        return a + b
-
-    @weave.op
-    def double_adder(a: int, b: int) -> int:
-        return adder(a, a) + adder(b, b)
-
-    res = double_adder(1, 2)
-    assert res == 6
+    model = MyModel(a=1)
+    assert model.predict.name == "MyModel.predict"
+    assert MyModel.predict.name == "MyModel.predict"
 
 
 @pytest.mark.asyncio
@@ -75,45 +69,42 @@ def test_weaveflow_publish_numpy(weave_active):
     ref = weave.publish(v, "dict-with-numpy")
 
 
-def test_weaveflow_unknown_type_op_param_undeclared():
+@pytest.mark.parametrize("declaration", ["undeclared", "declared", "closure"])
+def test_weaveflow_unknown_type_op_param(declaration):
+    """Ops accept an unknown-typed param whether undeclared, declared, or closed over."""
+
     @dataclass
     class SomeUnknownObject:
         x: int
 
-    @weave.op
-    def op_with_unknown_param(v) -> int:
-        return v.x + 2
+    if declaration == "undeclared":
 
-    assert op_with_unknown_param(SomeUnknownObject(x=10)) == 12
+        @weave.op
+        def op_with_unknown_param(v) -> int:
+            return v.x + 2
 
+        assert op_with_unknown_param(SomeUnknownObject(x=10)) == 12
+    elif declaration == "declared":
 
-def test_weaveflow_unknown_type_op_param_declared():
-    @dataclass
-    class SomeUnknownObject:
-        x: int
+        @weave.op
+        def op_with_unknown_param(v: SomeUnknownObject) -> int:
+            return v.x + 2
 
-    @weave.op
-    def op_with_unknown_param(v: SomeUnknownObject) -> int:
-        return v.x + 2
+        assert op_with_unknown_param(SomeUnknownObject(x=10)) == 12
+    elif declaration == "closure":
+        v = SomeUnknownObject(x=10)
 
-    assert op_with_unknown_param(SomeUnknownObject(x=10)) == 12
+        @weave.op
+        def op_with_unknown_param() -> int:
+            return v.x + 2
 
-
-def test_weaveflow_unknown_type_op_param_closure():
-    @dataclass
-    class SomeUnknownObject:
-        x: int
-
-    v = SomeUnknownObject(x=10)
-
-    @weave.op
-    def op_with_unknown_param() -> int:
-        return v.x + 2
-
-    assert op_with_unknown_param() == 12
+        assert op_with_unknown_param() == 12
+    else:
+        raise ValueError(f"unhandled declaration: {declaration}")
 
 
-def test_subobj_ref_passing(client):
+def test_dataset_save_and_ref_flows(client):
+    """Saved dataset: subobj-ref passing into an op and ref round-trip into Evaluation."""
     dataset = client.save(
         weave.Dataset(rows=[{"x": 1, "y": 3}, {"x": 2, "y": 16}]), "my-dataset"
     )
@@ -125,20 +116,10 @@ def test_subobj_ref_passing(client):
     res = get_item(dataset.rows[0])
     assert res == {"in": 1, "out": 1}
 
-
-class MyModel(weave.Model):
-    a: int
-
-    @weave.op
-    def predict(self, x: int) -> int:
-        return x + 1
-
-
-def test_op_method_name():
-    model = MyModel(a=1)
-
-    assert model.predict.name == "MyModel.predict"
-    assert MyModel.predict.name == "MyModel.predict"
+    ref = dataset.ref
+    assert ref is not None
+    dataset2 = weave.ref(ref.uri).get()
+    weave.Evaluation(dataset=dataset2)
 
 
 def test_agent_has_tools(client):
@@ -155,16 +136,6 @@ def test_agent_has_tools(client):
     saved = client.save(agent, "agent")
 
     assert len(saved.tools) == 1
-
-
-def test_construct_eval_with_dataset_get(client):
-    dataset = client.save(
-        weave.Dataset(rows=[{"x": 1, "y": 3}, {"x": 2, "y": 16}]), "my-dataset"
-    )
-    ref = dataset.ref
-    assert ref is not None
-    dataset2 = weave.ref(ref.uri).get()
-    weave.Evaluation(dataset=dataset2)
 
 
 def test_weave_op_mutates_and_returns_same_object(weave_active):
@@ -188,3 +159,11 @@ def test_weave_op_mutates_and_returns_same_object(weave_active):
     thing.append_tool(lambda: 2)
     assert len(thing.tools) == 2
     assert thing.tools is thing.tools
+
+
+class MyModel(weave.Model):
+    a: int
+
+    @weave.op
+    def predict(self, x: int) -> int:
+        return x + 1


### PR DESCRIPTION
## Summary
- Split from #7235. Densify `tests/flow` tests into fewer, denser parametrized / multi-assert functions: 4 files, +240/-315.

## Testing
per-file coverage-superset gate (each touched file's executed weave/ lines+branches after >= before); tests/flow dir run shows no new failures vs master.