### PR TITLE
feat(weave): migrate clickhouse_trace_server_batched.py to @traced

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -3663,27 +3663,25 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
     # Dataset Sources API
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.dataset_sources_link")
+    @traced(name="clickhouse_trace_server_batched.dataset_sources_link")
     def dataset_sources_link(
         self, req: tsi.DatasetSourcesLinkReq
     ) -> tsi.DatasetSourcesLinkRes:
         return self._dataset_sources_handler().link(req)
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.dataset_sources_link_delete"
-    )
+    @traced(name="clickhouse_trace_server_batched.dataset_sources_link_delete")
     def dataset_sources_link_delete(
         self, req: tsi.DatasetSourcesLinkDeleteReq
     ) -> tsi.DatasetSourcesLinkDeleteRes:
         return self._dataset_sources_handler().link_delete(req)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.dataset_sources_query")
+    @traced(name="clickhouse_trace_server_batched.dataset_sources_query")
     def dataset_sources_query(
         self, req: tsi.DatasetSourcesQueryReq
     ) -> tsi.DatasetSourcesQueryRes:
         return self._dataset_sources_handler().query(req)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.source_datasets_query")
+    @traced(name="clickhouse_trace_server_batched.source_datasets_query")
     def source_datasets_query(
         self, req: tsi.SourceDatasetsQueryReq
     ) -> tsi.SourceDatasetsQueryRes:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -15,7 +15,6 @@ from typing import Any, NamedTuple, TypeVar, cast
 from zoneinfo import ZoneInfo
 
 import clickhouse_connect
-import ddtrace
 from cachetools import TTLCache
 from clickhouse_connect import common as ch_common
 from clickhouse_connect.driver.client import Client as CHClient
