### PR TITLE
feat(weave): extend `/agent_search` endpoint

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -1393,6 +1393,43 @@ class TestMakeMessageSearchQuery:
 
         assert pb.get_params()["genai_1"] == r"%88\%\_off\\sale%"
 
+    def test_trace_id_full_content_no_query(self) -> None:
+        """Empty query drops the content LIKE; trace_id + full_content drive
+        structured retrieval (used by the agent scoring fallback).
+        """
+        pb = ParamBuilder("genai")
+        query = make_message_search_query(
+            pb,
+            AgentSearchReq(
+                project_id="p1",
+                query="",
+                trace_id="t1",
+                roles=["user", "assistant", "system"],
+                full_content=True,
+            ),
+        )
+
+        expected = """
+            SELECT conversation_id, conversation_name, agent_name,
+                   span_id, trace_id, role,
+                   content AS content,
+                   lower(hex(content_digest)) AS content_digest, started_at
+            FROM messages
+            WHERE project_id = {genai_0:String}
+              AND trace_id = {genai_1:String}
+              AND role IN {genai_2:Array(String)}
+            ORDER BY started_at DESC
+            LIMIT {genai_3:UInt64} OFFSET {genai_4:UInt64}
+        """
+        expected_params = {
+            "genai_0": "p1",
+            "genai_1": "t1",
+            "genai_2": ["user", "assistant", "system"],
+            "genai_3": 20,
+            "genai_4": 0,
+        }
+        assert_sql(expected, expected_params, query, pb.get_params())
+
     def test_limit_rejected_when_above_max(self) -> None:
         with pytest.raises(ValidationError):
             AgentSearchReq(project_id="p1", query="x", limit=5000)

--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -1405,7 +1405,7 @@ class TestMakeMessageSearchQuery:
                 query="",
                 trace_id="t1",
                 roles=["user", "assistant", "system"],
-                full_content=True,
+                truncate_content=False,
             ),
         )
 

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -1655,7 +1655,7 @@ def test_message_search_trace_id_full_content(ch_server):
             query="",
             trace_id=trace_id,
             roles=["user", "assistant", "system"],
-            full_content=True,
+            truncate_content=False,
         )
     )
     by_role: dict[str, list[str]] = {}

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -1616,6 +1616,59 @@ def test_message_search_shared_digest_across_spans(ch_server):
     assert len(digests) == 1
 
 
+def test_message_search_trace_id_full_content(ch_server):
+    """Structured retrieval: empty query + trace_id + full_content returns the
+    trace's user/assistant/system messages untruncated, excluding tool roles.
+    This is the path the agent scoring fallback uses.
+    """
+    project_id = _make_project_id("search_trace_full")
+    trace_id = uuid.uuid4().hex
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    long_text = "x" * 600  # exceeds the 500-char preview cap
+
+    spans = [
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=uuid.uuid4().hex,
+            operation_name="chat",
+            started_at=now,
+            system_instructions=["be helpful"],
+            input_messages=[NormalizedMessage(role="user", content=long_text)],
+            output_messages=[NormalizedMessage(role="assistant", content="hi")],
+        ),
+        # A tool span in the same trace — its tool_result row must be filtered out.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=uuid.uuid4().hex,
+            operation_name="execute_tool",
+            started_at=now + datetime.timedelta(seconds=1),
+            tool_call_result="tool output",
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_search(
+        AgentSearchReq(
+            project_id=project_id,
+            query="",
+            trace_id=trace_id,
+            roles=["user", "assistant", "system"],
+            full_content=True,
+        )
+    )
+    by_role: dict[str, list[str]] = {}
+    for r in res.results:
+        for m in r.matched_messages:
+            by_role.setdefault(m.role, []).append(m.content_preview)
+
+    assert by_role["user"] == [long_text]  # full content, not the 500-char preview
+    assert by_role["assistant"] == ["hi"]
+    assert by_role["system"] == ["be helpful"]
+    assert "tool_result" not in by_role  # excluded by the roles filter
+
+
 def test_message_search_indexes_tool_calls(ch_server):
     """tool_call_arguments and tool_call_result should each produce a
     searchable occurrence with role 'tool_call' / 'tool_result'.

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -810,9 +810,9 @@ class AgentSearchReq(BaseModel):
     agent_name: str | None = None
     provider_name: str | None = None
     request_model: str | None = None
-    # Return full message content instead of a truncated preview. Off by default
-    # to keep search-UI payloads small.
-    full_content: bool = False
+    # Truncate message content to a preview (default) to keep search-UI payloads
+    # small; set False to return full content (e.g. for structured retrieval).
+    truncate_content: bool = True
     started_after: datetime.datetime | None = None
     started_before: datetime.datetime | None = None
 

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -790,21 +790,29 @@ class AgentCustomAttrsSchemaRes(BaseModel):
 
 
 class AgentSearchReq(BaseModel):
-    """Full-text search across message content and span metadata.
+    """Query the `messages` table by content and/or span-level filters.
 
-    Scans the `messages` table (one row per message occurrence, populated
-    by an MV from spans) and returns matching span-level hits. The caller
-    groups by conversation for the response shape.
+    Scans the `messages` table (one row per message occurrence, populated by an
+    MV from spans) and returns matching span-level hits. Full-text search sets
+    `query`; structured retrieval (e.g. all messages in a trace) leaves `query`
+    empty and uses the filters below. The caller groups by conversation for the
+    response shape.
     """
 
     project_id: str
