### PR TITLE
feat(weave_ts): send trace_id on call-end ingest messages

### DIFF
--- a/sdks/node/src/__tests__/opFlow.test.ts
+++ b/sdks/node/src/__tests__/opFlow.test.ts
@@ -351,4 +351,30 @@ describe('Op Flow', () => {
       expect(call.trace_id).toBe(traceId);
     });
   });
+
+  test('call-end carries the same trace_id as the call-start', async () => {
+    // Inspect the raw upsert batch instead of reading calls back: the in-memory
+    // server merges end fields onto the start record, and the start already
+    // carries trace_id, so a merged read would pass even without the fix.
+    const batchSpy = jest.spyOn(
+      inMemoryTraceServer.call,
+      'callStartBatchCallUpsertBatchPost'
+    );
+
+    const myOp = op((x: number) => x * 2, {name: 'myOp'});
+    await myOp(21);
+
+    await inMemoryTraceServer.waitForPendingOperations();
+
+    const items = batchSpy.mock.calls.flatMap(([batchReq]) => batchReq.batch);
+    const startItem = items.find(item => item.mode === 'start');
+    const endItem = items.find(item => item.mode === 'end');
+
+    expect(startItem).toBeDefined();
+    expect(endItem).toBeDefined();
+
+    const startTraceId = startItem!.req.start.trace_id;
+    expect(startTraceId).toBeTruthy();
+    expect(endItem!.req.end.trace_id).toBe(startTraceId);
+  });
 });

