### PR TITLE
feat(weave): tag declarative evaluation child calls with eval metadata

### DIFF
--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -110,7 +110,7 @@ library_cases = [
             "trials": 1,
             "metadata": None,
             "evaluation_name": None,
-            "evaluate": "weave:///shawn/test-project/op/Evaluation.evaluate:R1uv1KcKTPKfQSrXKDQxq08ucuYDd5vG9X1zJaepehw",
+            "evaluate": "weave:///shawn/test-project/op/Evaluation.evaluate:cxDBvbYWzWkgNFoYzJogSAzxhSWzlL3wd4nnis0A2SE",
             "predict_and_score": "weave:///shawn/test-project/op/Evaluation.predict_and_score:jd4m1EJuNnrGmHeiGY1T2CUngsk9x7knOgRJ2sYpU2g",
             "summarize": "weave:///shawn/test-project/op/Evaluation.summarize:Y0s05NYTuqlmXieehHPogfq2JXKl4Y1Xgy8CKumdmjI",
             "_class_name": "Evaluation",
@@ -131,12 +131,12 @@ library_cases = [
             },
             {
                 "object_id": "Evaluation.evaluate",
-                "digest": "R1uv1KcKTPKfQSrXKDQxq08ucuYDd5vG9X1zJaepehw",
+                "digest": "cxDBvbYWzWkgNFoYzJogSAzxhSWzlL3wd4nnis0A2SE",
                 "exp_val": {
                     "_type": "CustomWeaveType",
                     "weave_type": {"type": "Op"},
                     # Regenerated: declarative evaluate now tags child calls with _weave_eval_meta
-                    "files": {"obj.py": "tSXma8p9442MvcXhGGMOfuXVP25iYFL3Yszx1WECRe8"},
+                    "files": {"obj.py": "wjQ3fexYGMuUi1mJcXPkUnZO7t6govV8hOFkyE7wyYw"},
                 },
             },
             {
@@ -251,8 +251,8 @@ library_cases = [
         ],
         exp_files=[
             {
-                "digest": "tSXma8p9442MvcXhGGMOfuXVP25iYFL3Yszx1WECRe8",
-                "exp_content": b'from weave.trace.op_protocol import Op\nfrom weave.flow.model import Model\nimport weave.trace.context.call_context as call_context\nfrom weave.trace.api import attributes\nimport json\nfrom weave.trace.op import op\nfrom weave.trace.call import Call\nfrom datetime import datetime\nfrom weave.flow.util import make_memorable_name\n\ndef _safe_summarize_to_str(summary: dict) -> str:\n    summary_str = ""\n    try:\n        summary_str = json.dumps(summary, indent=2)\n    except Exception:\n        try:\n            summary_str = str(summary)\n        except Exception:\n            pass\n    return summary_str\n\nlogger = "<Logger weave.evaluation.eval (DEBUG)>"\n\ndef default_evaluation_display_name(call: Call) -> str:\n    date = datetime.now().strftime("%Y-%m-%d")\n    unique_name = make_memorable_name()\n    return f"eval-{date}-{unique_name}"\n\n@call_context.op\n@op(call_display_name=default_evaluation_display_name, eager_call_start=True)\nasync def evaluate(self, model: Op | Model) -> dict:\n    # Tag every eval child call (mirrors the imperative path); merge into any\n    # existing _weave_eval_meta (e.g. evaluate_model_worker), don\'t overwrite.\n    prev_eval_meta = call_context.call_attributes.get().get("_weave_eval_meta", {})\n    with attributes({"_weave_eval_meta": {**prev_eval_meta, "declarative": True}}):\n        eval_results = await self.get_eval_results(model)\n        summary = await self.summarize(eval_results)\n\n    summary_str = _safe_summarize_to_str(summary)\n    if summary_str:\n        logger.info("Evaluation summary %s", summary_str)\n\n    return summary\n',
+                "digest": "wjQ3fexYGMuUi1mJcXPkUnZO7t6govV8hOFkyE7wyYw",
+                "exp_content": b'from weave.trace.op_protocol import Op\nfrom weave.flow.model import Model\nimport weave.trace.context.call_context as call_context\nfrom weave.evaluation.eval_meta import EvalMeta\nfrom weave.trace.api import attributes\nimport json\nfrom weave.trace.op import op\nfrom weave.trace.call import Call\nfrom datetime import datetime\nfrom weave.flow.util import make_memorable_name\n\nEVAL_META_KEY = "_weave_eval_meta"\n\ndef _safe_summarize_to_str(summary: dict) -> str:\n    summary_str = ""\n    try:\n        summary_str = json.dumps(summary, indent=2)\n    except Exception:\n        try:\n            summary_str = str(summary)\n        except Exception:\n            pass\n    return summary_str\n\nlogger = "<Logger weave.evaluation.eval (DEBUG)>"\n\ndef default_evaluation_display_name(call: Call) -> str:\n    date = datetime.now().strftime("%Y-%m-%d")\n    unique_name = make_memorable_name()\n    return f"eval-{date}-{unique_name}"\n\n@call_context.op\n@op(call_display_name=default_evaluation_display_name, eager_call_start=True)\nasync def evaluate(self, model: Op | Model) -> dict:\n    # Tag every eval child call (mirrors the imperative path); merge into any\n    # existing _weave_eval_meta (e.g. evaluate_model_worker), don\'t overwrite.\n    prev_eval_meta = call_context.call_attributes.get().get(EVAL_META_KEY, {})\n    declarative_meta: EvalMeta = {"declarative": True}\n    with attributes({EVAL_META_KEY: {**prev_eval_meta, **declarative_meta}}):\n        eval_results = await self.get_eval_results(model)\n        summary = await self.summarize(eval_results)\n\n    summary_str = _safe_summarize_to_str(summary)\n    if summary_str:\n        logger.info("Evaluation summary %s", summary_str)\n\n    return summary\n',
             },
             {
                 "digest": "Y7lSNR7UXFYVtxWyD8GOE3CFXRWfdLX2n1mcYfbSErs",

--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -110,7 +110,7 @@ library_cases = [
             "trials": 1,
             "metadata": None,
             "evaluation_name": None,
-            "evaluate": "weave:///shawn/test-project/op/Evaluation.evaluate:vvs7uu17cnFTlOPIrYnneU8AVfSihXwDk0kMHf6w6cU",
+            "evaluate": "weave:///shawn/test-project/op/Evaluation.evaluate:1etaL8LDoXiMGA5grodkZHbZE7RuC6hCD3EA6Nitjkw",
             "predict_and_score": "weave:///shawn/test-project/op/Evaluation.predict_and_score:jd4m1EJuNnrGmHeiGY1T2CUngsk9x7knOgRJ2sYpU2g",
             "summarize": "weave:///shawn/test-project/op/Evaluation.summarize:Y0s05NYTuqlmXieehHPogfq2JXKl4Y1Xgy8CKumdmjI",
             "_class_name": "Evaluation",
@@ -131,12 +131,12 @@ library_cases = [
             },
             {
                 "object_id": "Evaluation.evaluate",
-                "digest": "vvs7uu17cnFTlOPIrYnneU8AVfSihXwDk0kMHf6w6cU",
+                "digest": "1etaL8LDoXiMGA5grodkZHbZE7RuC6hCD3EA6Nitjkw",
                 "exp_val": {
                     "_type": "CustomWeaveType",
                     "weave_type": {"type": "Op"},
-                    # Updated with G004 lint fix (f-string -> %s formatting in logging)
-                    "files": {"obj.py": "qmkYo6tZ2imoZbCzmOJlpsZq0T3mTOQAm5NJVYnXYHQ"},
+                    # Regenerated: declarative evaluate now tags child calls with _weave_eval_meta
+                    "files": {"obj.py": "yzvJk9MXEHhoeF8yTctT48XR9NPKYJopifbATsdWoYY"},
                 },
             },
             {
@@ -251,8 +251,8 @@ library_cases = [
         ],
         exp_files=[
             {
-                "digest": "qmkYo6tZ2imoZbCzmOJlpsZq0T3mTOQAm5NJVYnXYHQ",
-                "exp_content": b'import weave\nfrom weave.trace.op_protocol import Op\nfrom weave.flow.model import Model\nimport json\nfrom weave.trace.op import op\nfrom weave.trace.call import Call\nfrom datetime import datetime\nfrom weave.flow.util import make_memorable_name\n\ndef _safe_summarize_to_str(summary: dict) -> str:\n    summary_str = ""\n    try:\n        summary_str = json.dumps(summary, indent=2)\n    except Exception:\n        try:\n            summary_str = str(summary)\n        except Exception:\n            pass\n    return summary_str\n\nlogger = "<Logger weave.evaluation.eval (DEBUG)>"\n\ndef default_evaluation_display_name(call: Call) -> str:\n    date = datetime.now().strftime("%Y-%m-%d")\n    unique_name = make_memorable_name()\n    return f"eval-{date}-{unique_name}"\n\n@weave.op\n@op(call_display_name=default_evaluation_display_name, eager_call_start=True)\nasync def evaluate(self, model: Op | Model) -> dict:\n    eval_results = await self.get_eval_results(model)\n    summary = await self.summarize(eval_results)\n\n    summary_str = _safe_summarize_to_str(summary)\n    if summary_str:\n        logger.info("Evaluation summary %s", summary_str)\n\n    return summary\n',
+                "digest": "yzvJk9MXEHhoeF8yTctT48XR9NPKYJopifbATsdWoYY",
+                "exp_content": b'from weave.trace.op_protocol import Op\nfrom weave.flow.model import Model\nimport weave.trace.context.call_context as call_context\nfrom weave.trace.api import attributes\nimport json\nfrom weave.trace.op import op\nfrom weave.trace.call import Call\nfrom datetime import datetime\nfrom weave.flow.util import make_memorable_name\n\ndef _safe_summarize_to_str(summary: dict) -> str:\n    summary_str = ""\n    try:\n        summary_str = json.dumps(summary, indent=2)\n    except Exception:\n        try:\n            summary_str = str(summary)\n        except Exception:\n            pass\n    return summary_str\n\nlogger = "<Logger weave.evaluation.eval (DEBUG)>"\n\ndef default_evaluation_display_name(call: Call) -> str:\n    date = datetime.now().strftime("%Y-%m-%d")\n    unique_name = make_memorable_name()\n    return f"eval-{date}-{unique_name}"\n\n@call_context.op\n@op(call_display_name=default_evaluation_display_name, eager_call_start=True)\nasync def evaluate(self, model: Op | Model) -> dict:\n    # Mark every child call (predict_and_score, model, scorers, summarize)\n    # so server-side ingest sampling can identify eval calls from their own\n    # attributes; children are ingested before the root, so its op_name is\n    # not yet known. Merge into any existing _weave_eval_meta (e.g. set by\n    # evaluate_model_worker) rather than overwriting it. The literal mirrors\n    # eval_imperative.EVAL_META_KEY (importing it here would be circular).\n    prev_eval_meta = call_context.call_attributes.get().get("_weave_eval_meta", {})\n    with attributes({"_weave_eval_meta": {**prev_eval_meta, "declarative": True}}):\n        eval_results = await self.get_eval_results(model)\n        summary = await self.summarize(eval_results)\n\n    summary_str = _safe_summarize_to_str(summary)\n    if summary_str:\n        logger.info("Evaluation summary %s", summary_str)\n\n    return summary\n',
             },
             {
                 "digest": "Y7lSNR7UXFYVtxWyD8GOE3CFXRWfdLX2n1mcYfbSErs",

--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -110,7 +110,7 @@ library_cases = [
             "trials": 1,
             "metadata": None,
             "evaluation_name": None,
-            "evaluate": "weave:///shawn/test-project/op/Evaluation.evaluate:1etaL8LDoXiMGA5grodkZHbZE7RuC6hCD3EA6Nitjkw",
+            "evaluate": "weave:///shawn/test-project/op/Evaluation.evaluate:R1uv1KcKTPKfQSrXKDQxq08ucuYDd5vG9X1zJaepehw",
             "predict_and_score": "weave:///shawn/test-project/op/Evaluation.predict_and_score:jd4m1EJuNnrGmHeiGY1T2CUngsk9x7knOgRJ2sYpU2g",
             "summarize": "weave:///shawn/test-project/op/Evaluation.summarize:Y0s05NYTuqlmXieehHPogfq2JXKl4Y1Xgy8CKumdmjI",
             "_class_name": "Evaluation",
@@ -131,12 +131,12 @@ library_cases = [
             },
             {
                 "object_id": "Evaluation.evaluate",
-                "digest": "1etaL8LDoXiMGA5grodkZHbZE7RuC6hCD3EA6Nitjkw",
+                "digest": "R1uv1KcKTPKfQSrXKDQxq08ucuYDd5vG9X1zJaepehw",
                 "exp_val": {
                     "_type": "CustomWeaveType",
                     "weave_type": {"type": "Op"},
                     # Regenerated: declarative evaluate now tags child calls with _weave_eval_meta
-                    "files": {"obj.py": "yzvJk9MXEHhoeF8yTctT48XR9NPKYJopifbATsdWoYY"},
+                    "files": {"obj.py": "tSXma8p9442MvcXhGGMOfuXVP25iYFL3Yszx1WECRe8"},
                 },
             },
             {
@@ -251,8 +251,8 @@ library_cases = [
         ],
         exp_files=[
             {
-                "digest": "yzvJk9MXEHhoeF8yTctT48XR9NPKYJopifbATsdWoYY",
-                "exp_content": b'from weave.trace.op_protocol import Op\nfrom weave.flow.model import Model\nimport weave.trace.context.call_context as call_context\nfrom weave.trace.api import attributes\nimport json\nfrom weave.trace.op import op\nfrom weave.trace.call import Call\nfrom datetime import datetime\nfrom weave.flow.util import make_memorable_name\n\ndef _safe_summarize_to_str(summary: dict) -> str:\n    summary_str = ""\n    try:\n        summary_str = json.dumps(summary, indent=2)\n    except Exception:\n        try:\n            summary_str = str(summary)\n        except Exception:\n            pass\n    return summary_str\n\nlogger = "<Logger weave.evaluation.eval (DEBUG)>"\n\ndef default_evaluation_display_name(call: Call) -> str:\n    date = datetime.now().strftime("%Y-%m-%d")\n    unique_name = make_memorable_name()\n    return f"eval-{date}-{unique_name}"\n\n@call_context.op\n@op(call_display_name=default_evaluation_display_name, eager_call_start=True)\nasync def evaluate(self, model: Op | Model) -> dict:\n    # Mark every child call (predict_and_score, model, scorers, summarize)\n    # so server-side ingest sampling can identify eval calls from their own\n    # attributes; children are ingested before the root, so its op_name is\n    # not yet known. Merge into any existing _weave_eval_meta (e.g. set by\n    # evaluate_model_worker) rather than overwriting it. The literal mirrors\n    # eval_imperative.EVAL_META_KEY (importing it here would be circular).\n    prev_eval_meta = call_context.call_attributes.get().get("_weave_eval_meta", {})\n    with attributes({"_weave_eval_meta": {**prev_eval_meta, "declarative": True}}):\n        eval_results = await self.get_eval_results(model)\n        summary = await self.summarize(eval_results)\n\n    summary_str = _safe_summarize_to_str(summary)\n    if summary_str:\n        logger.info("Evaluation summary %s", summary_str)\n\n    return summary\n',
+                "digest": "tSXma8p9442MvcXhGGMOfuXVP25iYFL3Yszx1WECRe8",
+                "exp_content": b'from weave.trace.op_protocol import Op\nfrom weave.flow.model import Model\nimport weave.trace.context.call_context as call_context\nfrom weave.trace.api import attributes\nimport json\nfrom weave.trace.op import op\nfrom weave.trace.call import Call\nfrom datetime import datetime\nfrom weave.flow.util import make_memorable_name\n\ndef _safe_summarize_to_str(summary: dict) -> str:\n    summary_str = ""\n    try:\n        summary_str = json.dumps(summary, indent=2)\n    except Exception:\n        try:\n            summary_str = str(summary)\n        except Exception:\n            pass\n    return summary_str\n\nlogger = "<Logger weave.evaluation.eval (DEBUG)>"\n\ndef default_evaluation_display_name(call: Call) -> str:\n    date = datetime.now().strftime("%Y-%m-%d")\n    unique_name = make_memorable_name()\n    return f"eval-{date}-{unique_name}"\n\n@call_context.op\n@op(call_display_name=default_evaluation_display_name, eager_call_start=True)\nasync def evaluate(self, model: Op | Model) -> dict:\n    # Tag every eval child call (mirrors the imperative path); merge into any\n    # existing _weave_eval_meta (e.g. evaluate_model_worker), don\'t overwrite.\n    prev_eval_meta = call_context.call_attributes.get().get("_weave_eval_meta", {})\n    with attributes({"_weave_eval_meta": {**prev_eval_meta, "declarative": True}}):\n        eval_results = await self.get_eval_results(model)\n        summary = await self.summarize(eval_results)\n\n    summary_str = _safe_summarize_to_str(summary)\n    if summary_str:\n        logger.info("Evaluation summary %s", summary_str)\n\n    return summary\n',
             },
             {
                 "digest": "Y7lSNR7UXFYVtxWyD8GOE3CFXRWfdLX2n1mcYfbSErs",

--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -244,6 +244,50 @@ async def test_declarative_eval_marks_child_calls_with_eval_meta(client):
     assert "_weave_eval_meta" not in root.attributes
 
 
+@pytest.mark.asyncio
+async def test_declarative_eval_meta_merges_with_existing(client):
+    # An outer wrapper (e.g. the evaluate_model_worker) may already set
+    # `_weave_eval_meta`. The declarative marker must merge into it, not overwrite
+    # it, so both keys survive on every child call.
+    examples = [{"question": "What is the capital of France?", "expected": "Paris"}]
+
+    @weave.op
+    def match_score(expected: str, output: dict) -> dict:
+        return {"match": expected == output["generated_text"]}
+
+    model = MyModel(prompt="World")
+    evaluation = Evaluation(dataset=examples, scorers=[match_score])
+    with weave.attributes({"_weave_eval_meta": {"evaluate_model_worker": True}}):
+        await evaluation.evaluate(model)
+
+    calls = client.server.calls_query(
+        tsi.CallsQueryReq(project_id=client.project_id)
+    ).calls
+
+    by_op: dict[str, list] = defaultdict(list)
+    for c in calls:
+        by_op[op_name_from_ref(c.op_name)].append(c)
+
+    # Children carry both the pre-existing key and the declarative marker.
+    expected_meta = {"evaluate_model_worker": True, "declarative": True}
+    for op_name in (
+        "Evaluation.predict_and_score",
+        "MyModel.predict",
+        "match_score",
+        "Evaluation.summarize",
+    ):
+        for c in by_op[op_name]:
+            assert c.attributes.get("_weave_eval_meta") == expected_meta, (
+                op_name,
+                c.attributes,
+            )
+
+    # The root keeps only the outer key (its attributes are read before the
+    # wrapper body adds `declarative`).
+    (root,) = by_op["Evaluation.evaluate"]
+    assert root.attributes["_weave_eval_meta"] == {"evaluate_model_worker": True}
+
+
 @weave.op
 def gpt_mocker(question: str):
     return {

--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -276,6 +276,7 @@ async def test_declarative_eval_meta_merges_with_existing(client):
         "match_score",
         "Evaluation.summarize",
     ):
+        assert by_op[op_name], op_name
         for c in by_op[op_name]:
             assert c.attributes.get("_weave_eval_meta") == expected_meta, (
                 op_name,

--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -1,5 +1,6 @@
 import dataclasses
 import random
+from collections import defaultdict
 from typing import Any
 
 import pydantic
@@ -189,6 +190,58 @@ async def test_basic_evaluation(client):
     for call in predict_and_score_calls:
         inputs.add(call.inputs["example"])
     assert len(inputs) == 3
+
+
+@pytest.mark.asyncio
+async def test_declarative_eval_marks_child_calls_with_eval_meta(client):
+    # The declarative path must tag every eval call (predict_and_score, model,
+    # scorers, summarize) with `_weave_eval_meta`, mirroring the imperative path,
+    # so server-side ingest sampling can recognize eval calls from their own
+    # attributes. trials=2 proves the marker reaches every example's subtree, not
+    # just the first.
+    examples = [
+        {"question": "What is the capital of France?", "expected": "Paris"},
+        {"question": "Who wrote 'To Kill a Mockingbird'?", "expected": "Harper Lee"},
+    ]
+
+    @weave.op
+    def match_score(expected: str, output: dict) -> dict:
+        return {"match": expected == output["generated_text"]}
+
+    model = MyModel(prompt="World")
+    evaluation = Evaluation(dataset=examples, scorers=[match_score], trials=2)
+    await evaluation.evaluate(model)
+
+    calls = client.server.calls_query(
+        tsi.CallsQueryReq(project_id=client.project_id)
+    ).calls
+
+    by_op: dict[str, list] = defaultdict(list)
+    for c in calls:
+        by_op[op_name_from_ref(c.op_name)].append(c)
+
+    # 2 examples * 2 trials -> 4 of each per-example op; summarize runs once.
+    assert len(by_op["Evaluation.predict_and_score"]) == 4
+    assert len(by_op["MyModel.predict"]) == 4
+    assert len(by_op["match_score"]) == 4
+    assert len(by_op["Evaluation.summarize"]) == 1
+
+    for op_name in (
+        "Evaluation.predict_and_score",
+        "MyModel.predict",
+        "match_score",
+        "Evaluation.summarize",
+    ):
+        for c in by_op[op_name]:
+            assert c.attributes.get("_weave_eval_meta") == {"declarative": True}, (
+                op_name,
+                c.attributes,
+            )
+
+    # The root is recognized by op_name and is intentionally not marked: its own
+    # attributes are read before the wrapper body runs.
+    (root,) = by_op["Evaluation.evaluate"]
+    assert "_weave_eval_meta" not in root.attributes
 
 
 @weave.op

--- a/weave/evaluation/eval.py
+++ b/weave/evaluation/eval.py
@@ -379,12 +379,8 @@ class Evaluation(Object):
 
     @op(call_display_name=default_evaluation_display_name, eager_call_start=True)
     async def evaluate(self, model: Op | Model) -> dict:
-        # Mark every child call (predict_and_score, model, scorers, summarize)
-        # so server-side ingest sampling can identify eval calls from their own
-        # attributes; children are ingested before the root, so its op_name is
-        # not yet known. Merge into any existing _weave_eval_meta (e.g. set by
-        # evaluate_model_worker) rather than overwriting it. The literal mirrors
-        # eval_imperative.EVAL_META_KEY (importing it here would be circular).
+        # Tag every eval child call (mirrors the imperative path); merge into any
+        # existing _weave_eval_meta (e.g. evaluate_model_worker), don't overwrite.
         prev_eval_meta = call_context.call_attributes.get().get("_weave_eval_meta", {})
         with attributes({"_weave_eval_meta": {**prev_eval_meta, "declarative": True}}):
             eval_results = await self.get_eval_results(model)

--- a/weave/evaluation/eval.py
+++ b/weave/evaluation/eval.py
@@ -29,6 +29,7 @@ from weave.flow.scorer import (
 )
 from weave.flow.util import make_memorable_name, transpose
 from weave.object.obj import Object
+from weave.trace.api import attributes
 from weave.trace.call import Call, CallsIter
 from weave.trace.context import call_context
 from weave.trace.context.weave_client_context import require_weave_client
@@ -378,8 +379,16 @@ class Evaluation(Object):
 
     @op(call_display_name=default_evaluation_display_name, eager_call_start=True)
     async def evaluate(self, model: Op | Model) -> dict:
-        eval_results = await self.get_eval_results(model)
-        summary = await self.summarize(eval_results)
+        # Mark every child call (predict_and_score, model, scorers, summarize)
+        # so server-side ingest sampling can identify eval calls from their own
+        # attributes; children are ingested before the root, so its op_name is
+        # not yet known. Merge into any existing _weave_eval_meta (e.g. set by
+        # evaluate_model_worker) rather than overwriting it. The literal mirrors
+        # eval_imperative.EVAL_META_KEY (importing it here would be circular).
+        prev_eval_meta = call_context.call_attributes.get().get("_weave_eval_meta", {})
+        with attributes({"_weave_eval_meta": {**prev_eval_meta, "declarative": True}}):
+            eval_results = await self.get_eval_results(model)
+            summary = await self.summarize(eval_results)
 
         summary_str = _safe_summarize_to_str(summary)
         if summary_str:

--- a/weave/evaluation/eval.py
+++ b/weave/evaluation/eval.py
@@ -13,6 +13,7 @@ from pydantic import PrivateAttr
 from typing_extensions import Self
 
 from weave.dataset.dataset import Dataset
+from weave.evaluation.eval_meta import EVAL_META_KEY, EvalMeta
 from weave.flow import util
 from weave.flow.casting import DatasetLike, ScorerLike
 from weave.flow.model import (
@@ -381,8 +382,9 @@ class Evaluation(Object):
     async def evaluate(self, model: Op | Model) -> dict:
         # Tag every eval child call (mirrors the imperative path); merge into any
         # existing _weave_eval_meta (e.g. evaluate_model_worker), don't overwrite.
-        prev_eval_meta = call_context.call_attributes.get().get("_weave_eval_meta", {})
-        with attributes({"_weave_eval_meta": {**prev_eval_meta, "declarative": True}}):
+        prev_eval_meta = call_context.call_attributes.get().get(EVAL_META_KEY, {})
+        declarative_meta: EvalMeta = {"declarative": True}
+        with attributes({EVAL_META_KEY: {**prev_eval_meta, **declarative_meta}}):
             eval_results = await self.get_eval_results(model)
             summary = await self.summarize(eval_results)
 

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -24,7 +24,7 @@ from weave.evaluation.eval import (
     _active_eval_prediction_context,
     default_evaluation_display_name,
 )
-from weave.evaluation.eval_meta import EVAL_META_KEY, EvalMeta
+from weave.evaluation.eval_meta import EVAL_META_KEY
 from weave.flow.model import MissingInferenceMethodError, Model
 from weave.flow.scorer import Scorer
 from weave.flow.scorer import auto_summarize as auto_summarize_fn
@@ -85,8 +85,8 @@ current_predict_call: ContextVar[Call | None] = ContextVar(
     "current_predict_call", default=None
 )
 
-IMPERATIVE_EVAL_META_MARKER: EvalMeta = {"imperative": True}
-IMPERATIVE_SCORE_META_MARKER: EvalMeta = {"imperative": True, "score": True}
+IMPERATIVE_EVAL_META_MARKER = {"imperative": True}
+IMPERATIVE_SCORE_META_MARKER = {"imperative": True, "score": True}
 
 
 def _as_call_attributes(eval_meta: dict[str, Any]) -> dict[str, Any]:

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -24,6 +24,7 @@ from weave.evaluation.eval import (
     _active_eval_prediction_context,
     default_evaluation_display_name,
 )
+from weave.evaluation.eval_meta import EVAL_META_KEY, EvalMeta
 from weave.flow.model import MissingInferenceMethodError, Model
 from weave.flow.scorer import Scorer
 from weave.flow.scorer import auto_summarize as auto_summarize_fn
@@ -84,9 +85,8 @@ current_predict_call: ContextVar[Call | None] = ContextVar(
     "current_predict_call", default=None
 )
 
-EVAL_META_KEY = "_weave_eval_meta"
-IMPERATIVE_EVAL_META_MARKER = {"imperative": True}
-IMPERATIVE_SCORE_META_MARKER = {"imperative": True, "score": True}
+IMPERATIVE_EVAL_META_MARKER: EvalMeta = {"imperative": True}
+IMPERATIVE_SCORE_META_MARKER: EvalMeta = {"imperative": True, "score": True}
 
 
 def _as_call_attributes(eval_meta: dict[str, Any]) -> dict[str, Any]:

--- a/weave/evaluation/eval_meta.py
+++ b/weave/evaluation/eval_meta.py
@@ -1,0 +1,27 @@
+"""Shared contract for the `_weave_eval_meta` call attribute.
+
+Both evaluation paths (the declarative ``Evaluation.evaluate`` and the imperative
+``EvaluationLogger``) tag their calls with this attribute so consumers — eval-results
+rendering and a future server-side ingest sampler — can recognize and classify eval
+calls. It lives in its own leaf module because ``eval_imperative`` imports ``eval``,
+so neither can host a symbol the other needs without a circular import.
+"""
+
+from typing import TypedDict
+
+# Call-attribute key under which evaluation metadata is stored.
+EVAL_META_KEY = "_weave_eval_meta"
+
+
+class EvalMeta(TypedDict, total=False):
+    """Known fields under ``_weave_eval_meta``.
+
+    All keys are optional and a call carries any subset. Callers (e.g.
+    ``EvaluationLogger``) may also inject their own keys, so consumers must not
+    assume the set is closed.
+    """
+
+    imperative: bool  # set on every call of the imperative path (EvaluationLogger)
+    score: bool  # scorer call on the imperative path
+    declarative: bool  # set on every child call of Evaluation.evaluate
+    evaluate_model_worker: bool  # set by the eval-model worker


### PR DESCRIPTION
## JIRA Issue(s)

[WB-35748](https://coreweave.atlassian.net/browse/WB-35748)

## Description

The imperative evaluation path (`EvaluationLogger`) already tags each of its calls with the `_weave_eval_meta` attribute, but the declarative path (`Evaluation.evaluate`) tagged nothing on its children. Those calls could be recognized only indirectly, by the op name on the root `Evaluation.evaluate` call. This change wraps the body of `evaluate` in a single `weave.attributes` context, so every call it produces — `predict_and_score`, the model call, the scorers, and `summarize` — now carries the marker. The two paths behave the same.

The reason the marker has to sit on the children is server-side ingest sampling, a planned feature that drops a portion of incoming traces to reduce storage. Evaluation traces must be kept whole, so the sampler needs to recognize eval calls. It decides one message at a time, and a child call is ingested before its root arrives, so the only reliable signal is an attribute on the child itself. The value is merged into any `_weave_eval_meta` an outer wrapper may have already set, so existing markers are preserved rather than overwritten.

## Backward compatibility

The marker is `{"declarative": true}`. The current readers of `_weave_eval_meta` key off `imperative` or `score`, neither of which this sets, so they treat these calls exactly as before. A no-`score` marker is already written on this same path in production today (by the evaluate-model worker), so this is a proven shape, not a new one. The sampler that reads the marker is a separate, later change.

## Testing

Added a declarative-path test that runs an evaluation with `trials=2` and asserts the marker lands on `predict_and_score`, the model call, all scorer calls, and `summarize` for every example. `trials=2` is what proves the marker reaches each example's subtree and not just the first. It also checks that the root stays unmarked, since it is recognized by op name.

Ran locally against ClickHouse with no regressions: the new test, the full declarative eval suites (`test_evaluations.py` and `test_evaluate.py`, 38 passed), the imperative meta-propagation tests, and the server-side eval-results tests (35 passed).


[WB-35748]: https://coreweave.atlassian.net/browse/WB-35748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