### PR TITLE
feat(weave): add query-time costs to agent spans and stats APIs

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -12,6 +12,7 @@ import pytest
 import sqlparse
 from pydantic import ValidationError
 
+from weave.trace_server.agents.span_costs import cost_augmented_source_sql
 from weave.trace_server.agents.types import (
     AgentConversationChatReq,
     AgentCustomAttrsSchemaReq,
@@ -32,7 +33,10 @@ from weave.trace_server.interface.query import Query
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.agent_query_builder import (
     CHAT_VIEW_COLS,
+    QUALIFIED_CHAT_VIEW_COLS,
+    QUALIFIED_SPANS_COST_COLS,
     SPAN_SORTABLE_COLS,
+    SPANS_COST_COLS,
     SPANS_LIST_COLS,
     build_order_by,
     make_agent_versions_count_query,
@@ -1036,18 +1040,20 @@ class TestMakeTraceDetailSpansQuery:
         pb = ParamBuilder("genai")
         query = make_trace_detail_spans_query(pb, "p1", "t1")
 
+        # Always cost-augmented (the chat/detail views render per-message and
+        # per-trace cost). Compose the expected cost source from the same
+        # helper so the snapshot stays exact without copying the price-JOIN SQL.
+        expected_pb = ParamBuilder("genai")
+        expected_pb.add("p1", param_type="String")  # genai_0: project filter
+        expected_pb.add("t1", param_type="String")  # genai_1: trace filter
+        source = cost_augmented_source_sql(expected_pb, "p1")
         expected = f"""
-            SELECT {CHAT_VIEW_COLS} FROM spans s
+            SELECT {CHAT_VIEW_COLS}, {SPANS_COST_COLS} FROM {source} s
             WHERE s.project_id = {{genai_0:String}}
             AND s.trace_id = {{genai_1:String}}
             ORDER BY s.started_at ASC
         """
-        assert_sql(
-            expected,
-            {"genai_0": "p1", "genai_1": "t1"},
-            query,
-            pb.get_params(),
-        )
+        assert_sql(expected, expected_pb.get_params(), query, pb.get_params())
 
 
 # ============================================================================
@@ -1456,9 +1462,17 @@ class TestMakeConversationChatSpansQuery:
             AgentConversationChatReq(project_id="p1", conversation_id="c1"),
         )
 
+        # Always cost-augmented (per-message + per-turn cost in the multi-turn
+        # chat view). Compose the expected cost source from the same helper.
+        expected_pb = ParamBuilder("genai")
+        expected_pb.add("p1", param_type="String")  # genai_0: project
+        expected_pb.add("c1", param_type="String")  # genai_1: conversation
+        expected_pb.add(50, param_type="UInt64")  # genai_2: limit (default)
+        expected_pb.add(0, param_type="UInt64")  # genai_3: offset
+        source = cost_augmented_source_sql(expected_pb, "p1")
         expected = f"""
-            SELECT {", ".join(f"s.{c} AS {c}" for c in CHAT_VIEW_COLS.split(", "))}
-            FROM spans s
+            SELECT {QUALIFIED_CHAT_VIEW_COLS}, {QUALIFIED_SPANS_COST_COLS}
+            FROM {source} s
             INNER JOIN (
                 SELECT trace_id, min(started_at) AS turn_started_at
                 FROM spans
@@ -1471,12 +1485,7 @@ class TestMakeConversationChatSpansQuery:
             WHERE s.project_id = {{genai_0:String}}
             ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
         """
-        assert_sql(
-            expected,
-            {"genai_0": "p1", "genai_1": "c1", "genai_2": 50, "genai_3": 0},
-            query,
-            pb.get_params(),
-        )
+        assert_sql(expected, expected_pb.get_params(), query, pb.get_params())
 
     def test_with_pagination(self) -> None:
         pb = ParamBuilder("genai")
@@ -1487,9 +1496,15 @@ class TestMakeConversationChatSpansQuery:
             ),
         )
 
+        expected_pb = ParamBuilder("genai")
+        expected_pb.add("p1", param_type="String")  # genai_0: project
+        expected_pb.add("c1", param_type="String")  # genai_1: conversation
+        expected_pb.add(10, param_type="UInt64")  # genai_2: limit
+        expected_pb.add(20, param_type="UInt64")  # genai_3: offset
+        source = cost_augmented_source_sql(expected_pb, "p1")
         expected = f"""
-            SELECT {", ".join(f"s.{c} AS {c}" for c in CHAT_VIEW_COLS.split(", "))}
-            FROM spans s
+            SELECT {QUALIFIED_CHAT_VIEW_COLS}, {QUALIFIED_SPANS_COST_COLS}
+            FROM {source} s
             INNER JOIN (
                 SELECT trace_id, min(started_at) AS turn_started_at
                 FROM spans
@@ -1502,12 +1517,7 @@ class TestMakeConversationChatSpansQuery:
             WHERE s.project_id = {{genai_0:String}}
             ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
         """
