### PR TITLE
perf(weave): bucket project_id partition keys for HPA-friendly scaling

### DIFF
--- a/tests/trace_server/test_agent_scorer_event_producer.py
+++ b/tests/trace_server/test_agent_scorer_event_producer.py
@@ -10,7 +10,7 @@ from weave.trace_server.agents.kafka_events import (
     SCORE_AGENT_SPANS_TOPIC,
     ScoreAgentSpansEvent,
 )
-from weave.trace_server.kafka import KafkaProducer
+from weave.trace_server.kafka import KafkaProducer, _bucketed_project_key
 
 
 def _make_event(**overrides) -> ScoreAgentSpansEvent:
@@ -75,3 +75,25 @@ def test_producer_publishes_under_buffer_limit() -> None:
     producer.produce.assert_called_once()
     call_kwargs = producer.produce.call_args.kwargs
     assert call_kwargs["topic"] == "weave.score_agent_spans"
+
+
+@pytest.mark.disable_logging_error_check
+def test_bucketed_project_key(monkeypatch):
+    """Bucket suffix is deterministic per salt, scoped to N, off by default."""
+    key = "WF_KAFKA_PROJECT_ID_BUCKET_COUNT"
+
+    monkeypatch.delenv(key, raising=False)
+    assert _bucketed_project_key("proj-a", "call-1") == "proj-a"
+
+    monkeypatch.setenv(key, "4")
+    first = _bucketed_project_key("proj-a", "call-1")
+    assert first == _bucketed_project_key("proj-a", "call-1")
+    prefix, _, bucket = first.partition(":")
+    assert prefix == "proj-a"
+    assert 0 <= int(bucket) < 4
+
+    seen = {
+        _bucketed_project_key("proj-a", f"call-{i}").split(":")[1] for i in range(100)
+    }
+    assert len(seen) > 1
+    assert _bucketed_project_key("proj-b", "call-1").startswith("proj-b:")

--- a/tests/trace_server/test_environment.py
+++ b/tests/trace_server/test_environment.py
@@ -10,6 +10,7 @@ from weave.trace_server.environment import (
     VALID_CALLS_SHARD_KEYS,
     kafka_producer_max_buffer_size,
     wf_clickhouse_calls_shard_key,
+    wf_kafka_project_id_bucket_count,
     wf_scoring_worker_check_cancellation,
     wf_scoring_worker_debounced_scoring_max_call_history,
     wf_scoring_worker_debounced_scoring_max_sampling_rate,
@@ -269,3 +270,24 @@ def test_wf_scoring_worker_remote_scorer_allow_insecure_http(monkeypatch):
     assert wf_scoring_worker_remote_scorer_allow_insecure_http() is False
     monkeypatch.setenv(key, "1")
     assert wf_scoring_worker_remote_scorer_allow_insecure_http() is False
+
+
+@pytest.mark.disable_logging_error_check
+def test_wf_kafka_project_id_bucket_count(monkeypatch):
+    """Bucket count defaults to 1, parses ints, floors at 1, falls back on garbage."""
+    key = "WF_KAFKA_PROJECT_ID_BUCKET_COUNT"
+    monkeypatch.delenv(key, raising=False)
+    assert wf_kafka_project_id_bucket_count() == 1
+
+    monkeypatch.setenv(key, "4")
+    assert wf_kafka_project_id_bucket_count() == 4
+    monkeypatch.setenv(key, "1")
+    assert wf_kafka_project_id_bucket_count() == 1
+    monkeypatch.setenv(key, "0")
+    assert wf_kafka_project_id_bucket_count() == 1
+    monkeypatch.setenv(key, "-3")
+    assert wf_kafka_project_id_bucket_count() == 1
+    monkeypatch.setenv(key, "not-a-number")
+    assert wf_kafka_project_id_bucket_count() == 1
+    monkeypatch.setenv(key, "")
+    assert wf_kafka_project_id_bucket_count() == 1

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -50,6 +50,19 @@ def kafka_producer_max_buffer_size() -> int | None:
         return None
 
 
+def wf_kafka_project_id_bucket_count() -> int:
+    """Sub-buckets applied to `project_id`-keyed Kafka messages. `1` disables bucketing."""
+    raw = os.environ.get("WF_KAFKA_PROJECT_ID_BUCKET_COUNT", "1")
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.exception(
+            "WF_KAFKA_PROJECT_ID_BUCKET_COUNT value '%s' is not a valid int", raw
+        )
+        return 1
+    return value if value >= 1 else 1
+
+
 # Scoring worker settings
 
 

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -60,7 +60,7 @@ def wf_kafka_project_id_bucket_count() -> int:
             "WF_KAFKA_PROJECT_ID_BUCKET_COUNT value '%s' is not a valid int", raw
         )
         return 1