-    query: str
+    # Substring match on message content. Empty matches all (no content filter),
+    # turning this into structured retrieval over the filters below.
+    query: str = ""
 
+    trace_id: str | None = None
     roles: list[SearchMessageRole] | None = None
     conversation_id: str | None = None
     agent_name: str | None = None
     provider_name: str | None = None
     request_model: str | None = None
+    # Return full message content instead of a truncated preview. Off by default
+    # to keep search-UI payloads small.
+    full_content: bool = False
     started_after: datetime.datetime | None = None
     started_before: datetime.datetime | None = None
 

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -865,11 +865,15 @@ def _escape_like_pattern(value: str) -> str:
 def _search_filter_sql(pb: ParamBuilder, req: AgentSearchReq) -> _FilterSQL:
     """Build WHERE filters for a search against the messages table."""
     pid_slot = pb.add(req.project_id, param_type="String")
-    content_slot = pb.add(f"%{_escape_like_pattern(req.query)}%", param_type="String")
-    conditions = [
-        _project_filter_sql("project_id", pid_slot),
-        f"content LIKE {content_slot}",
-    ]
+    conditions = [_project_filter_sql("project_id", pid_slot)]
+    if req.query:
+        content_slot = pb.add(
+            f"%{_escape_like_pattern(req.query)}%", param_type="String"
+        )
+        conditions.append(f"content LIKE {content_slot}")
+    if req.trace_id:
+        trace_slot = pb.add(req.trace_id, param_type="String")
+        conditions.append(f"trace_id = {trace_slot}")
     if req.roles:
         roles_slot = pb.add(
             _normalize_search_roles(req.roles), param_type="Array(String)"
@@ -1506,13 +1510,20 @@ def make_message_search_query(pb: ParamBuilder, req: AgentSearchReq) -> str:
     # enforced on AgentSearchReq.
     limit_slot = pb.add(req.limit, param_type="UInt64")
     offset_slot = pb.add(req.offset, param_type="UInt64")
+    # Full content for structured retrieval (e.g. agent scoring); the truncated
+    # preview keeps search-UI payloads small by default.
+    content_expr = (
+        "content"
+        if req.full_content
+        else f"substring(content, 1, {SEARCH_CONTENT_PREVIEW_CHARS})"
+    )
     # content_digest is stored raw as FixedString(16); hex-encode here so
     # the Python API surface (AgentSearchMatchedMessage.content_digest: str)
     # keeps a portable text representation.
     return f"""
         SELECT conversation_id, conversation_name, agent_name,
                span_id, trace_id, role,
-               substring(content, 1, {SEARCH_CONTENT_PREVIEW_CHARS}) AS content,
+               {content_expr} AS content,
                lower(hex(content_digest)) AS content_digest, started_at
         FROM messages
         WHERE {filters.where}

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1510,12 +1510,12 @@ def make_message_search_query(pb: ParamBuilder, req: AgentSearchReq) -> str:
     # enforced on AgentSearchReq.
     limit_slot = pb.add(req.limit, param_type="UInt64")
     offset_slot = pb.add(req.offset, param_type="UInt64")
-    # Full content for structured retrieval (e.g. agent scoring); the truncated
-    # preview keeps search-UI payloads small by default.
+    # Truncated preview keeps search-UI payloads small by default; full content
+    # is for structured retrieval (e.g. agent scoring).
     content_expr = (
-        "content"
-        if req.full_content
-        else f"substring(content, 1, {SEARCH_CONTENT_PREVIEW_CHARS})"
+        f"substring(content, 1, {SEARCH_CONTENT_PREVIEW_CHARS})"
+        if req.truncate_content
+        else "content"
     )
     # content_digest is stored raw as FixedString(16); hex-encode here so
     # the Python API surface (AgentSearchMatchedMessage.content_digest: str)


### PR DESCRIPTION
## Summary

Generalizes the `messages`-table search endpoint (`agent_search`) for structured retrieval, so callers can pull a slice of messages by filters rather than only full-text search:

- `trace_id` is now one filter among many (alongside `conversation_id`, `roles`, `agent_name`, etc.).
- `query` is optional — an empty query drops the `content LIKE` clause and matches all messages.
- `truncate_content` returns truncated message content (default True).

This is to support the agent scoring worker, so it can efficiently fetch message content for scoring (in cases where it's not already present on the root span).

## Testing

- Query-builder unit test for the `trace_id` + `full_content` + empty-query path.
- ClickHouse integration test: inserts messages on child spans, retrieves by `trace_id` with `full_content`, asserts content is returned untruncated (600-char message) and tool roles are filtered out by the `roles` filter.
- Existing `TestMakeMessageSearchQuery` and search integration tests still pass (param numbering unchanged when `query` is set and `trace_id` is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)