-        assert_sql(
-            expected,
-            {"genai_0": "p1", "genai_1": "c1", "genai_2": 10, "genai_3": 20},
-            query,
-            pb.get_params(),
-        )
+        assert_sql(expected, expected_pb.get_params(), query, pb.get_params())
 
     def test_limit_rejected_above_max_turns(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/trace_server/test_genai_agent_costs.py
+++ b/tests/trace_server/test_genai_agent_costs.py
@@ -1,0 +1,335 @@
+"""Integration tests for query-time costs on GenAI agent spans.
+
+Runs against the ClickHouse backend. Seeds a project-scoped price row in
+`llm_token_prices`, ingests spans referencing that model, and asserts the cost
+columns surfaced by the spans query and stats APIs. Project-level pricing keeps
+each test deterministic and isolated from the migration-seeded default prices.
+"""
+
+import datetime
+import uuid
+
+import pytest
+
+from tests.trace_server.helpers import make_project_id as _make_project_id
+from weave.trace_server.agents.helpers import genai_span_to_row
+from weave.trace_server.agents.schema import (
+    ALL_SPAN_INSERT_COLUMNS,
+    AgentSpanCHInsertable,
+)
+from weave.trace_server.agents.types import (
+    AgentGroupByRef,
+    AgentSpansQueryReq,
+    AgentSpanStatsMetricSpec,
+    AgentSpanStatsReq,
+    AgentSpanValueRef,
+    AgentsQueryReq,
+    AgentTraceChatReq,
+    AgentVersionsQueryReq,
+)
+
+# Per-token prices used by the tests. Small, exact, and unlikely to collide
+# with a real model's seeded default price.
+_PROMPT_COST = 0.00001
+_COMPLETION_COST = 0.00003
+_CACHE_READ_COST = 0.000005
+_CACHE_CREATION_COST = 0.0000125
+
+
+def _insert_project_price(ch_client, project_id: str, llm_id: str) -> None:
+    """Insert a project-level price row for `llm_id`."""
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    ch_client.insert(
+        "llm_token_prices",
+        [
+            (
+                str(uuid.uuid4()),
+                "project",
+                project_id,
+                "test-provider",
+                llm_id,
+                now,
+                _PROMPT_COST,
+                "USD",
+                _COMPLETION_COST,
+                "USD",
+                _CACHE_READ_COST,
+                _CACHE_CREATION_COST,
+                "system",
+                now,
+            )
+        ],
+        column_names=[
+            "id",
+            "pricing_level",
+            "pricing_level_id",
+            "provider_id",
+            "llm_id",
+            "effective_date",
+            "prompt_token_cost",
+            "prompt_token_cost_unit",
+            "completion_token_cost",
+            "completion_token_cost_unit",
+            "cache_read_input_token_cost",
+            "cache_creation_input_token_cost",
+            "created_by",
+            "created_at",
+        ],
+    )
+
+
+def _make_span(project_id: str, **overrides: object) -> AgentSpanCHInsertable:
+    defaults = {
+        "project_id": project_id,
+        "trace_id": uuid.uuid4().hex,
+        "span_id": uuid.uuid4().hex,
+        "span_name": "test-span",
+        "started_at": datetime.datetime.now(tz=datetime.timezone.utc),
+        "ended_at": datetime.datetime.now(tz=datetime.timezone.utc),
+        "status_code": "OK",
+        "operation_name": "chat",
+        "agent_name": "test-agent",
+        "provider_name": "test-provider",
+        "input_tokens": 1000,
+        "output_tokens": 500,
+    }
+    defaults.update(overrides)
+    return AgentSpanCHInsertable(**defaults)
+
+
+def _insert_spans(ch_client, spans: list[AgentSpanCHInsertable]) -> None:
+    rows = [genai_span_to_row(s) for s in spans]
+    ch_client.insert("spans", data=rows, column_names=ALL_SPAN_INSERT_COLUMNS)
+
+
+def test_spans_query_includes_costs(ch_server):
+    """Ungrouped spans query returns per-span costs when include_costs=True."""
+    project_id = _make_project_id("span-costs")
+    model = f"test-cost-model-{uuid.uuid4().hex}"
+    _insert_project_price(ch_server.ch_client, project_id, model)
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                project_id,
+                request_model=model,
+                input_tokens=1000,
+                output_tokens=500,
+            )
+        ],
+    )
+
+    # Without include_costs, no cost is computed.
+    res = ch_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
+    assert res.spans[0].total_cost_usd is None
+
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(project_id=project_id, include_costs=True)
+    )
+    span = res.spans[0]
+    assert span.input_cost_usd == pytest.approx(1000 * _PROMPT_COST)
+    assert span.output_cost_usd == pytest.approx(500 * _COMPLETION_COST)
+    assert span.total_cost_usd == pytest.approx(
+        1000 * _PROMPT_COST + 500 * _COMPLETION_COST
+    )
+
+
+def test_spans_query_cost_subtracts_cache_tokens(ch_server):
+    """Cached input tokens are billed at the cache rate, not the input rate."""
+    project_id = _make_project_id("span-costs-cache")
+    model = f"test-cost-model-{uuid.uuid4().hex}"
+    _insert_project_price(ch_server.ch_client, project_id, model)
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                project_id,
+                request_model=model,
+                input_tokens=1000,
+                output_tokens=500,
+                cache_read_input_tokens=200,
+                cache_creation_input_tokens=100,
+            )
+        ],
+    )
+
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(project_id=project_id, include_costs=True)
+    )
+    span = res.spans[0]
+    expected_input = (1000 - 200 - 100) * _PROMPT_COST
+    expected_total = (
+        expected_input
+        + 500 * _COMPLETION_COST
+        + 200 * _CACHE_READ_COST
+        + 100 * _CACHE_CREATION_COST
+    )
+    assert span.input_cost_usd == pytest.approx(expected_input)
+    assert span.cache_read_cost_usd == pytest.approx(200 * _CACHE_READ_COST)
+    assert span.cache_creation_cost_usd == pytest.approx(100 * _CACHE_CREATION_COST)
+    assert span.total_cost_usd == pytest.approx(expected_total)
+
+
+def test_spans_query_unpriced_model_has_none_cost(ch_server):
+    """A span whose model has no matching price gets None (not 0) costs."""
+    project_id = _make_project_id("span-costs-none")
+    _insert_spans(
+        ch_server.ch_client,
+        [_make_span(project_id, request_model=f"unpriced-{uuid.uuid4().hex}")],
+    )
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(project_id=project_id, include_costs=True)
+    )
+    assert res.spans[0].total_cost_usd is None
+    assert res.spans[0].input_cost_usd is None
+
+
+def test_grouped_spans_query_sums_costs(ch_server):
+    """Grouped spans query sums per-span costs into total_cost_usd."""
+    project_id = _make_project_id("span-costs-grouped")
+    model = f"test-cost-model-{uuid.uuid4().hex}"
+    conversation_id = uuid.uuid4().hex
+    _insert_project_price(ch_server.ch_client, project_id, model)
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                project_id,
+                request_model=model,
+                conversation_id=conversation_id,
+                input_tokens=1000,
+                output_tokens=500,
+            )
+            for _ in range(3)
+        ],
+    )
+
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(
+            project_id=project_id,
+            include_costs=True,
+            group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+        )
+    )
+    group = next(
+        g for g in res.groups if g.group_keys.get("conversation_id") == conversation_id
+    )
+    per_span = 1000 * _PROMPT_COST + 500 * _COMPLETION_COST
+    assert group.total_cost_usd == pytest.approx(3 * per_span)
+    assert group.total_input_cost_usd == pytest.approx(3 * 1000 * _PROMPT_COST)
+    assert group.total_output_cost_usd == pytest.approx(3 * 500 * _COMPLETION_COST)
+
+
+def test_spans_stats_total_cost_metric(ch_server):
+    """Stats API aggregates the total_cost_usd derived metric over time."""
+    project_id = _make_project_id("span-costs-stats")
+    model = f"test-cost-model-{uuid.uuid4().hex}"
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    _insert_project_price(ch_server.ch_client, project_id, model)
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                project_id,
+                request_model=model,
+                started_at=now,
+                input_tokens=1000,
+                output_tokens=500,
+            )
+            for _ in range(2)
+        ],
+    )
+
+    res = ch_server.agent_spans_stats(
+        AgentSpanStatsReq(
+            project_id=project_id,
+            start=now - datetime.timedelta(hours=1),
+            end=now + datetime.timedelta(hours=1),
+            metrics=[
+                AgentSpanStatsMetricSpec(
+                    alias="cost",
+                    value_type="number",
+                    aggregations=["sum"],
+                    value=AgentSpanValueRef(source="derived", key="total_cost_usd"),
+                )
+            ],
+        )
+    )
+    per_span = 1000 * _PROMPT_COST + 500 * _COMPLETION_COST
+    total = sum(float(row.get("sum_cost") or 0) for row in res.rows)
+    assert total == pytest.approx(2 * per_span)
+
+
+def test_trace_chat_includes_cost(ch_server):
+    """The trace chat view sums per-span cost into the trace total."""
+    project_id = _make_project_id("span-costs-chat")
+    model = f"test-cost-model-{uuid.uuid4().hex}"
+    trace_id = uuid.uuid4().hex
+    _insert_project_price(ch_server.ch_client, project_id, model)
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                project_id,
+                trace_id=trace_id,
+                span_id=uuid.uuid4().hex,
+                request_model=model,
+                operation_name="invoke_agent",
+                output_messages=[{"role": "assistant", "content": "hello"}],
+                input_tokens=1000,
+                output_tokens=500,
+            )
+        ],
+    )
+
+    res = ch_server.agent_traces_chat(
+        AgentTraceChatReq(project_id=project_id, trace_id=trace_id)
+    )
+    per_span = 1000 * _PROMPT_COST + 500 * _COMPLETION_COST
+    assert res.total_cost_usd == pytest.approx(per_span)
+    assistant = next(m for m in res.messages if m.type == "assistant_message")
+    assert assistant.assistant_message.total_cost_usd == pytest.approx(per_span)
+
+
+def test_agents_query_includes_cost(ch_server):
+    """agents_query / agent_versions_query fill total_cost_usd when include_costs is set."""
+    project_id = _make_project_id("span-costs-agents")
+    model = f"test-cost-model-{uuid.uuid4().hex}"
+    agent_name = f"agent-{uuid.uuid4().hex}"
+    version = "v1"
+    _insert_project_price(ch_server.ch_client, project_id, model)
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                project_id,
+                request_model=model,
+                agent_name=agent_name,
+                agent_version=version,
+                operation_name="invoke_agent",
+                input_tokens=1000,
+                output_tokens=500,
+            )
+            for _ in range(2)
+        ],
+    )
+    per_span = 1000 * _PROMPT_COST + 500 * _COMPLETION_COST
+
+    res = ch_server.agent_agents_query(
+        AgentsQueryReq(project_id=project_id, include_costs=True)
+    )
+    agent = next(a for a in res.agents if a.agent_name == agent_name)
+    assert agent.total_cost_usd == pytest.approx(2 * per_span)
+
+    # Without include_costs, total_cost_usd stays None.
+    res_no_cost = ch_server.agent_agents_query(AgentsQueryReq(project_id=project_id))
+    agent_no_cost = next(a for a in res_no_cost.agents if a.agent_name == agent_name)
+    assert agent_no_cost.total_cost_usd is None
+
+    versions = ch_server.agent_versions_query(
+        AgentVersionsQueryReq(
+            project_id=project_id, agent_name=agent_name, include_costs=True
+        )
+    )
+    v = next(x for x in versions.versions if x.agent_version == version)
+    assert v.total_cost_usd == pytest.approx(2 * per_span)

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -232,6 +232,74 @@ def test_full_agent_turn() -> None:
     assert _assistant_payload(by_type["assistant_message"]).output_tokens == 105
 
 
