### PR TITLE
feat(weave): attribute agent / conversation identity at read time

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -7,6 +7,7 @@ formatted SQL + param dict against an expected value, matching the style of
 """
 
 import datetime
+import re
 
 import pytest
 import sqlparse
@@ -55,6 +56,9 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_trace_detail_spans_query,
     resolve_group_by,
 )
+from weave.trace_server.query_builder.agent_trace_attribution import (
+    attributed_spans_source,
+)
 
 
 def assert_sql(
@@ -69,6 +73,40 @@ def assert_sql(
     assert expected_params == params, (
         f"\nExpected params: {expected_params}\n\nGot params: {params}"
     )
+
+
+class _AttrSrc:
+    """Expected FROM source + params for queries that read attributed spans.
+
+    Reuses the real `attributed_spans_source` so these tests assert the builder
+    wires it in (the source SQL itself is golden-tested in
+    `test_agent_trace_attribution.py`). The builder allocates the source params
+    *last*, so `offset` shifts the helper's `genai_0`-based slots to where they
+    land in the full query.
+    """
+
+    def __init__(
+        self,
+        offset: int,
+        *,
+        project_id: str = "p1",
+        started_after: datetime.datetime | None = None,
+        started_before: datetime.datetime | None = None,
+    ) -> None:
+        pb = ParamBuilder("genai")
+        sql = attributed_spans_source(
+            pb,
+            project_id=project_id,
+            started_after=started_after,
+            started_before=started_before,
+        )
+        self.sql = re.sub(
+            r"genai_(\d+)", lambda m: f"genai_{int(m.group(1)) + offset}", sql
+        )
+        self.params = {
+            f"genai_{int(k.split('_')[1]) + offset}": v
+            for k, v in pb.get_params().items()
+        }
 
 
 # ============================================================================
@@ -117,12 +155,14 @@ class TestMakeSpansCountQuery:
             ),
         )
 
-        expected = """
-            SELECT count() FROM spans s
-            WHERE s.project_id = {genai_0:String}
-              AND s.started_at >= {genai_1:DateTime64(6)}
-              AND s.started_at < {genai_2:DateTime64(6)}
-            AND ((s.agent_name = {genai_3:String}) AND (if(mapContains(s.custom_attrs_string, {genai_4:String}), s.custom_attrs_string[{genai_4:String}], NULL) = {genai_5:String}))
+        # Filtering on agent.name (identity) reads the attributed source.
+        src = _AttrSrc(6, started_after=start, started_before=end)
+        expected = f"""
+            SELECT count() FROM {src.sql} s
+            WHERE s.project_id = {{genai_0:String}}
+              AND s.started_at >= {{genai_1:DateTime64(6)}}
+              AND s.started_at < {{genai_2:DateTime64(6)}}
+            AND ((s.agent_name = {{genai_3:String}}) AND (if(mapContains(s.custom_attrs_string, {{genai_4:String}}), s.custom_attrs_string[{{genai_4:String}}], NULL) = {{genai_5:String}}))
         """
         expected_params = {
             "genai_0": "p1",
@@ -131,6 +171,7 @@ class TestMakeSpansCountQuery:
             "genai_3": "bot",
             "genai_4": "env",
             "genai_5": "prod",
+            **src.params,
         }
         assert_sql(expected, expected_params, query, pb.get_params())
 
@@ -186,14 +227,15 @@ class TestMakeSpansListQuery:
         pb = ParamBuilder("genai")
         query = make_spans_list_query(pb, AgentSpansQueryReq(project_id="p1"))
 
+        src = _AttrSrc(3)
         expected = f"""
             SELECT {SPANS_LIST_COLS}
-            FROM spans s
+            FROM {src.sql} s
             WHERE s.project_id = {{genai_0:String}}
             ORDER BY started_at DESC
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
         """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
+        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0, **src.params}
         assert_sql(expected, expected_params, query, pb.get_params())
 
     def test_with_custom_sort(self) -> None:
@@ -206,14 +248,15 @@ class TestMakeSpansListQuery:
             ),
         )
 
+        src = _AttrSrc(3)
         expected = f"""
             SELECT {SPANS_LIST_COLS}
-            FROM spans s
+            FROM {src.sql} s
             WHERE s.project_id = {{genai_0:String}}
             ORDER BY input_tokens asc
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
         """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
+        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0, **src.params}
         assert_sql(expected, expected_params, query, pb.get_params())
 
     def test_projects_and_sorts_selected_custom_attr_columns(self) -> None:
@@ -231,9 +274,10 @@ class TestMakeSpansListQuery:
             ),
         )
 
+        src = _AttrSrc(5)
         expected = f"""
             SELECT {SPANS_LIST_COLS}, mapFilter((k, v) -> has({{genai_4:Array(String)}}, k), s.custom_attrs_float) AS custom_attrs_float
-            FROM spans s
+            FROM {src.sql} s
             WHERE s.project_id = {{genai_0:String}}
             ORDER BY if(mapContains(s.custom_attrs_float, {{genai_3:String}}), toFloat64(s.custom_attrs_float[{{genai_3:String}}]), NULL) desc
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
@@ -244,6 +288,7 @@ class TestMakeSpansListQuery:
             "genai_2": 0,
             "genai_3": "score",
             "genai_4": ["score"],
+            **src.params,
         }
         assert_sql(expected, expected_params, query, pb.get_params())
 
@@ -290,14 +335,15 @@ class TestMakeSpansListQuery:
             pb, AgentSpansQueryReq(project_id="p1", include_details=True)
         )
 
+        src = _AttrSrc(3)
         expected = f"""
             SELECT {SPANS_LIST_COLS}, {SPANS_DETAILS_COLS}
-            FROM spans s
+            FROM {src.sql} s
             WHERE s.project_id = {{genai_0:String}}
             ORDER BY started_at DESC
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
         """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
+        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0, **src.params}
         assert_sql(expected, expected_params, query, pb.get_params())
 
     def test_include_details_rejected_with_group_by(self) -> None:
@@ -430,16 +476,17 @@ class TestMakeGroupedSpansListQuery:
             ),
         )
 
+        src = _AttrSrc(3)
         expected = f"""
             SELECT s.trace_id AS trace_id,
                    {_GROUPED_AGG_TAIL}
-            FROM spans s
+            FROM {src.sql} s
             WHERE s.project_id = {{genai_0:String}}
             GROUP BY trace_id
             ORDER BY last_seen DESC
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
         """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
+        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0, **src.params}
         assert_sql(expected, expected_params, query, pb.get_params())
 
     def test_group_by_conversation_id_with_time(self) -> None:
@@ -458,10 +505,11 @@ class TestMakeGroupedSpansListQuery:
             ),
         )
 
+        src = _AttrSrc(5, started_after=start, started_before=end)
         expected = f"""
             SELECT s.conversation_id AS conversation_id,
                    {_GROUPED_AGG_TAIL}
-            FROM spans s
+            FROM {src.sql} s
             WHERE s.project_id = {{genai_0:String}}
               AND s.started_at >= {{genai_1:DateTime64(6)}}
               AND s.started_at < {{genai_2:DateTime64(6)}}
@@ -475,6 +523,7 @@ class TestMakeGroupedSpansListQuery:
             "genai_2": end,
             "genai_3": 100,
             "genai_4": 0,
+            **src.params,
         }
         assert_sql(expected, expected_params, query, pb.get_params())
 
@@ -490,10 +539,11 @@ class TestMakeGroupedSpansListQuery:
             ),
         )
 
+        src = _AttrSrc(4)
         expected = f"""
             SELECT if(mapContains(s.custom_attrs_string, {{genai_3:String}}), s.custom_attrs_string[{{genai_3:String}}], NULL) AS env,
                    {_GROUPED_AGG_TAIL}
-            FROM spans s
+            FROM {src.sql} s
             WHERE s.project_id = {{genai_0:String}}
             GROUP BY env
             ORDER BY last_seen DESC
@@ -504,6 +554,7 @@ class TestMakeGroupedSpansListQuery:
             "genai_1": 100,
             "genai_2": 0,
             "genai_3": "env",
+            **src.params,
         }
         assert_sql(expected, expected_params, query, pb.get_params())
 
@@ -521,17 +572,18 @@ class TestMakeGroupedSpansListQuery:
             ),
         )
 
+        src = _AttrSrc(3)
         expected = f"""
             SELECT s.agent_name AS agent_name,
                    s.request_model AS request_model,
                    {_GROUPED_AGG_TAIL}
-            FROM spans s
+            FROM {src.sql} s
             WHERE s.project_id = {{genai_0:String}}
             GROUP BY agent_name, request_model
             ORDER BY agent_name asc
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
         """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
+        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0, **src.params}
         assert_sql(expected, expected_params, query, pb.get_params())
 
     def test_group_by_with_dynamic_measures_filter_and_sort(self) -> None:
@@ -591,14 +643,17 @@ class TestMakeGroupedSpansListQuery:
                    count() AS spans,
                    countIf(((s.operation_name = {genai_3:String}))) AS tool_calls,
                    avgOrNull(if((mapContains(s.custom_attrs_float, {genai_4:String})), toFloat64(s.custom_attrs_float[{genai_4:String}]), NULL)) AS avg_score
-            FROM spans s
+            FROM {_ATTR_SRC} s
             WHERE s.project_id = {genai_0:String}
             GROUP BY conversation_id
             HAVING avgOrNull(if((mapContains(s.custom_attrs_float, {genai_5:String})), toFloat64(s.custom_attrs_float[{genai_5:String}]), NULL)) >= {genai_6:Float64}
             ORDER BY avg_score desc
             LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
         """
