### PR TITLE
chore(weave): Add 'examples/openai_integration.py'

### DIFF
--- a/examples/openai_agents.py
+++ b/examples/openai_agents.py
@@ -1,0 +1,120 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "weave",
+#     "openai",
+#     "openai-agents>=0.14.7",
+# ]
+#
+# # Resolve `weave` against this checkout (../) instead of PyPI, so local
+# # edits to the SDK are picked up without a release/install cycle.
+# [tool.uv.sources]
+# weave = { path = "..", editable = true }
+# ///
+"""
+Example: OpenAI Agents Integration with Weave (Python)
+
+    uv run examples/openai_agents.py
+
+Required env:
+
+    WANDB_API_KEY            — your wandb API key
+    OPENAI_API_KEY           — your openai API key
+    WANDB_PROJECT            — optional; defaults to ``example``
+"""
+
+import asyncio
+import os
+import re
+from typing import Literal
+
+from agents import Agent, Runner, function_tool, gen_trace_id, trace
+
+import weave
+
+WANDB_PROJECT = os.environ.get("WANDB_PROJECT", "example-python-agent")
+
+
+# --- Tools ---
+
+
+@function_tool
+def get_weather(city: str, unit: Literal["celsius", "fahrenheit"]) -> str:
+    """Get the current weather for a given city.
+
+    Args:
+        city: The name of the city.
+        unit: Temperature unit, either ``celsius`` or ``fahrenheit``.
+    """
+    weather = {
+        "San Francisco": {"temp": 18, "condition": "Foggy"},
+        "New York": {"temp": 22, "condition": "Sunny"},
+        "London": {"temp": 12, "condition": "Cloudy"},
+        "Tokyo": {"temp": 28, "condition": "Humid"},
+    }
+
+    data = weather.get(city, {"temp": 20, "condition": "Clear"})
+    temp = round(data["temp"] * 9 / 5 + 32) if unit == "fahrenheit" else data["temp"]
+    unit_label = "°F" if unit == "fahrenheit" else "°C"
+
+    return f"{city}: {data['condition']}, {temp}{unit_label}"
+
+
+@function_tool
+def calculate(expression: str) -> str:
+    """Evaluate a basic arithmetic expression.
+
+    Args:
+        expression: A math expression, e.g. ``"3 * (4 + 2)"``.
+    """
+    # NOTE: ``eval`` is unsafe in production. In a real application, use a
+    # proper math library (e.g. ``sympy``) instead.
+    if not re.match(r"^[\d\s+\-*/().]+$", expression):
+        return "Error: invalid expression"
+    try:
+        result = eval(expression, {"__builtins__": {}}, {})  # noqa: S307
+    except Exception:
+        return "Error: could not evaluate expression"
+    return f"{expression} = {result}"
+
+
+# --- Agent ---
+
+
+async def main() -> None:
+    weave.init(WANDB_PROJECT)
+
+    agent = Agent(
+        name="Assistant",
+        instructions=(
+            "You are a helpful assistant. Use the available tools when "
+            "appropriate to answer questions accurately."
+        ),
+        tools=[get_weather, calculate],
+    )
+
+    queries = [
+        "What's the temperature difference between Tokyo and San Francisco in "
+        "celsius? Use the calculator to subtract.",
+        "If the temperature in London tripled, what would it be? Get the "
+        "weather first, then use the calculator.",
+    ]
+
+    # Group all runs under a single conversation trace so they share a
+    # ``group_id`` in Weave — equivalent to passing ``groupId`` to the TS
+    # ``Runner`` constructor.
+    with trace("Conversation", group_id=gen_trace_id()):
+        history: list = []
+        for query in queries:
+            print(f"\nQuery: {query}")
+            result = await Runner.run(agent, query)
+            history = result.to_input_list()
+            print(f"Answer: {result.final_output}")
+
+    # ``history`` is collected for parity with the TS example; it is not used
+    # in subsequent queries there either.
+    _ = history
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Description

* Adds runnable example of our OpenAI Agents SDK integration -- not sure if we'll merge this, just adding to show what data is currently making its way to the Weave UI.

* Example: input / output tokens aren't represented on any of these screens:

<img width="1456" height="1162" alt="Screenshot 2026-06-16 at 1 15 51 PM" src="https://github.com/user-attachments/assets/dd7d276a-ea4f-4b58-9fa6-fb70c3743737" />

<img width="1456" height="1162" alt="Screenshot 2026-06-16 at 1 15 56 PM" src="https://github.com/user-attachments/assets/ab21be0b-1dca-4ffa-86ee-197e15e75ddd" />

<img width="1456" height="1162" alt="Screenshot 2026-06-16 at 1 15 59 PM" src="https://github.com/user-attachments/assets/2aeadacd-1300-410f-89ff-18d30d64db9a" />