+def test_chat_view_aggregates_cost() -> None:
+    """Per-message cost sums across the agent subtree; trace cost sums all spans."""
+
+    def at(seconds: int) -> datetime.datetime:
+        return datetime.datetime(
+            2026, 1, 1, 0, 0, seconds, tzinfo=datetime.timezone.utc
+        )
+
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="my-bot",
+            output_messages=[{"role": "assistant", "content": "done"}],
+            input_cost_usd=0.001,
+            output_cost_usd=0.002,
+            total_cost_usd=0.003,
+            started_at=at(0),
+        ),
+        _span(
+            span_id="tool",
+            parent_span_id="agent",
+            operation_name="execute_tool",
+            tool_name="get_weather",
+            started_at=at(1),
+        ),
+        _span(
+            span_id="llm",
+            parent_span_id="agent",
+            operation_name="chat",
+            input_cost_usd=0.02,
+            output_cost_usd=0.01,
+            total_cost_usd=0.03,
+            started_at=at(2),
+        ),
+    ]
+
+    res = build_trace_chat(spans, "trace-cost")
+
+    assistant = _assistant_payload(
+        next(m for m in res.messages if m.type == "assistant_message")
+    )
+    # Aggregated across root + llm (tool contributes no cost).
+    assert assistant.input_cost_usd == pytest.approx(0.021)
+    assert assistant.output_cost_usd == pytest.approx(0.012)
+    assert assistant.total_cost_usd == pytest.approx(0.033)
+    # Trace total sums every span's cost.
+    assert res.total_cost_usd == pytest.approx(0.033)
+
+
+def test_chat_view_cost_none_when_unpriced() -> None:
+    """With no priced spans, costs stay None (unknown), not 0."""
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="my-bot",
+            output_messages=[{"role": "assistant", "content": "done"}],
+        ),
+    ]
+    res = build_trace_chat(spans, "trace-unpriced")
+    assistant = _assistant_payload(
+        next(m for m in res.messages if m.type == "assistant_message")
+    )
+    assert assistant.total_cost_usd is None
+    assert res.total_cost_usd is None
+
+
 def test_chat_view_exposes_agent_metadata_for_reactions() -> None:
     """The chat view surfaces agent_version + status_code so reaction feedback
     can carry them: per-message from the message's span, and the trace root's

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -70,6 +70,22 @@ class TokenTotals:
     output_tokens: int
     reasoning_tokens: int
     reasoning_content: str | None
+    # Query-time costs (USD). None means no contributing span had a price, so
+    # the cost is unknown rather than 0 (mirrors AgentSpanSchema cost columns).
+    input_cost_usd: float | None = None
+    output_cost_usd: float | None = None
+    total_cost_usd: float | None = None
+
+
+def add_optional_cost(acc: float | None, value: float | None) -> float | None:
+    """Sum two optional costs, treating None as "no contribution".
+
+    Stays None until a non-None value appears, so a collection of entirely
+    unpriced spans reports None (unknown) rather than 0.0.
+    """
+    if value is None:
+        return acc
+    return (acc or 0.0) + value
 
 
 def _datetime_sort_seconds(dt: datetime | None) -> float:
@@ -156,6 +172,7 @@ def build_trace_chat(
     root_status_code: str | None = None
     provider: str | None = None
     total_duration_ms: int | None = None
+    total_cost_usd: float | None = None
 
     if spans:
         root = _select_root_span(spans)
@@ -170,6 +187,9 @@ def build_trace_chat(
         # whole turn — not a sum of child durations (which would double
         # count overlapping subagents / parallel tool calls).
         total_duration_ms = _compute_duration_ms(root.started_at, root.ended_at)
+        # Cost, unlike duration, IS a sum across every span in the trace.
+        for span in spans:
+            total_cost_usd = add_optional_cost(total_cost_usd, span.total_cost_usd)
 
     return AgentTraceChatRes(
         trace_id=trace_id,
@@ -179,6 +199,7 @@ def build_trace_chat(
         status_code=root_status_code,
         provider=provider,
         total_duration_ms=total_duration_ms,
+        total_cost_usd=total_cost_usd,
         messages=messages,
     )
 
@@ -609,11 +630,14 @@ def _input_content_refs(spans: list[AgentSpanSchema]) -> list[str]:
 
 
 def _sum_descendant_tokens(node: SpanNode) -> TokenTotals:
-    """Sum input, output, and reasoning tokens across a subtree."""
+    """Sum input, output, and reasoning tokens (and costs) across a subtree."""
     input_t = node.span.input_tokens or 0
     output_t = node.span.output_tokens or 0
     reasoning_t = node.span.reasoning_tokens or 0
     reasoning_text = node.span.reasoning_content
+    input_cost_usd = node.span.input_cost_usd
+    output_cost_usd = node.span.output_cost_usd
+    total_cost_usd = node.span.total_cost_usd
     for child in node.children:
         child_totals = _sum_descendant_tokens(child)
         input_t += child_totals.input_tokens
@@ -621,7 +645,20 @@ def _sum_descendant_tokens(node: SpanNode) -> TokenTotals:
         reasoning_t += child_totals.reasoning_tokens
         if child_totals.reasoning_content and not reasoning_text:
             reasoning_text = child_totals.reasoning_content
-    return TokenTotals(input_t, output_t, reasoning_t, reasoning_text)
+        input_cost_usd = add_optional_cost(input_cost_usd, child_totals.input_cost_usd)
+        output_cost_usd = add_optional_cost(
+            output_cost_usd, child_totals.output_cost_usd
+        )
+        total_cost_usd = add_optional_cost(total_cost_usd, child_totals.total_cost_usd)
+    return TokenTotals(
+        input_t,
+        output_t,
+        reasoning_t,
+        reasoning_text,
+        input_cost_usd=input_cost_usd,
+        output_cost_usd=output_cost_usd,
+        total_cost_usd=total_cost_usd,
+    )
 
 
 def _find_user_message(spans: list[AgentSpanSchema]) -> AgentChatMessage | None:
@@ -687,6 +724,9 @@ def _emit_assistant_message(
             output_tokens=span.output_tokens or 0,
             reasoning_tokens=span.reasoning_tokens or 0,
             reasoning_content=span.reasoning_content,
+            input_cost_usd=span.input_cost_usd,
+            output_cost_usd=span.output_cost_usd,
+            total_cost_usd=span.total_cost_usd,
         )
 
     return AgentChatMessage(
@@ -703,6 +743,9 @@ def _emit_assistant_message(
             reasoning_tokens=totals.reasoning_tokens,
             input_tokens=totals.input_tokens or span.input_tokens,
             output_tokens=totals.output_tokens or span.output_tokens,
+            input_cost_usd=totals.input_cost_usd,
+            output_cost_usd=totals.output_cost_usd,
+            total_cost_usd=totals.total_cost_usd,
             duration_ms=_compute_duration_ms(span.started_at, span.ended_at),
             status=span.status_code,
             content_refs=_directional_content_refs(

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -17,6 +17,7 @@ import ddtrace
 
 from weave.shared import refs_internal as ri
 from weave.trace_server.agents.chat_view import (
+    add_optional_cost,
     build_trace_chat,
     first_user_preview_text,
     last_assistant_preview_text,
@@ -74,6 +75,7 @@ from weave.trace_server.agents.types import (
 )
 from weave.trace_server.clickhouse.utilities import insert_with_empty_query_retry
 from weave.trace_server.datadog import record_db_insert, set_root_span_dd_tags
+from weave.trace_server.interface.query import Query
 from weave.trace_server.opentelemetry.genai_extraction import extract_genai_span
 from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
 from weave.trace_server.opentelemetry.python_spans import Resource, Span
@@ -395,6 +397,12 @@ class AgentQueryHandler:
             )
             for r in rows
         ]
+        if req.include_costs and agents:
+            cost_map = self._grouped_cost_map(
+                req.project_id, "agent_name", [a.agent_name for a in agents]
+            )
+            for agent in agents:
+                agent.total_cost_usd = cost_map.get(agent.agent_name)
         return AgentsQueryRes(agents=agents, total_count=total)
 
     def agent_versions_query(self, req: AgentVersionsQueryReq) -> AgentVersionsQueryRes:
@@ -411,7 +419,62 @@ class AgentQueryHandler:
             )
             for r in rows
         ]
+        if req.include_costs and versions:
+            cost_map = self._grouped_cost_map(
+                req.project_id,
+                "agent_version",
+                [v.agent_version for v in versions],
+                extra_exprs=[
+                    {
+                        "$eq": [
+                            {"$getField": "agent_name"},
+                            {"$literal": req.agent_name},
+                        ]
+                    }
+                ],
+            )
+            for version in versions:
+                version.total_cost_usd = cost_map.get(version.agent_version)
         return AgentVersionsQueryRes(versions=versions, total_count=total)
+
+    def _grouped_cost_map(
+        self,
+        project_id: str,
+        field: str,
+        values: list[str],
+        *,
+        extra_exprs: list[dict[str, Any]] | None = None,
+    ) -> dict[str, float]:
+        """Map each `field` value to its summed span cost (USD).
+
+        The agents / agent_versions materialized views don't store cost, so this
+        runs a supplementary cost-augmented grouped spans query scoped to the
+        `values` on the current page and returns {value: total_cost_usd} for the
+        priced ones. All-time (no time filter), matching the AMT aggregates.
+        """
+        names = [v for v in values if v]
+        if not names:
+            return {}
+        conditions: list[dict[str, Any]] = [
+            {"$in": [{"$getField": field}, [{"$literal": v} for v in names]]}
+        ]
+        if extra_exprs:
+            conditions.extend(extra_exprs)
+        expr = conditions[0] if len(conditions) == 1 else {"$and": conditions}
+        cost_req = AgentSpansQueryReq(
+            project_id=project_id,
+            query=Query.model_validate({"$expr": expr}),
+            group_by=[AgentGroupByRef(source="column", key=field)],
+            include_costs=True,
+            limit=len(names),
+        )
+        res = self.spans_query(cost_req)
+        out: dict[str, float] = {}
+        for group in res.groups:
+            key = group.group_keys.get(field)
+            if isinstance(key, str) and group.total_cost_usd is not None:
+                out[key] = group.total_cost_usd
+        return out
 
     # ------------------------------------------------------------------
     # Message search
@@ -528,6 +591,12 @@ class AgentQueryHandler:
             if trace_spans
         ]
 
+        conversation_cost: float | None = None
+        for turn in turns:
+            conversation_cost = add_optional_cost(
+                conversation_cost, turn.total_cost_usd
+            )
+
         res = AgentConversationChatRes(
             conversation_id=req.conversation_id,
             turns=turns,
@@ -535,6 +604,7 @@ class AgentQueryHandler:
             has_more=req.offset + len(turns) < total_turns,
             limit=req.limit,
             offset=req.offset,
+            total_cost_usd=conversation_cost,
         )
 
         if req.include_feedback:
@@ -798,6 +868,21 @@ def _first_cell_int(result: QueryResult) -> int:
     return safe_int(result.result_rows[0][0]) if result.result_rows else 0
 
 
+def _optional_float(val: Any) -> float | None:
+    """Coerce to float, preserving None.
+
+    Unlike `safe_float` (which maps None -> 0.0), this keeps a missing/NULL
+    cost as None so the response distinguishes "unpriced" from "$0". Used for
+    cost columns that are only present when `include_costs` was requested.
+    """
+    if val is None:
+        return None
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
 def _agent_aggregate_fields(row: ClickHouseRow) -> dict[str, Any]:
     """Hydrate the aggregate fields shared by agent and version rows."""
     return {
@@ -857,6 +942,11 @@ def _hydrate_group_row(
         total_reasoning_tokens=safe_int(row.get("total_reasoning_tokens")),
         total_duration_ms=safe_int(row.get("total_duration_ms")),
         error_count=safe_int(row.get("error_count")),
+        # Cost aggregates are present only when include_costs was set; absent
+        # keys stay None (default on AgentSpanGroupRow).
+        total_cost_usd=_optional_float(row.get("total_cost_usd")),
+        total_input_cost_usd=_optional_float(row.get("total_input_cost_usd")),
+        total_output_cost_usd=_optional_float(row.get("total_output_cost_usd")),
         agent_names=unpack_string_array(row.get("agent_names")),
         agent_versions=unpack_string_array(row.get("agent_versions")),
         provider_names=unpack_string_array(row.get("provider_names")),

--- a/weave/trace_server/agents/constants.py
+++ b/weave/trace_server/agents/constants.py
@@ -91,6 +91,11 @@ SPAN_GROUP_RESULT_COLS: frozenset[str] = SPAN_GROUP_AGGREGATE_COLS.union(
             "provider_names",
             "request_models",
             "conversation_names",
+            # Cost aggregate aliases (populated only when include_costs is set).
+            # Reserved here so user measure aliases can never collide with them.
+            "total_cost_usd",
+            "total_input_cost_usd",
+            "total_output_cost_usd",
         }
     )
 )

--- a/weave/trace_server/agents/span_costs.py
+++ b/weave/trace_server/agents/span_costs.py
@@ -1,0 +1,219 @@
+"""Query-time cost computation for GenAI agent spans.
+
+Unlike the older calls cost path (see `weave/trace_server/token_costs.py`),
+spans store token usage and the model name as first-class columns, and every
+span carries exactly one model. That makes per-span cost a clean LEFT JOIN
+against the best-matching row in `llm_token_prices` rather than the
+`arrayJoin` over a per-model usage JSON blob that the calls path needs.
+
+The pricing source of truth is shared: the same `llm_token_prices` table,
+the same project > default pricing-level precedence, and the same "latest
+`effective_date` wins" tie-break used by `token_costs.build_model_prices_query`.
+
+Cost is never stored on the span; it is computed at read time only when a
+caller opts in (`include_costs` on the spans query, or a cost derived metric
+on the stats query). Callers stitch three pieces into their own SQL:
+
+  * `cost_join_sql` — the `LEFT JOIN` against ranked prices, keyed on the
+    span's model.
+  * `cost_select_exprs` — the `<expr> AS <name>` cost projections.
+  * `COST_COLUMN_NAMES` — the resulting column names, for projections and
+    response hydration.
+
+Keeping the SQL here makes it unit-testable without a live ClickHouse and lets
+the spans list, grouped, and stats query builders share one definition of how
+cost is computed.
+"""
+
+from __future__ import annotations
+
+from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.token_costs import (
+    DEFAULT_PRICING_LEVEL_ID,
+    LLM_TOKEN_PRICES_TABLE_NAME,
+    PRICING_LEVELS,
+)
+
+# Cost columns produced by `cost_select_exprs`, in projection order. These are
+# also added to `AgentSpanSchema` so the list-query projection validates and
+# the response hydrates them.
+COST_INPUT = "input_cost_usd"
+COST_OUTPUT = "output_cost_usd"
+COST_CACHE_READ = "cache_read_cost_usd"
+COST_CACHE_CREATION = "cache_creation_cost_usd"
+COST_TOTAL = "total_cost_usd"
+
+COST_COLUMN_NAMES: tuple[str, ...] = (
+    COST_INPUT,
+    COST_OUTPUT,
+    COST_CACHE_READ,
+    COST_CACHE_CREATION,
+    COST_TOTAL,
+)
+
+# Grouped-query sum aggregates over the per-span cost columns.
+GROUPED_COST_ALIASES: tuple[str, ...] = (
+    "total_cost_usd",
+    "total_input_cost_usd",
+    "total_output_cost_usd",
+)
+
+# Stats derived metrics that read a cost column. These resolve only when the
+# query's span source is cost-augmented (see the stats / spans query builders).
+# Single source of truth for both builders and the AgentSpanStatsDerivedMetric
+# Literal in agents/types.py — keep those in sync with this set.
+COST_DERIVED_METRIC_NAMES: frozenset[str] = frozenset(
+    {COST_TOTAL, COST_INPUT, COST_OUTPUT}
+)
+
+_PRICE_ALIAS = "mp"
+# Sentinel column selected from the ranked-price subquery so a LEFT JOIN miss
+# (ClickHouse fills non-nullable price columns with 0, not NULL) is
+# distinguishable from a genuine $0 price.
+_PRICE_MATCHED = "price_matched"
+
+
+def model_match_sql(span_alias: str) -> str:
+    """SQL for the model key used to join a span to its price.
+
+    Prefer the model the provider actually served (`response_model`); fall
+    back to the requested model when the response model is absent.
+    """
+    return (
+        f"if({span_alias}.response_model != '', "
+        f"{span_alias}.response_model, {span_alias}.request_model)"
+    )
+
+
+def ranked_model_prices_sql(pb: ParamBuilder, project_id: str) -> str:
+    """Build a subquery returning the single best price per `llm_id`.
+
+    Mirrors `token_costs.build_model_prices_query`: project-level pricing
+    wins over default, ties broken by the most recent `effective_date`. Only
+    the rank-1 row per model survives. Parameterized (no f-string project_id),
+    so it is safe to embed directly in a JOIN.
+    """
+    pid_slot = pb.add(project_id, param_type="String")
+    default_slot = pb.add(DEFAULT_PRICING_LEVEL_ID, param_type="String")
+    project_level = PRICING_LEVELS["PROJECT"]
+    default_level = PRICING_LEVELS["DEFAULT"]
+    return f"""
+        SELECT
+            llm_id,
+            prompt_token_cost,
+            completion_token_cost,
+            cache_read_input_token_cost,
+            cache_creation_input_token_cost,
+            1 AS {_PRICE_MATCHED}
+        FROM (
+            SELECT
+                llm_id,
+                prompt_token_cost,
+                completion_token_cost,
+                cache_read_input_token_cost,
+                cache_creation_input_token_cost,
+                ROW_NUMBER() OVER (
+                    PARTITION BY llm_id
+                    ORDER BY
+                        CASE
+                            WHEN pricing_level = '{project_level}'
+                                AND pricing_level_id = {pid_slot} THEN 1
+                            WHEN pricing_level = '{default_level}'
+                                AND pricing_level_id = {default_slot} THEN 2
+                            ELSE 3
+                        END,
+                        effective_date DESC
+                ) AS rank
+            FROM {LLM_TOKEN_PRICES_TABLE_NAME}
+            WHERE (pricing_level = '{project_level}' AND pricing_level_id = {pid_slot})
+               OR (pricing_level = '{default_level}' AND pricing_level_id = {default_slot})
+        )
+        WHERE rank = 1
+    """
+
+
+def cost_join_sql(
+    pb: ParamBuilder,
+    project_id: str,
+    *,
+    span_alias: str = "s",
+    price_alias: str = _PRICE_ALIAS,
+) -> str:
+    """Return the `LEFT JOIN` that attaches ranked prices to spans.
+
+    The join is on the span's model; spans whose model has no matching price
+    keep NULL cost columns (see `cost_select_exprs`) so they are excluded
+    from aggregates rather than counted as $0.
+    """
+    prices = ranked_model_prices_sql(pb, project_id)
+    return (
+        f"LEFT JOIN ({prices}) {price_alias} "
+        f"ON {price_alias}.llm_id = {model_match_sql(span_alias)}"
+    )
+
+
+def cost_select_exprs(
+    *,
+    span_alias: str = "s",
+    price_alias: str = _PRICE_ALIAS,
+) -> list[str]:
+    """Return the per-span `<expr> AS <name>` cost projections.
+
+    Cost formulas mirror the calls path (`token_costs._build_cost_summary_dump_snippet`):
+    cached input tokens are billed at the cache rate, so they are subtracted
+    from the regular input-token cost. Reasoning tokens are not priced
+    separately — providers fold them into `output_tokens` — matching the
+    calls behavior. When no price matched, every cost column is NULL.
+    """
+    matched = f"{price_alias}.{_PRICE_MATCHED} = 1"
+    s = span_alias
+    p = price_alias
+    input_cost_usd = (
+        f"({s}.input_tokens - {s}.cache_read_input_tokens "
+        f"- {s}.cache_creation_input_tokens) * {p}.prompt_token_cost"
+    )
+    output_cost_usd = f"{s}.output_tokens * {p}.completion_token_cost"
+    cache_read_cost_usd = (
+        f"{s}.cache_read_input_tokens * {p}.cache_read_input_token_cost"
+    )
+    cache_creation_cost_usd = (
+        f"{s}.cache_creation_input_tokens * {p}.cache_creation_input_token_cost"
+    )
+    total_cost_usd = (
+        f"({input_cost_usd}) + ({output_cost_usd}) "
+        f"+ ({cache_read_cost_usd}) + ({cache_creation_cost_usd})"
+    )
+    return [
+        f"if({matched}, {input_cost_usd}, NULL) AS {COST_INPUT}",
+        f"if({matched}, {output_cost_usd}, NULL) AS {COST_OUTPUT}",
+        f"if({matched}, {cache_read_cost_usd}, NULL) AS {COST_CACHE_READ}",
+        f"if({matched}, {cache_creation_cost_usd}, NULL) AS {COST_CACHE_CREATION}",
+        f"if({matched}, {total_cost_usd}, NULL) AS {COST_TOTAL}",
+    ]
+
+
+def cost_augmented_source_sql(
+    pb: ParamBuilder,
+    project_id: str,
+    *,
+    span_alias: str = "s",
+) -> str:
+    """Return a `spans`-shaped relation with the cost columns appended.
+
+    The result is a parenthesized subquery exposing every `spans` column
+    (`s.*`) plus `COST_COLUMN_NAMES` as real columns. Callers substitute it
+    for `spans` wherever they need cost available downstream — grouped
+    aggregates (`sum(s.total_cost_usd)`) and stats derived metrics
+    (`s.total_cost_usd`) — without rewriting their grouping or bucketing logic.
+    Span-level WHERE filters applied by the caller push down to the inner
+    `spans` scan, so this does not force a full-table materialization.
+    """
+    exprs = cost_select_exprs(span_alias=span_alias)
+    cost_projection = ",\n            ".join(exprs)
+    join = cost_join_sql(pb, project_id, span_alias=span_alias)
+    return f"""(
+        SELECT {span_alias}.*,
+            {cost_projection}
+        FROM spans {span_alias}
+        {join}
+    )"""

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -69,6 +69,13 @@ AgentSpanStatsDerivedMetric = Literal[
     "total_tokens",
     "is_error",
     "is_invocation",
+    # Query-time costs (USD). Computed by joining the span's model against
+    # llm_token_prices; only resolvable when the query's span source is
+    # cost-augmented. Mirror of span_costs.COST_DERIVED_METRIC_NAMES — keep the
+    # two in sync. See weave/trace_server/agents/span_costs.py.
+    "total_cost_usd",
+    "input_cost_usd",
+    "output_cost_usd",
 ]
 AgentSpanValueSource = Literal[
     "field",
@@ -108,6 +115,9 @@ AGENT_SPAN_STATS_DERIVED_VALUE_TYPES: dict[
     "total_tokens": "number",
     "is_error": "boolean",
     "is_invocation": "boolean",
+    "total_cost_usd": "number",
+    "input_cost_usd": "number",
+    "output_cost_usd": "number",
 }
 _ALLOWED_AGGS_BY_TYPE: dict[AgentSpanStatsValueType, set[AgentSpanStatsAggregation]] = {
     "datetime": {"min", "max", "count", "count_distinct"},
@@ -445,6 +455,14 @@ class AgentSpanSchema(BaseModel):
     reasoning_tokens: int | None = None
     cache_creation_input_tokens: int | None = None
     cache_read_input_tokens: int | None = None
+    # Query-time costs (USD), only populated when AgentSpansQueryReq.include_costs
+    # is set. None (not 0) when the span's model has no matching price, so the UI
+    # can distinguish "unpriced" from "free". See agents/span_costs.py.
+    input_cost_usd: float | None = None
+    output_cost_usd: float | None = None
+    cache_read_cost_usd: float | None = None
+    cache_creation_cost_usd: float | None = None
+    total_cost_usd: float | None = None
     reasoning_content: str | None = None
     conversation_id: str | None = None
     conversation_name: str | None = None
@@ -628,6 +646,12 @@ class AgentSpanGroupRow(BaseModel):
     total_reasoning_tokens: int = 0
     total_duration_ms: int = 0
     error_count: int = 0
+    # Summed query-time costs (USD) across the group's spans. Only populated
+    # when AgentSpansQueryReq.include_costs is set; None when no span in the
+    # group had a matching model price. See agents/span_costs.py.
+    total_cost_usd: float | None = None
+    total_input_cost_usd: float | None = None
+    total_output_cost_usd: float | None = None
     agent_names: list[str] = Field(default_factory=list)
     agent_versions: list[str] = Field(default_factory=list)
     provider_names: list[str] = Field(default_factory=list)
@@ -670,6 +694,11 @@ class AgentSpansQueryReq(BaseModel):
     # etc.) in each row. Intended for single-trace detail fetches; do not set
     # for broad list queries.
     include_details: bool = False
+    # When true, compute per-span costs (USD) by joining each span's model
+    # against llm_token_prices. Adds input_cost_usd/output_cost_usd/.../total_cost_usd to
+    # ungrouped span rows, or summed total_cost_usd/total_input_cost_usd/
+    # total_output_cost_usd to grouped rows. See agents/span_costs.py.
+    include_costs: bool = False
     sort_by: list[AgentSortBy] | None = None
     limit: int = Field(
         default=DEFAULT_AGENT_QUERY_LIMIT, ge=0, le=MAX_AGENT_QUERY_LIMIT
@@ -874,6 +903,11 @@ class AgentChatAssistantMessage(BaseModel):
     reasoning_tokens: int | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
+    # Query-time costs (USD) for this message's span (or, for aggregated agent
+    # turns, summed across the subtree). None when the model has no price.
+    input_cost_usd: float | None = None
+    output_cost_usd: float | None = None
+    total_cost_usd: float | None = None
     duration_ms: int | None = None
     status: StatusCodeLiteral | None = None
     content_refs: list[str] = Field(default_factory=list)
@@ -988,6 +1022,9 @@ class AgentTraceChatRes(BaseModel):
             "This is not a sum of child span durations."
         ),
     )
+    # Summed query-time cost (USD) across all spans in the trace. Unlike
+    # duration, this IS a sum across spans. None when no span had a price.
+    total_cost_usd: float | None = None
     messages: list[AgentChatMessage] = Field(default_factory=list)
     feedback: list[dict[str, Any]] | None = None
 
@@ -1030,6 +1067,9 @@ class AgentConversationChatRes(BaseModel):
     has_more: bool = False
     limit: int = MAX_CONVERSATION_CHAT_TURNS
     offset: int = 0
+    # Summed query-time cost (USD) across the returned turns. None when no turn
+    # had a priced span.
+    total_cost_usd: float | None = None
     feedback: list[dict[str, Any]] | None = None
 
 
@@ -1046,6 +1086,11 @@ class AgentSchema(BaseModel):
     error_count: int
     first_seen: datetime.datetime | None
     last_seen: datetime.datetime | None
+    # Summed query-time cost (USD), populated only when the query sets
+    # include_costs. The agents/agent_versions materialized views don't store
+    # cost, so the handler fills this from a supplementary grouped spans query.
+    # None when costs weren't requested or no span had a price.
+    total_cost_usd: float | None = None
 
 
 class AgentsQueryFilters(BaseModel):
@@ -1064,6 +1109,9 @@ class AgentsQueryReq(BaseModel):
         default=DEFAULT_AGENT_QUERY_LIMIT, ge=0, le=MAX_AGENT_QUERY_LIMIT
     )
     offset: int = Field(default=0, ge=0)
+    # When true, fill AgentSchema.total_cost_usd from a supplementary grouped spans
+    # cost query (the agents materialized view has no cost column).
+    include_costs: bool = False
 
 
 class AgentsQueryRes(BaseModel):
@@ -1094,6 +1142,9 @@ class AgentVersionsQueryReq(BaseModel):
         default=DEFAULT_AGENT_QUERY_LIMIT, ge=0, le=MAX_AGENT_QUERY_LIMIT
     )
     offset: int = Field(default=0, ge=0)
+    # When true, fill AgentVersionSchema.total_cost_usd from a supplementary grouped
+    # spans cost query (the agent_versions materialized view has no cost column).
+    include_costs: bool = False
 
 
 class AgentVersionsQueryRes(BaseModel):

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -24,6 +24,12 @@ from weave.trace_server.agents.constants import (
     SPAN_GROUP_AGGREGATE_COLS,
     SPAN_GROUP_RESULT_COLS,
 )
+from weave.trace_server.agents.span_costs import (
+    COST_COLUMN_NAMES,
+    COST_DERIVED_METRIC_NAMES,
+    GROUPED_COST_ALIASES,
+    cost_augmented_source_sql,
+)
 from weave.trace_server.agents.types import (
     AGENT_CUSTOM_ATTR_SOURCE_VALUE_TYPES,
     AgentConversationChatReq,
@@ -172,7 +178,6 @@ _DERIVED_DURATION_MS: AgentSpanStatsDerivedMetric = "duration_ms"
 _DERIVED_TOTAL_TOKENS: AgentSpanStatsDerivedMetric = "total_tokens"
 _DERIVED_IS_ERROR: AgentSpanStatsDerivedMetric = "is_error"
 _DERIVED_IS_INVOCATION: AgentSpanStatsDerivedMetric = "is_invocation"
-
 _STATUS_CODE_ERROR = "ERROR"
 
 _CUSTOM_ATTR_VALUE_TYPES: dict[str, AgentSpanStatsValueType] = {
@@ -317,6 +322,12 @@ _SPANS_LIST_FIELD_NAMES = [
     "wb_run_step_end",
 ]
 SPANS_LIST_COLS: str = _projection(_SPANS_LIST_FIELD_NAMES)
+
+# Per-span cost columns, projected only when the caller sets `include_costs`.
+# These are computed by the cost-augmented spans source, not stored columns.
+SPANS_COST_COLS: str = _projection(list(COST_COLUMN_NAMES))
+QUALIFIED_SPANS_COST_COLS: str = _projection(list(COST_COLUMN_NAMES), table_alias="s")
+_SPAN_COST_SORTABLE_COLS: frozenset[str] = frozenset(COST_COLUMN_NAMES)
 
 # Detail-only fields: heavy text/array payloads. Included only when the
 # caller sets `include_details` (the span detail panel does this; the main
@@ -641,6 +652,15 @@ def _derived_value_sql(
             valid_sql="1",
             value_type=_VALUE_TYPE_BOOLEAN,
         )
+    if metric in COST_DERIVED_METRIC_NAMES:
+        # The cost column (same name as the metric) is supplied by the
+        # cost-augmented span source. NULL means the span's model had no
+        # matching price, so guard it out of aggregates rather than scoring 0.
+        return SpanValueSQL(
+            value_sql=f"toFloat64({table_alias}.{metric})",
+            valid_sql=f"isNotNull({table_alias}.{metric})",
+            value_type=_VALUE_TYPE_NUMBER,
+        )
     raise ValueError(f"unknown derived metric: {metric!r}")
 
 
@@ -958,12 +978,21 @@ def make_spans_list_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
     """List spans (ungrouped) or aggregate groups (grouped)."""
     span_filters = _spans_filter_sql(pb, req)
     limit_slot, offset_slot = _pagination_slots(pb, req.limit, req.offset)
+    # Read from the cost-augmented source (per-span price JOIN) only when costs
+    # were requested; the bare `spans` table otherwise. Shared by both the
+    # ungrouped and grouped branches below.
+    source = (
+        cost_augmented_source_sql(pb, req.project_id) if req.include_costs else "spans"
+    )
 
     if not req.group_by:
         custom_sort_exprs = _custom_attr_sort_exprs(pb, req.custom_attr_columns)
+        sortable = SPAN_SORTABLE_COLS.union(frozenset(custom_sort_exprs.keys()))
+        if req.include_costs:
+            sortable = sortable.union(_SPAN_COST_SORTABLE_COLS)
         order_by = build_order_by(
             req.sort_by,
-            SPAN_SORTABLE_COLS.union(frozenset(custom_sort_exprs.keys())),
+            sortable,
             "started_at DESC",
             column_exprs=custom_sort_exprs,
         )
@@ -971,9 +1000,10 @@ def make_spans_list_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
             pb, req.custom_attr_columns
         )
         details_projection = f", {SPANS_DETAILS_COLS}" if req.include_details else ""
+        cost_projection = f", {SPANS_COST_COLS}" if req.include_costs else ""
         return f"""
