### PR TITLE
wontmerge: set gen_ai.agent.name on other spans

### DIFF
--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
@@ -144,6 +144,10 @@ async def test_simple_text_query_otel(otel_spans: InMemorySpanExporter) -> None:
     chat_span = chat_spans[0]
     assert check_integration_and_strip(get_attrs(chat_span)) == {
         "gen_ai.operation.name": "chat",
+        # Inherited from the enclosing invoke_agent so the chat span lands
+        # in the agents MV (WHERE agent_name != '') and its token usage
+        # rolls up under the right agent.
+        "gen_ai.agent.name": "claude_agent_sdk",
         "gen_ai.provider.name": "anthropic",
         "gen_ai.conversation.id": "s-abc123",
         "gen_ai.request.model": "claude-sonnet-4-6",
@@ -180,6 +184,12 @@ async def test_tool_use_query_otel(otel_spans: InMemorySpanExporter) -> None:
     assert "ls -la" in tool_attrs["gen_ai.tool.call.arguments"]
     assert "file1.py" in tool_attrs["gen_ai.tool.call.result"]
     assert tool_span.parent.span_id == agent_span.context.span_id
+
+    # Descendants inherit gen_ai.agent.name from the enclosing invoke_agent
+    # so the agents MV picks them up and tokens roll up under the agent.
+    assert tool_attrs["gen_ai.agent.name"] == "claude_agent_sdk"
+    for chat_span in chat_spans:
+        assert get_attrs(chat_span)["gen_ai.agent.name"] == "claude_agent_sdk"
 
     # Aggregate usage lands on exactly one (the final) chat span.
     chats_with_usage = [

--- a/tests/integrations/openai_agents/openai_agents_otel_test.py
+++ b/tests/integrations/openai_agents/openai_agents_otel_test.py
@@ -248,6 +248,53 @@ def test_agent_name_override_wins_over_native(
     assert _attrs(agent)["gen_ai.agent.name"] == "research_agent"
 
 
+def test_descendant_spans_inherit_agent_name(
+    client: WeaveClient, otel_spans: InMemorySpanExporter
+) -> None:
+    """Tool/chat children inherit gen_ai.agent.name from the enclosing agent.
+
+    Without this, descendants land with `agent_name = ''` and the `agents`
+    MV's `WHERE agent_name != ''` filter drops their token rows from the
+    per-agent rollup — see migration 030_add_agent_tables.up.sql.
+    """
+    processor = WeaveOtelTracingProcessor()
+    trace = Mock(spec=Trace)
+    trace.trace_id = "trace_i"
+    trace.name = "wf"
+    trace.group_id = None
+
+    agent_span = Mock(spec=Span)
+    agent_span.trace_id = "trace_i"
+    agent_span.span_id = "agent_i"
+    agent_span.parent_id = None
+    agent_span.span_data = AgentSpanData(name="Assistant")
+    agent_span.started_at = None
+    agent_span.ended_at = None
+    agent_span.error = None
+
+    fn_span = Mock(spec=Span)
+    fn_span.trace_id = "trace_i"
+    fn_span.span_id = "fn_i"
+    fn_span.parent_id = "agent_i"
+    fn_span.span_data = FunctionSpanData(name="get_weather", input="", output="")
+    fn_span.started_at = None
+    fn_span.ended_at = None
+    fn_span.error = None
+
+    processor.on_trace_start(trace)
+    processor.on_span_start(agent_span)
+    processor.on_span_start(fn_span)
+    processor.on_span_end(fn_span)
+    processor.on_span_end(agent_span)
+    processor.on_trace_end(trace)
+
+    spans = otel_spans.get_finished_spans()
+    tool = next(
+        s for s in spans if _attrs(s).get("gen_ai.operation.name") == "execute_tool"
+    )
+    assert _attrs(tool)["gen_ai.agent.name"] == "Assistant"
+
+
 def test_response_span_emits_chat_with_messages(
     client: WeaveClient, otel_spans: InMemorySpanExporter
 ) -> None:

--- a/weave/integrations/claude_agent_sdk/otel_integration.py
+++ b/weave/integrations/claude_agent_sdk/otel_integration.py
@@ -231,6 +231,10 @@ def _process_message(msg: Any, tracer: Any, state: _TurnState) -> None:
             reasoning=output.reasoning if output.reasoning.content else None,
         )
         chat_attrs.update(_INTEGRATION_OTEL_ATTRS)
+        # Stamp the enclosing agent's name so the chat span lands in the
+        # agents MV (WHERE agent_name != '') and its token usage rolls up
+        # under the right agent in the agents-list query.
+        chat_attrs["gen_ai.agent.name"] = state.agent_name
         state.pending_chat = _PendingChat(span=chat, attrs=chat_attrs)
         state.accumulated.append(output.message)
 
@@ -263,6 +267,8 @@ def _process_message(msg: Any, tracer: Any, state: _TurnState) -> None:
                 tool_call_id=block.tool_use_id,
             )
             attrs.update(_INTEGRATION_OTEL_ATTRS)
+            # See the chat span for why this stamps gen_ai.agent.name.
+            attrs["gen_ai.agent.name"] = state.agent_name
             for key, value in attrs.items():
                 open_tool.span.set_attribute(key, value)
             if block.is_error:

--- a/weave/integrations/openai_agents/otel_processor.py
+++ b/weave/integrations/openai_agents/otel_processor.py
@@ -498,6 +498,14 @@ class WeaveOtelTracingProcessor(TracingProcessor):  # pyright: ignore[reportGene
         # almost never match LIFO. Lets the sweep handle spans the SDK never
         # closed without leaking state across Runner.run calls.
         self._trace_spans: dict[str, dict[str, None]] = {}
+        # Resolved gen_ai.agent.name per openai span_id. AgentSpan resolves
+        # its own name (with override); descendant chat/tool/turn spans
+        # inherit the name from their nearest enclosing invoke_agent
+        # ancestor so the `agents` MV (WHERE agent_name != '') captures
+        # their token usage in the per-agent rollup. Populated in
+        # on_span_start so children that start under this one see the
+        # value; cleared in on_span_end.
+        self._agent_name: dict[str, str] = {}
 
     def _tracer(self) -> Any:
         return otel_trace.get_tracer(_TRACER_NAME)
@@ -525,6 +533,7 @@ class WeaveOtelTracingProcessor(TracingProcessor):  # pyright: ignore[reportGene
         leftover = self._trace_spans.pop(trace.trace_id, {})
         # Detach in LIFO order — see comment on ``self._trace_spans``.
         for span_id in reversed(leftover):
+            self._agent_name.pop(span_id, None)
             token = self._span_tokens.pop(span_id, None)
             if token is not None:
                 otel_context.detach(token)
@@ -534,6 +543,20 @@ class WeaveOtelTracingProcessor(TracingProcessor):  # pyright: ignore[reportGene
         self._conversation_ids.pop(trace.trace_id, None)
 
     def on_span_start(self, span: Span) -> None:
+        # Resolve the agent_name to attribute to this span *before* any
+        # children start under it — they read this entry by parent_id.
+        # AgentSpan: own name (override-aware). Anything else: inherit from
+        # the nearest enclosing invoke_agent ancestor so the agents MV
+        # (WHERE agent_name != '') sees descendant chat/tool tokens.
+        sd = span.span_data
+        if isinstance(sd, AgentSpanData):
+            agent_name = resolve_agent_name(sd.name or "")
+        elif span.parent_id:
+            agent_name = self._agent_name.get(span.parent_id, "")
+        else:
+            agent_name = ""
+        self._agent_name[span.span_id] = agent_name
+
         parent_ctx = self._parent_context(span)
         otel_span = self._tracer().start_span(
             _otel_span_name(span),
@@ -554,6 +577,7 @@ class WeaveOtelTracingProcessor(TracingProcessor):  # pyright: ignore[reportGene
 
     def on_span_end(self, span: Span) -> None:
         otel_span = self._span_otel.pop(span.span_id, None)
+        agent_name = self._agent_name.pop(span.span_id, "")
         if otel_span is None:
             return
         trace_spans = self._trace_spans.get(span.trace_id)
@@ -576,6 +600,13 @@ class WeaveOtelTracingProcessor(TracingProcessor):  # pyright: ignore[reportGene
 
             conversation_id = self._conversation_ids.get(span.trace_id, "")
             attrs = _attrs_for_span(span, conversation_id)
+            # Inherit gen_ai.agent.name from the nearest enclosing
+            # invoke_agent ancestor so descendant chat/tool spans satisfy
+            # the agents MV filter and their tokens roll up under the
+            # right agent. AgentSpan's _agent_attrs already set this key
+            # (and may carry an override), so don't clobber.
+            if agent_name and "gen_ai.agent.name" not in attrs:
+                attrs["gen_ai.agent.name"] = agent_name
             _set_attrs(otel_span, attrs)
 
             if span.error:
@@ -619,6 +650,7 @@ class WeaveOtelTracingProcessor(TracingProcessor):  # pyright: ignore[reportGene
         self._span_otel.clear()
         self._conversation_ids.clear()
         self._trace_spans.clear()
+        self._agent_name.clear()
 
 
 def _otel_span_name(span: Span) -> str:


### PR DESCRIPTION
## Description

* Don't think this fix is what we'd want to do exactly, but just illustrating that the token data gets to the UI when `gen_ai.agent.name` is set on children spans:

<img width="1607" height="1162" alt="Screenshot 2026-06-16 at 1 54 10 PM" src="https://github.com/user-attachments/assets/5a642087-9d88-411c-ad27-3d606dd2492f" />