-        expected = expected.replace("{_GROUPED_AGG_TAIL}", _GROUPED_AGG_TAIL)
+        src = _AttrSrc(7)
+        expected = expected.replace("{_GROUPED_AGG_TAIL}", _GROUPED_AGG_TAIL).replace(
+            "{_ATTR_SRC}", src.sql
+        )
         expected_params = {
             "genai_0": "p1",
             "genai_1": 100,
@@ -607,6 +662,7 @@ class TestMakeGroupedSpansListQuery:
             "genai_4": "score",
             "genai_5": "score",
             "genai_6": 0.5,
+            **src.params,
         }
         assert_sql(expected, expected_params, query, pb.get_params())
 
@@ -655,18 +711,22 @@ class TestMakeGroupedSpansListQuery:
             SELECT s.conversation_id AS conversation_id,
                    {_GROUPED_AGG_TAIL},
                    countIf((mapContains(s.custom_attrs_bool, {genai_3:String})) AND s.custom_attrs_bool[{genai_3:String}] = 1) AS flagged_count
-            FROM spans s
+            FROM {_ATTR_SRC} s
             WHERE s.project_id = {genai_0:String}
             GROUP BY conversation_id
             ORDER BY flagged_count DESC
             LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
         """
-        expected = expected.replace("{_GROUPED_AGG_TAIL}", _GROUPED_AGG_TAIL)
+        src = _AttrSrc(4)
+        expected = expected.replace("{_GROUPED_AGG_TAIL}", _GROUPED_AGG_TAIL).replace(
+            "{_ATTR_SRC}", src.sql
+        )
         expected_params = {
             "genai_0": "p1",
             "genai_1": 100,
             "genai_2": 0,
             "genai_3": "flagged",
+            **src.params,
         }
         assert_sql(expected, expected_params, query, pb.get_params())
 
@@ -796,7 +856,7 @@ class TestMakeSpanGroupDistributionQueries:
                          tupleElement(spec, 1) AS alias,
                          tupleElement(spec, 4) AS bins,
                          multiIf(tupleElement(spec, 2) = 'custom_attrs_int', toFloat64(s.custom_attrs_int[tupleElement(spec, 3)]), tupleElement(spec, 2) = 'custom_attrs_float', toFloat64(s.custom_attrs_float[tupleElement(spec, 3)]), NULL) AS value
-                  FROM spans s
+                  FROM {_ATTR_SRC} s
                   ARRAY JOIN array(tuple({genai_2:String}, {genai_3:String}, {genai_4:String}, {genai_5:UInt64}), tuple({genai_6:String}, {genai_7:String}, {genai_8:String}, {genai_9:UInt64})) AS spec
                   WHERE s.project_id = {genai_0:String}
                     AND toString(s.conversation_id) IN {genai_1:Array(String)}
@@ -856,6 +916,8 @@ class TestMakeSpanGroupDistributionQueries:
               )
             ORDER BY group_key ASC, alias ASC, bucket_index ASC
         """
+        src = _AttrSrc(10)
+        expected = expected.replace("{_ATTR_SRC}", src.sql)
         expected_params = {
             "genai_0": "p1",
             "genai_1": ["conv-a", "", "12"],
@@ -867,6 +929,7 @@ class TestMakeSpanGroupDistributionQueries:
             "genai_7": "custom_attrs_int",
             "genai_8": "latency",
             "genai_9": 3,
+            **src.params,
         }
         assert_sql(expected, expected_params, query, pb.get_params())
 
@@ -906,7 +969,7 @@ class TestMakeSpanGroupDistributionQueries:
                          tupleElement(spec, 1) AS alias,
                          tupleElement(spec, 4) AS top_n,
                          multiIf(tupleElement(spec, 2) = 'custom_attrs_bool', if(s.custom_attrs_bool[tupleElement(spec, 3)] = 1, 'true', 'false'), tupleElement(spec, 2) = 'custom_attrs_string', toString(s.custom_attrs_string[tupleElement(spec, 3)]), '') AS raw_value
-                  FROM spans s
+                  FROM {_ATTR_SRC} s
                   ARRAY JOIN array(tuple({genai_2:String}, {genai_3:String}, {genai_4:String}, {genai_5:UInt64}), tuple({genai_6:String}, {genai_7:String}, {genai_8:String}, {genai_9:UInt64})) AS spec
                   WHERE s.project_id = {genai_0:String}
                     AND toString(s.conversation_id) IN {genai_1:Array(String)}
@@ -938,6 +1001,8 @@ class TestMakeSpanGroupDistributionQueries:
             WHERE value_rank <= top_n
             ORDER BY group_key ASC, alias ASC, count DESC, raw_value ASC
         """
+        src = _AttrSrc(10)
+        expected = expected.replace("{_ATTR_SRC}", src.sql)
         expected_params = {
             "genai_0": "p1",
             "genai_1": ["conv-a"],
@@ -949,6 +1014,7 @@ class TestMakeSpanGroupDistributionQueries:
             "genai_7": "custom_attrs_bool",
             "genai_8": "cached",
             "genai_9": 2,
+            **src.params,
         }
         assert_sql(expected, expected_params, query, pb.get_params())
 

--- a/tests/trace_server/query_builder/test_agent_stats_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_stats_query_builder.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 
 import pytest
 import sqlparse
@@ -19,6 +20,37 @@ from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.agent_stats_query_builder import (
     build_agent_span_stats_query,
 )
+from weave.trace_server.query_builder.agent_trace_attribution import (
+    attributed_spans_source,
+)
+
+
+def _attr_src(
+    offset: int,
+    *,
+    project_id: str = "p1",
+    started_after: datetime.datetime | None = None,
+    started_before: datetime.datetime | None = None,
+) -> tuple[str, dict]:
+    """Expected attributed-spans FROM source + params, slot-shifted by `offset`.
+
+    The stats builder allocates the trace-attribution source params right after
+    the span filter (project + window), so they land mid-query; `offset` moves
+    the helper's `genai_0`-based slots to match. The source SQL itself is
+    golden-tested in `test_agent_trace_attribution.py`.
+    """
+    pb = ParamBuilder("genai")
+    sql = attributed_spans_source(
+        pb,
+        project_id=project_id,
+        started_after=started_after,
+        started_before=started_before,
+    )
+    sql = re.sub(r"genai_(\d+)", lambda m: f"genai_{int(m.group(1)) + offset}", sql)
+    params = {
+        f"genai_{int(k.split('_')[1]) + offset}": v for k, v in pb.get_params().items()
+    }
+    return sql, params
 
 
 def assert_sql(
@@ -92,34 +124,38 @@ def test_ungrouped_stats_query_full_sql_shape() -> None:
 
     result = build_agent_span_stats_query(req, pb)
 
+    start = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    end = datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc)
+    # Filtering on agent.name (identity) reads the attributed source.
+    src_sql, src_params = _attr_src(4, started_after=start, started_before=end)
     expected_sql = """
         WITH all_buckets AS (
           SELECT toStartOfInterval(
-            toDateTime({genai_4:Float64}, {genai_6:String}),
+            toDateTime({genai_9:Float64}, {genai_11:String}),
             INTERVAL 3600 SECOND,
-            {genai_6:String}
-          ) + toIntervalSecond(number * {genai_7:Int64}) AS bucket
+            {genai_11:String}
+          ) + toIntervalSecond(number * {genai_12:Int64}) AS bucket
           FROM numbers(
             toUInt64(
               ceil(
                 (
-                  toUnixTimestamp(toDateTime({genai_5:Float64}, {genai_6:String})) -
+                  toUnixTimestamp(toDateTime({genai_10:Float64}, {genai_11:String})) -
                   toUnixTimestamp(
                     toStartOfInterval(
-                      toDateTime({genai_4:Float64}, {genai_6:String}),
+                      toDateTime({genai_9:Float64}, {genai_11:String}),
                       INTERVAL 3600 SECOND,
-                      {genai_6:String}
+                      {genai_11:String}
                     )
                   )
-                ) / {genai_7:Float64}
+                ) / {genai_12:Float64}
               )
             )
           )
