### PR TITLE
feat(weave): migrate 10 remaining weave/trace_server files to @traced

### DIFF
--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -13,8 +13,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, TypeVar, cast
 
-import ddtrace
-
 from weave.shared import refs_internal as ri
 from weave.trace_server.agents.chat_view import (
     add_optional_cost,
@@ -85,6 +83,7 @@ from weave.trace_server.agents.types import (
 )
 from weave.trace_server.clickhouse.utilities import insert_with_empty_query_retry
 from weave.trace_server.datadog import record_db_insert, set_root_span_dd_tags
+from weave.trace_server.tracing import traced
 from weave.trace_server.interface.query import Query
 from weave.trace_server.opentelemetry.genai_extraction import extract_genai_span
 from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
@@ -905,7 +904,7 @@ class AgentWriteHandler:
         """
         self.insert_spans([span])
 
-    @ddtrace.tracer.wrap(name="agents.clickhouse.insert_spans")
+    @traced(name="agents.clickhouse.insert_spans")
     def insert_spans(self, span_rows: list[AgentSpanCHInsertable]) -> None:
         """Bulk-insert pre-built span rows in one round-trip; traced for APM.
 

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -83,7 +83,6 @@ from weave.trace_server.agents.types import (
 )
 from weave.trace_server.clickhouse.utilities import insert_with_empty_query_retry
 from weave.trace_server.datadog import record_db_insert, set_root_span_dd_tags
-from weave.trace_server.tracing import traced
 from weave.trace_server.interface.query import Query
 from weave.trace_server.opentelemetry.genai_extraction import extract_genai_span
 from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
@@ -123,6 +122,7 @@ from weave.trace_server.trace_server_interface import (
     FeedbackQueryReq,
     FeedbackQueryRes,
 )
+from weave.trace_server.tracing import traced
 
 if TYPE_CHECKING:
     from clickhouse_connect.driver.client import Client as CHClient

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -9,7 +9,6 @@ import logging
 import re
 from typing import Any, TypeVar
 
-
 from weave.trace_server.content.content import Content
 from weave.trace_server.trace_server_interface import (
     CallEndReq,

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -9,7 +9,6 @@ import logging
 import re
 from typing import Any, TypeVar
 
-import ddtrace
 
 from weave.trace_server.content.content import Content
 from weave.trace_server.trace_server_interface import (
@@ -20,6 +19,7 @@ from weave.trace_server.trace_server_interface import (
     FileCreateReq,
     TraceServerInterface,
 )
+from weave.trace_server.tracing import traced
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ def is_data_uri(data_uri: str) -> bool:
     return DATA_URI_PATTERN.match(data_uri) is not None
 
 
-@ddtrace.tracer.wrap(name="store_content_object")
+@traced(name="store_content_object")
 def store_content_object(
     content_obj: Content,
     project_id: str,

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 from collections.abc import Sequence
 from typing import Any, TypeVar, cast
 
-import ddtrace
 import sqlparse
 from clickhouse_connect.driver.client import Client as CHClient
 from clickhouse_connect.driver.exceptions import DatabaseError
@@ -23,6 +22,7 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.datadog import set_current_span_dd_tags
 from weave.trace_server.errors import InsertTooLarge
 from weave.trace_server.kafka import KafkaProducer
+from weave.trace_server.tracing import traced
 
 logger = logging.getLogger(__name__)
 
@@ -398,7 +398,7 @@ def maybe_enqueue_minimal_call_end(
 # ---------------------------------------------------------------------------
 
 
-@ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.find_call_descendants")
+@traced(name="clickhouse_trace_server_batched.find_call_descendants")
 def find_call_descendants(
     root_ids: list[str],
     all_calls: list[tsi.CallSchema],

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -3663,27 +3663,25 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
     # Dataset Sources API
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.dataset_sources_link")
+    @traced(name="clickhouse_trace_server_batched.dataset_sources_link")
     def dataset_sources_link(
         self, req: tsi.DatasetSourcesLinkReq
     ) -> tsi.DatasetSourcesLinkRes:
         return self._dataset_sources_handler().link(req)
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.dataset_sources_link_delete"
-    )
+    @traced(name="clickhouse_trace_server_batched.dataset_sources_link_delete")
     def dataset_sources_link_delete(
         self, req: tsi.DatasetSourcesLinkDeleteReq
     ) -> tsi.DatasetSourcesLinkDeleteRes:
         return self._dataset_sources_handler().link_delete(req)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.dataset_sources_query")
+    @traced(name="clickhouse_trace_server_batched.dataset_sources_query")
     def dataset_sources_query(
         self, req: tsi.DatasetSourcesQueryReq
     ) -> tsi.DatasetSourcesQueryRes:
         return self._dataset_sources_handler().query(req)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.source_datasets_query")
+    @traced(name="clickhouse_trace_server_batched.source_datasets_query")
     def source_datasets_query(
         self, req: tsi.SourceDatasetsQueryReq
     ) -> tsi.SourceDatasetsQueryRes:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -15,7 +15,6 @@ from typing import Any, NamedTuple, TypeVar, cast
 from zoneinfo import ZoneInfo
 
 import clickhouse_connect
-import ddtrace
 from cachetools import TTLCache
 from clickhouse_connect import common as ch_common
 from clickhouse_connect.driver.client import Client as CHClient
@@ -171,7 +170,6 @@ from weave.trace_server.constants import (
     IMAGE_GENERATION_CREATE_OP_NAME,
 )
 from weave.trace_server.datadog import (
-    generator_trace,
     record_db_insert,
     set_current_span_dd_tags,
     set_root_span_dd_tags,
@@ -329,6 +327,7 @@ from weave.trace_server.ttl_settings import (
 from weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker import (
     EvaluateModelDispatcher,
 )
+from weave.trace_server.tracing import traced, traced_generator
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -662,7 +661,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
     @tag_db_insert_path("otel_export")
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.otel_export")
+    @traced(name="clickhouse_trace_server_batched.otel_export")
     def otel_export(self, req: tsi.OTelExportReq) -> tsi.OTelExportRes:
         assert_non_null_wb_user_id(req)
         calls, rejected_spans, error_messages = self._otel_proto_to_calls(req)
@@ -759,9 +758,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             )
         return tsi.OTelExportRes()
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.otel_export.proto_to_calls"
-    )
+    @traced(name="clickhouse_trace_server_batched.otel_export.proto_to_calls")
     def _otel_proto_to_calls(
         self, req: tsi.OTelExportReq
     ) -> tuple[
@@ -818,7 +815,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         set_current_span_dd_tags({"call_count": len(calls)})
         return calls, rejected_spans, error_messages
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.otel_export.build_rows")
+    @traced(name="clickhouse_trace_server_batched.otel_export.build_rows")
     def _otel_build_rows(
         self,
         calls: list[
@@ -852,7 +849,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         set_current_span_dd_tags({"row_count": len(rows)})
         return rows
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.kafka_producer.flush")
+    @traced(name="clickhouse_trace_server_batched.kafka_producer.flush")
     def _flush_kafka_producer(self) -> None:
         producer = self.kafka_producer
         if producer is not None:
@@ -1129,9 +1126,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.CallEndV2Res()
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched._update_call_end_in_calls_complete"
-    )
+    @traced(name="clickhouse_trace_server_batched._update_call_end_in_calls_complete")
     def _update_call_end_in_calls_complete(
         self, end_call: tsi.EndedCallSchemaForInsert
     ) -> None:
@@ -1277,7 +1272,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         stream = self.calls_query_stream(req)
         return tsi.CallsQueryRes(calls=list(stream))
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.calls_query_stats")
+    @traced(name="clickhouse_trace_server_batched.calls_query_stats")
     def calls_query_stats(self, req: tsi.CallsQueryStatsReq) -> tsi.CallsQueryStatsRes:
         """Returns a stats object for the given query. This is useful for counts or other
         aggregate statistics that are not directly queryable from the calls themselves.
@@ -1495,7 +1490,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         """Discover feedback payload schema from sample rows."""
         return feedback_payload_schema_handler(self, req)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.trace_usage")
+    @traced(name="clickhouse_trace_server_batched.trace_usage")
     def trace_usage(self, req: tsi.TraceUsageReq) -> tsi.TraceUsageRes:
         """Compute per-call usage for a trace, with descendant rollup.
 
@@ -1535,7 +1530,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             unfinished_call_ids=sorted(unfinished_call_ids),
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.calls_usage")
+    @traced(name="clickhouse_trace_server_batched.calls_usage")
     def calls_usage(self, req: tsi.CallsUsageReq) -> tsi.CallsUsageRes:
         """Compute aggregated usage for multiple root calls.
 
@@ -1599,7 +1594,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             unfinished_call_ids=sorted(unfinished_call_ids),
         )
 
-    @generator_trace("clickhouse_trace_server_batched.calls_query_stream")
+    @traced_generator(name="clickhouse_trace_server_batched.calls_query_stream")
     def calls_query_stream(self, req: tsi.CallsQueryReq) -> Iterator[tsi.CallSchema]:
         """Returns a stream of calls that match the given query."""
         read_table = self.table_routing_resolver.resolve_read_table(
@@ -1751,7 +1746,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             if hasattr(raw_res, "close"):
                 raw_res.close()
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._add_feedback_to_calls")
+    @traced(name="clickhouse_trace_server_batched._add_feedback_to_calls")
     def _add_feedback_to_calls(
         self, project_id: str, calls: list[dict[str, Any]]
     ) -> None:
@@ -1785,7 +1780,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 refs_to_resolve[i, col] = ref
         return refs_to_resolve
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._expand_call_refs")
+    @traced(name="clickhouse_trace_server_batched._expand_call_refs")
     def _expand_call_refs(
         self,
         project_id: str,
@@ -1833,7 +1828,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                         val["_ref"] = ref.uri
                     set_nested_key(calls[i], col, val)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.calls_delete")
+    @traced(name="clickhouse_trace_server_batched.calls_delete")
     @tag_db_insert_path("calls_delete")
     def calls_delete(self, req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
         assert_non_null_wb_user_id(req)
@@ -1929,7 +1924,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.CallsDeleteRes(num_deleted=len(all_descendants))
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._delete_calls_complete")
+    @traced(name="clickhouse_trace_server_batched._delete_calls_complete")
     def _delete_calls_complete(
         self,
         project_id: str,
@@ -1975,7 +1970,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             f"One of [{', '.join(valid_update_fields)}] is required for call update"
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.call_update")
+    @traced(name="clickhouse_trace_server_batched.call_update")
     @tag_db_insert_path("call_update")
     def call_update(self, req: tsi.CallUpdateReq) -> tsi.CallUpdateRes:
         assert_non_null_wb_user_id(req)
@@ -1999,7 +1994,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.CallUpdateRes()
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._update_calls_complete")
+    @traced(name="clickhouse_trace_server_batched._update_calls_complete")
     def _update_calls_complete(
         self, project_id: str, call_id: str, display_name: str
     ) -> None:
@@ -2022,7 +2017,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             settings=ch_settings.CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.obj_create")
+    @traced(name="clickhouse_trace_server_batched.obj_create")
     @tag_db_insert_path("obj_create")
     def obj_create(self, req: tsi.ObjCreateReq) -> tsi.ObjCreateRes:
         # Partial-failure semantics: ClickHouse cannot atomically write
@@ -2123,7 +2118,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 existing_base_object_classes=mismatched,
             )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.create_obj_batch")
+    @traced(name="clickhouse_trace_server_batched.create_obj_batch")
     @tag_db_insert_path("obj_create_batch")
     def obj_create_batch(
         self, batch: list[tsi.ObjSchemaForInsert]
@@ -2252,7 +2247,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._enrich_objs_with_tags_and_aliases(req.project_id, [obj_schema])
         return tsi.ObjReadRes(obj=obj_schema)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.objs_query")
+    @traced(name="clickhouse_trace_server_batched.objs_query")
     def objs_query(self, req: tsi.ObjQueryReq) -> tsi.ObjQueryRes:
         object_query_builder = ObjectMetadataQueryBuilder(req.project_id)
         if req.filter:
@@ -2525,7 +2520,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         aliases = [row[0] for row in query_result.result_rows]
         return tsi.AliasesListRes(aliases=aliases)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._get_tags_for_objects")
+    @traced(name="clickhouse_trace_server_batched._get_tags_for_objects")
     def _get_tags_for_objects(
         self,
         project_id: str,
@@ -2544,9 +2539,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             result.setdefault(key, []).append(row[2])
         return result
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched._get_aliases_for_objects"
-    )
+    @traced(name="clickhouse_trace_server_batched._get_aliases_for_objects")
     def _get_aliases_for_objects(
         self,
         project_id: str,
@@ -2565,7 +2558,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             result.setdefault(key, []).append(row[2])
         return result
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._maybe_resolve_alias")
+    @traced(name="clickhouse_trace_server_batched._maybe_resolve_alias")
     def _maybe_resolve_alias(
         self,
         project_id: str,
@@ -2800,7 +2793,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             offset=req.offset,
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._table_query_stream")
+    @traced_generator(name="clickhouse_trace_server_batched._table_query_stream")
     def _table_query_stream(
         self,
         project_id: str,
@@ -2955,9 +2948,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             **dict(zip(columns, query_result.result_rows[0], strict=False))
         )
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.project_ttl_settings_read"
-    )
+    @traced(name="clickhouse_trace_server_batched.project_ttl_settings_read")
     def project_ttl_settings_read(
         self, req: tsi.ProjectTTLSettingsReadReq
     ) -> tsi.ProjectTTLSettingsReadRes:
@@ -2967,9 +2958,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
     @tag_db_insert_path("project_ttl_settings_update")
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.project_ttl_settings_update"
-    )
+    @traced(name="clickhouse_trace_server_batched.project_ttl_settings_update")
     def project_ttl_settings_update(
         self, req: tsi.ProjectTTLSettingsUpdateReq
     ) -> tsi.ProjectTTLSettingsUpdateRes:
@@ -3064,7 +3053,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             )
 
     # Annotation Queue API
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.annotation_queue_create")
+    @traced(name="clickhouse_trace_server_batched.annotation_queue_create")
     def annotation_queue_create(
         self, req: tsi.AnnotationQueueCreateReq
     ) -> tsi.AnnotationQueueCreateRes:
@@ -3094,9 +3083,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.AnnotationQueueCreateRes(id=queue_id)
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.annotation_queues_query_stream"
-    )
+    @traced_generator(name="clickhouse_trace_server_batched.annotation_queues_query_stream")
     def annotation_queues_query_stream(
         self, req: tsi.AnnotationQueuesQueryReq
     ) -> Iterator[tsi.AnnotationQueueSchema]:
@@ -3149,7 +3136,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 deleted_at=deleted_at_with_tz,
             )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.annotation_queue_read")
+    @traced(name="clickhouse_trace_server_batched.annotation_queue_read")
     def annotation_queue_read(
         self, req: tsi.AnnotationQueueReadReq
     ) -> tsi.AnnotationQueueReadRes:
@@ -3183,7 +3170,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.AnnotationQueueReadRes(queue=queue)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.annotation_queue_update")
+    @traced(name="clickhouse_trace_server_batched.annotation_queue_update")
     def annotation_queue_update(
         self, req: tsi.AnnotationQueueUpdateReq
     ) -> tsi.AnnotationQueueUpdateRes:
@@ -3280,7 +3267,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.AnnotationQueueUpdateRes(queue=queue)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.annotation_queue_delete")
+    @traced(name="clickhouse_trace_server_batched.annotation_queue_delete")
     def annotation_queue_delete(
         self, req: tsi.AnnotationQueueDeleteReq
     ) -> tsi.AnnotationQueueDeleteRes:
@@ -3337,9 +3324,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return tsi.AnnotationQueueDeleteRes(queue=queue)
 
     @tag_db_insert_path("annotation_queue_add_calls")
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.annotation_queue_add_calls"
-    )
+    @traced(name="clickhouse_trace_server_batched.annotation_queue_add_calls")
     def annotation_queue_add_calls(
         self, req: tsi.AnnotationQueueAddCallsReq
     ) -> tsi.AnnotationQueueAddCallsRes:
@@ -3434,9 +3419,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             added_count=len(calls_data), duplicates=len(existing_call_ids)
         )
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.annotation_queue_items_query"
-    )
+    @traced(name="clickhouse_trace_server_batched.annotation_queue_items_query")
     def annotation_queue_items_query(
         self, req: tsi.AnnotationQueueItemsQueryReq
     ) -> tsi.AnnotationQueueItemsQueryRes:
@@ -3482,7 +3465,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.AnnotationQueueItemsQueryRes(items=items)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.annotation_queues_stats")
+    @traced(name="clickhouse_trace_server_batched.annotation_queues_stats")
     def annotation_queues_stats(
         self, req: tsi.AnnotationQueuesStatsReq
     ) -> tsi.AnnotationQueuesStatsRes:
@@ -3556,9 +3539,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         raise ValueError(f"Failed to fetch queue item '{item_id}'")
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched.annotator_queue_items_progress_update"
-    )
+    @traced(name="clickhouse_trace_server_batched.annotator_queue_items_progress_update")
     def annotator_queue_items_progress_update(
         self, req: tsi.AnnotatorQueueItemsProgressUpdateReq
     ) -> tsi.AnnotatorQueueItemsProgressUpdateRes:
@@ -5791,7 +5772,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return _do_read()
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._obj_read_with_retry")
+    @traced(name="clickhouse_trace_server_batched._obj_read_with_retry")
     def _obj_read_with_retry(
         self, req: tsi.ObjReadReq, max_attempts: int = 2
     ) -> tsi.ObjReadRes:
@@ -5800,9 +5781,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             lambda: self.obj_read(req), max_attempts=max_attempts
         )
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched._file_content_read_with_retry"
-    )
+    @traced(name="clickhouse_trace_server_batched._file_content_read_with_retry")
     def _file_content_read_with_retry(
         self, req: tsi.FileContentReadReq, max_attempts: int = 2
     ) -> tsi.FileContentReadRes:
@@ -5811,7 +5790,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             lambda: self._file_content_read_once(req), max_attempts=max_attempts
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._parsed_refs_read_batch")
+    @traced(name="clickhouse_trace_server_batched._parsed_refs_read_batch")
     def _parsed_refs_read_batch(
         self,
         parsed_refs: ObjRefListType,
@@ -5840,9 +5819,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # Return the final data payload
         return [final_result_cache[make_ref_cache_key(ref)] for ref in parsed_refs]
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched._refs_read_batch_within_project"
-    )
+    @traced(name="clickhouse_trace_server_batched._refs_read_batch_within_project")
     def _refs_read_batch_within_project(
         self,
         project_id_scope: str,
@@ -6122,12 +6099,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         set_root_span_dd_tags({"write_bytes": len(req.content)})
         return tsi.FileCreateRes(digest=digest)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._file_create_clickhouse")
+    @traced(name="clickhouse_trace_server_batched._file_create_clickhouse")
     def _file_create_clickhouse(self, req: tsi.FileCreateReq, digest: str) -> None:
         set_root_span_dd_tags({"storage_provider": "clickhouse"})
         self._insert_file_chunks(file_chunks_for(req, digest))
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._file_create_bucket")
+    @traced(name="clickhouse_trace_server_batched._file_create_bucket")
     def _file_create_bucket(
         self, req: tsi.FileCreateReq, digest: str, client: FileStorageClient
     ) -> None:
@@ -6159,7 +6136,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             ]
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._flush_file_chunks")
+    @traced(name="clickhouse_trace_server_batched._flush_file_chunks")
     def _flush_file_chunks(self) -> None:
         if not self._flush_immediately:
             raise ValueError("File chunks must be flushed immediately")
@@ -6296,7 +6273,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         set_root_span_dd_tags({"read_bytes": len(bytes)})
         return tsi.FileContentReadRes(content=bytes)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._file_read_bucket")
+    @traced(name="clickhouse_trace_server_batched._file_read_bucket")
     def _file_read_bucket(self, file_storage_uri: FileStorageURI) -> bytes:
         set_root_span_dd_tags({"storage_provider": "bucket"})
         client = self.file_storage_client
@@ -6438,7 +6415,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return format_feedback_to_res(row)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.feedback_create_batch")
+    @traced(name="clickhouse_trace_server_batched.feedback_create_batch")
     @tag_db_insert_path("feedback_create_batch")
     def feedback_create_batch(
         self, req: tsi.FeedbackCreateBatchReq
@@ -7206,7 +7183,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         migrator.apply_migrations(self._database)
 
-    @generator_trace("clickhouse_trace_server_batched._query_stream")
+    @traced_generator(name="clickhouse_trace_server_batched._query_stream")
     def _query_stream(
         self,
         query: str,
@@ -7255,7 +7232,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             # always raises, optionally with custom error class
             handle_clickhouse_query_error(e)
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._query")
+    @traced(name="clickhouse_trace_server_batched._query")
     def _query(
         self,
         query: str,
@@ -7303,7 +7280,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         return res
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._command")
+    @traced(name="clickhouse_trace_server_batched._command")
     def _command(
         self,
         command: str,
@@ -7352,7 +7329,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         return
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._insert")
+    @traced(name="clickhouse_trace_server_batched._insert")
     def _insert(
         self,
         table: str,
@@ -7439,7 +7416,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if self._flush_immediately:
             self._flush_calls()
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._flush_calls")
+    @traced(name="clickhouse_trace_server_batched._flush_calls")
     def _flush_calls(self) -> None:
         try:
             self._insert_call_batch(self._call_batch)
@@ -7523,7 +7500,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             do_sync_insert=do_sync_insert,
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._flush_calls_complete")
+    @traced(name="clickhouse_trace_server_batched._flush_calls_complete")
     def _flush_calls_complete(self) -> None:
         """Flush the calls_complete batch to the database."""
         if not self._calls_complete_batch:
@@ -7538,7 +7515,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         finally:
             self._calls_complete_batch = []
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._strip_large_values")
+    @traced(name="clickhouse_trace_server_batched._strip_large_values")
     def _strip_large_values(self, batch: list[list[Any]]) -> list[list[Any]]:
         """Iterate through the batch and replace large JSON values with placeholders.
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1980,6 +1980,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self.ch_client,
         )
         if write_target == WriteTarget.CALLS_COMPLETE:
+            # _ensure_valid_update_field guarantees display_name is not None.
+            assert req.display_name is not None
             self._update_calls_complete(req.project_id, req.call_id, req.display_name)
             return tsi.CallUpdateRes()
 
@@ -3082,7 +3084,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.AnnotationQueueCreateRes(id=queue_id)
 
-    @traced_generator(name="clickhouse_trace_server_batched.annotation_queues_query_stream")
+    @traced_generator(
+        name="clickhouse_trace_server_batched.annotation_queues_query_stream"
+    )
     def annotation_queues_query_stream(
         self, req: tsi.AnnotationQueuesQueryReq
     ) -> Iterator[tsi.AnnotationQueueSchema]:
@@ -3538,7 +3542,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         raise ValueError(f"Failed to fetch queue item '{item_id}'")
 
-    @traced(name="clickhouse_trace_server_batched.annotator_queue_items_progress_update")
+    @traced(
+        name="clickhouse_trace_server_batched.annotator_queue_items_progress_update"
+    )
     def annotator_queue_items_progress_update(
         self, req: tsi.AnnotatorQueueItemsProgressUpdateReq
     ) -> tsi.AnnotatorQueueItemsProgressUpdateRes:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -319,6 +319,7 @@ from weave.trace_server.trace_server_interface import (
     EvaluateModelArgs,
     RescoringArgs,
 )
+from weave.trace_server.tracing import traced, traced_generator
 from weave.trace_server.ttl_settings import (
     RETENTION_DAYS_NO_TTL,
     get_project_retention_days,
@@ -327,7 +328,6 @@ from weave.trace_server.ttl_settings import (
 from weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker import (
     EvaluateModelDispatcher,
 )
-from weave.trace_server.tracing import traced, traced_generator
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -172,7 +172,6 @@ from weave.trace_server.constants import (
 from weave.trace_server.datadog import (
     record_db_insert,
     set_current_span_dd_tags,
-    set_root_span_dd_tags,
     tag_db_insert_path,
 )
 from weave.trace_server.dataset_sources import DatasetSourcesHandler
@@ -2243,7 +2242,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         obj_schema = ch_obj_to_obj_schema(obj)
         if req.include_tags_and_aliases:
-            set_root_span_dd_tags({"include_tags_and_aliases": True})
+            set_current_span_dd_tags({"include_tags_and_aliases": True})
             self._enrich_objs_with_tags_and_aliases(req.project_id, [obj_schema])
         return tsi.ObjReadRes(obj=obj_schema)
 
@@ -2291,7 +2290,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         objs = self._select_objs_query(object_query_builder, metadata_only)
         obj_schemas = [ch_obj_to_obj_schema(obj) for obj in objs]
         if req.include_tags_and_aliases:
-            set_root_span_dd_tags({"include_tags_and_aliases": True})
+            set_current_span_dd_tags({"include_tags_and_aliases": True})
             self._enrich_objs_with_tags_and_aliases(req.project_id, obj_schemas)
         return tsi.ObjQueryRes(objs=obj_schemas)
 
@@ -6096,12 +6095,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 self._file_create_clickhouse(req, digest)
         else:
             self._file_create_clickhouse(req, digest)
-        set_root_span_dd_tags({"write_bytes": len(req.content)})
+        set_current_span_dd_tags({"write_bytes": len(req.content)})
         return tsi.FileCreateRes(digest=digest)
 
     @traced(name="clickhouse_trace_server_batched._file_create_clickhouse")
     def _file_create_clickhouse(self, req: tsi.FileCreateReq, digest: str) -> None:
-        set_root_span_dd_tags({"storage_provider": "clickhouse"})
+        set_current_span_dd_tags({"storage_provider": "clickhouse"})
         self._insert_file_chunks(file_chunks_for(req, digest))
 
     @traced(name="clickhouse_trace_server_batched._file_create_bucket")
@@ -6117,7 +6116,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             # tag matches where the bytes actually land.
             self._bucket_uploads.stage(req, digest)
             return
-        set_root_span_dd_tags({"storage_provider": "bucket"})
+        set_current_span_dd_tags({"storage_provider": "bucket"})
         target_file_storage_uri = store_in_bucket(
             client, key_for_project_digest(req.project_id, digest), req.content
         )
@@ -6268,14 +6267,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             else:
                 chunk_bytes = result_row[1]
                 bytes += chunk_bytes
-                set_root_span_dd_tags({"storage_provider": "clickhouse"})
+                set_current_span_dd_tags({"storage_provider": "clickhouse"})
 
-        set_root_span_dd_tags({"read_bytes": len(bytes)})
+        set_current_span_dd_tags({"read_bytes": len(bytes)})
         return tsi.FileContentReadRes(content=bytes)
 
     @traced(name="clickhouse_trace_server_batched._file_read_bucket")
     def _file_read_bucket(self, file_storage_uri: FileStorageURI) -> bytes:
-        set_root_span_dd_tags({"storage_provider": "bucket"})
+        set_current_span_dd_tags({"storage_provider": "bucket"})
         client = self.file_storage_client
         if client is None:
             raise FileStorageReadError("File storage client is not configured")
@@ -6424,7 +6423,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         rows_to_insert = []
         results = []
 
-        set_root_span_dd_tags({"feedback_create_batch.count": len(req.batch)})
+        set_current_span_dd_tags({"feedback_create_batch.count": len(req.batch)})
 
         for feedback_req in req.batch:
             assert_non_null_wb_user_id(feedback_req)
@@ -7344,7 +7343,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 "clickhouse_trace_server_batched._insert.table": table,
             }
         )
-        set_root_span_dd_tags(
+        set_current_span_dd_tags(
             {
                 "weave_trace_server.insert.table": table,
                 "weave_trace_server.insert.row_count": len(data),

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -172,6 +172,7 @@ from weave.trace_server.constants import (
 from weave.trace_server.datadog import (
     record_db_insert,
     set_current_span_dd_tags,
+    set_root_span_dd_tags,
     tag_db_insert_path,
 )
 from weave.trace_server.dataset_sources import DatasetSourcesHandler
@@ -2244,7 +2245,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         obj_schema = ch_obj_to_obj_schema(obj)
         if req.include_tags_and_aliases:
-            set_current_span_dd_tags({"include_tags_and_aliases": True})
+            set_root_span_dd_tags({"include_tags_and_aliases": True})
             self._enrich_objs_with_tags_and_aliases(req.project_id, [obj_schema])
         return tsi.ObjReadRes(obj=obj_schema)
 
@@ -2292,7 +2293,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         objs = self._select_objs_query(object_query_builder, metadata_only)
         obj_schemas = [ch_obj_to_obj_schema(obj) for obj in objs]
         if req.include_tags_and_aliases:
-            set_current_span_dd_tags({"include_tags_and_aliases": True})
+            set_root_span_dd_tags({"include_tags_and_aliases": True})
             self._enrich_objs_with_tags_and_aliases(req.project_id, obj_schemas)
         return tsi.ObjQueryRes(objs=obj_schemas)
 
@@ -6101,12 +6102,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 self._file_create_clickhouse(req, digest)
         else:
             self._file_create_clickhouse(req, digest)
-        set_current_span_dd_tags({"write_bytes": len(req.content)})
+        set_root_span_dd_tags({"write_bytes": len(req.content)})
         return tsi.FileCreateRes(digest=digest)
 
     @traced(name="clickhouse_trace_server_batched._file_create_clickhouse")
     def _file_create_clickhouse(self, req: tsi.FileCreateReq, digest: str) -> None:
-        set_current_span_dd_tags({"storage_provider": "clickhouse"})
+        set_root_span_dd_tags({"storage_provider": "clickhouse"})
         self._insert_file_chunks(file_chunks_for(req, digest))
 
     @traced(name="clickhouse_trace_server_batched._file_create_bucket")
@@ -6122,7 +6123,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             # tag matches where the bytes actually land.
             self._bucket_uploads.stage(req, digest)
             return
-        set_current_span_dd_tags({"storage_provider": "bucket"})
+        set_root_span_dd_tags({"storage_provider": "bucket"})
         target_file_storage_uri = store_in_bucket(
             client, key_for_project_digest(req.project_id, digest), req.content
         )
@@ -6273,14 +6274,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             else:
                 chunk_bytes = result_row[1]
                 bytes += chunk_bytes
-                set_current_span_dd_tags({"storage_provider": "clickhouse"})
+                set_root_span_dd_tags({"storage_provider": "clickhouse"})
 
-        set_current_span_dd_tags({"read_bytes": len(bytes)})
+        set_root_span_dd_tags({"read_bytes": len(bytes)})
         return tsi.FileContentReadRes(content=bytes)
 
     @traced(name="clickhouse_trace_server_batched._file_read_bucket")
     def _file_read_bucket(self, file_storage_uri: FileStorageURI) -> bytes:
-        set_current_span_dd_tags({"storage_provider": "bucket"})
+        set_root_span_dd_tags({"storage_provider": "bucket"})
         client = self.file_storage_client
         if client is None:
             raise FileStorageReadError("File storage client is not configured")
@@ -6429,7 +6430,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         rows_to_insert = []
         results = []
 
-        set_current_span_dd_tags({"feedback_create_batch.count": len(req.batch)})
+        set_root_span_dd_tags({"feedback_create_batch.count": len(req.batch)})
 
         for feedback_req in req.batch:
             assert_non_null_wb_user_id(feedback_req)
@@ -7349,7 +7350,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 "clickhouse_trace_server_batched._insert.table": table,
             }
         )
-        set_current_span_dd_tags(
+        set_root_span_dd_tags(
             {
                 "weave_trace_server.insert.table": table,
                 "weave_trace_server.insert.row_count": len(data),

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable
 from typing import Any
 
-import ddtrace
 from pydantic import ValidationError
 
 from weave.shared import refs_internal as ri
@@ -21,6 +20,7 @@ from weave.trace_server import constants
 from weave.trace_server import trace_server_common as tsc
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import InvalidRequest
+from weave.trace_server.tracing import traced
 
 _SUPPORTED_SORT_PREFIXES = (
     "scores.",
@@ -366,7 +366,7 @@ def _build_trial(
     )
 
 
-@ddtrace.tracer.wrap(name="eval_results_helpers.build_eval_rows_from_calls")
+@traced(name="eval_results_helpers.build_eval_rows_from_calls")
 def build_eval_rows_from_calls(
     predict_and_score_calls: list[tsi.CallSchema],
     child_by_parent: dict[str, list[tsi.CallSchema]],
@@ -432,7 +432,7 @@ def finalize_rows(
     return apply_row_selection(rows, eval_root_ids, require_intersection, offset, limit)
 
 
-@ddtrace.tracer.wrap(name="eval_results_helpers.build_eval_rows")
+@traced(name="eval_results_helpers.build_eval_rows")
 def build_eval_rows(
     page_calls: list[tsi.CallSchema],
     eval_root_ids: list[str],
@@ -541,7 +541,7 @@ def resolve_eval_row_refs(
     return []
 
 
-@ddtrace.tracer.wrap(name="eval_results_helpers.eval_results_grouped_rows")
+@traced(name="eval_results_helpers.eval_results_grouped_rows")
 def eval_results_grouped_rows(
     req: tsi.EvalResultsQueryReq,
     eval_root_ids: list[str],
@@ -575,7 +575,7 @@ def eval_results_grouped_rows(
     )
 
 
-@ddtrace.tracer.wrap(name="eval_results_helpers.fetch_eval_root_metadata")
+@traced(name="eval_results_helpers.fetch_eval_root_metadata")
 def fetch_eval_root_metadata(
     server: tsi.TraceServerInterface,
     project_id: str,
@@ -617,7 +617,7 @@ def validate_eval_results_request(req: tsi.EvalResultsQueryReq) -> None:
                 )
 
 
-@ddtrace.tracer.wrap(name="eval_results_helpers.eval_results_query")
+@traced(name="eval_results_helpers.eval_results_query")
 def eval_results_query(
     server: tsi.TraceServerInterface,
     req: tsi.EvalResultsQueryReq,
@@ -743,7 +743,7 @@ def _process_scorer_output(
             )
 
 
-@ddtrace.tracer.wrap(name="eval_results_helpers.compute_summary_from_rows")
+@traced(name="eval_results_helpers.compute_summary_from_rows")
 def compute_summary_from_rows(
     rows: list[tsi.EvalResultsRow],
     eval_call_metadata: dict[str, dict[str, Any]] | None = None,

--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -18,7 +18,7 @@ from weave.trace_server.agents.kafka_events import (
     SCORE_AGENT_SPANS_TOPIC,
     ScoreAgentSpansEvent,
 )
-from weave.trace_server.datadog import set_current_span_dd_tags
+from weave.trace_server.datadog import set_root_span_dd_tags
 from weave.trace_server.environment import (
     kafka_broker_host,
     kafka_broker_port,
@@ -203,7 +203,7 @@ class KafkaProducer(ConfluentKafkaProducer):
                     **(logging_extra or {}),
                 },
             )
-            set_current_span_dd_tags({"kafka.producer.buffer_size": buffer_size})
+            set_root_span_dd_tags({"kafka.producer.buffer_size": buffer_size})
             return True
 
         if buffer_size >= self.max_buffer_size * BUFFER_WARN_THRESHOLD:
@@ -218,7 +218,7 @@ class KafkaProducer(ConfluentKafkaProducer):
                     **(logging_extra or {}),
                 },
             )
-            set_current_span_dd_tags(
+            set_root_span_dd_tags(
                 {
                     "kafka.producer.buffer_size": buffer_size,
                     "kafka.producer.buffer_percentage": buffer_percentage,

--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -18,7 +18,7 @@ from weave.trace_server.agents.kafka_events import (
     SCORE_AGENT_SPANS_TOPIC,
     ScoreAgentSpansEvent,
 )
-from weave.trace_server.datadog import set_root_span_dd_tags
+from weave.trace_server.datadog import set_current_span_dd_tags
 from weave.trace_server.environment import (
     kafka_broker_host,
     kafka_broker_port,
@@ -203,7 +203,7 @@ class KafkaProducer(ConfluentKafkaProducer):
                     **(logging_extra or {}),
                 },
             )
-            set_root_span_dd_tags({"kafka.producer.buffer_size": buffer_size})
+            set_current_span_dd_tags({"kafka.producer.buffer_size": buffer_size})
             return True
 
         if buffer_size >= self.max_buffer_size * BUFFER_WARN_THRESHOLD:
@@ -218,7 +218,7 @@ class KafkaProducer(ConfluentKafkaProducer):
                     **(logging_extra or {}),
                 },
             )
-            set_root_span_dd_tags(
+            set_current_span_dd_tags(
                 {
                     "kafka.producer.buffer_size": buffer_size,
                     "kafka.producer.buffer_percentage": buffer_percentage,

--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -3,7 +3,6 @@ import socket
 import zlib
 from typing import Any
 
-import ddtrace
 from confluent_kafka import (
     Consumer as ConfluentKafkaConsumer,
 )
@@ -28,6 +27,7 @@ from weave.trace_server.environment import (
     kafka_producer_max_buffer_size,
     wf_kafka_project_id_bucket_count,
 )
+from weave.trace_server.tracing import traced
 
 CALL_ENDED_TOPIC = "weave.call_ended"
 SCORE_CALLS_TOPIC = "weave.score_calls"
@@ -148,7 +148,7 @@ class KafkaProducer(ConfluentKafkaProducer):
         if flush_immediately:
             self.flush(0)
 
-    @ddtrace.tracer.wrap(name="kafka_producer.produce_score_agent_spans")
+    @traced(name="kafka_producer.produce_score_agent_spans")
     def produce_score_agent_spans(self, event: ScoreAgentSpansEvent) -> None:
         """Produce a weave.score_agent_spans event to Kafka.
 

--- a/weave/trace_server/parallel_bucket_uploads.py
+++ b/weave/trace_server/parallel_bucket_uploads.py
@@ -44,7 +44,6 @@ import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 
-
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.clickhouse_schema import FileChunkCreateCHInsertable

--- a/weave/trace_server/parallel_bucket_uploads.py
+++ b/weave/trace_server/parallel_bucket_uploads.py
@@ -44,7 +44,6 @@ import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 
-import ddtrace
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server import trace_server_interface as tsi
@@ -57,6 +56,7 @@ from weave.trace_server.file_storage import (
     key_for_project_digest,
     store_in_bucket,
 )
+from weave.trace_server.tracing import traced
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +129,7 @@ class BucketUploadBatch:
     def __bool__(self) -> bool:
         return bool(self._pending)
 
-    @ddtrace.tracer.wrap(name="bucket_upload_batch.flush")
+    @traced(name="bucket_upload_batch.flush")
     def flush(
         self, client: FileStorageClient | None
     ) -> list[FileChunkCreateCHInsertable]:

--- a/weave/trace_server/project_version/clickhouse_project_version.py
+++ b/weave/trace_server/project_version/clickhouse_project_version.py
@@ -49,7 +49,9 @@ def get_project_data_residence(
         has_complete = row[0]
         has_merged = row[1]
 
-        set_current_span_dd_tags({"has_complete": has_complete, "has_merged": has_merged})
+        set_current_span_dd_tags(
+            {"has_complete": has_complete, "has_merged": has_merged}
+        )
 
         if has_complete and has_merged:
             return ProjectDataResidence.BOTH

--- a/weave/trace_server/project_version/clickhouse_project_version.py
+++ b/weave/trace_server/project_version/clickhouse_project_version.py
@@ -6,7 +6,7 @@ from clickhouse_connect.driver.client import Client as CHClient
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.calls_query_builder.utils import param_slot
-from weave.trace_server.datadog import set_current_span_dd_tags
+from weave.trace_server.datadog import set_root_span_dd_tags
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.project_version.types import ProjectDataResidence
 from weave.trace_server.tracing import traced
@@ -49,7 +49,7 @@ def get_project_data_residence(
         has_complete = row[0]
         has_merged = row[1]
 
-        set_current_span_dd_tags(
+        set_root_span_dd_tags(
             {"has_complete": has_complete, "has_merged": has_merged}
         )
 

--- a/weave/trace_server/project_version/clickhouse_project_version.py
+++ b/weave/trace_server/project_version/clickhouse_project_version.py
@@ -49,9 +49,7 @@ def get_project_data_residence(
         has_complete = row[0]
         has_merged = row[1]
 
-        set_root_span_dd_tags(
-            {"has_complete": has_complete, "has_merged": has_merged}
-        )
+        set_root_span_dd_tags({"has_complete": has_complete, "has_merged": has_merged})
 
         if has_complete and has_merged:
             return ProjectDataResidence.BOTH

--- a/weave/trace_server/project_version/clickhouse_project_version.py
+++ b/weave/trace_server/project_version/clickhouse_project_version.py
@@ -2,18 +2,19 @@
 
 import logging
 
-import ddtrace
 from clickhouse_connect.driver.client import Client as CHClient
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.calls_query_builder.utils import param_slot
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.project_version.types import ProjectDataResidence
+from weave.trace_server.tracing import traced
+from opentelemetry import trace
 
 logger = logging.getLogger(__name__)
 
 
-@ddtrace.tracer.wrap(name="clickhouse_project_version.get_project_data_residence")
+@traced(name="clickhouse_project_version.get_project_data_residence")
 def get_project_data_residence(
     project_id: str, ch_client: CHClient
 ) -> ProjectDataResidence:
@@ -48,9 +49,9 @@ def get_project_data_residence(
         has_complete = row[0]
         has_merged = row[1]
 
-        root_span = ddtrace.tracer.current_root_span()
-        if root_span:
-            root_span.set_tags({"has_complete": has_complete, "has_merged": has_merged})
+        root_span = trace.get_current_span()
+        if root_span.is_recording():
+            root_span.set_attributes({"has_complete": has_complete, "has_merged": has_merged})
 
         if has_complete and has_merged:
             return ProjectDataResidence.BOTH

--- a/weave/trace_server/project_version/clickhouse_project_version.py
+++ b/weave/trace_server/project_version/clickhouse_project_version.py
@@ -6,10 +6,10 @@ from clickhouse_connect.driver.client import Client as CHClient
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.calls_query_builder.utils import param_slot
+from weave.trace_server.datadog import set_root_span_dd_tags
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.project_version.types import ProjectDataResidence
 from weave.trace_server.tracing import traced
-from opentelemetry import trace
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +49,7 @@ def get_project_data_residence(
         has_complete = row[0]
         has_merged = row[1]
 
-        root_span = trace.get_current_span()
-        if root_span.is_recording():
-            root_span.set_attributes({"has_complete": has_complete, "has_merged": has_merged})
+        set_root_span_dd_tags({"has_complete": has_complete, "has_merged": has_merged})
 
         if has_complete and has_merged:
             return ProjectDataResidence.BOTH

--- a/weave/trace_server/project_version/clickhouse_project_version.py
+++ b/weave/trace_server/project_version/clickhouse_project_version.py
@@ -6,7 +6,7 @@ from clickhouse_connect.driver.client import Client as CHClient
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.calls_query_builder.utils import param_slot
-from weave.trace_server.datadog import set_root_span_dd_tags
+from weave.trace_server.datadog import set_current_span_dd_tags
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.project_version.types import ProjectDataResidence
 from weave.trace_server.tracing import traced
@@ -49,7 +49,7 @@ def get_project_data_residence(
         has_complete = row[0]
         has_merged = row[1]
 
-        set_root_span_dd_tags({"has_complete": has_complete, "has_merged": has_merged})
+        set_current_span_dd_tags({"has_complete": has_complete, "has_merged": has_merged})
 
         if has_complete and has_merged:
             return ProjectDataResidence.BOTH

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -63,9 +63,7 @@ class TableRoutingResolver:
         with _tracer.start_as_current_span("table_routing.fetch_residence"):
             residence = get_project_data_residence(project_id, ch_client)
 
-            set_root_span_dd_tags(
-                {"project_version.fetch_residence": residence.value}
-            )
+            set_root_span_dd_tags({"project_version.fetch_residence": residence.value})
 
             # Log warning if we detect dual residency - data should only ever be in
             # calls_merged OR calls_complete, not both. This is handled gracefully but

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -6,6 +6,7 @@ from clickhouse_connect.driver.client import Client as CHClient
 
 from weave.trace_server.datadog import (
     set_current_span_dd_tags,
+    set_root_span_dd_tags,
 )
 from weave.trace_server.project_version.clickhouse_project_version import (
     get_project_data_residence,
@@ -62,7 +63,7 @@ class TableRoutingResolver:
         with _tracer.start_as_current_span("table_routing.fetch_residence"):
             residence = get_project_data_residence(project_id, ch_client)
 
-            set_current_span_dd_tags(
+            set_root_span_dd_tags(
                 {"project_version.fetch_residence": residence.value}
             )
 
@@ -90,7 +91,7 @@ class TableRoutingResolver:
     def resolve_read_table(self, project_id: str, ch_client: CHClient) -> ReadTable:
         """Resolve which table to read from for a given project."""
         result = self._resolve_read_table(project_id, ch_client)
-        set_current_span_dd_tags({"call_project_residence": result.value})
+        set_root_span_dd_tags({"call_project_residence": result.value})
         return result
 
     def _resolve_read_table(self, project_id: str, ch_client: CHClient) -> ReadTable:
@@ -139,7 +140,7 @@ class TableRoutingResolver:
             WriteTarget indicating which table to write to.
         """
         result = self._resolve_v1_write_target(project_id, ch_client)
-        set_current_span_dd_tags({"call_project_residence": result.value})
+        set_root_span_dd_tags({"call_project_residence": result.value})
         return result
 
     def _resolve_v1_write_target(
@@ -188,7 +189,7 @@ class TableRoutingResolver:
             WriteTarget indicating which table to write to.
         """
         result = self._resolve_v2_write_target(project_id, ch_client)
-        set_current_span_dd_tags({"call_project_residence": result.value})
+        set_root_span_dd_tags({"call_project_residence": result.value})
         return result
 
     def _resolve_v2_write_target(

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -6,7 +6,6 @@ from clickhouse_connect.driver.client import Client as CHClient
 
 from weave.trace_server.datadog import (
     set_current_span_dd_tags,
-    set_root_span_dd_tags,
 )
 from weave.trace_server.project_version.clickhouse_project_version import (
     get_project_data_residence,
@@ -63,7 +62,7 @@ class TableRoutingResolver:
         with _tracer.start_as_current_span("table_routing.fetch_residence"):
             residence = get_project_data_residence(project_id, ch_client)
 
-            set_root_span_dd_tags({"project_version.fetch_residence": residence.value})
+            set_current_span_dd_tags({"project_version.fetch_residence": residence.value})
 
             # Log warning if we detect dual residency - data should only ever be in
             # calls_merged OR calls_complete, not both. This is handled gracefully but
@@ -89,7 +88,7 @@ class TableRoutingResolver:
     def resolve_read_table(self, project_id: str, ch_client: CHClient) -> ReadTable:
         """Resolve which table to read from for a given project."""
         result = self._resolve_read_table(project_id, ch_client)
-        set_root_span_dd_tags({"call_project_residence": result.value})
+        set_current_span_dd_tags({"call_project_residence": result.value})
         return result
 
     def _resolve_read_table(self, project_id: str, ch_client: CHClient) -> ReadTable:
@@ -138,7 +137,7 @@ class TableRoutingResolver:
             WriteTarget indicating which table to write to.
         """
         result = self._resolve_v1_write_target(project_id, ch_client)
-        set_root_span_dd_tags({"call_project_residence": result.value})
+        set_current_span_dd_tags({"call_project_residence": result.value})
         return result
 
     def _resolve_v1_write_target(
@@ -187,7 +186,7 @@ class TableRoutingResolver:
             WriteTarget indicating which table to write to.
         """
         result = self._resolve_v2_write_target(project_id, ch_client)
-        set_root_span_dd_tags({"call_project_residence": result.value})
+        set_current_span_dd_tags({"call_project_residence": result.value})
         return result
 
     def _resolve_v2_write_target(

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -62,7 +62,9 @@ class TableRoutingResolver:
         with _tracer.start_as_current_span("table_routing.fetch_residence"):
             residence = get_project_data_residence(project_id, ch_client)
 
-            set_current_span_dd_tags({"project_version.fetch_residence": residence.value})
+            set_current_span_dd_tags(
+                {"project_version.fetch_residence": residence.value}
+            )
 
             # Log warning if we detect dual residency - data should only ever be in
             # calls_merged OR calls_complete, not both. This is handled gracefully but

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -17,7 +17,7 @@ from weave.trace_server.project_version.types import (
     ReadTable,
     WriteTarget,
 )
-from weave.trace_server.tracing import _tracer  # noqa: PLC2701
+from weave.trace_server.tracing import _tracer
 
 logger = logging.getLogger(__name__)
 

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 
-import ddtrace
 from cachetools import LRUCache
 from clickhouse_connect.driver.client import Client as CHClient
 
@@ -18,6 +17,7 @@ from weave.trace_server.project_version.types import (
     ReadTable,
     WriteTarget,
 )
+from weave.trace_server.tracing import _tracer  # noqa: PLC2701
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ class TableRoutingResolver:
 
         # Only span the cache-miss path. Cache-hit calls are extremely high
         # volume and produce noisy DD spans with no useful information.
-        with ddtrace.tracer.trace("table_routing.fetch_residence"):
+        with _tracer.start_as_current_span("table_routing.fetch_residence"):
             residence = get_project_data_residence(project_id, ch_client)
 
             set_root_span_dd_tags({"project_version.fetch_residence": residence.value})

--- a/weave/trace_server/ttl_settings.py
+++ b/weave/trace_server/ttl_settings.py
@@ -18,7 +18,6 @@ import datetime
 import logging
 import threading
 
-import ddtrace
 import redis
 from cachetools import TTLCache
 from clickhouse_connect.driver.client import Client as CHClient
@@ -26,6 +25,7 @@ from clickhouse_connect.driver.client import Client as CHClient
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.datadog import set_current_span_dd_tags
 from weave.trace_server.redis_client import get_redis_client
+from weave.trace_server.tracing import _tracer, traced  # noqa: PLC2701
 
 logger = logging.getLogger(__name__)
 
@@ -67,18 +67,18 @@ def get_project_retention_days(
         set_current_span_dd_tags({"ttl.cache_hit": "L1"})
         return cached
 
-    with ddtrace.tracer.trace("ttl_settings.get_project_retention_days") as span:
+    with _tracer.start_as_current_span("ttl_settings.get_project_retention_days") as span:
         redis_client = get_redis_client()
         if redis_client is not None:
             redis_val = _l2_get(redis_client, project_id)
             if redis_val is not None:
                 _l1_set(project_id, redis_val)
-                span.set_tag("ttl.cache_hit", "L2")
+                span.set_attribute("ttl.cache_hit", "L2")
                 return redis_val
 
         retention_days = _query_clickhouse(ch_client, project_id)
-        span.set_tag("ttl.cache_hit", "clickhouse")
-        span.set_tag("ttl.retention_days", retention_days)
+        span.set_attribute("ttl.cache_hit", "clickhouse")
+        span.set_attribute("ttl.retention_days", retention_days)
 
         if redis_client is not None:
             _l2_set(redis_client, project_id, retention_days)
@@ -180,7 +180,7 @@ def _l2_delete(redis_client: redis.Redis, project_id: str) -> None:
         logger.exception("Redis L2 cache delete failed for project %s", project_id)
 
 
-@ddtrace.tracer.wrap(name="ttl_settings.query_clickhouse")
+@traced(name="ttl_settings.query_clickhouse")
 def _query_clickhouse(ch_client: CHClient, project_id: str) -> int:
     """Query ClickHouse for the latest retention_days via argMax.
 

--- a/weave/trace_server/ttl_settings.py
+++ b/weave/trace_server/ttl_settings.py
@@ -25,7 +25,7 @@ from clickhouse_connect.driver.client import Client as CHClient
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.datadog import set_current_span_dd_tags
 from weave.trace_server.redis_client import get_redis_client
-from weave.trace_server.tracing import _tracer, traced  # noqa: PLC2701
+from weave.trace_server.tracing import _tracer, traced
 
 logger = logging.getLogger(__name__)
 

--- a/weave/trace_server/ttl_settings.py
+++ b/weave/trace_server/ttl_settings.py
@@ -67,7 +67,9 @@ def get_project_retention_days(
         set_current_span_dd_tags({"ttl.cache_hit": "L1"})
         return cached
 
-    with _tracer.start_as_current_span("ttl_settings.get_project_retention_days") as span:
+    with _tracer.start_as_current_span(
+        "ttl_settings.get_project_retention_days"
+    ) as span:
         redis_client = get_redis_client()
         if redis_client is not None:
             redis_val = _l2_get(redis_client, project_id)

--- a/weave/trace_server/usage_utils.py
+++ b/weave/trace_server/usage_utils.py
@@ -5,9 +5,9 @@ from collections import deque
 from collections.abc import Iterable
 from typing import Any
 
-import ddtrace
 
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.tracing import traced
 
 
 @dataclasses.dataclass(frozen=True)
@@ -17,7 +17,7 @@ class UsageCall:
     summary: dict[str, Any] | None
 
 
-@ddtrace.tracer.wrap(name="usage_utils.aggregate_usage_with_descendants")
+@traced(name="usage_utils.aggregate_usage_with_descendants")
 def aggregate_usage_with_descendants(
     calls: Iterable[UsageCall],
     include_costs: bool,

--- a/weave/trace_server/usage_utils.py
+++ b/weave/trace_server/usage_utils.py
@@ -5,7 +5,6 @@ from collections import deque
 from collections.abc import Iterable
 from typing import Any
 
-
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.tracing import traced
 

--- a/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
+++ b/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
@@ -1,7 +1,6 @@
 import asyncio
 from abc import ABC, abstractmethod
 
-
 import weave
 from weave.evaluation.eval import Evaluation
 from weave.scorers.llm_as_a_judge_scorer import LLMAsAJudgeScorer

--- a/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
+++ b/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
@@ -1,7 +1,6 @@
 import asyncio
 from abc import ABC, abstractmethod
 
-import ddtrace
 
 import weave
 from weave.evaluation.eval import Evaluation
@@ -13,6 +12,7 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
     LLMStructuredCompletionModel,
 )
 from weave.trace_server.trace_server_interface import EvaluateModelArgs
+from weave.trace_server.tracing import traced
 
 EVALUATE_MODEL_WORKER_MARKER = {"_weave_eval_meta": {"evaluate_model_worker": True}}
 
@@ -34,7 +34,7 @@ def evaluate_model(args: EvaluateModelArgs) -> None:
     _evaluate_model(args)
 
 
-@ddtrace.tracer.wrap(name="evaluate_model_worker.evaluate_model")
+@traced(name="evaluate_model_worker.evaluate_model")
 def _evaluate_model(args: EvaluateModelArgs) -> None:
     # This worker reconstructs user-supplied objects; it must never deserialize
     # code-bearing custom objects (Op / load_op). The secure client locks the decode
@@ -51,7 +51,7 @@ def _evaluate_model(args: EvaluateModelArgs) -> None:
     _run_evaluation(loaded_evaluation, loaded_model, args.evaluation_call_id)
 
 
-@ddtrace.tracer.wrap(name="evaluate_model_worker.evaluate_model.get_valid_evaluation")
+@traced(name="evaluate_model_worker.evaluate_model.get_valid_evaluation")
 def _get_valid_evaluation(client: WeaveClient, evaluation_ref: str) -> Evaluation:
     loaded_evaluation = client.get(Ref.parse_uri(evaluation_ref))
 
@@ -73,7 +73,7 @@ def _get_valid_evaluation(client: WeaveClient, evaluation_ref: str) -> Evaluatio
     return loaded_evaluation
 
 
-@ddtrace.tracer.wrap(name="evaluate_model_worker.evaluate_model.get_valid_model")
+@traced(name="evaluate_model_worker.evaluate_model.get_valid_model")
 def _get_valid_model(
     client: WeaveClient, model_ref: str
 ) -> LLMStructuredCompletionModel:
@@ -87,7 +87,7 @@ def _get_valid_model(
     return loaded_model
 
 
-@ddtrace.tracer.wrap(name="evaluate_model_worker.evaluate_model.run_evaluation")
+@traced(name="evaluate_model_worker.evaluate_model.run_evaluation")
 def _run_evaluation(
     loaded_evaluation: Evaluation,
     loaded_model: LLMStructuredCompletionModel,


### PR DESCRIPTION
## Summary

PR 3 of 4 in the `weave/trace_server/*` ddtrace → OpenTelemetry migration. Migrates the remaining files — everything except `datadog.py`, which is PR-4.

**Counts (against current master):**

| Pattern | Count |
|---|---:|
| `@ddtrace.tracer.wrap` → `@traced` | 18 |
| `with ddtrace.tracer.trace(...)` → `with _tracer.start_as_current_span(...)` | 2 |
| `span.set_tag` / `set_tags` → `span.set_attribute` / `set_attributes` | 3 |
| `ddtrace.tracer.current_root_span()` → `set_root_span_dd_tags()` | 1 |

## Files touched

| File | Changes |
|---|---|
| `agents/clickhouse.py` | 1 wrap (added on master while the PR was open; rebased in) |
| `base64_content_conversion.py` | 1 wrap |
| `clickhouse/utilities.py` | 1 wrap |
| `eval_results_helpers.py` | 6 wraps via local `_trace_wrap` helper; helper deleted along with its conditional ddtrace import block (no longer needed once OTel is a direct dep) |
| `kafka.py` | 1 wrap (+ 2 callers of `set_root_span_dd_tags`) |
| `parallel_bucket_uploads.py` | 1 wrap |
| `project_version/clickhouse_project_version.py` | 1 wrap + `current_root_span()` → `set_root_span_dd_tags()` |
| `project_version/project_version.py` | 1 trace block → `_tracer.start_as_current_span` (+ 4 callers of `set_root_span_dd_tags`) |
| `ttl_settings.py` | 1 wrap + 1 trace block + 3 `set_attribute` calls |
| `usage_utils.py` | 1 wrap |
| `workers/evaluate_model_worker/evaluate_model_worker.py` | 4 wraps |

## Notable: `current_root_span` semantics

OTel has no built-in current-root-span accessor. The one call site (`get_project_data_residence` in `clickhouse_project_version.py`, which IS inside a `@traced` decorator) is routed through the `set_root_span_dd_tags(...)` helper rather than the raw OTel API. PR-4 (#7268) re-implements `set_root_span_dd_tags` on top of a new `local_root.py` module (contextvar-based root tracker, mirrored from wandb/core's `services/weave-trace/src/tracing/local_root.py`). Until the wandb/core middleware switches its import to use the weave-trace shared copy (follow-up PR), `set_root_span_dd_tags` is a no-op at runtime — same as the historical state on master where `current_root_span()` returned `None` outside of ddtrace-managed entry points.

This addresses a review concern from @gtarpenning on an earlier revision of this PR: an audit caught 7 sites where the original mass-rename to `set_current_span_dd_tags` silently shifted tag emission from the trace root to inner `@traced` spans. All 7 sites + the 10 in #7263 were reverted back to `set_root_span_dd_tags` and the helper was re-implemented properly.

## After this PR

The only remaining `import ddtrace` in `weave/trace_server/` is inside `datadog.py`, which PR-4 (#7268) rewrites and drops `ddtrace>=2.7.0` from `pyproject.toml`.

## Test plan

- [x] All 19 unit tests pass locally (`test_tracing.py` + `test_local_root.py`)
- [x] Import smoke test: `from weave.trace_server import clickhouse_trace_server_batched` resolves with `import ddtrace` removed
- [x] `grep -rn 'import ddtrace' weave/trace_server/` returns only `datadog.py` (which PR-4 rewrites)
- [x] Ruff + ruff format clean on touched files
- [x] CI green

## Stack

1. ✅ **MERGED** [#7258](https://github.com/wandb/weave/pull/7258) — decorator surface
2. ✅ **MERGED** [#7263](https://github.com/wandb/weave/pull/7263) — `clickhouse_trace_server_batched.py`
3. ⏳ **This PR** — remaining files
4. ⏳ [#7268](https://github.com/wandb/weave/pull/7268) — `datadog.py` rewrite + drop `ddtrace>=2.7.0`