-            SELECT {SPANS_LIST_COLS}{details_projection}{custom_attr_projection}
-            FROM spans s
+            SELECT {SPANS_LIST_COLS}{details_projection}{custom_attr_projection}{cost_projection}
+            FROM {source} s
             WHERE {span_filters.where}
             ORDER BY {order_by}
             LIMIT {limit_slot} OFFSET {offset_slot}
@@ -994,9 +1024,18 @@ def make_spans_list_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
         aggregate_selects = (
             f"{aggregate_selects},\n               {dynamic_aggregate_selects}"
         )
+    if req.include_costs:
+        aggregate_selects = (
+            f"{aggregate_selects},\n"
+            "               sum(s.total_cost_usd) AS total_cost_usd,\n"
+            "               sum(s.input_cost_usd) AS total_input_cost_usd,\n"
+            "               sum(s.output_cost_usd) AS total_output_cost_usd"
+        )
     sortable = SPAN_GROUP_AGGREGATE_COLS.union(frozenset(aliases)).union(
         measure.alias for measure in measure_sqls
     )
+    if req.include_costs:
+        sortable = sortable.union(frozenset(GROUPED_COST_ALIASES))
     default_order_by = (
         f"{measure_sqls[0].alias} DESC" if measure_sqls else "last_seen DESC"
     )