-    return value if value >= 1 else 1
+    return max(1, value)
 
 
 # Scoring worker settings

--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -1,5 +1,6 @@
 import logging
 import socket
+import zlib
 from typing import Any
 
 import ddtrace
@@ -25,6 +26,7 @@ from weave.trace_server.environment import (
     kafka_client_password,
     kafka_client_user,
     kafka_producer_max_buffer_size,
+    wf_kafka_project_id_bucket_count,
 )
 
 CALL_ENDED_TOPIC = "weave.call_ended"
@@ -96,13 +98,10 @@ class KafkaProducer(ConfluentKafkaProducer):
         ):
             return
 
-        # The scoring worker assumes that events for each project all route to the same worker instance.
-        # Before changing the partition key, ensure the scoring worker has been updated to support this.
-        publish_key = call_end.project_id
         self.produce(
             topic=CALL_ENDED_TOPIC,
             value=call_end.model_dump_json(),
-            key=publish_key,
+            key=_bucketed_project_key(call_end.project_id, call_end.id),
         )
 
         if flush_immediately:
@@ -143,7 +142,7 @@ class KafkaProducer(ConfluentKafkaProducer):
             self.produce(
                 topic=SCORE_CALLS_TOPIC,
                 value=req.model_copy(update={"call_ids": chunk}).model_dump_json(),
-                key=req.project_id,
+                key=_bucketed_project_key(req.project_id, chunk[0]),
             )
 
         if flush_immediately:
@@ -307,6 +306,15 @@ class KafkaConsumer(ConfluentKafkaConsumer):
             # Async commit failure is non-fatal: the messages will be
             # redelivered on the next rebalance and reprocessed.
             logger.warning("Async batch commit failed", exc_info=True)
+
+
+def _bucketed_project_key(project_id: str, salt: str) -> str:
+    """Partition key with optional bucket suffix for spreading hot projects."""
+    bucket_count = wf_kafka_project_id_bucket_count()
+    if bucket_count <= 1:
+        return project_id
+    bucket = zlib.crc32(salt.encode()) % bucket_count
+    return f"{project_id}:{bucket}"
 
 
 def _make_broker_host() -> str:

--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -308,12 +308,14 @@ class KafkaConsumer(ConfluentKafkaConsumer):
             logger.warning("Async batch commit failed", exc_info=True)
 
 
-def _bucketed_project_key(project_id: str, salt: str) -> str:
+def _bucketed_project_key(project_id: str, bucket_seed: str) -> str:
     """Partition key with optional bucket suffix for spreading hot projects."""
     bucket_count = wf_kafka_project_id_bucket_count()
     if bucket_count <= 1:
         return project_id
-    bucket = zlib.crc32(salt.encode()) % bucket_count
+    # crc32 picks the bucket; the murmur2 partitioner re-hashes the composite key,
+    # so bucket_count caps (not equals) the partitions a project spreads across.
+    bucket = zlib.crc32(bucket_seed.encode()) % bucket_count
     return f"{project_id}:{bucket}"
 
 


### PR DESCRIPTION
## Summary
- Adds `WF_KAFKA_PROJECT_ID_BUCKET_COUNT` env var (default `1`, no-op). When `N > 1`, the produce key on `weave.call_ended` and `weave.score_calls` becomes `project_id:crc32(seed) % N`, spreading one hot project across up to N partitions/workers so we can scale on consumer-group lag.
- `produce_call_end` seeds on `call_end.id`; `produce_score_calls` on the chunk's first call_id. `produce_score_agent_spans` untouched (already keyed by conversation/trace).

## Prereqs before setting `N > 1` in prod
- alert_worker `recent_alerts_cache` is a per-pod 60s TTLCache that assumes project locality; splitting a project across pods can fire duplicate alerts (move to redis).
- scoring_worker debounced/online-eval scoring (`_filter_to_newest_in_aggregation` + delayed-task supersession) also assumes one worker sees a project's full call stream; splitting degrades debounce (superseded calls can leak through). Confirm tolerance first. Stale comment fixed in wandb/core#46115.
- Confirm `weave.call_ended` / `weave.score_calls` topics have `> 1` partitions, else bucketing is a silent no-op.

## Testing
unit tests for the env helper and the bucketed-key formula