-          WHERE bucket < toDateTime({genai_5:Float64}, {genai_6:String})
+          WHERE bucket < toDateTime({genai_10:Float64}, {genai_11:String})
         ),
         filtered_spans AS (
           SELECT *
-          FROM spans s
+          FROM {_ATTR_SRC} s
           WHERE s.project_id = {genai_0:String}
             AND s.started_at >= {genai_1:DateTime64(6)}
             AND s.started_at < {genai_2:DateTime64(6)}
@@ -133,7 +169,7 @@ def test_ungrouped_stats_query_full_sql_shape() -> None:
             countIf(v_errors AND m_errors = 1) AS count_true_errors
           FROM (
             SELECT
-              toStartOfInterval(s.started_at, INTERVAL 3600 SECOND, {genai_6:String}) AS bucket,
+              toStartOfInterval(s.started_at, INTERVAL 3600 SECOND, {genai_11:String}) AS bucket,
               if(
                 s.ended_at > s.started_at,
                 toFloat64(toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at)),
@@ -155,16 +191,17 @@ def test_ungrouped_stats_query_full_sql_shape() -> None:
         LEFT JOIN aggregated_data
           ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY timestamp
-    """
+    """.replace("{_ATTR_SRC}", src_sql)
     expected_params = {
         "genai_0": "p1",
-        "genai_1": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        "genai_2": datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
+        "genai_1": start,
+        "genai_2": end,
         "genai_3": "agent-a",
-        "genai_4": 1767225600.0,
-        "genai_5": 1767312000.0,
-        "genai_6": "UTC",
-        "genai_7": 3600,
+        "genai_9": 1767225600.0,
+        "genai_10": 1767312000.0,
+        "genai_11": "UTC",
+        "genai_12": 3600,
+        **src_params,
     }
     assert_sql(expected_sql, expected_params, result.sql, result.parameters)
     assert result.columns == [
@@ -316,14 +353,18 @@ def test_basic_stats_query_uses_query_filter_and_bucket() -> None:
 
     result = build_agent_span_stats_query(req, pb)
 
+    start = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    end = datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc)
+    # Filtering on agent.name (identity) reads the attributed source.
+    src_sql, src_params = _attr_src(4, started_after=start, started_before=end)
     expected_sql = """
         WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({genai_4:Float64}, {genai_6:String}), INTERVAL 3600 SECOND, {genai_6:String}) + toIntervalSecond(number * {genai_7:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({genai_5:Float64}, {genai_6:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({genai_4:Float64}, {genai_6:String}), INTERVAL 3600 SECOND, {genai_6:String}))) / {genai_7:Float64})))
-           WHERE bucket < toDateTime({genai_5:Float64}, {genai_6:String}) ),
+          (SELECT toStartOfInterval(toDateTime({genai_9:Float64}, {genai_11:String}), INTERVAL 3600 SECOND, {genai_11:String}) + toIntervalSecond(number * {genai_12:Int64}) AS bucket
+           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({genai_10:Float64}, {genai_11:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({genai_9:Float64}, {genai_11:String}), INTERVAL 3600 SECOND, {genai_11:String}))) / {genai_12:Float64})))
+           WHERE bucket < toDateTime({genai_10:Float64}, {genai_11:String}) ),
              filtered_spans AS
           (SELECT *
-           FROM spans s
+           FROM {_ATTR_SRC} s
            WHERE s.project_id = {genai_0:String}
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)}
@@ -335,7 +376,7 @@ def test_basic_stats_query_uses_query_filter_and_bucket() -> None:
                   countIf(v_errors
                           AND m_errors = 1) AS count_true_errors
            FROM
-             (SELECT toStartOfInterval(s.started_at, INTERVAL 3600 SECOND, {genai_6:String}) AS bucket,
+             (SELECT toStartOfInterval(s.started_at, INTERVAL 3600 SECOND, {genai_11:String}) AS bucket,
                      if(s.ended_at > s.started_at, toFloat64(toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at)), NULL) AS m_duration_ms,
                      toUInt8(s.ended_at > s.started_at) AS v_duration_ms,
                      s.status_code = 'ERROR' AS m_errors,
@@ -349,16 +390,17 @@ def test_basic_stats_query_uses_query_filter_and_bucket() -> None:
         FROM all_buckets
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY timestamp
-    """
+    """.replace("{_ATTR_SRC}", src_sql)
     expected_params = {
         "genai_0": "p1",
-        "genai_1": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        "genai_2": datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
+        "genai_1": start,
+        "genai_2": end,
         "genai_3": "agent-a",
-        "genai_4": 1767225600.0,
-        "genai_5": 1767312000.0,
-        "genai_6": "UTC",
-        "genai_7": 3600,
+        "genai_9": 1767225600.0,
+        "genai_10": 1767312000.0,
+        "genai_11": "UTC",
+        "genai_12": 3600,
+        **src_params,
     }
     assert_sql(expected_sql, expected_params, result.sql, result.parameters)
     assert result.columns == [
@@ -469,15 +511,20 @@ def test_numeric_bucket_stats_query_groups_custom_attr_measure() -> None:
 
     result = build_agent_span_stats_query(req, pb)
 
+    start = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    end = datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc)
+    # Grouping by conversation_id (an identity column) reads attributed spans so
+    # child spans inherit it; the source params land after the span filter.
+    src_sql, src_params = _attr_src(3, started_after=start, started_before=end)
     expected_sql = """
         WITH filtered_spans AS
           (SELECT *
-           FROM spans s
+           FROM {_ATTR_SRC} s
            WHERE s.project_id = {genai_0:String}
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)} ),
              value_rows AS
-          (SELECT avgOrNull(if((mapContains(s.custom_attrs_float, {genai_4:String})), toFloat64(s.custom_attrs_float[{genai_4:String}]), NULL)) AS bucket_value
+          (SELECT avgOrNull(if((mapContains(s.custom_attrs_float, {genai_9:String})), toFloat64(s.custom_attrs_float[{genai_9:String}]), NULL)) AS bucket_value
            FROM filtered_spans s
            GROUP BY s.conversation_id),
              bounds AS
@@ -487,9 +534,9 @@ def test_numeric_bucket_stats_query_groups_custom_attr_measure() -> None:
            FROM value_rows),
              all_buckets AS
           (SELECT toUInt64(number) AS bucket
-           FROM numbers({genai_3:UInt64})),
+           FROM numbers({genai_8:UInt64})),
              aggregated_data AS