@@ -1012,7 +1051,7 @@ def make_spans_list_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
     return f"""
         SELECT {select_group_cols},
                {aggregate_selects}
-        FROM spans s
+        FROM {source} s
         WHERE {span_filters.where}
         GROUP BY {group_by_clause}
         {having_sql}
@@ -1401,8 +1440,11 @@ def make_trace_detail_spans_query(
     """
     pid = pb.add(project_id, param_type="String")
     tid = pb.add(trace_id, param_type="String")
+    # Always cost-augmented: the chat/detail views render per-message and
+    # per-trace cost, and this is a single-trace fetch so the price JOIN is cheap.
+    source = cost_augmented_source_sql(pb, project_id)
     return f"""
-        SELECT {CHAT_VIEW_COLS} FROM spans s
+        SELECT {CHAT_VIEW_COLS}, {SPANS_COST_COLS} FROM {source} s
         WHERE {_project_filter_sql("s.project_id", pid)}
           AND s.trace_id = {tid}
         ORDER BY s.started_at ASC
@@ -1539,9 +1581,12 @@ def make_conversation_chat_spans_query(
     cid = pb.add(req.conversation_id, param_type="String")
     limit_slot = pb.add(req.limit, param_type="UInt64")
     offset_slot = pb.add(req.offset, param_type="UInt64")
+    # Always cost-augmented so the multi-turn chat view can render per-message
+    # and per-turn cost; bounded to one conversation's turns, so cheap.
+    source = cost_augmented_source_sql(pb, req.project_id)
     return f"""
