### PR TITLE
feat(weave_ts): re-export getWeaveTracer for custom-span emitters

### DIFF
--- a/sdks/node/src/genai/index.ts
+++ b/sdks/node/src/genai/index.ts
@@ -19,6 +19,10 @@ export {
   runIsolated,
 } from './context';
 export {flushOTel} from './flush';
+// Raw access to the Weave OTel tracer. Lets a custom-span emitter (e.g. a host
+// integration) start spans on the same provider the GenAI classes use, so its
+// spans export to Weave and nest correctly under Turn/Tool/SubAgent/LLM.
+export {getWeaveTracer} from './provider';
 export {LLM, type LLMInit} from './llm';
 export {Session, type SessionInit} from './session';
 export {SubAgent, type SubAgentInit} from './subagent';

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -31,6 +31,7 @@ export {
   getCurrentLLM,
   getCurrentSession,
   getCurrentTurn,
+  getWeaveTracer,
   runIsolated,
   startLLM,
   startSession,


### PR DESCRIPTION
## Summary
Re-export the existing `getWeaveTracer` provider helper from the genai entrypoint so host integrations that emit their own spans (e.g. the Weave Claude Code plugin during its incremental migration to the GenAI classes) can start spans on the same OTel provider the GenAI classes use. Without it, such spans land on a different provider and never export to Weave or nest under Turn/Tool/SubAgent/LLM.

Pure additive re-export; no behavior change to existing code. (#7195 dropped the earlier re-export as unused; this restores it now that there is a consumer.)

## Test plan
- `npm run build` (sdks/node)
- `npm test` (genai suite)