### PR TITLE
feat(weave): add agent_trace_messages trace-server endpoint

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -1066,13 +1066,13 @@ class TestMakeTraceMessagesQuery:
         expected = """
             SELECT role,
                    any(content) AS content,
-                   min(created_at) AS min_created_at
+                   min(started_at) AS min_started_at
             FROM messages
             WHERE project_id = {genai_0:String}
               AND trace_id = {genai_1:String}
               AND role IN ('assistant', 'system', 'user')
             GROUP BY role, content_digest
-            ORDER BY min_created_at ASC
+            ORDER BY min_started_at ASC
             LIMIT {genai_2:UInt64}
         """
         assert_sql(

--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -1070,7 +1070,7 @@ class TestMakeTraceMessagesQuery:
             FROM messages
             WHERE project_id = {genai_0:String}
               AND trace_id = {genai_1:String}
-              AND role IN ('user', 'assistant', 'system')
+              AND role IN ('assistant', 'system', 'user')
             GROUP BY role, content_digest
             ORDER BY min_created_at ASC
             LIMIT {genai_2:UInt64}

--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -13,6 +13,7 @@ import sqlparse
 from pydantic import ValidationError
 
 from weave.trace_server.agents.types import (
+    MAX_TRACE_MESSAGES_LIMIT,
     AgentConversationChatReq,
     AgentCustomAttrsSchemaReq,
     AgentGroupByRef,
@@ -25,6 +26,7 @@ from weave.trace_server.agents.types import (
     AgentSpanValueRef,
     AgentsQueryFilters,
     AgentsQueryReq,
+    AgentTraceMessagesReq,
     AgentVersionsQueryReq,
 )
 from weave.trace_server.interface import query as tsi_query
@@ -1064,13 +1066,13 @@ class TestMakeTraceMessagesQuery:
         expected = """
             SELECT role,
                    any(content) AS content,
-                   min(created_at) AS ordered_at
+                   min(created_at) AS min_created_at
             FROM messages
             WHERE project_id = {genai_0:String}
               AND trace_id = {genai_1:String}
               AND role IN ('user', 'assistant', 'system')
             GROUP BY role, content_digest
-            ORDER BY ordered_at ASC
+            ORDER BY min_created_at ASC
             LIMIT {genai_2:UInt64}
         """
         assert_sql(
@@ -1079,6 +1081,15 @@ class TestMakeTraceMessagesQuery:
             query,
             pb.get_params(),
         )
+
+    def test_limit_is_bounded(self) -> None:
+        AgentTraceMessagesReq(project_id="p1", trace_id="t1", limit=1)
+        AgentTraceMessagesReq(
+            project_id="p1", trace_id="t1", limit=MAX_TRACE_MESSAGES_LIMIT
+        )
+        for bad in (0, MAX_TRACE_MESSAGES_LIMIT + 1):
+            with pytest.raises(ValidationError):
+                AgentTraceMessagesReq(project_id="p1", trace_id="t1", limit=bad)
 
 
 # ============================================================================

--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -49,6 +49,7 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_spans_count_query,
     make_spans_list_query,
     make_trace_detail_spans_query,
+    make_trace_messages_query,
     resolve_group_by,
 )
 
@@ -1045,6 +1046,36 @@ class TestMakeTraceDetailSpansQuery:
         assert_sql(
             expected,
             {"genai_0": "p1", "genai_1": "t1"},
+            query,
+            pb.get_params(),
+        )
+
+
+# ============================================================================
+# make_trace_messages_query
+# ============================================================================
+
+
+class TestMakeTraceMessagesQuery:
+    def test_basic(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_trace_messages_query(pb, "p1", "t1", 100)
+
+        expected = """
+            SELECT role,
+                   any(content) AS content,
+                   min(created_at) AS ordered_at
+            FROM messages
+            WHERE project_id = {genai_0:String}
+              AND trace_id = {genai_1:String}
+              AND role IN ('user', 'assistant', 'system')
+            GROUP BY role, content_digest
+            ORDER BY ordered_at ASC
+            LIMIT {genai_2:UInt64}
+        """
+        assert_sql(
+            expected,
+            {"genai_0": "p1", "genai_1": "t1", "genai_2": 100},
             query,
             pb.get_params(),
         )

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -372,14 +372,14 @@ def test_trace_messages_reads_and_dedups_child_span_messages(ch_server):
         AgentTraceMessagesReq(project_id=project_id, trace_id=trace_id, limit=100)
     )
 
-    by_role: dict[str, list[str]] = {}
-    for m in res.messages:
-        by_role.setdefault(m.role, []).append(m.content)
-
-    assert by_role.get("user") == ["hi"]  # deduped across the two spans
-    assert by_role.get("assistant") == ["hello"]
-    assert by_role.get("system") == ["be helpful"]
-    assert "tool_result" not in by_role  # tool roles excluded by the query
+    # Entire payload: the user echo is deduped to one, tool_result is excluded,
+    # and the three scoring roles come back. Sorted by (role, content) because
+    # ordering is by ingest time, which ties within a single insert batch.
+    assert sorted(res.messages, key=lambda m: (m.role, m.content)) == [
+        NormalizedMessage(role="assistant", content="hello"),
+        NormalizedMessage(role="system", content="be helpful"),
+        NormalizedMessage(role="user", content="hi"),
+    ]
 
 
 def test_group_by_conversation_id_filters_numeric_aggregates(ch_server):

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -31,6 +31,7 @@ from weave.trace_server.agents.types import (
     AgentSpanStatsReq,
     AgentSpanValueRef,
     AgentsQueryReq,
+    AgentTraceMessagesReq,
 )
 from weave.trace_server.interface.query import Query
 
@@ -325,6 +326,60 @@ def test_group_by_conversation_id_message_previews(ch_server):
     assert row.last_message is not None
     assert row.last_message.role == "assistant_message"
     assert row.last_message.text == "final reply"
+
+
+def test_trace_messages_reads_and_dedups_child_span_messages(ch_server):
+    """`agent_trace_messages` reads role-tagged messages across a trace's spans.
+
+    Validates the real `messages`-table behavior the query depends on: content
+    repeated across spans is deduped (`GROUP BY role, content_digest`), the three
+    scoring roles are returned, and tool/unknown roles are filtered out. This is
+    the fallback source for agent scoring when a root span carries no messages.
+    """
+    project_id = _make_project_id("trace-messages")
+    trace_id = uuid.uuid4().hex
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    spans = [
+        # First LLM call in the turn: system + user input, assistant output.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=uuid.uuid4().hex,
+            operation_name="chat",
+            started_at=now,
+            ended_at=now + datetime.timedelta(seconds=1),
+            system_instructions=["be helpful"],
+            input_messages=[NormalizedMessage(role="user", content="hi")],
+            output_messages=[NormalizedMessage(role="assistant", content="hello")],
+        ),
+        # A later span echoes the same user turn (history) and carries a tool
+        # result: the echo must dedup away, the tool row must be filtered out.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=uuid.uuid4().hex,
+            operation_name="execute_tool",
+            started_at=now + datetime.timedelta(seconds=2),
+            ended_at=now + datetime.timedelta(seconds=3),
+            input_messages=[NormalizedMessage(role="user", content="hi")],
+            tool_call_result="some tool output",
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_trace_messages(
+        AgentTraceMessagesReq(project_id=project_id, trace_id=trace_id, limit=100)
+    )
+
+    by_role: dict[str, list[str]] = {}
+    for m in res.messages:
+        by_role.setdefault(m.role, []).append(m.content)
+
+    assert by_role.get("user") == ["hi"]  # deduped across the two spans
+    assert by_role.get("assistant") == ["hello"]
+    assert by_role.get("system") == ["be helpful"]
+    assert "tool_result" not in by_role  # tool roles excluded by the query
 
 
 def test_group_by_conversation_id_filters_numeric_aggregates(ch_server):

--- a/tests/trace_server/test_genai_agent_query_handler.py
+++ b/tests/trace_server/test_genai_agent_query_handler.py
@@ -9,6 +9,7 @@ from weave.trace_server.agents.types import (
     AgentSpanGroupDistributionSpec,
     AgentSpansQueryReq,
     AgentSpanValueRef,
+    AgentTraceMessagesReq,
 )
 from weave.trace_server.trace_server_interface import FeedbackQueryRes
 
@@ -240,3 +241,33 @@ def test_grouped_rows_hydrate_message_previews() -> None:
     # No renderable text → no preview, so the UI falls back to the conversation id.
     assert empty.first_message is None
     assert empty.last_message is None
+
+
+def test_trace_messages_maps_rows_to_normalized_messages() -> None:
+    result = _FakeQueryResult(
+        column_names=["role", "content", "ordered_at"],
+        result_rows=[
+            ("system", "be helpful", None),
+            ("user", "hi", None),
+            ("assistant", "hello", None),
+        ],
+    )
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def query(sql: str, params: dict[str, Any]) -> _FakeQueryResult:
+        calls.append((sql, params))
+        return result
+
+    handler = AgentQueryHandler(query, lambda req: FeedbackQueryRes(result=[]))
+
+    res = handler.trace_messages(
+        AgentTraceMessagesReq(project_id="p1", trace_id="t1", limit=100)
+    )
+
+    assert [(m.role, m.content) for m in res.messages] == [
+        ("system", "be helpful"),
+        ("user", "hi"),
+        ("assistant", "hello"),
+    ]
+    assert len(calls) == 1
+    assert "t1" in calls[0][1].values()

--- a/tests/trace_server/test_genai_agent_query_handler.py
+++ b/tests/trace_server/test_genai_agent_query_handler.py
@@ -245,7 +245,7 @@ def test_grouped_rows_hydrate_message_previews() -> None:
 
 def test_trace_messages_maps_rows_to_normalized_messages() -> None:
     result = _FakeQueryResult(
-        column_names=["role", "content", "ordered_at"],
+        column_names=["role", "content", "min_created_at"],
         result_rows=[
             ("system", "be helpful", None),
             ("user", "hi", None),

--- a/tests/trace_server/test_genai_agent_query_handler.py
+++ b/tests/trace_server/test_genai_agent_query_handler.py
@@ -4,12 +4,14 @@ from dataclasses import dataclass
 from typing import Any
 
 from weave.trace_server.agents.clickhouse import AgentQueryHandler
+from weave.trace_server.agents.schema import NormalizedMessage
 from weave.trace_server.agents.types import (
     AgentGroupByRef,
     AgentSpanGroupDistributionSpec,
     AgentSpansQueryReq,
     AgentSpanValueRef,
     AgentTraceMessagesReq,
+    AgentTraceMessagesRes,
 )
 from weave.trace_server.trace_server_interface import FeedbackQueryRes
 
@@ -264,10 +266,12 @@ def test_trace_messages_maps_rows_to_normalized_messages() -> None:
         AgentTraceMessagesReq(project_id="p1", trace_id="t1", limit=100)
     )
 
-    assert [(m.role, m.content) for m in res.messages] == [
-        ("system", "be helpful"),
-        ("user", "hi"),
-        ("assistant", "hello"),
-    ]
+    assert res == AgentTraceMessagesRes(
+        messages=[
+            NormalizedMessage(role="system", content="be helpful"),
+            NormalizedMessage(role="user", content="hi"),
+            NormalizedMessage(role="assistant", content="hello"),
+        ]
+    )
     assert len(calls) == 1
     assert "t1" in calls[0][1].values()

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -63,6 +63,8 @@ from weave.trace_server.agents.types import (
     AgentsQueryRes,
     AgentTraceChatReq,
     AgentTraceChatRes,
+    AgentTraceMessagesReq,
+    AgentTraceMessagesRes,
     AgentVersionSchema,
     AgentVersionsQueryReq,
     AgentVersionsQueryRes,
@@ -92,6 +94,7 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_spans_count_query,
     make_spans_list_query,
     make_trace_detail_spans_query,
+    make_trace_messages_query,
     safe_float,
     safe_int,
     safe_str,
@@ -468,6 +471,24 @@ class AgentQueryHandler:
         rows = self._run_trace_detail_query(project_id, trace_id)
         return [AgentSpanSchema.model_validate(normalize_span_row(r)) for r in rows]
 
+    def trace_messages(self, req: AgentTraceMessagesReq) -> AgentTraceMessagesRes:
+        """Fetch role-tagged messages for a trace from the ``messages`` table.
+
+        Scoring fallback for root spans with no message content of their own.
+        Rows map directly to ``NormalizedMessage``; ``finish_reason`` is not
+        stored per message row, so it is left empty.
+        """
+        rows = self._run_trace_messages_query(
+            req.project_id, req.trace_id, req.limit
+        )
+        messages = [
+            NormalizedMessage(
+                role=safe_str(r.get("role")), content=safe_str(r.get("content"))
+            )
+            for r in rows
+        ]
+        return AgentTraceMessagesRes(messages=messages)
+
     def traces_chat(self, req: AgentTraceChatReq) -> AgentTraceChatRes:
         """Build chat trajectory for a single trace."""
         spans = self.trace_detail_spans(req.project_id, req.trace_id)
@@ -602,6 +623,14 @@ class AgentQueryHandler:
         """Build and run the trace detail SQL, returning rows as dicts."""
         pb = ParamBuilder(PARAM_NAMESPACE)
         sql = make_trace_detail_spans_query(pb, project_id, trace_id)
+        return _rows_as_dicts(self._query(sql, pb.get_params()))
+
+    def _run_trace_messages_query(
+        self, project_id: str, trace_id: str, limit: int
+    ) -> list[ClickHouseRow]:
+        """Build and run the trace messages SQL, returning rows as dicts."""
+        pb = ParamBuilder(PARAM_NAMESPACE)
+        sql = make_trace_messages_query(pb, project_id, trace_id, limit)
         return _rows_as_dicts(self._query(sql, pb.get_params()))
 
 

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -472,10 +472,10 @@ class AgentQueryHandler:
         return [AgentSpanSchema.model_validate(normalize_span_row(r)) for r in rows]
 
     def trace_messages(self, req: AgentTraceMessagesReq) -> AgentTraceMessagesRes:
-        """Fetch role-tagged messages for a trace from the ``messages`` table.
+        """Fetch role-tagged messages for a trace from the `messages` table.
 
         Scoring fallback for root spans with no message content of their own.
-        Rows map directly to ``NormalizedMessage``; ``finish_reason`` is not
+        Rows map directly to `NormalizedMessage`; `finish_reason` is not
         stored per message row, so it is left empty.
         """
         rows = self._run_trace_messages_query(

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -472,11 +472,10 @@ class AgentQueryHandler:
         return [AgentSpanSchema.model_validate(normalize_span_row(r)) for r in rows]
 
     def trace_messages(self, req: AgentTraceMessagesReq) -> AgentTraceMessagesRes:
-        """Fetch role-tagged messages for a trace from the `messages` table.
+        """Fetch a trace's role-tagged messages from the `messages` table.
 
-        Scoring fallback for root spans with no message content of their own.
-        Rows map directly to `NormalizedMessage`; `finish_reason` is not
-        stored per message row, so it is left empty.
+        Rows map directly to `NormalizedMessage`; `finish_reason` is not stored
+        per message row, so it is left empty.
         """
         rows = self._run_trace_messages_query(
             req.project_id, req.trace_id, req.limit

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -972,6 +972,24 @@ class AgentTraceChatRes(BaseModel):
     feedback: list[dict[str, Any]] | None = None
 
 
+class AgentTraceMessagesReq(BaseModel):
+    """Request for the role-tagged messages of a single trace.
+
+    Fallback source for agent scoring when a root span carries no message
+    content of its own.
+    """
+
+    project_id: str
+    trace_id: str
+    limit: int = 100
+
+
+class AgentTraceMessagesRes(BaseModel):
+    """Role-tagged messages for a trace, ordered by ingest time."""
+
+    messages: list[NormalizedMessage] = Field(default_factory=list)
+
+
 class AgentConversationChatReq(BaseModel):
     """Request to get the multi-turn chat view for a conversation."""
 

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -972,20 +972,21 @@ class AgentTraceChatRes(BaseModel):
     feedback: list[dict[str, Any]] | None = None
 
 
-class AgentTraceMessagesReq(BaseModel):
-    """Request for the role-tagged messages of a single trace.
+MAX_TRACE_MESSAGES_LIMIT = 100
 
-    Fallback source for agent scoring when a root span carries no message
-    content of its own.
-    """
+
+class AgentTraceMessagesReq(BaseModel):
+    """Request for the messages of a single trace."""
 
     project_id: str
     trace_id: str
-    limit: int = 100
+    limit: int = Field(
+        default=MAX_TRACE_MESSAGES_LIMIT, gt=0, le=MAX_TRACE_MESSAGES_LIMIT
+    )
 
 
 class AgentTraceMessagesRes(BaseModel):
-    """Role-tagged messages for a trace, ordered by ingest time."""
+    """The messages of a single trace."""
 
     messages: list[NormalizedMessage] = Field(default_factory=list)
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -74,6 +74,8 @@ from weave.trace_server.agents.types import (
     AgentsQueryRes,
     AgentTraceChatReq,
     AgentTraceChatRes,
+    AgentTraceMessagesReq,
+    AgentTraceMessagesRes,
     AgentVersionsQueryReq,
     AgentVersionsQueryRes,
     GenAIOTelExportReq,
@@ -6905,6 +6907,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     def agent_spans_query(self, req: AgentSpansQueryReq) -> AgentSpansQueryRes:
         return AgentQueryHandler(self._query, self.feedback_query).spans_query(req)
+
+    def agent_trace_messages(
+        self, req: AgentTraceMessagesReq
+    ) -> AgentTraceMessagesRes:
+        return AgentQueryHandler(self._query, self.feedback_query).trace_messages(req)
 
     def agent_spans_stats(self, req: AgentSpanStatsReq) -> AgentSpanStatsRes:
         return AgentQueryHandler(self._query, self.feedback_query).spans_stats(req)

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1315,6 +1315,16 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             req.project_id,
         )
 
+    def agent_trace_messages(
+        self, req: tsi.agent_types.AgentTraceMessagesReq
+    ) -> tsi.agent_types.AgentTraceMessagesRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(
+            self._internal_trace_server.agent_trace_messages,
+            req,
+            req.project_id,
+        )
+
     def agent_agents_query(
         self, req: tsi.agent_types.AgentsQueryReq
     ) -> tsi.agent_types.AgentsQueryRes:

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1386,6 +1386,34 @@ def make_span_group_categorical_distributions_query(
     """
 
 
+def make_trace_messages_query(
+    pb: ParamBuilder, project_id: str, trace_id: str, limit: int
+) -> str:
+    """Role-tagged messages for a single trace, read from the ``messages`` table.
+
+    Scoring fallback for root spans that carry no message content of their own.
+    Dedups identical content per role via ``GROUP BY role, content_digest`` and
+    orders by ingest time (``created_at``) so no join back to ``spans`` is
+    needed; ingest order is good enough for a fallback. The indexed ``trace_id``
+    plus ``LIMIT`` bound the scan.
+    """
+    pid = pb.add(project_id, param_type="String")
+    tid = pb.add(trace_id, param_type="String")
+    limit_slot = pb.add(limit, param_type="UInt64")
+    return f"""
+        SELECT role,
+               any(content) AS content,
+               min(created_at) AS ordered_at
+        FROM messages
+        WHERE {_project_filter_sql("project_id", pid)}
+          AND trace_id = {tid}
+          AND role IN ('user', 'assistant', 'system')
+        GROUP BY role, content_digest
+        ORDER BY ordered_at ASC
+        LIMIT {limit_slot}
+    """
+
+
 def make_trace_detail_spans_query(
     pb: ParamBuilder, project_id: str, trace_id: str
 ) -> str:

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1389,13 +1389,10 @@ def make_span_group_categorical_distributions_query(
 def make_trace_messages_query(
     pb: ParamBuilder, project_id: str, trace_id: str, limit: int
 ) -> str:
-    """Role-tagged messages for a single trace, read from the `messages` table.
+    """Build SQL selecting a trace's distinct user/assistant/system messages.
 
-    Scoring fallback for root spans that carry no message content of their own.
-    Dedups identical content per role via `GROUP BY role, content_digest` and
-    orders by ingest time (`created_at`) so no join back to `spans` is
-    needed; ingest order is good enough for a fallback. The indexed `trace_id`
-    plus `LIMIT` bound the scan.
+    Reads the `messages` table, dedups identical content per role via `GROUP BY
+    role, content_digest`, orders by earliest ingest time, and caps at `limit`.
     """
     pid = pb.add(project_id, param_type="String")
     tid = pb.add(trace_id, param_type="String")
@@ -1403,13 +1400,13 @@ def make_trace_messages_query(
     return f"""
         SELECT role,
                any(content) AS content,
-               min(created_at) AS ordered_at
+               min(created_at) AS min_created_at
         FROM messages
         WHERE {_project_filter_sql("project_id", pid)}
           AND trace_id = {tid}
           AND role IN ('user', 'assistant', 'system')
         GROUP BY role, content_digest
-        ORDER BY ordered_at ASC
+        ORDER BY min_created_at ASC
         LIMIT {limit_slot}
     """
 

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1398,7 +1398,8 @@ def make_trace_messages_query(
     """Build SQL selecting a trace's distinct user/assistant/system messages.
 
     Reads the `messages` table, dedups identical content per role via `GROUP BY
-    role, content_digest`, orders by earliest ingest time, and caps at `limit`.
+    role, content_digest`, orders by earliest `started_at` (the table's sort key,
+    so no extra sort), and caps at `limit`.
     """
     pid = pb.add(project_id, param_type="String")
     tid = pb.add(trace_id, param_type="String")
@@ -1407,13 +1408,13 @@ def make_trace_messages_query(
     return f"""
         SELECT role,
                any(content) AS content,
-               min(created_at) AS min_created_at
+               min(started_at) AS min_started_at
         FROM messages
         WHERE {_project_filter_sql("project_id", pid)}
           AND trace_id = {tid}
           AND role IN ({role_list})
         GROUP BY role, content_digest
-        ORDER BY min_created_at ASC
+        ORDER BY min_started_at ASC
         LIMIT {limit_slot}
     """
 

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1389,13 +1389,13 @@ def make_span_group_categorical_distributions_query(
 def make_trace_messages_query(
     pb: ParamBuilder, project_id: str, trace_id: str, limit: int
 ) -> str:
-    """Role-tagged messages for a single trace, read from the ``messages`` table.
+    """Role-tagged messages for a single trace, read from the `messages` table.
 
     Scoring fallback for root spans that carry no message content of their own.
-    Dedups identical content per role via ``GROUP BY role, content_digest`` and
-    orders by ingest time (``created_at``) so no join back to ``spans`` is
-    needed; ingest order is good enough for a fallback. The indexed ``trace_id``
-    plus ``LIMIT`` bound the scan.
+    Dedups identical content per role via `GROUP BY role, content_digest` and
+    orders by ingest time (`created_at`) so no join back to `spans` is
+    needed; ingest order is good enough for a fallback. The indexed `trace_id`
+    plus `LIMIT` bound the scan.
     """
     pid = pb.add(project_id, param_type="String")
     tid = pb.add(trace_id, param_type="String")

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1386,6 +1386,12 @@ def make_span_group_categorical_distributions_query(
     """
 
 
+# Message roles the trace-messages fallback selects from the `messages` table,
+# mapped downstream to the scorer's input/output/system buckets. Rendered sorted
+# so the generated SQL is stable; add a role here to include it.
+TRACE_MESSAGE_ROLES: frozenset[str] = frozenset({"user", "assistant", "system"})
+
+
 def make_trace_messages_query(
     pb: ParamBuilder, project_id: str, trace_id: str, limit: int
 ) -> str:
@@ -1397,6 +1403,7 @@ def make_trace_messages_query(
     pid = pb.add(project_id, param_type="String")
     tid = pb.add(trace_id, param_type="String")
     limit_slot = pb.add(limit, param_type="UInt64")
+    role_list = ", ".join(f"'{role}'" for role in sorted(TRACE_MESSAGE_ROLES))
     return f"""
         SELECT role,
                any(content) AS content,
@@ -1404,7 +1411,7 @@ def make_trace_messages_query(
         FROM messages
         WHERE {_project_filter_sql("project_id", pid)}
           AND trace_id = {tid}
-          AND role IN ('user', 'assistant', 'system')
+          AND role IN ({role_list})
         GROUP BY role, content_digest
         ORDER BY min_created_at ASC
         LIMIT {limit_slot}

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3236,6 +3236,9 @@ class TraceServerInterface(Protocol):
     def agent_spans_query(
         self, req: agent_types.AgentSpansQueryReq
     ) -> agent_types.AgentSpansQueryRes: ...
+    def agent_trace_messages(
+        self, req: agent_types.AgentTraceMessagesReq
+    ) -> agent_types.AgentTraceMessagesRes: ...
     def agent_spans_stats(
         self, req: agent_types.AgentSpanStatsReq
     ) -> agent_types.AgentSpanStatsRes: ...


### PR DESCRIPTION
## Summary

Adds a read-only `agent_trace_messages` endpoint that returns the role-tagged messages of a single trace, read from the `messages` table by `trace_id`. Dedups identical content per role (`GROUP BY role, content_digest`), filters to `user`/`assistant`/`system`, and orders by ingest time (`created_at`) so no join back to `spans` is needed.

Consumed by the wandb/core agent scoring worker as a fallback: when a root span carries no message content of its own (some customers attach messages only to child spans), the worker backfills the scorer inputs from the trace's child spans instead of reporting "no messages present."

New surface: `AgentTraceMessagesReq`/`AgentTraceMessagesRes`, `make_trace_messages_query`, `AgentQueryHandler.trace_messages`, `ClickHouseTraceServer.agent_trace_messages`, plus the interface stub and external adapter method. All additive; no existing behavior changes.

## Testing

- `make_trace_messages_query` SQL-shape unit test.
- Handler row→`NormalizedMessage` mapping test (injected query fn).
- ClickHouse integration test: inserts spans whose messages live on child spans, asserts the query dedups repeated content, returns the three scoring roles, and filters out tool roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)