-        SELECT {QUALIFIED_CHAT_VIEW_COLS}
-        FROM spans s
+        SELECT {QUALIFIED_CHAT_VIEW_COLS}, {QUALIFIED_SPANS_COST_COLS}
+        FROM {source} s
         INNER JOIN (
             SELECT trace_id, min(started_at) AS turn_started_at
             FROM spans

--- a/weave/trace_server/query_builder/agent_stats_query_builder.py
+++ b/weave/trace_server/query_builder/agent_stats_query_builder.py
@@ -17,6 +17,10 @@ from typing import Any
 
 from weave.trace_server.agents import semconv
 from weave.trace_server.agents.constants import MAX_AGENT_STATS_RESULT_ROWS
+from weave.trace_server.agents.span_costs import (
+    COST_DERIVED_METRIC_NAMES,
+    cost_augmented_source_sql,
+)
 from weave.trace_server.agents.types import (
     AgentGroupByRef,
     AgentSpanGroupFilter,
@@ -141,6 +145,42 @@ def _span_col(column: str) -> str:
     return f"{_SPAN_ALIAS}.{column}"
 
 
+def _value_ref_is_cost(value: Any) -> bool:
+    return (
+        value is not None
+        and getattr(value, "source", None) == "derived"
+        and getattr(value, "key", None) in COST_DERIVED_METRIC_NAMES
+    )
+
+
+def _stats_requires_costs(req: AgentSpanStatsReq) -> bool:
+    """Whether any value ref in the request reads a cost column.
+
+    Scans metrics, numeric-bucket value/measure, and group-filter measures so
+    the query reads from the cost-augmented span source iff cost is needed —
+    avoiding the price JOIN on the common no-cost path.
+    """
+    if any(_value_ref_is_cost(metric.value) for metric in req.metrics):
+        return True
+    bucket = req.bucket_by
+    if isinstance(bucket, AgentSpanStatsNumericBucketSpec):
+        if _value_ref_is_cost(bucket.value):
+            return True
+        if bucket.measure is not None and _value_ref_is_cost(bucket.measure.value):
+            return True
+    return any(
+        _value_ref_is_cost(group_filter.measure.value)
+        for group_filter in req.group_filters
+    )
+
+
+def _resolve_spans_source(req: AgentSpanStatsReq, pb: ParamBuilder) -> str:
+    """Return the FROM relation for stats: bare `spans`, or cost-augmented."""
+    if _stats_requires_costs(req):
+        return cost_augmented_source_sql(pb, req.project_id)
+    return _SPANS_TABLE
+
+
 def _conversation_group_by() -> list[AgentGroupByRef]:
     return [AgentGroupByRef(source="column", key="conversation_id")]
 
@@ -217,6 +257,7 @@ def build_agent_span_stats_query(
     tz = req.timezone or "UTC"
 
     source_filter = _spans_source_filter_sql(pb, req, start, end)
+    spans_source = _resolve_spans_source(req, pb)
     group_refs = req.group_by or []
     resolved_groups = resolve_group_by(pb, group_refs) if group_refs else []
 
@@ -259,6 +300,7 @@ def build_agent_span_stats_query(
     if numeric_bucket is not None:
         raw_sql = _build_numeric_bucket_stats_query(
             source_filter=source_filter,
+            spans_source=spans_source,
             bucket=numeric_bucket,
             metric_exprs=metric_exprs,
             agg_selects=agg_selects,
@@ -291,6 +333,7 @@ def build_agent_span_stats_query(
 
     raw_sql = _build_stats_query(
         source_filter=source_filter,
+        spans_source=spans_source,
         resolved_groups=resolved_groups,
         metric_exprs=metric_exprs,
         agg_selects=agg_selects,
@@ -649,6 +692,7 @@ def _group_value_type(group_ref: AgentGroupByRef) -> AgentSpanStatsColumnValueTy
 def _build_stats_query(
     *,
     source_filter: _SpanSourceFilterSQL,
+    spans_source: str,
     resolved_groups: list[tuple[str, str]],
     metric_exprs: list[str],
     agg_selects: list[str],
@@ -677,6 +721,7 @@ def _build_stats_query(
     if not resolved_groups:
         return _build_ungrouped_stats_query(
             source_filter=source_filter,
+            spans_source=spans_source,
             parts=parts,
             group_filters=group_filters,
             pb=pb,
@@ -685,6 +730,7 @@ def _build_stats_query(
     assert group_limit_slot is not None
     return _build_grouped_stats_query(
         source_filter=source_filter,
+        spans_source=spans_source,
         resolved_groups=resolved_groups,
         group_limit_slot=group_limit_slot,
         parts=parts,
@@ -694,6 +740,7 @@ def _build_stats_query(
 def _build_numeric_bucket_stats_query(
     *,
     source_filter: _SpanSourceFilterSQL,
+    spans_source: str,
     bucket: AgentSpanStatsNumericBucketSpec,
     metric_exprs: list[str],
     agg_selects: list[str],
@@ -781,7 +828,7 @@ def _build_numeric_bucket_stats_query(
     WITH
       {_CTE_FILTERED_SPANS} AS (
         SELECT *
-        FROM {_SPANS_TABLE} {_SPAN_ALIAS}
+        FROM {spans_source} {_SPAN_ALIAS}
         {source_filter.clause}
       ),
       {_CTE_VALUE_ROWS} AS (
@@ -862,6 +909,7 @@ def _stats_query_sql_parts(
 def _build_ungrouped_stats_query(
     *,
     source_filter: _SpanSourceFilterSQL,
+    spans_source: str,
     parts: _StatsQuerySQLParts,
     group_filters: list[AgentSpanGroupFilter],
     pb: ParamBuilder,
@@ -875,7 +923,7 @@ def _build_ungrouped_stats_query(
       ),
       {_CTE_FILTERED_SPANS} AS (
         SELECT *
-        FROM {_SPANS_TABLE} {_SPAN_ALIAS}
+        FROM {spans_source} {_SPAN_ALIAS}
         {source_filter.clause}
       ){group_filter_ctes},
       {_CTE_AGGREGATED_DATA} AS (
@@ -950,6 +998,7 @@ def _group_filter_ctes(
 def _build_grouped_stats_query(
     *,
     source_filter: _SpanSourceFilterSQL,
+    spans_source: str,
     resolved_groups: list[tuple[str, str]],
     group_limit_slot: str,
     parts: _StatsQuerySQLParts,
@@ -978,7 +1027,7 @@ def _build_grouped_stats_query(
       ),
       {_CTE_FILTERED_SPANS} AS (
         SELECT *
-        FROM {_SPANS_TABLE} {_SPAN_ALIAS}
+        FROM {spans_source} {_SPAN_ALIAS}
         {source_filter.clause}
       ),
       {_CTE_TOP_GROUPS} AS (


### PR DESCRIPTION
## Purpose

Integrate token costs into the GenAI agent spans system, mirroring how costs work for calls today. Costs are computed at read time (opt-in) and surfaced across the spans, stats, chat-view, and agents APIs so the frontend (companion PR wandb/core#46041) can show cost everywhere it shows token data.

## Approach

Spans differ from calls in a way that makes costs simpler: token usage and the model name are first-class columns, and each span has exactly one model. So per-span cost is a clean LEFT JOIN against the best-matching row in `llm_token_prices` — same pricing source of truth as calls (same table, `project > default` precedence, latest-`effective_date` tie-break). Cost is never stored; it's computed only when a caller opts in. Unpriced models yield `NULL` (not `0`) so "unpriced" stays distinguishable from "free".

## Changes

**Spans + stats**
- New `agents/span_costs.py`: ranked-model-prices subquery, the cost JOIN (keyed on `response_model`→`request_model`), per-span cost projections, and a `cost_augmented_source_sql` spans-shaped relation.
- `AgentSpansQueryReq.include_costs`: per-span cost columns (ungrouped) / summed `total_cost`/`total_input_cost`/`total_output_cost` (grouped).
- Stats: `total_cost`/`input_cost`/`output_cost` derived metrics; the stats query only reads the cost-augmented source when a cost metric is referenced.

**Chat view (trace + conversation detail)**
- The chat-view span fetch is cost-augmented, so `build_trace_chat` sums per-span cost into `AgentChatAssistantMessage.{input,output,total}_cost` (aggregated across the subtree for `invoke_agent` turns), `AgentTraceChatRes.total_cost`, and `AgentConversationChatRes.total_cost`.

**Agents / versions**
- `AgentsQueryReq` / `AgentVersionsQueryReq` gain `include_costs`; `AgentSchema` gains `total_cost`. The materialized views don't store cost, so the handler fills it from a supplementary cost-augmented grouped spans query scoped to the page's agents/versions.

## Testing

`tests/trace_server/test_genai_agent_costs.py` + chat-view unit tests, all against ClickHouse: per-span cost, cache-token subtraction, unpriced → `None`, grouped sums, stats `total_cost`, trace-chat per-message + total cost, and agents/versions cost. Full agent query/stats/chat suites pass (139 tests locally).

## Notes

- Pricing follows calls exactly (most-recent price, not time-of-span).
- Chat-view and conversations/agents queries request costs unconditionally (the price JOIN is cheap and these are low-volume detail/aggregate reads); the spans table opts in only when a cost column is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)