-          (SELECT if(bounds.bucket_max_bound = bounds.bucket_min_bound, toUInt64(0), toUInt64(least(toFloat64({genai_3:UInt64}) - 1.0, floor((value_rows.bucket_value - bounds.bucket_min_bound) / if(bounds.bucket_max_bound > bounds.bucket_min_bound, (bounds.bucket_max_bound - bounds.bucket_min_bound) / {genai_3:Float64}, 1.0))))) AS bucket,
+          (SELECT if(bounds.bucket_max_bound = bounds.bucket_min_bound, toUInt64(0), toUInt64(least(toFloat64({genai_8:UInt64}) - 1.0, floor((value_rows.bucket_value - bounds.bucket_min_bound) / if(bounds.bucket_max_bound > bounds.bucket_min_bound, (bounds.bucket_max_bound - bounds.bucket_min_bound) / {genai_8:Float64}, 1.0))))) AS bucket,
                   count() AS count
            FROM value_rows
            CROSS JOIN bounds
@@ -498,8 +545,8 @@ def test_numeric_bucket_stats_query_groups_custom_attr_measure() -> None:
              AND value_rows.bucket_value <= bounds.bucket_max_bound
            GROUP BY bucket)
         SELECT all_buckets.bucket AS bucket_index,
-               if(bounds.bucket_max_bound = bounds.bucket_min_bound, bounds.bucket_min_bound, bounds.bucket_min_bound + toFloat64(all_buckets.bucket) * if(bounds.bucket_max_bound > bounds.bucket_min_bound, (bounds.bucket_max_bound - bounds.bucket_min_bound) / {genai_3:Float64}, 1.0)) AS bucket_min,
-               if(bounds.bucket_max_bound = bounds.bucket_min_bound, bounds.bucket_max_bound, if(all_buckets.bucket = {genai_3:UInt64} - toUInt64(1), bounds.bucket_max_bound, bounds.bucket_min_bound + toFloat64(all_buckets.bucket + 1) * if(bounds.bucket_max_bound > bounds.bucket_min_bound, (bounds.bucket_max_bound - bounds.bucket_min_bound) / {genai_3:Float64}, 1.0))) AS bucket_max,
+               if(bounds.bucket_max_bound = bounds.bucket_min_bound, bounds.bucket_min_bound, bounds.bucket_min_bound + toFloat64(all_buckets.bucket) * if(bounds.bucket_max_bound > bounds.bucket_min_bound, (bounds.bucket_max_bound - bounds.bucket_min_bound) / {genai_8:Float64}, 1.0)) AS bucket_min,
+               if(bounds.bucket_max_bound = bounds.bucket_min_bound, bounds.bucket_max_bound, if(all_buckets.bucket = {genai_8:UInt64} - toUInt64(1), bounds.bucket_max_bound, bounds.bucket_min_bound + toFloat64(all_buckets.bucket + 1) * if(bounds.bucket_max_bound > bounds.bucket_min_bound, (bounds.bucket_max_bound - bounds.bucket_min_bound) / {genai_8:Float64}, 1.0))) AS bucket_max,
                COALESCE(aggregated_data.count, 0) AS count
         FROM all_buckets
         CROSS JOIN bounds
@@ -508,13 +555,14 @@ def test_numeric_bucket_stats_query_groups_custom_attr_measure() -> None:
           AND (bounds.bucket_max_bound > bounds.bucket_min_bound
                OR all_buckets.bucket = 0)
         ORDER BY bucket_index
-    """
+    """.replace("{_ATTR_SRC}", src_sql)
     expected_params = {
         "genai_0": "p1",
-        "genai_1": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        "genai_2": datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
-        "genai_3": 8,
-        "genai_4": "score",
+        "genai_1": start,
+        "genai_2": end,
+        "genai_8": 8,
+        "genai_9": "score",
+        **src_params,
     }
     assert_sql(expected_sql, expected_params, result.sql, result.parameters)
     assert result.columns == ["bucket_index", "bucket_min", "bucket_max", "count"]
@@ -682,14 +730,19 @@ def test_time_stats_apply_group_filters() -> None:
 
     result = build_agent_span_stats_query(req, pb)
 
+    start = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    end = datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc)
+    # The count_distinct metric is over conversation_id (an identity column), so
+    # the stats source reads attributed spans; its params land after the filter.
+    src_sql, src_params = _attr_src(3, started_after=start, started_before=end)
     expected_sql = """
         WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({genai_3:Float64}, {genai_5:String}), INTERVAL 3600 SECOND, {genai_5:String}) + toIntervalSecond(number * {genai_6:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({genai_4:Float64}, {genai_5:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({genai_3:Float64}, {genai_5:String}), INTERVAL 3600 SECOND, {genai_5:String}))) / {genai_6:Float64})))
-           WHERE bucket < toDateTime({genai_4:Float64}, {genai_5:String}) ),
+          (SELECT toStartOfInterval(toDateTime({genai_8:Float64}, {genai_10:String}), INTERVAL 3600 SECOND, {genai_10:String}) + toIntervalSecond(number * {genai_11:Int64}) AS bucket
+           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({genai_9:Float64}, {genai_10:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({genai_8:Float64}, {genai_10:String}), INTERVAL 3600 SECOND, {genai_10:String}))) / {genai_11:Float64})))
+           WHERE bucket < toDateTime({genai_9:Float64}, {genai_10:String}) ),
              filtered_spans AS
           (SELECT *
-           FROM spans s
+           FROM {_ATTR_SRC} s
            WHERE s.project_id = {genai_0:String}
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)} ),
@@ -697,8 +750,8 @@ def test_time_stats_apply_group_filters() -> None:
           (SELECT s.conversation_id AS conversation_id
            FROM filtered_spans s
            GROUP BY conversation_id
-           HAVING sumOrNull(if((1), toFloat64(s.input_tokens + s.output_tokens + s.reasoning_tokens), NULL)) >= {genai_7:Float64}
-           AND sumOrNull(if((1), toFloat64(s.input_tokens + s.output_tokens + s.reasoning_tokens), NULL)) <= {genai_8:Float64}),
+           HAVING sumOrNull(if((1), toFloat64(s.input_tokens + s.output_tokens + s.reasoning_tokens), NULL)) >= {genai_12:Float64}
+           AND sumOrNull(if((1), toFloat64(s.input_tokens + s.output_tokens + s.reasoning_tokens), NULL)) <= {genai_13:Float64}),
              filtered_metric_spans AS
           (SELECT s.*
            FROM filtered_spans s
@@ -707,7 +760,7 @@ def test_time_stats_apply_group_filters() -> None:
           (SELECT bucket,
                   uniqExactIf(m_conversations, v_conversations) AS count_distinct_conversations
            FROM
-             (SELECT toStartOfInterval(s.started_at, INTERVAL 3600 SECOND, {genai_5:String}) AS bucket,
+             (SELECT toStartOfInterval(s.started_at, INTERVAL 3600 SECOND, {genai_10:String}) AS bucket,
                      s.conversation_id AS m_conversations,
                      toUInt8(1) AS v_conversations
               FROM filtered_metric_spans s)
@@ -717,17 +770,18 @@ def test_time_stats_apply_group_filters() -> None:
         FROM all_buckets
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY timestamp
-    """
+    """.replace("{_ATTR_SRC}", src_sql)
     expected_params = {
         "genai_0": "p1",
-        "genai_1": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        "genai_2": datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
-        "genai_3": 1767225600.0,
-        "genai_4": 1767312000.0,
-        "genai_5": "UTC",
-        "genai_6": 3600,
-        "genai_7": 10.0,
-        "genai_8": 100.0,
+        "genai_1": start,
+        "genai_2": end,
+        "genai_8": 1767225600.0,
+        "genai_9": 1767312000.0,
+        "genai_10": "UTC",
+        "genai_11": 3600,
+        "genai_12": 10.0,
+        "genai_13": 100.0,
+        **src_params,
     }
     assert_sql(expected_sql, expected_params, result.sql, result.parameters)
 

--- a/tests/trace_server/query_builder/test_agent_trace_attribution.py
+++ b/tests/trace_server/query_builder/test_agent_trace_attribution.py
@@ -1,0 +1,109 @@
+"""Unit tests for read-time trace attribution of agent / conversation identity.
+
+`attributed_spans_source` is the single place the four identity columns get
+their trace-inherited value; the builders just swap it in for `FROM spans`.
+These tests pin its SQL shape and the `references_identity` gating helpers.
+"""
+
+import datetime
+import re
+
+from weave.trace_server.interface.query import Query
+from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.query_builder.agent_trace_attribution import (
+    IDENTITY_COLUMNS,
+    attributed_spans_source,
+    fields_reference_identity,
+    query_references_identity,
+)
+
+
+def _fmt(sql: str) -> str:
+    """Normalize whitespace (incl. around punctuation) to ignore formatting."""
+    return re.sub(r"\s*([(),])\s*", r"\1", " ".join(sql.split()))
+
+
+def test_identity_columns_are_the_four_inheriting_fields() -> None:
+    assert set(IDENTITY_COLUMNS) == {
+        "agent_name",
+        "agent_version",
+        "agent_id",
+        "conversation_id",
+    }
+
+
+def test_attributed_source_inherits_agent_triple_coherently() -> None:
+    pb = ParamBuilder("genai")
+    sql = attributed_spans_source(
+        pb, project_id="p1", started_after=None, started_before=None
+    )
+    # agent_name / agent_version / agent_id inherit together as one tuple taken
+    # from a single span (argMinIf by started_at, gated on agent_name), so a
+    # span's inherited identity can never mix two agents. A span that declares
+    # its own agent_name keeps its entire own triple. conversation_id is
+    # inherited on its own.
+    expected = """
+        (SELECT * EXCEPT (agent_name, agent_version, agent_id, conversation_id,
+                          has_own_agent_identity, fb_agent_identity, fb_conversation_id),
+            if(has_own_agent_identity, agent_name, fb_agent_identity.1) AS agent_name,
+            if(has_own_agent_identity, agent_version, fb_agent_identity.2) AS agent_version,
+            if(has_own_agent_identity, agent_id, fb_agent_identity.3) AS agent_id,
+            if(conversation_id != '', conversation_id, fb_conversation_id) AS conversation_id
+         FROM (
+           SELECT s0.*, (s0.agent_name != '') AS has_own_agent_identity,
+                  tf.fb_agent_identity, tf.fb_conversation_id
+           FROM spans s0
+           LEFT JOIN (
+             SELECT trace_id,
+                 argMinIf((agent_name, agent_version, agent_id), started_at, agent_name != '')
+                   AS fb_agent_identity,
+                 anyIf(conversation_id, conversation_id != '') AS fb_conversation_id
+             FROM spans
+             WHERE project_id = {genai_0:String}
+             GROUP BY trace_id) tf ON s0.trace_id = tf.trace_id
+           WHERE s0.project_id = {genai_0:String}))
+    """
+    assert _fmt(sql) == _fmt(expected)
+    assert pb.get_params() == {"genai_0": "p1"}
+
+
+def test_attributed_source_bounds_fallback_scan_with_slack() -> None:
+    after = datetime.datetime(2026, 1, 10, tzinfo=datetime.timezone.utc)
+    before = datetime.datetime(2026, 1, 11, tzinfo=datetime.timezone.utc)
+    pb = ParamBuilder("genai")
+    sql = attributed_spans_source(
+        pb, project_id="p1", started_after=after, started_before=before
+    )
+    params = pb.get_params()
+    # Inner base scan uses the exact window; the fallback scan widens it by one
+    # trace-duration of slack on each side so edge spans still resolve.
+    slack = datetime.timedelta(hours=1)
+    assert after - slack in params.values()
+    assert before + slack in params.values()
+    assert after in params.values()
+    assert before in params.values()
+    assert (
+        "argMinIf((agent_name, agent_version, agent_id), started_at, agent_name != '')"
+        in sql
+    )
+
+
+def test_query_references_identity_resolves_aliases() -> None:
+    def q(field: str) -> Query:
+        return Query.model_validate(
+            {"$expr": {"$eq": [{"$getField": field}, {"$literal": "x"}]}}
+        )
+
+    assert query_references_identity(q("agent.name"))
+    assert query_references_identity(q("gen_ai.agent.name"))
+    assert query_references_identity(q("agent_name"))
+    assert query_references_identity(q("conversation_id"))
+    assert not query_references_identity(q("operation_name"))
+    assert not query_references_identity(None)
+
+
+def test_fields_reference_identity() -> None:
+    assert fields_reference_identity(["agent.version"])
+    assert fields_reference_identity(["operation_name", "agent_id"])
+    assert not fields_reference_identity(["operation_name", "request_model"])
+    assert not fields_reference_identity([])

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -120,6 +120,232 @@ def test_spans_insert_and_query(ch_server):
 
 
 # ---------------------------------------------------------------------------
+# Test: read-time trace attribution of agent / conversation identity
+# ---------------------------------------------------------------------------
+
+
+def _agent_name_eq(value: str) -> Query:
+    return Query.model_validate(
+        {"$expr": {"$eq": [{"$getField": "agent.name"}, {"$literal": value}]}}
+    )
+
+
+def test_unset_span_inherits_identity_from_its_trace(ch_server):
+    """A child span with no direct agent metadata inherits it from its turn.
+
+    Identity is reported only on the `invoke_agent` span, while the child llm
+    span carries no agent_name. The spans query reads from the attributed
+    source, so the child both *displays* and *filters as* the turn's agent —
+    while a span from an unrelated trace is never pulled in.
+    """
+    project_id = _make_project_id("attribution")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    trace_id = uuid.uuid4().hex
+    invoke_span_id = uuid.uuid4().hex
+    child_span_id = uuid.uuid4().hex
+    other_span_id = uuid.uuid4().hex
+
+    spans = [
+        # invoke_agent span carries the agent identity.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=invoke_span_id,
+            operation_name="invoke_agent",
+            agent_name="Planner",
+            started_at=now,
+        ),
+        # child llm span has NO direct agent metadata; it should inherit.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=child_span_id,
+            parent_span_id=invoke_span_id,
+            operation_name="chat",
+            agent_name="",
+            started_at=now + datetime.timedelta(seconds=1),
+        ),
+        # unrelated trace / agent — must never be pulled in.
+        _make_span(
+            project_id,
+            trace_id=uuid.uuid4().hex,
+            span_id=other_span_id,
+            agent_name="OtherAgent",
+            started_at=now + datetime.timedelta(seconds=2),
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    # Unfiltered list: the child *displays* the inherited agent name.
+    listed = ch_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
+    by_id = {s.span_id: s for s in listed.spans}
+    assert by_id[child_span_id].agent_name == "Planner"
+    assert by_id[invoke_span_id].agent_name == "Planner"
+    assert by_id[other_span_id].agent_name == "OtherAgent"
+
+    # Filtering on the agent matches the whole turn (own + inherited), and
+    # nothing from the unrelated trace.
+    matched = ch_server.agent_spans_query(
+        AgentSpansQueryReq(project_id=project_id, query=_agent_name_eq("Planner"))
+    )
+    assert matched.total_count == 2
+    assert {s.span_id for s in matched.spans} == {invoke_span_id, child_span_id}
+
+    # Time-bounded query: the fallback scan is slack-widened to the same window
+    # and still attributes the child span.
+    windowed = ch_server.agent_spans_query(
+        AgentSpansQueryReq(
+            project_id=project_id,
+            started_after=now - datetime.timedelta(minutes=1),
+            started_before=now + datetime.timedelta(minutes=1),
+            query=_agent_name_eq("Planner"),
+        )
+    )
+    assert {s.span_id for s in windowed.spans} == {invoke_span_id, child_span_id}
+
+
+def test_span_with_own_identity_is_not_reattributed(ch_server):
+    """A span that sets its own agent identity keeps it (singleton).
+
+    In a multi-agent turn, a sub-agent span that reported its own agent_name
+    must not be pulled into the parent agent's filter, and must not be displayed
+    as the parent agent.
+    """
+    project_id = _make_project_id("attribution_singleton")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    trace_id = uuid.uuid4().hex
+    coordinator_span_id = uuid.uuid4().hex
+    worker_span_id = uuid.uuid4().hex
+
+    spans = [
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=coordinator_span_id,
+            operation_name="invoke_agent",
+            agent_name="Coordinator",
+            started_at=now,
+        ),
+        # Sub-agent span reports its OWN agent_name.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=worker_span_id,
+            parent_span_id=coordinator_span_id,
+            operation_name="invoke_agent",
+            agent_name="Worker",
+            started_at=now + datetime.timedelta(seconds=1),
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    # The sub-agent span keeps its own identity on display.
+    listed = ch_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
+    by_id = {s.span_id: s for s in listed.spans}
+    assert by_id[worker_span_id].agent_name == "Worker"
+    assert by_id[coordinator_span_id].agent_name == "Coordinator"
+
+    # Filtering for the sub-agent returns only its own span, not the parent's.
+    worker = ch_server.agent_spans_query(
+        AgentSpansQueryReq(project_id=project_id, query=_agent_name_eq("Worker"))
+    )
+    assert {s.span_id for s in worker.spans} == {worker_span_id}
+
+    # Filtering for the parent does not pull in the self-identified sub-agent.
+    coordinator = ch_server.agent_spans_query(
+        AgentSpansQueryReq(project_id=project_id, query=_agent_name_eq("Coordinator"))
+    )
+    assert {s.span_id for s in coordinator.spans} == {coordinator_span_id}
+
+
+def test_unset_span_inherits_a_coherent_agent_triple(ch_server):
+    """An inherited identity is one real agent, never a mix of two.
+
+    agent_name / agent_version / agent_id identify one agent, so an unset span
+    inherits all three from a single span (the earliest in its trace that
+    declares an agent_name). Here two identity-bearing spans deliberately split
+    the columns — one carries the name, a later one carries a version — so a
+    per-column inheritance would synthesize the (name, version) pair
+    ('Planner', 'v2') that never existed on any span. The child must instead
+    inherit Planner's own (coherent) triple.
+    """
+    project_id = _make_project_id("attribution_coherent")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    trace_id = uuid.uuid4().hex
+    planner_span_id = uuid.uuid4().hex
+    versioned_span_id = uuid.uuid4().hex
+    child_span_id = uuid.uuid4().hex
+
+    spans = [
+        # Earliest identity-bearing span: name set, version blank.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=planner_span_id,
+            operation_name="invoke_agent",
+            agent_name="Planner",
+            agent_version="",
+            started_at=now,
+        ),
+        # A later span carries a version but no name.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=versioned_span_id,
+            operation_name="invoke_agent",
+            agent_name="",
+            agent_version="v2",
+            started_at=now + datetime.timedelta(seconds=1),
+        ),
+        # Unset child: must inherit Planner's whole triple, not a mix.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=child_span_id,
+            parent_span_id=planner_span_id,
+            operation_name="chat",
+            agent_name="",
+            agent_version="",
+            started_at=now + datetime.timedelta(seconds=2),
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    listed = ch_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
+    child = {s.span_id: s for s in listed.spans}[child_span_id]
+    # Coherent: the inherited (name, version) co-occurred on a real span.
+    assert (child.agent_name, child.agent_version) == ("Planner", "")
+
+    # And filtering on the phantom pair must not pull the child in.
+    phantom = ch_server.agent_spans_query(
+        AgentSpansQueryReq(
+            project_id=project_id,
+            query=Query.model_validate(
+                {
+                    "$expr": {
+                        "$and": [
+                            {
+                                "$eq": [
+                                    {"$getField": "agent.name"},
+                                    {"$literal": "Planner"},
+                                ]
+                            },
+                            {
+                                "$eq": [
+                                    {"$getField": "agent.version"},
+                                    {"$literal": "v2"},
+                                ]
+                            },
+                        ]
+                    }
+                }
+            ),
+        )
+    )
+    assert phantom.spans == []
+
+
+# ---------------------------------------------------------------------------
 # Test: group by trace_id (replaces old traces_query)
 # ---------------------------------------------------------------------------
 

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -52,6 +52,7 @@ from weave.trace_server.agents.types import (
     group_by_ref_alias,
 )
 from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.query_builder import agent_trace_attribution
 from weave.trace_server.query_builder.agent_custom_attrs import (
     custom_attr_value_or_null,
 )
@@ -859,6 +860,49 @@ def _spans_filter_sql(
     return _FilterSQL(where=" AND ".join(where_conditions))
 
 
+def _group_by_references_identity(group_by: list[AgentGroupByRef] | None) -> bool:
+    """Whether any field/column group-by ref targets an identity column."""
+    if not group_by:
+        return False
+    field_keys = [ref.key for ref in group_by if ref.source in _FIELD_GROUP_BY_SOURCES]
+    return agent_trace_attribution.fields_reference_identity(field_keys)
+
+
+def _spans_query_references_identity(req: AgentSpansQueryReq) -> bool:
+    """Whether a spans query filters or groups by a trace-attributed column."""
+    return agent_trace_attribution.query_references_identity(
+        req.query
+    ) or _group_by_references_identity(req.group_by)
+
+
+def _spans_source(
+    pb: ParamBuilder,
+    req: AgentSpansQueryReq,
+    *,
+    attribute: bool,
+    include_costs: bool = False,
+) -> str:
+    """Return the FROM source for a spans query.
+
+    The base relation is the raw `spans` table, or the cost-augmented source
+    (per-span price JOIN) when `include_costs` is set so cost columns are
+    available downstream. When `attribute` is set, that base is wrapped so the
+    four identity columns inherit from their trace when unset (see
+    `agent_trace_attribution`); otherwise the base is used directly so
+    non-identity queries skip the extra trace scan.
+    """
+    base = cost_augmented_source_sql(pb, req.project_id) if include_costs else "spans"
+    if not attribute:
+        return base
+    return agent_trace_attribution.attributed_spans_source(
+        pb,
+        project_id=req.project_id,
+        started_after=req.started_after,
+        started_before=req.started_before,
+        base_relation=base,
+    )
+
+
 def _agents_where(pb: ParamBuilder, req: AgentsQueryReq) -> str:
     conditions: list[str] = []
     if req.filters and req.filters.agent_name:
@@ -951,9 +995,15 @@ _GROUPED_SPAN_AGGREGATES: str = """count() AS span_count,
 
 def make_spans_count_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
     """Count spans matching the request, or count of distinct groups if grouped."""