--- a/sdks/node/src/generated/traceServerApi.ts
+++ b/sdks/node/src/generated/traceServerApi.ts
@@ -2544,6 +2544,8 @@ export interface EndedCallSchemaForInsert {
   project_id: string;
   /** Id */
   id: string;
+  /** Trace Id */
+  trace_id?: string | null;
   /**
    * Ended At
    * @format date-time

--- a/sdks/node/src/integrations/openai-agents/weave-tracing-processor.ts
+++ b/sdks/node/src/integrations/openai-agents/weave-tracing-processor.ts
@@ -258,6 +258,7 @@ export class WeaveTracingProcessor implements TracingProcessor {
     const callEnd = {
       project_id: client.projectId,
       id: callData.callId,
+      trace_id: callData.traceId,
       ended_at: new Date().toISOString(),
       output: {
         status: 'completed',
@@ -398,6 +399,7 @@ export class WeaveTracingProcessor implements TracingProcessor {
     const callEnd = {
       project_id: client.projectId,
       id: callData.callId,
+      trace_id: callData.traceId,
       ended_at: new Date().toISOString(),
       output: {
         output: spanData.output,
@@ -466,6 +468,7 @@ export class WeaveTracingProcessor implements TracingProcessor {
       const callEnd = {
         project_id: client.projectId,
         id: callData.callId,
+        trace_id: callData.traceId,
         ended_at: now,
         output: {status},
         summary: {},
@@ -478,6 +481,7 @@ export class WeaveTracingProcessor implements TracingProcessor {
       const callEnd = {
         project_id: client.projectId,
         id: callData.callId,
+        trace_id: callData.traceId,
         ended_at: now,
         output: {status},
         summary: {},

--- a/sdks/node/src/integrations/openai.realtime.agent.ts
+++ b/sdks/node/src/integrations/openai.realtime.agent.ts
@@ -429,6 +429,7 @@ export class WeaveRealtimeTracingAdapter {
     client.saveCallEnd({
       project_id: client.projectId,
       id: this.sessionCallId,
+      trace_id: this.sessionTraceId,
       ended_at: new Date().toISOString(),
       output: {},
       summary: {},
@@ -464,6 +465,7 @@ export class WeaveRealtimeTracingAdapter {
     client.saveCallEnd({
       project_id: client.projectId,
       id: callId,
+      trace_id: this.sessionTraceId,
       ended_at: now,
       output: {},
       summary: {},
@@ -506,6 +508,7 @@ export class WeaveRealtimeTracingAdapter {
     if (!client || !callId) return;
 
     const endedAt = new Date().toISOString();
+    const traceId = this.sessionTraceId;
     this.voiceInputCalls.delete(itemId);
     const chunks = this.audioInputChunks.get(itemId);
     this.audioInputChunks.delete(itemId);
@@ -524,6 +527,7 @@ export class WeaveRealtimeTracingAdapter {
       client.saveCallEnd({
         project_id: client.projectId,
         id: callId,
+        trace_id: traceId,
         ended_at: endedAt,
         output,
         summary: {},
@@ -557,6 +561,7 @@ export class WeaveRealtimeTracingAdapter {
     client.saveCallEnd({
       project_id: client.projectId,
       id: callId,
+      trace_id: this.sessionTraceId,
       ended_at: now,
       output: sessionData,
       summary: {},
@@ -606,6 +611,7 @@ export class WeaveRealtimeTracingAdapter {
     client.saveCallEnd({
       project_id: client.projectId,
       id: callId,
+      trace_id: this.sessionTraceId,
       ended_at: new Date().toISOString(),
       output: response,
       summary,
@@ -652,6 +658,7 @@ export class WeaveRealtimeTracingAdapter {
     const callId = this.audioCallId;
     const responseId = this.audioResponseId;
     const endedAt = new Date().toISOString();
+    const traceId = this.sessionTraceId;
     this.audioCallId = null;
     this.audioResponseId = null;
 
@@ -672,6 +679,7 @@ export class WeaveRealtimeTracingAdapter {
       client.saveCallEnd({
         project_id: client.projectId,
         id: callId,
+        trace_id: traceId,
         ended_at: endedAt,
         output: finalOutput,
         summary: {},
@@ -716,6 +724,7 @@ export class WeaveRealtimeTracingAdapter {
     client.saveCallEnd({
       project_id: client.projectId,
       id: callId,
+      trace_id: this.sessionTraceId,
       ended_at: new Date().toISOString(),
       output,
       summary: {},

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -1072,6 +1072,7 @@ export class WeaveClient {
     this.saveCallEnd({
       project_id: this.projectId,
       id: currentCall.callId,
+      trace_id: currentCall.traceId,
       ...callSchemaExchangeData,
       // User might change the display name of the call after the call has started.
       // take this into account when logging the end call.
@@ -1108,6 +1109,7 @@ export class WeaveClient {
     this.saveCallEnd({
       project_id: this.projectId,
       id: currentCall.callId,
+      trace_id: currentCall.traceId,
       ...callSchemaExchangeData,
       // User might change the display name of the call after the call has started.
       // take this into account when logging the end call.

--- a/sdks/node/weave.openapi.json
+++ b/sdks/node/weave.openapi.json
@@ -11238,6 +11238,17 @@
             "type": "string",
             "title": "Id"
           },
+          "trace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trace Id"
+          },
           "ended_at": {
             "type": "string",
             "format": "date-time",


### PR DESCRIPTION
## JIRA Issue(s)
https://coreweave.atlassian.net/browse/WB-35711

## Description
A call's `trace_id` reaches the server on call-start but not on call-end. A trace arrives as many separate ingest messages, and a future server-side ingest sampler needs to make one keep/drop decision for the whole trace, so every message has to carry the trace key. This change sets `trace_id` on every call-end the Node SDK sends, so the end carries the same key the start already does.

It is the TypeScript mirror of the Python change in #7237, with one difference: the Node SDK sends calls only in batches via `/call/upsert_batch` and never makes single-call requests, so it needs only the body field — no `X-Weave-Trace-Id` header. The field is optional and nullable, so the change is purely additive; older clients omit it and the server derives it from the matching start. `/call/update` and deletes are left for a follow-up, as in Python.

## Why this approach
Python had a single funnel for call-ends; the Node SDK builds the end body by hand in 13 places (the core client plus two integrations), so `trace_id` is set at each one. The two realtime sites that send from an async closure snapshot the id into a local before the `await`, because session teardown clears it synchronously and the closure would otherwise read a cleared value. The end schema gains the optional field; the generated API types and the OpenAPI snapshot are hand-edited to match (both are already hand-maintained here), so `generate-api` is not re-run.

## Testing
`pnpm test` is green with one new test in `opFlow.test.ts`: it runs an op and asserts the call-end batch item carries the same `trace_id` as the call-start, reading the raw upsert batch so the in-memory server's start/end merge cannot produce a false pass (verified it fails without the change). Typecheck and prettier-check are clean.
