### PR TITLE
fix(weave): exclude reasoning parts from agent chat view body text

### DIFF
--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -497,6 +497,41 @@ def test_invoke_agent_emits_when_no_descendant_llm_span() -> None:
     assert _assistant_payload(agent_messages[0]).text == "hi there"
 
 
+def test_reasoning_part_not_duplicated_in_assistant_text() -> None:
+    """A reasoning part in output_messages surfaces only as `reasoning_content`,
+    never concatenated into the assistant body text.
+
+    `_serialize_output_messages` folds reasoning into the assistant message's
+    parts as a ReasoningPart (so downstream extraction can populate
+    `reasoning_content`). The chat view must render that reasoning solely in the
+    Reasoning block — otherwise the same text renders twice: once in the
+    collapsible and again as body text.
+    """
+    reasoning = "Investigating scenario counts"
+    answer = "There are 17 scenarios, not 16."
+    span = _span(
+        operation_name="chat",
+        output_messages=[
+            {
+                "role": "assistant",
+                "content": _parts(
+                    {"type": "reasoning", "content": reasoning},
+                    _text_part(answer),
+                ),
+            }
+        ],
+        reasoning_content=reasoning,
+    )
+
+    messages = build_chat_messages([span])
+    assistant = next(m for m in messages if m.type == "assistant_message")
+    payload = _assistant_payload(assistant)
+
+    assert payload.text == answer
+    assert reasoning not in payload.text
+    assert payload.reasoning_content == reasoning
+
+
 def test_subagent_spans_render_inline_with_agent_label_inheritance() -> None:
     def at(seconds: int) -> datetime.datetime:
         return datetime.datetime(

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -408,8 +408,9 @@ def _display_text(content: str) -> str:
     """Extract human-readable text from a message content field.
 
     Content is either plain text (legacy) or a JSON-serialized parts array
-    (multimodal messages).  For parts arrays, concatenate text and reasoning
-    parts; for plain text, return as-is.
+    (multimodal messages).  For parts arrays, concatenate the text parts;
+    reasoning parts are excluded (they surface separately via
+    `reasoning_content`).  For plain text, return as-is.
     """
     if not content or not content.startswith("["):
         return content
@@ -422,6 +423,10 @@ def _display_text(content: str) -> str:
     texts: list[str] = []
     for p in parts:
         if isinstance(p, dict) and isinstance(p.get("content"), str):
+            # Reasoning is rendered separately via `reasoning_content`;
+            # concatenating it here would duplicate it in the message body.
+            if p.get("type") == "reasoning":
+                continue
             texts.append(p["content"])
         elif isinstance(p, str):
             texts.append(p)


### PR DESCRIPTION
## Summary

Reasoning content rendered twice in the agent chat view (Session SDK / GenAI spans): once in the **Reasoning** collapsible (from `reasoning_content`) and again as the assistant message body text.

`_serialize_output_messages` folds reasoning into the assistant message's `parts` as a `ReasoningPart` so downstream extraction can populate `reasoning_content`. `_display_text` then concatenated **every** part with a `content` string — including that `ReasoningPart` — into the body text, so the same reasoning appeared in both places.

This excludes `type == "reasoning"` parts in `_display_text`. Reasoning still flows into `reasoning_content` → the Reasoning block; it no longer leaks into the body. The shared user/assistant preview extractors that route through `_display_text` benefit too.

## Before
<img width="763" height="728" alt="Snipaste_2026-06-16_15-36-42" src="https://github.com/user-attachments/assets/302d2e7e-7129-44cd-9547-776cd9e75b65" />

## After
<img width="736" height="478" alt="image" src="https://github.com/user-attachments/assets/3d73746b-cc7e-4fdd-a93a-7bab044297f2" />


## Testing
- New regression test `test_reasoning_part_not_duplicated_in_assistant_text` (fails before, passes after).
- `tests/trace_server/test_genai_chat_view.py` + `test_genai_extraction.py`: pass — extraction confirms `reasoning_content` still populates from the `ReasoningPart`.
- `tests/session/` + `test_genai_helpers/schema/semconv`: pass.
- `ruff check` + `ruff format --check`: clean.

## Breaking changes

None.