+    # Count only needs trace attribution when identity participates in matching
+    # or grouping; otherwise the raw table avoids the extra trace scan. The
+    # attributed source is allocated last (see `_spans_source`) so it never
+    # renumbers the filter / group params.
+    attribute = _spans_query_references_identity(req)
     span_filters = _spans_filter_sql(pb, req)
     if not req.group_by:
-        return f"SELECT count() FROM spans s WHERE {span_filters.where}"
+        source = _spans_source(pb, req, attribute=attribute)
+        return f"SELECT count() FROM {source} s WHERE {span_filters.where}"
     resolved = resolve_group_by(pb, req.group_by)
     aliases = [alias for _, alias in resolved]
     _ensure_group_measure_aliases_do_not_collide(aliases, req.measures)
@@ -965,9 +1015,10 @@ def make_spans_count_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
     ensure_group_filters_match(group_filters, req.group_by, context="spans count")
     having = group_filters_having_sql(pb, group_filters)
     having_sql = f" HAVING {having}" if having else ""
+    source = _spans_source(pb, req, attribute=attribute)
     return (
         f"SELECT count() FROM ("
-        f"SELECT {group_exprs} FROM spans s WHERE {span_filters.where} "
+        f"SELECT {group_exprs} FROM {source} s WHERE {span_filters.where} "
         f"GROUP BY {group_exprs}"
         f"{having_sql}"
         f")"
@@ -976,14 +1027,12 @@ def make_spans_count_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
 
 def make_spans_list_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
     """List spans (ungrouped) or aggregate groups (grouped)."""
+    # Always attribute: the spans table and its grouped rollups exist to show
+    # each span's agent / conversation identity, which child spans only have via
+    # their trace. The attributed source is allocated last (see `_spans_source`)
+    # so it never renumbers the filter / projection params.
     span_filters = _spans_filter_sql(pb, req)
     limit_slot, offset_slot = _pagination_slots(pb, req.limit, req.offset)
-    # Read from the cost-augmented source (per-span price JOIN) only when costs
-    # were requested; the bare `spans` table otherwise. Shared by both the
-    # ungrouped and grouped branches below.
-    source = (
-        cost_augmented_source_sql(pb, req.project_id) if req.include_costs else "spans"
-    )
 
     if not req.group_by:
         custom_sort_exprs = _custom_attr_sort_exprs(pb, req.custom_attr_columns)
@@ -1001,6 +1050,7 @@ def make_spans_list_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
         )
         details_projection = f", {SPANS_DETAILS_COLS}" if req.include_details else ""
         cost_projection = f", {SPANS_COST_COLS}" if req.include_costs else ""