@@ -171,7 +170,6 @@ from weave.trace_server.constants import (
     IMAGE_GENERATION_CREATE_OP_NAME,
 )
 from weave.trace_server.datadog import (
-    generator_trace,
     record_db_insert,
     set_current_span_dd_tags,
     set_root_span_dd_tags,
@@ -329,6 +327,7 @@ from weave.trace_server.ttl_settings import (
 from weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker import (
     EvaluateModelDispatcher,
 )
+from weave.trace_server.tracing import traced, traced_generator
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -662,7 +661,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
     @tag_db_insert_path("otel_export")
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.otel_export")
+    @traced(name="clickhouse_trace_server_batched.otel_export")
     def otel_export(self, req: tsi.OTelExportReq) -> tsi.OTelExportRes:
         assert_non_null_wb_user_id(req)
         calls, rejected_spans, error_messages = self._otel_proto_to_calls(req)
@@ -759,9 +758,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             )
         return tsi.OTelExportRes()
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.otel_export.proto_to_calls"
-    )
+    @traced(name="clickhouse_trace_server_batched.otel_export.proto_to_calls")
     def _otel_proto_to_calls(
         self, req: tsi.OTelExportReq
     ) -> tuple[
@@ -818,7 +815,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         set_current_span_dd_tags({"call_count": len(calls)})
         return calls, rejected_spans, error_messages
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.otel_export.build_rows")
+    @traced(name="clickhouse_trace_server_batched.otel_export.build_rows")
     def _otel_build_rows(
         self,
         calls: list[
@@ -852,7 +849,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         set_current_span_dd_tags({"row_count": len(rows)})
         return rows
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.kafka_producer.flush")
+    @traced(name="clickhouse_trace_server_batched.kafka_producer.flush")
     def _flush_kafka_producer(self) -> None:
         producer = self.kafka_producer
         if producer is not None:
@@ -1129,9 +1126,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.CallEndV2Res()
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched._update_call_end_in_calls_complete"
-    )
+    @traced(name="clickhouse_trace_server_batched._update_call_end_in_calls_complete")
     def _update_call_end_in_calls_complete(
         self, end_call: tsi.EndedCallSchemaForInsert
     ) -> None:
@@ -1277,7 +1272,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         stream = self.calls_query_stream(req)
         return tsi.CallsQueryRes(calls=list(stream))
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.calls_query_stats")
+    @traced(name="clickhouse_trace_server_batched.calls_query_stats")
     def calls_query_stats(self, req: tsi.CallsQueryStatsReq) -> tsi.CallsQueryStatsRes:
         """Returns a stats object for the given query. This is useful for counts or other
         aggregate statistics that are not directly queryable from the calls themselves.
@@ -1495,7 +1490,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         """Discover feedback payload schema from sample rows."""
         return feedback_payload_schema_handler(self, req)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.trace_usage")
+    @traced(name="clickhouse_trace_server_batched.trace_usage")
     def trace_usage(self, req: tsi.TraceUsageReq) -> tsi.TraceUsageRes:
         """Compute per-call usage for a trace, with descendant rollup.
 
@@ -1535,7 +1530,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             unfinished_call_ids=sorted(unfinished_call_ids),
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.calls_usage")
+    @traced(name="clickhouse_trace_server_batched.calls_usage")
     def calls_usage(self, req: tsi.CallsUsageReq) -> tsi.CallsUsageRes:
         """Compute aggregated usage for multiple root calls.
 
@@ -1599,7 +1594,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             unfinished_call_ids=sorted(unfinished_call_ids),
         )
 
-    @generator_trace("clickhouse_trace_server_batched.calls_query_stream")
+    @traced_generator(name="clickhouse_trace_server_batched.calls_query_stream")
     def calls_query_stream(self, req: tsi.CallsQueryReq) -> Iterator[tsi.CallSchema]:
         """Returns a stream of calls that match the given query."""
         read_table = self.table_routing_resolver.resolve_read_table(
@@ -1751,7 +1746,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             if hasattr(raw_res, "close"):
                 raw_res.close()
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._add_feedback_to_calls")
+    @traced(name="clickhouse_trace_server_batched._add_feedback_to_calls")
     def _add_feedback_to_calls(
         self, project_id: str, calls: list[dict[str, Any]]
     ) -> None:
@@ -1785,7 +1780,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 refs_to_resolve[i, col] = ref
         return refs_to_resolve
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._expand_call_refs")
+    @traced(name="clickhouse_trace_server_batched._expand_call_refs")
     def _expand_call_refs(
         self,
         project_id: str,
@@ -1833,7 +1828,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                         val["_ref"] = ref.uri
                     set_nested_key(calls[i], col, val)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.calls_delete")
+    @traced(name="clickhouse_trace_server_batched.calls_delete")
     @tag_db_insert_path("calls_delete")
     def calls_delete(self, req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
         assert_non_null_wb_user_id(req)
@@ -1929,7 +1924,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.CallsDeleteRes(num_deleted=len(all_descendants))
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._delete_calls_complete")
+    @traced(name="clickhouse_trace_server_batched._delete_calls_complete")
     def _delete_calls_complete(
         self,
         project_id: str,
@@ -1975,7 +1970,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             f"One of [{', '.join(valid_update_fields)}] is required for call update"
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.call_update")
+    @traced(name="clickhouse_trace_server_batched.call_update")
     @tag_db_insert_path("call_update")
     def call_update(self, req: tsi.CallUpdateReq) -> tsi.CallUpdateRes:
         assert_non_null_wb_user_id(req)
@@ -1999,7 +1994,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.CallUpdateRes()
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._update_calls_complete")
+    @traced(name="clickhouse_trace_server_batched._update_calls_complete")
     def _update_calls_complete(
         self, project_id: str, call_id: str, display_name: str
     ) -> None:
@@ -2022,7 +2017,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             settings=ch_settings.CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.obj_create")
+    @traced(name="clickhouse_trace_server_batched.obj_create")
     @tag_db_insert_path("obj_create")
     def obj_create(self, req: tsi.ObjCreateReq) -> tsi.ObjCreateRes:
         # Partial-failure semantics: ClickHouse cannot atomically write
@@ -2123,7 +2118,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 existing_base_object_classes=mismatched,
             )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.create_obj_batch")
+    @traced(name="clickhouse_trace_server_batched.create_obj_batch")
     @tag_db_insert_path("obj_create_batch")
     def obj_create_batch(
         self, batch: list[tsi.ObjSchemaForInsert]
@@ -2252,7 +2247,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._enrich_objs_with_tags_and_aliases(req.project_id, [obj_schema])
         return tsi.ObjReadRes(obj=obj_schema)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.objs_query")
+    @traced(name="clickhouse_trace_server_batched.objs_query")
     def objs_query(self, req: tsi.ObjQueryReq) -> tsi.ObjQueryRes:
         object_query_builder = ObjectMetadataQueryBuilder(req.project_id)
         if req.filter:
@@ -2525,7 +2520,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         aliases = [row[0] for row in query_result.result_rows]
         return tsi.AliasesListRes(aliases=aliases)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._get_tags_for_objects")
+    @traced(name="clickhouse_trace_server_batched._get_tags_for_objects")
     def _get_tags_for_objects(
         self,
         project_id: str,
@@ -2544,9 +2539,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             result.setdefault(key, []).append(row[2])
         return result
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched._get_aliases_for_objects"
-    )
+    @traced(name="clickhouse_trace_server_batched._get_aliases_for_objects")
     def _get_aliases_for_objects(
         self,
         project_id: str,
@@ -2565,7 +2558,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             result.setdefault(key, []).append(row[2])
         return result
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._maybe_resolve_alias")
+    @traced(name="clickhouse_trace_server_batched._maybe_resolve_alias")
     def _maybe_resolve_alias(
         self,
         project_id: str,
@@ -2800,7 +2793,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             offset=req.offset,
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._table_query_stream")
+    @traced_generator(name="clickhouse_trace_server_batched._table_query_stream")
     def _table_query_stream(
         self,
         project_id: str,
@@ -2955,9 +2948,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             **dict(zip(columns, query_result.result_rows[0], strict=False))
         )
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.project_ttl_settings_read"
-    )
+    @traced(name="clickhouse_trace_server_batched.project_ttl_settings_read")
     def project_ttl_settings_read(
         self, req: tsi.ProjectTTLSettingsReadReq
     ) -> tsi.ProjectTTLSettingsReadRes:
@@ -2967,9 +2958,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
     @tag_db_insert_path("project_ttl_settings_update")
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.project_ttl_settings_update"
-    )
+    @traced(name="clickhouse_trace_server_batched.project_ttl_settings_update")
     def project_ttl_settings_update(
         self, req: tsi.ProjectTTLSettingsUpdateReq
     ) -> tsi.ProjectTTLSettingsUpdateRes:
@@ -3064,7 +3053,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             )
 
     # Annotation Queue API
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.annotation_queue_create")
+    @traced(name="clickhouse_trace_server_batched.annotation_queue_create")
     def annotation_queue_create(
         self, req: tsi.AnnotationQueueCreateReq
     ) -> tsi.AnnotationQueueCreateRes:
@@ -3094,9 +3083,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.AnnotationQueueCreateRes(id=queue_id)
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.annotation_queues_query_stream"
-    )
+    @traced_generator(name="clickhouse_trace_server_batched.annotation_queues_query_stream")
     def annotation_queues_query_stream(
         self, req: tsi.AnnotationQueuesQueryReq
     ) -> Iterator[tsi.AnnotationQueueSchema]:
@@ -3149,7 +3136,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 deleted_at=deleted_at_with_tz,
             )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.annotation_queue_read")
+    @traced(name="clickhouse_trace_server_batched.annotation_queue_read")
     def annotation_queue_read(
         self, req: tsi.AnnotationQueueReadReq
     ) -> tsi.AnnotationQueueReadRes:
@@ -3183,7 +3170,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.AnnotationQueueReadRes(queue=queue)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.annotation_queue_update")
+    @traced(name="clickhouse_trace_server_batched.annotation_queue_update")
     def annotation_queue_update(
         self, req: tsi.AnnotationQueueUpdateReq
     ) -> tsi.AnnotationQueueUpdateRes:
@@ -3280,7 +3267,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.AnnotationQueueUpdateRes(queue=queue)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.annotation_queue_delete")
+    @traced(name="clickhouse_trace_server_batched.annotation_queue_delete")
     def annotation_queue_delete(
         self, req: tsi.AnnotationQueueDeleteReq
     ) -> tsi.AnnotationQueueDeleteRes:
@@ -3337,9 +3324,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return tsi.AnnotationQueueDeleteRes(queue=queue)
 
     @tag_db_insert_path("annotation_queue_add_calls")
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.annotation_queue_add_calls"
-    )
+    @traced(name="clickhouse_trace_server_batched.annotation_queue_add_calls")
     def annotation_queue_add_calls(
         self, req: tsi.AnnotationQueueAddCallsReq
     ) -> tsi.AnnotationQueueAddCallsRes:
@@ -3434,9 +3419,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             added_count=len(calls_data), duplicates=len(existing_call_ids)
         )
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.annotation_queue_items_query"
-    )
+    @traced(name="clickhouse_trace_server_batched.annotation_queue_items_query")
     def annotation_queue_items_query(
         self, req: tsi.AnnotationQueueItemsQueryReq
     ) -> tsi.AnnotationQueueItemsQueryRes:
@@ -3482,7 +3465,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.AnnotationQueueItemsQueryRes(items=items)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.annotation_queues_stats")
+    @traced(name="clickhouse_trace_server_batched.annotation_queues_stats")
     def annotation_queues_stats(
         self, req: tsi.AnnotationQueuesStatsReq
     ) -> tsi.AnnotationQueuesStatsRes:
@@ -3556,9 +3539,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         raise ValueError(f"Failed to fetch queue item '{item_id}'")
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.annotator_queue_items_progress_update"
-    )
+    @traced(name="clickhouse_trace_server_batched.annotator_queue_items_progress_update")
     def annotator_queue_items_progress_update(
         self, req: tsi.AnnotatorQueueItemsProgressUpdateReq
     ) -> tsi.AnnotatorQueueItemsProgressUpdateRes:
@@ -5791,7 +5772,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return _do_read()
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._obj_read_with_retry")
+    @traced(name="clickhouse_trace_server_batched._obj_read_with_retry")
     def _obj_read_with_retry(
         self, req: tsi.ObjReadReq, max_attempts: int = 2
     ) -> tsi.ObjReadRes:
@@ -5800,9 +5781,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             lambda: self.obj_read(req), max_attempts=max_attempts
         )
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched._file_content_read_with_retry"
-    )
+    @traced(name="clickhouse_trace_server_batched._file_content_read_with_retry")
     def _file_content_read_with_retry(
         self, req: tsi.FileContentReadReq, max_attempts: int = 2
     ) -> tsi.FileContentReadRes:
@@ -5811,7 +5790,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             lambda: self._file_content_read_once(req), max_attempts=max_attempts
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._parsed_refs_read_batch")
+    @traced(name="clickhouse_trace_server_batched._parsed_refs_read_batch")
     def _parsed_refs_read_batch(
         self,
         parsed_refs: ObjRefListType,
@@ -5840,9 +5819,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # Return the final data payload
         return [final_result_cache[make_ref_cache_key(ref)] for ref in parsed_refs]
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched._refs_read_batch_within_project"
-    )
+    @traced(name="clickhouse_trace_server_batched._refs_read_batch_within_project")
     def _refs_read_batch_within_project(
         self,
         project_id_scope: str,
@@ -6122,12 +6099,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         set_root_span_dd_tags({"write_bytes": len(req.content)})
         return tsi.FileCreateRes(digest=digest)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._file_create_clickhouse")
+    @traced(name="clickhouse_trace_server_batched._file_create_clickhouse")
     def _file_create_clickhouse(self, req: tsi.FileCreateReq, digest: str) -> None:
         set_root_span_dd_tags({"storage_provider": "clickhouse"})
         self._insert_file_chunks(file_chunks_for(req, digest))
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._file_create_bucket")
+    @traced(name="clickhouse_trace_server_batched._file_create_bucket")
     def _file_create_bucket(
         self, req: tsi.FileCreateReq, digest: str, client: FileStorageClient
     ) -> None:
@@ -6159,7 +6136,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             ]
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._flush_file_chunks")
+    @traced(name="clickhouse_trace_server_batched._flush_file_chunks")
     def _flush_file_chunks(self) -> None:
         if not self._flush_immediately:
             raise ValueError("File chunks must be flushed immediately")
@@ -6296,7 +6273,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         set_root_span_dd_tags({"read_bytes": len(bytes)})
         return tsi.FileContentReadRes(content=bytes)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._file_read_bucket")
+    @traced(name="clickhouse_trace_server_batched._file_read_bucket")
     def _file_read_bucket(self, file_storage_uri: FileStorageURI) -> bytes:
         set_root_span_dd_tags({"storage_provider": "bucket"})
         client = self.file_storage_client
@@ -6438,7 +6415,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return format_feedback_to_res(row)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.feedback_create_batch")
+    @traced(name="clickhouse_trace_server_batched.feedback_create_batch")
     @tag_db_insert_path("feedback_create_batch")
     def feedback_create_batch(
         self, req: tsi.FeedbackCreateBatchReq
@@ -7206,7 +7183,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         migrator.apply_migrations(self._database)
 
-    @generator_trace("clickhouse_trace_server_batched._query_stream")
+    @traced_generator(name="clickhouse_trace_server_batched._query_stream")
     def _query_stream(
         self,
         query: str,
@@ -7255,7 +7232,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             # always raises, optionally with custom error class
             handle_clickhouse_query_error(e)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._query")
+    @traced(name="clickhouse_trace_server_batched._query")
     def _query(
         self,
         query: str,
@@ -7303,7 +7280,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         return res
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._command")
+    @traced(name="clickhouse_trace_server_batched._command")
     def _command(
         self,
         command: str,
@@ -7352,7 +7329,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         return
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._insert")
+    @traced(name="clickhouse_trace_server_batched._insert")
     def _insert(
         self,
         table: str,
@@ -7439,7 +7416,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if self._flush_immediately:
             self._flush_calls()
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._flush_calls")
+    @traced(name="clickhouse_trace_server_batched._flush_calls")
     def _flush_calls(self) -> None:
         try:
             self._insert_call_batch(self._call_batch)
@@ -7523,7 +7500,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             do_sync_insert=do_sync_insert,
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._flush_calls_complete")
+    @traced(name="clickhouse_trace_server_batched._flush_calls_complete")
     def _flush_calls_complete(self) -> None:
         """Flush the calls_complete batch to the database."""
         if not self._calls_complete_batch:
@@ -7538,7 +7515,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         finally:
             self._calls_complete_batch = []
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._strip_large_values")
+    @traced(name="clickhouse_trace_server_batched._strip_large_values")
     def _strip_large_values(self, batch: list[list[Any]]) -> list[list[Any]]:
         """Iterate through the batch and replace large JSON values with placeholders.
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1980,6 +1980,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self.ch_client,
         )
         if write_target == WriteTarget.CALLS_COMPLETE:
+            # _ensure_valid_update_field guarantees display_name is not None.
+            assert req.display_name is not None
             self._update_calls_complete(req.project_id, req.call_id, req.display_name)
             return tsi.CallUpdateRes()
 
@@ -3082,7 +3084,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.AnnotationQueueCreateRes(id=queue_id)
 
-    @traced_generator(name="clickhouse_trace_server_batched.annotation_queues_query_stream")
+    @traced_generator(
+        name="clickhouse_trace_server_batched.annotation_queues_query_stream"
+    )
     def annotation_queues_query_stream(
         self, req: tsi.AnnotationQueuesQueryReq
     ) -> Iterator[tsi.AnnotationQueueSchema]:
@@ -3538,7 +3542,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         raise ValueError(f"Failed to fetch queue item '{item_id}'")
 
-    @traced(name="clickhouse_trace_server_batched.annotator_queue_items_progress_update")
+    @traced(
+        name="clickhouse_trace_server_batched.annotator_queue_items_progress_update"
+    )
     def annotator_queue_items_progress_update(
         self, req: tsi.AnnotatorQueueItemsProgressUpdateReq
     ) -> tsi.AnnotatorQueueItemsProgressUpdateRes:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -319,6 +319,7 @@ from weave.trace_server.trace_server_interface import (
     EvaluateModelArgs,
     RescoringArgs,
 )
+from weave.trace_server.tracing import traced, traced_generator
 from weave.trace_server.ttl_settings import (
     RETENTION_DAYS_NO_TTL,
     get_project_retention_days,
@@ -327,7 +328,6 @@ from weave.trace_server.ttl_settings import (
 from weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker import (
     EvaluateModelDispatcher,
 )
-from weave.trace_server.tracing import traced, traced_generator
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -172,7 +172,6 @@ from weave.trace_server.constants import (
 from weave.trace_server.datadog import (
     record_db_insert,
     set_current_span_dd_tags,
-    set_root_span_dd_tags,
     tag_db_insert_path,
 )
 from weave.trace_server.dataset_sources import DatasetSourcesHandler
@@ -2243,7 +2242,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         obj_schema = ch_obj_to_obj_schema(obj)
         if req.include_tags_and_aliases:
-            set_root_span_dd_tags({"include_tags_and_aliases": True})
+            set_current_span_dd_tags({"include_tags_and_aliases": True})
             self._enrich_objs_with_tags_and_aliases(req.project_id, [obj_schema])
         return tsi.ObjReadRes(obj=obj_schema)
 
@@ -2291,7 +2290,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         objs = self._select_objs_query(object_query_builder, metadata_only)
         obj_schemas = [ch_obj_to_obj_schema(obj) for obj in objs]
         if req.include_tags_and_aliases:
-            set_root_span_dd_tags({"include_tags_and_aliases": True})
+            set_current_span_dd_tags({"include_tags_and_aliases": True})
             self._enrich_objs_with_tags_and_aliases(req.project_id, obj_schemas)
         return tsi.ObjQueryRes(objs=obj_schemas)
 
@@ -6096,12 +6095,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 self._file_create_clickhouse(req, digest)
         else:
             self._file_create_clickhouse(req, digest)
-        set_root_span_dd_tags({"write_bytes": len(req.content)})
+        set_current_span_dd_tags({"write_bytes": len(req.content)})
         return tsi.FileCreateRes(digest=digest)
 
     @traced(name="clickhouse_trace_server_batched._file_create_clickhouse")
     def _file_create_clickhouse(self, req: tsi.FileCreateReq, digest: str) -> None:
-        set_root_span_dd_tags({"storage_provider": "clickhouse"})
+        set_current_span_dd_tags({"storage_provider": "clickhouse"})
         self._insert_file_chunks(file_chunks_for(req, digest))
 
     @traced(name="clickhouse_trace_server_batched._file_create_bucket")
@@ -6117,7 +6116,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             # tag matches where the bytes actually land.
             self._bucket_uploads.stage(req, digest)
             return
-        set_root_span_dd_tags({"storage_provider": "bucket"})
+        set_current_span_dd_tags({"storage_provider": "bucket"})
         target_file_storage_uri = store_in_bucket(
             client, key_for_project_digest(req.project_id, digest), req.content
         )
@@ -6268,14 +6267,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             else:
                 chunk_bytes = result_row[1]
                 bytes += chunk_bytes
-                set_root_span_dd_tags({"storage_provider": "clickhouse"})
+                set_current_span_dd_tags({"storage_provider": "clickhouse"})
 
-        set_root_span_dd_tags({"read_bytes": len(bytes)})
+        set_current_span_dd_tags({"read_bytes": len(bytes)})
         return tsi.FileContentReadRes(content=bytes)
 
     @traced(name="clickhouse_trace_server_batched._file_read_bucket")
     def _file_read_bucket(self, file_storage_uri: FileStorageURI) -> bytes:
-        set_root_span_dd_tags({"storage_provider": "bucket"})
+        set_current_span_dd_tags({"storage_provider": "bucket"})
         client = self.file_storage_client
         if client is None:
             raise FileStorageReadError("File storage client is not configured")
@@ -6424,7 +6423,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         rows_to_insert = []
         results = []
 
-        set_root_span_dd_tags({"feedback_create_batch.count": len(req.batch)})
+        set_current_span_dd_tags({"feedback_create_batch.count": len(req.batch)})
 
         for feedback_req in req.batch:
             assert_non_null_wb_user_id(feedback_req)
@@ -7344,7 +7343,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 "clickhouse_trace_server_batched._insert.table": table,
             }
         )
-        set_root_span_dd_tags(
+        set_current_span_dd_tags(
             {
                 "weave_trace_server.insert.table": table,
                 "weave_trace_server.insert.row_count": len(data),

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -172,6 +172,7 @@ from weave.trace_server.constants import (
 from weave.trace_server.datadog import (
     record_db_insert,
     set_current_span_dd_tags,
+    set_root_span_dd_tags,
     tag_db_insert_path,
 )
 from weave.trace_server.dataset_sources import DatasetSourcesHandler
@@ -2244,7 +2245,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         obj_schema = ch_obj_to_obj_schema(obj)
         if req.include_tags_and_aliases:
-            set_current_span_dd_tags({"include_tags_and_aliases": True})
+            set_root_span_dd_tags({"include_tags_and_aliases": True})
             self._enrich_objs_with_tags_and_aliases(req.project_id, [obj_schema])
         return tsi.ObjReadRes(obj=obj_schema)
 
@@ -2292,7 +2293,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         objs = self._select_objs_query(object_query_builder, metadata_only)
         obj_schemas = [ch_obj_to_obj_schema(obj) for obj in objs]
         if req.include_tags_and_aliases:
-            set_current_span_dd_tags({"include_tags_and_aliases": True})
+            set_root_span_dd_tags({"include_tags_and_aliases": True})
             self._enrich_objs_with_tags_and_aliases(req.project_id, obj_schemas)
         return tsi.ObjQueryRes(objs=obj_schemas)
 
@@ -6101,12 +6102,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 self._file_create_clickhouse(req, digest)
         else:
             self._file_create_clickhouse(req, digest)
-        set_current_span_dd_tags({"write_bytes": len(req.content)})
+        set_root_span_dd_tags({"write_bytes": len(req.content)})
         return tsi.FileCreateRes(digest=digest)
 
     @traced(name="clickhouse_trace_server_batched._file_create_clickhouse")
     def _file_create_clickhouse(self, req: tsi.FileCreateReq, digest: str) -> None:
-        set_current_span_dd_tags({"storage_provider": "clickhouse"})
+        set_root_span_dd_tags({"storage_provider": "clickhouse"})
         self._insert_file_chunks(file_chunks_for(req, digest))
 
     @traced(name="clickhouse_trace_server_batched._file_create_bucket")
@@ -6122,7 +6123,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             # tag matches where the bytes actually land.
             self._bucket_uploads.stage(req, digest)
             return
-        set_current_span_dd_tags({"storage_provider": "bucket"})
+        set_root_span_dd_tags({"storage_provider": "bucket"})
         target_file_storage_uri = store_in_bucket(
             client, key_for_project_digest(req.project_id, digest), req.content
         )
@@ -6273,14 +6274,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             else:
                 chunk_bytes = result_row[1]
                 bytes += chunk_bytes
-                set_current_span_dd_tags({"storage_provider": "clickhouse"})
+                set_root_span_dd_tags({"storage_provider": "clickhouse"})
 
-        set_current_span_dd_tags({"read_bytes": len(bytes)})
+        set_root_span_dd_tags({"read_bytes": len(bytes)})
         return tsi.FileContentReadRes(content=bytes)
 
     @traced(name="clickhouse_trace_server_batched._file_read_bucket")
     def _file_read_bucket(self, file_storage_uri: FileStorageURI) -> bytes:
-        set_current_span_dd_tags({"storage_provider": "bucket"})
+        set_root_span_dd_tags({"storage_provider": "bucket"})
         client = self.file_storage_client
         if client is None:
             raise FileStorageReadError("File storage client is not configured")
@@ -6429,7 +6430,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         rows_to_insert = []
         results = []
 
-        set_current_span_dd_tags({"feedback_create_batch.count": len(req.batch)})
+        set_root_span_dd_tags({"feedback_create_batch.count": len(req.batch)})
 
         for feedback_req in req.batch:
             assert_non_null_wb_user_id(feedback_req)
@@ -7349,7 +7350,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 "clickhouse_trace_server_batched._insert.table": table,
             }
         )
-        set_current_span_dd_tags(
+        set_root_span_dd_tags(
             {
                 "weave_trace_server.insert.table": table,
                 "weave_trace_server.insert.row_count": len(data),


### PR DESCRIPTION
> **Stacked PR.** Base: #7258 (PR-1, decorator surface). Will auto-retarget to `master` once PR-1 merges.

## Summary

PR 2 of 4 in the `weave/trace_server/*` ddtrace → OpenTelemetry migration. Migrates the largest file: `clickhouse_trace_server_batched.py`.

**Changes:**

- 47 `@ddtrace.tracer.wrap(name=X)` → `@traced(name=X)` (span names preserved 1:1 so DD APM dashboards keep working).
- 4 generator functions → `@traced_generator(name=X)`:
  - `_table_query_stream`, `annotation_queues_query_stream` — were `@ddtrace.tracer.wrap` (see "bug fix" note below)
  - `_query_stream`, `calls_query_stream` — were `@generator_trace` (custom helper from `datadog.py`)
- `import ddtrace` removed from the file.
- `generator_trace` removed from the `datadog.py` import block (the symbol itself stays in `datadog.py` for one more PR).
- Adds `from weave.trace_server.tracing import traced, traced_generator`.

**Net diff:** +50 / −73 lines. Mostly the same shape as before, just with the decorator name swapped and (in 4 cases) the file's import line updated.

## Bug fix bundled in: generator span durations

`@ddtrace.tracer.wrap` on a generator function closes the span when the wrapper *returns the generator object* — that is, before iteration begins. So spans for `_table_query_stream` and `annotation_queues_query_stream` were reporting span durations of ~0ms regardless of how long the actual ClickHouse iteration took. We discovered this when investigating mismatches between our slow-query alerts and DD APM percentiles.

`@traced_generator` `yield from`s inside the span body, so the span correctly covers the full iteration. Post-migration we measure these at 12-50ms, matching actual CH query times.

This is a bug fix, not a regression — but call it out for reviewers who might wonder why span durations on these endpoints suddenly look longer.

The other 2 (`_query_stream`, `calls_query_stream`) were already on the custom `@generator_trace` helper, which `yield from`s correctly. They're swapped to `@traced_generator` for consistency; behavior unchanged.

## Validation

- AST audit: every `@traced` lands on a non-generator function, every `@traced_generator` on a generator. Mismatches: 0.
- `python -m py_compile weave/trace_server/clickhouse_trace_server_batched.py` — passes.
- `grep -n "ddtrace\|generator_trace" weave/trace_server/clickhouse_trace_server_batched.py` — no hits.
- Counts: 45 `@traced`, 4 `@traced_generator`, sum = 49 (= original 47 wraps + 2 generator_trace calls).

## Test plan

- [ ] CI green
- [ ] Existing `tests/trace_server/` suite unchanged (no test file edits in this PR)
- [ ] End-to-end smoke after merge (PoC already validated this on a wandbench cluster — see #7201 for evidence)

## Stack

1. ✅ #7258 — decorator surface (`weave/trace_server/tracing.py`)
2. ✅ **This PR** — `clickhouse_trace_server_batched.py`
3. ⏳ Coming — remaining 10 files in `weave/trace_server/*`
4. ⏳ Coming — `datadog.py` rewrite + drop `ddtrace>=2.7.0` from `pyproject.toml`

## Historical PoC

PoC PR #7201 stays open as historical reference (validated end-to-end on a wandbench cluster under SDK load). This PR is the merge candidate.