+        source = _spans_source(pb, req, attribute=True, include_costs=req.include_costs)
         return f"""
             SELECT {SPANS_LIST_COLS}{details_projection}{custom_attr_projection}{cost_projection}
             FROM {source} s
@@ -1047,6 +1097,7 @@ def make_spans_list_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
     ensure_group_filters_match(group_filters, req.group_by, context="spans list")
     having = group_filters_having_sql(pb, group_filters)
     having_sql = f"HAVING {having}" if having else ""
+    source = _spans_source(pb, req, attribute=True, include_costs=req.include_costs)
 
     return f"""
         SELECT {select_group_cols},
@@ -1200,10 +1251,11 @@ def make_span_group_distribution_counts_query(
     """Count filtered spans per returned group row."""
     span_filters = _spans_filter_sql(pb, req)
     context = _span_group_distribution_context(pb, req, group_values)
+    source = _spans_source(pb, req, attribute=_spans_query_references_identity(req))
     return f"""
         SELECT {context.group_key_sql} AS group_key,
                count() AS total_count
-        FROM spans s
+        FROM {source} s
         WHERE {span_filters.where}
           AND {context.group_key_sql} IN {context.group_values_slot}
         GROUP BY group_key
@@ -1229,6 +1281,7 @@ def make_span_group_numeric_distributions_query(
         numeric_specs,
         get_limit=lambda spec: spec.bins,
     )
+    source = _spans_source(pb, req, attribute=_spans_query_references_identity(req))
     spec_alias_sql = "tupleElement(spec, 1)"
     spec_source_sql = "tupleElement(spec, 2)"
     spec_key_sql = "tupleElement(spec, 3)"
@@ -1280,7 +1333,7 @@ def make_span_group_numeric_distributions_query(
                      {spec_alias_sql} AS alias,
                      {spec_bins_sql} AS bins,
                      {value_sql} AS value
-              FROM spans s
+              FROM {source} s
               ARRAY JOIN {specs_sql} AS spec
               WHERE {span_filters.where}
                 AND {context.group_key_sql} IN {context.group_values_slot}
@@ -1363,6 +1416,7 @@ def make_span_group_categorical_distributions_query(
         categorical_specs,
         get_limit=lambda spec: spec.top_n,
     )
+    source = _spans_source(pb, req, attribute=_spans_query_references_identity(req))
     spec_alias_sql = "tupleElement(spec, 1)"
     spec_source_sql = "tupleElement(spec, 2)"
     spec_key_sql = "tupleElement(spec, 3)"
@@ -1395,7 +1449,7 @@ def make_span_group_categorical_distributions_query(
                      {spec_alias_sql} AS alias,
                      {spec_top_n_sql} AS top_n,
                      {value_sql} AS raw_value
-              FROM spans s
+              FROM {source} s
               ARRAY JOIN {specs_sql} AS spec
               WHERE {span_filters.where}
                 AND {context.group_key_sql} IN {context.group_values_slot}

--- a/weave/trace_server/query_builder/agent_query_compiler.py
+++ b/weave/trace_server/query_builder/agent_query_compiler.py
@@ -106,6 +106,12 @@ def compile_agent_query(
 
     Callers AND the returned condition with their other filter clauses.
     The condition may contain internal `AND` / `OR` / `NOT`.
+
+    Fields compile with span-exact semantics against `table_alias`. Trace-level
+    attribution of the agent / conversation identity columns is handled by the
+    caller's choice of FROM source (see `agent_trace_attribution`), not here, so
+    a filter like ``agent_name = 'X'`` transparently matches the attributed
+    value when the query reads from the attributed-spans source.
     """
     _validate_sql_identifier("table_alias", table_alias)
     return _compile_operation(query.expr_, pb, table_alias)

--- a/weave/trace_server/query_builder/agent_stats_query_builder.py
+++ b/weave/trace_server/query_builder/agent_stats_query_builder.py
@@ -39,7 +39,9 @@ from weave.trace_server.calls_query_builder.stats_query_base import (
 )
 from weave.trace_server.calls_query_builder.utils import param_slot, safely_format_sql
 from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.query_builder import agent_trace_attribution
 from weave.trace_server.query_builder.agent_query_builder import (
+    _FIELD_GROUP_BY_SOURCES,
     _project_filter_sql,
     add_time_filters,
     ensure_group_filters_match,
@@ -174,13 +176,6 @@ def _stats_requires_costs(req: AgentSpanStatsReq) -> bool:
     )
 
 
-def _resolve_spans_source(req: AgentSpanStatsReq, pb: ParamBuilder) -> str:
-    """Return the FROM relation for stats: bare `spans`, or cost-augmented."""
-    if _stats_requires_costs(req):
-        return cost_augmented_source_sql(pb, req.project_id)
-    return _SPANS_TABLE
-
-
 def _conversation_group_by() -> list[AgentGroupByRef]:
     return [AgentGroupByRef(source="column", key="conversation_id")]
 
@@ -239,9 +234,15 @@ class _StatsQuerySQLParts:
 
 @dataclass(frozen=True, slots=True)
 class _SpanSourceFilterSQL:
-    """WHERE filters for direct reads from the spans table."""
+    """WHERE filters and FROM source for direct reads from the spans table.
+
+    `source` is the raw `spans` table, or an attributed-spans subquery when the
+    request filters/groups/aggregates on an identity column that inherits from
+    its trace (see `agent_trace_attribution`).
+    """
 
     where: str
+    source: str = _SPANS_TABLE
 
     @property
     def clause(self) -> str:
@@ -257,7 +258,6 @@ def build_agent_span_stats_query(
     tz = req.timezone or "UTC"
 
     source_filter = _spans_source_filter_sql(pb, req, start, end)
-    spans_source = _resolve_spans_source(req, pb)
     group_refs = req.group_by or []
     resolved_groups = resolve_group_by(pb, group_refs) if group_refs else []
 
@@ -300,7 +300,6 @@ def build_agent_span_stats_query(
     if numeric_bucket is not None:
         raw_sql = _build_numeric_bucket_stats_query(
             source_filter=source_filter,
-            spans_source=spans_source,
             bucket=numeric_bucket,
             metric_exprs=metric_exprs,
             agg_selects=agg_selects,
@@ -333,7 +332,6 @@ def build_agent_span_stats_query(
 
     raw_sql = _build_stats_query(
         source_filter=source_filter,
-        spans_source=spans_source,
         resolved_groups=resolved_groups,
         metric_exprs=metric_exprs,
         agg_selects=agg_selects,
@@ -427,7 +425,50 @@ def _spans_source_filter_sql(
     )
     if req.query is not None:
         where_conditions.append(compile_agent_query(req.query, pb))
-    return _SpanSourceFilterSQL(where=" AND ".join(where_conditions))
+    # The base relation carries cost columns only when the request needs them;
+    # attribution then wraps that base so identity columns inherit from their
+    # trace while any cost columns pass through untouched.
+    base = (
+        cost_augmented_source_sql(pb, req.project_id)
+        if _stats_requires_costs(req)
+        else _SPANS_TABLE
+    )
+    source = base
+    if _stats_references_identity(req):
+        source = agent_trace_attribution.attributed_spans_source(
+            pb,
+            project_id=req.project_id,
+            started_after=start,
+            started_before=end,
+            base_relation=base,
+        )
+    return _SpanSourceFilterSQL(where=" AND ".join(where_conditions), source=source)
+
+
+def _stats_references_identity(req: AgentSpanStatsReq) -> bool:
+    """Whether a stats request touches a trace-attributed identity column.
+
+    Checks the filter, every group-by (top-level, numeric-bucket, and
+    group-filter), and metric value refs, so any identity reference pulls in the
+    attributed source. Errs toward attributing — a missed reference would read
+    raw values while the filter expects attributed ones.
+    """
+    if agent_trace_attribution.query_references_identity(req.query):
+        return True
+    group_refs = list(req.group_by)
+    bucket = req.bucket_by
+    if isinstance(bucket, AgentSpanStatsNumericBucketSpec):
+        group_refs += list(bucket.group_by)
+    for group_filter in req.group_filters or []:
+        group_refs += list(group_filter.group_by or [])
+    field_keys = [
+        ref.key for ref in group_refs if ref.source in _FIELD_GROUP_BY_SOURCES
+    ]
+    for metric in req.metrics:
+        value = metric.value
+        if value is not None and value.source in _FIELD_GROUP_BY_SOURCES:
+            field_keys.append(value.key)
+    return agent_trace_attribution.fields_reference_identity(field_keys)
 
 
 def _response_columns(
@@ -692,7 +733,6 @@ def _group_value_type(group_ref: AgentGroupByRef) -> AgentSpanStatsColumnValueTy
 def _build_stats_query(
     *,
     source_filter: _SpanSourceFilterSQL,
-    spans_source: str,
     resolved_groups: list[tuple[str, str]],
     metric_exprs: list[str],
     agg_selects: list[str],
@@ -721,7 +761,6 @@ def _build_stats_query(
     if not resolved_groups:
         return _build_ungrouped_stats_query(
             source_filter=source_filter,
-            spans_source=spans_source,
             parts=parts,
             group_filters=group_filters,
             pb=pb,
@@ -730,7 +769,6 @@ def _build_stats_query(
     assert group_limit_slot is not None
     return _build_grouped_stats_query(
         source_filter=source_filter,
-        spans_source=spans_source,
         resolved_groups=resolved_groups,
         group_limit_slot=group_limit_slot,
         parts=parts,
@@ -740,7 +778,6 @@ def _build_stats_query(
 def _build_numeric_bucket_stats_query(
     *,
     source_filter: _SpanSourceFilterSQL,
-    spans_source: str,
     bucket: AgentSpanStatsNumericBucketSpec,
     metric_exprs: list[str],
     agg_selects: list[str],
@@ -828,7 +865,7 @@ def _build_numeric_bucket_stats_query(
     WITH
       {_CTE_FILTERED_SPANS} AS (
         SELECT *
-        FROM {spans_source} {_SPAN_ALIAS}
+        FROM {source_filter.source} {_SPAN_ALIAS}
         {source_filter.clause}
       ),
       {_CTE_VALUE_ROWS} AS (
@@ -909,7 +946,6 @@ def _stats_query_sql_parts(
 def _build_ungrouped_stats_query(
     *,
     source_filter: _SpanSourceFilterSQL,
-    spans_source: str,
     parts: _StatsQuerySQLParts,
     group_filters: list[AgentSpanGroupFilter],
     pb: ParamBuilder,
@@ -923,7 +959,7 @@ def _build_ungrouped_stats_query(
       ),
       {_CTE_FILTERED_SPANS} AS (
         SELECT *
-        FROM {spans_source} {_SPAN_ALIAS}
+        FROM {source_filter.source} {_SPAN_ALIAS}
         {source_filter.clause}
       ){group_filter_ctes},
       {_CTE_AGGREGATED_DATA} AS (
@@ -998,7 +1034,6 @@ def _group_filter_ctes(
 def _build_grouped_stats_query(
     *,
     source_filter: _SpanSourceFilterSQL,
-    spans_source: str,
     resolved_groups: list[tuple[str, str]],
     group_limit_slot: str,
     parts: _StatsQuerySQLParts,
@@ -1027,7 +1062,7 @@ def _build_grouped_stats_query(
       ),
       {_CTE_FILTERED_SPANS} AS (
         SELECT *
-        FROM {spans_source} {_SPAN_ALIAS}
+        FROM {source_filter.source} {_SPAN_ALIAS}
         {source_filter.clause}
       ),
       {_CTE_TOP_GROUPS} AS (

--- a/weave/trace_server/query_builder/agent_trace_attribution.py
+++ b/weave/trace_server/query_builder/agent_trace_attribution.py
@@ -1,0 +1,209 @@
+"""Read-time trace attribution for agent-identity columns.
+
+Agent identity (`agent_name` / `agent_version` / `agent_id`) and conversation
+identity (`conversation_id`) are typically reported only on the `invoke_agent`
+span, not on the child llm / tool spans it encloses. A span-exact read of those
+columns therefore shows blank identity on every child span and undercounts the
+turn's real work.
+
+This module attributes that identity at *read time* with a single rule:
+
+    if a span declares its own agent (`agent_name != ''`), use its own
+    identity (singleton / span-exact); otherwise inherit the identity of the
+    span's trace.
+
+It is expressed by wrapping the `spans` table in an *attributed-spans*
+subquery (see :func:`attributed_spans_source`). Callers swap their
+`FROM spans s` for `FROM {attributed_spans_source(...)} s` and every
+downstream reference to `s.agent_name` (filter, GROUP BY, projection,
+aggregate) transparently sees the attributed value — what you filter on equals
+what you display.
+
+`agent_name` / `agent_version` / `agent_id` identify one agent, so they
+are inherited *together* as a single tuple taken from one span — the earliest
+span in the trace that declares an `agent_name` (`argMinIf` by
+`started_at`). Picking each column independently could synthesize a
+`(name, version)` pair that never co-occurred on any real span. Likewise, a
+span that declares its own `agent_name` keeps its *entire* own triple, so its
+version / id are never crossed with an inherited agent's. `conversation_id` is
+trace-scoped and inherited on its own.
+
+This is a deliberately *flat* attribution: in a multi-agent trace an unset span
+inherits the trace's earliest-declared agent. A span that set its own identity
+always keeps it, so sub-agent spans are never wrongly attributed. The
+hierarchical "nearest enclosing agent" projection used by the chat view lives in
+`weave.trace_server.agents.chat_view` and is intentionally separate — queries
+that feed the chat view must NOT use this source or they would double-attribute.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from weave.trace_server.agents import semconv
+from weave.trace_server.interface import query as tsi_query
+from weave.trace_server.orm import ParamBuilder
+
+# The identity columns that inherit from their trace when unset. Order is fixed
+# so the generated SQL is stable (and snapshot-testable).
+IDENTITY_COLUMNS: tuple[str, ...] = (
+    "agent_name",
+    "agent_version",
+    "agent_id",
+    "conversation_id",
+)
+
+_IDENTITY_COLUMN_SET = frozenset(IDENTITY_COLUMNS)
+
+# `agent_name` / `agent_version` / `agent_id` identify one agent and are
+# inherited together as a single tuple (see module docstring); `agent_name` is
+# the marker for "this span declares its own agent". `conversation_id` is
+# trace-scoped and inherited on its own.
+_AGENT_IDENTITY_COLUMNS: tuple[str, ...] = ("agent_name", "agent_version", "agent_id")
+_AGENT_IDENTITY_MARKER = "agent_name"
+
+# All spans of a trace fall within one turn, so a span needing attribution is at
+# most one trace-duration away from the identity-bearing span it inherits from.
+# We widen the trace-fallback scan's window by this slack so an edge span still
+# finds its identity-bearing span (which may have started just outside the outer
+# window) while ClickHouse can still prune by the (project_id, started_at)
+# primary key instead of scanning the project's whole history.
+_TRACE_FALLBACK_WINDOW_SLACK = datetime.timedelta(hours=1)
+
+
+def _collect_get_fields(node: object) -> set[str]:
+    """Recursively collect every `$getField` name in a dumped Query expr."""
+    found: set[str] = set()
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "$getField" and isinstance(value, str):
+                found.add(value)
+            else:
+                found |= _collect_get_fields(value)
+    elif isinstance(node, (list, tuple)):
+        # Comparison operands (e.g. `$eq`) serialize as tuples, not lists.
+        for item in node:
+            found |= _collect_get_fields(item)
+    return found
+
+
+def _names_hit_identity(names: set[str]) -> bool:
+    return any(
+        semconv.FILTERABLE_KEY_TO_COLUMN.get(name, name) in _IDENTITY_COLUMN_SET
+        for name in names
+    )
+
+
+def query_references_identity(query: tsi_query.Query | None) -> bool:
+    """Whether a Query filter references any trace-attributed identity column.
+
+    Walks the dumped expression for `$getField` references and resolves each
+    through semconv, so `agent.name` / `gen_ai.agent.name` / `agent_name`
+    all count.
+    """
+    if query is None:
+        return False
+    names = _collect_get_fields(query.model_dump(by_alias=True))
+    return _names_hit_identity(names)
+
+
+def fields_reference_identity(field_names: list[str]) -> bool:
+    """Whether any public field name resolves to an identity column."""
+    return _names_hit_identity(set(field_names))
+
+
+def attributed_spans_source(
+    pb: ParamBuilder,
+    *,
+    project_id: str,
+    started_after: datetime.datetime | None,
+    started_before: datetime.datetime | None,
+    base_relation: str = "spans",
+) -> str:
+    """Return a parenthesized subquery that stands in for the `spans` table.
+
+    The result exposes every column of `base_relation`, but the four identity
+    columns carry their trace-attributed value (own value if set, else a
+    per-trace `anyIf` fallback). The caller aliases it, e.g.
+    `FROM {attributed_spans_source(...)} s`.
+
+    `base_relation` is the relation the attributed columns are read from; it
+    defaults to the raw `spans` table but may be any `spans`-shaped subquery
+    (e.g. the cost-augmented source), in which case its extra columns pass
+    through untouched. The per-trace fallback always scans the raw `spans`
+    table since it only needs the identity columns and `trace_id`.
+
+    The inner scan is bounded to `project_id` and the outer time window so it
+    prunes by primary key; the fallback scan is bounded to the same window
+    widened by one trace-duration of slack so edge spans still resolve.
+    """
+    pid_slot = pb.add(project_id, param_type="String")
+
+    fallback_conds = [f"project_id = {pid_slot}"]
+    base_conds = [f"s0.project_id = {pid_slot}"]
+    if started_after is not None:
+        fb_after = pb.add(
+            started_after - _TRACE_FALLBACK_WINDOW_SLACK, param_type="DateTime64(6)"
+        )
+        fallback_conds.append(f"started_at >= {fb_after}")
+        base_after = pb.add(started_after, param_type="DateTime64(6)")
+        base_conds.append(f"s0.started_at >= {base_after}")
+    if started_before is not None:
+        fb_before = pb.add(
+            started_before + _TRACE_FALLBACK_WINDOW_SLACK, param_type="DateTime64(6)"
+        )
+        fallback_conds.append(f"started_at < {fb_before}")
+        base_before = pb.add(started_before, param_type="DateTime64(6)")
+        base_conds.append(f"s0.started_at < {base_before}")
+
+    # The agent triple is inherited together from one span (the earliest in the
+    # trace that declares an agent_name); conversation_id is inherited on its
+    # own. Picking each agent column independently could mix two agents.
+    agent_tuple = ", ".join(_AGENT_IDENTITY_COLUMNS)
+    fallback_selects = (
+        f"argMinIf(({agent_tuple}), started_at, {_AGENT_IDENTITY_MARKER} != '')\n"
+        "            AS fb_agent_identity,\n"
+        "          anyIf(conversation_id, conversation_id != '') AS fb_conversation_id"
+    )
+    # Whether the span declares its own agent, computed from the raw column so
+    # the coalesce gates below read it instead of the rewritten `agent_name`
+    # output alias (ClickHouse resolves a bare column name to a same-name
+    # SELECT alias — gating on `agent_name` itself would see the *attributed*
+    # value and leak one column of a different agent onto this span).
+    own_marker = "has_own_agent_identity"
+    middle_refs = (
+        f"(s0.{_AGENT_IDENTITY_MARKER} != '') AS {own_marker},"
+        " tf.fb_agent_identity, tf.fb_conversation_id"
+    )
+    except_cols = ", ".join(
+        [*IDENTITY_COLUMNS, own_marker, "fb_agent_identity", "fb_conversation_id"]
+    )
+    # A span that declares its own agent keeps its entire own triple; otherwise
+    # the whole triple is inherited — never a mix.
+    agent_coalesced = ",\n    ".join(
+        f"if({own_marker}, {col}, fb_agent_identity.{idx}) AS {col}"
+        for idx, col in enumerate(_AGENT_IDENTITY_COLUMNS, start=1)
+    )
+    coalesced = (
+        f"{agent_coalesced},\n"
+        "    if(conversation_id != '', conversation_id, fb_conversation_id)"
+        " AS conversation_id"
+    )
+
+    return f"""(
+  SELECT * EXCEPT ({except_cols}),
+    {coalesced}
+  FROM (
+    SELECT s0.*, {middle_refs}
+    FROM {base_relation} s0
+    LEFT JOIN (
+      SELECT
+          trace_id,
+          {fallback_selects}
+      FROM spans
+      WHERE {" AND ".join(fallback_conds)}
+      GROUP BY trace_id
+    ) tf ON s0.trace_id = tf.trace_id
+    WHERE {" AND ".join(base_conds)}
+  )
+)"""


### PR DESCRIPTION
## Problem

Agent identity (`agent_name` / `agent_version` / `agent_id`) and conversation identity (`conversation_id`) are typically reported by instrumentors **only on the `invoke_agent` span**, not on the child llm/tool spans it encloses. Because `/agents` filters, groups, sorts, and aggregates are span-exact (`s.agent_name = 'X'`), they see blank identity on every child span — so span lists, counts, charts, tokens, latency, costs, and conversation counts all **undercount** an agent's real work.

Computing an "effective agent" and storing it on each span was the original plan, but two constraints rule it out: (1) OTel spans export on *end*, so child spans usually arrive **before** the `invoke_agent` parent that defines their context; (2) `spans` is a `ReplacingMergeTree` whose `agents` / `agent_versions` / `messages` MVs fire on the INSERT trigger, so re-inserting enriched rows would double-count aggregates.

## Approach: read-time trace attribution

Attribute identity at **read time** by wrapping the `spans` table in an *attributed-spans* subquery (`agent_trace_attribution.attributed_spans_source`). The rule is one line:

> if a span declares its own agent (`agent_name != ''`), use its own identity (span-exact); otherwise inherit the identity of its trace.

Builders swap `FROM spans s` for `FROM {attributed_spans_source(...)} s`, so filter, `GROUP BY`, projection, sort and aggregates all transparently see the attributed value — **what you filter on equals what you display**. A span that set its own identity always keeps it, so sub-agent spans are never re-attributed.

This **replaces** the `$anyInTrace` existential operator that earlier revisions of this branch added (and which this PR originally described). Read-time attribution is strictly better here: `$anyInTrace` made a span match *every* agent in its trace, so per-agent aggregate sums double-counted shared spans; assigning each span exactly one identity keeps aggregates exact.

### Coherent identity

`agent_name` / `agent_version` / `agent_id` identify *one* agent, so they are inherited **together as a single tuple** taken from one span — the earliest span in the trace that declares an `agent_name` (`argMinIf(..., started_at, ...)`). Picking each column independently (e.g. four separate `anyIf`s) can synthesize a `(name, version)` pair that never co-occurred on any real span. The own-vs-inherited choice is likewise made once for the whole triple, gated on a raw-column marker (`(s0.agent_name != '') AS has_own_agent_identity`) so it isn't fooled by the rewritten `agent_name` output alias. `conversation_id` is trace-scoped and inherited on its own.

```sql
-- per-trace fallback (one row per trace)
argMinIf((agent_name, agent_version, agent_id), started_at, agent_name != '') AS fb_agent_identity,
anyIf(conversation_id, conversation_id != '')                                 AS fb_conversation_id
-- coalesce on each span
if(has_own_agent_identity, agent_name,    fb_agent_identity.1) AS agent_name,
if(has_own_agent_identity, agent_version, fb_agent_identity.2) AS agent_version,
if(has_own_agent_identity, agent_id,      fb_agent_identity.3) AS agent_id,
if(conversation_id != '', conversation_id, fb_conversation_id) AS conversation_id
```

## Changes

- **`query_builder/agent_trace_attribution.py`** (new) — `attributed_spans_source(...)` builds the wrapping subquery; `query_references_identity` / `fields_reference_identity` gate when attribution is needed. The fallback scan is bounded to the outer time window widened by one max-trace-duration of slack, so `(project_id, started_at)` primary-key pruning is preserved and the in-memory `trace_id` set stays bounded (no-window queries stay all-time). `base_relation` lets the source compose over the cost-augmented source.
- **`agent_query_builder.py`** — `_spans_source(...)` returns the attributed source (optionally over the cost source). The spans **list** always attributes (it exists to display identity); **count / distribution** attribute only when an identity column is filtered/grouped, so non-identity queries skip the extra trace scan.
- **`agent_stats_query_builder.py`** — `_spans_source_filter_sql` composes attribution over the (optionally cost-augmented) base and routes every CTE through that single source.
- **`agent_query_compiler.py`** — removes the `$anyInTrace` operator branch (net minimal).

Chat-view queries (which already inherit hierarchically in `chat_view`) and the `agents` / `agent_versions` rollup MVs are intentionally left untouched.

## Testing

- **Unit** (`test_agent_trace_attribution.py`) — pins the attributed-source SQL shape (coherent tuple via `argMinIf`, slack-widened fallback) and the `references_identity` gating helpers.
- **End-to-end ClickHouse** (`test_genai_agent_queries.py`) —
  - an unset child span inherits its turn's identity and filters/displays as that agent;
  - a self-identified sub-agent span keeps its own identity and is not pulled into the parent's filter;
  - **an inherited identity is a single coherent agent** — a trace that splits name onto one span and version onto another never produces the phantom `(name, version)` pair.
- Composes with query-time **costs** (ungrouped/grouped/stats `include_costs` e2e still green).
- 157 tests green across `query_builder/` + genai agent / costs / chat-view suites; `nox -e lint` clean (ty, pyright, mypy, ruff).

## Notes / follow-ups

- Frontend wiring (wraps the `agent_name` / `agent_version` / `conversation_id` filters) is a separate **wandb/core** PR; backend deploys first.
- Flat attribution: in a rare multi-agent trace an unset span inherits the trace's earliest-declared agent (a single coherent agent, never a cross-agent mix). Exact for single-agent traces (the norm). The hierarchical "nearest enclosing agent" projection remains separate in `chat_view`.
- v1 optimization, if the per-trace fallback aggregation is too slow at scale: a per-trace `trace_agents` set-table MV; only this module's SQL would change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
