### PR TITLE
fix(weave): sync migration status writes so a finished migration can't be left partial

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -204,7 +204,10 @@ def test_apply_migrations_with_target_version(
     # Verify the actual SQL commands were executed
     assert migrator.ch_client.command.call_count == 2
     migrator.ch_client.command.assert_has_calls(
-        [call("CREATE TABLE test1 (id Int32)"), call("CREATE TABLE test2 (id Int32)")]
+        [
+            call("CREATE TABLE test1 (id Int32)", settings=None),
+            call("CREATE TABLE test2 (id Int32)", settings=None),
+        ]
     )
 
 
@@ -460,14 +463,16 @@ def test_execute_migration_command(migrator):
     assert (
         migrator.ch_client.database == "original_db"
     )  # Should restore original database
-    migrator.ch_client.command.assert_called_once_with("CREATE TABLE test (id Int32)")
+    migrator.ch_client.command.assert_called_once_with(
+        "CREATE TABLE test (id Int32)", settings=None
+    )
 
 
 def test_migration_non_replicated(migrator):
     # Test that non-replicated mode doesn't transform the SQL
     orig = "CREATE TABLE test (id String, project_id String) ENGINE = MergeTree ORDER BY (project_id, id);"
     migrator._execute_migration_command("test_db", orig)
-    migrator.ch_client.command.assert_called_once_with(orig)
+    migrator.ch_client.command.assert_called_once_with(orig, settings=None)
 
 
 def test_update_migration_status(migrator):
@@ -480,13 +485,15 @@ def test_update_migration_status(migrator):
     # Test start of migration
     migrator._update_migration_status("test_db", 2, is_start=True)
     migrator.ch_client.command.assert_called_with(
-        "ALTER TABLE db_management.migrations UPDATE partially_applied_version = 2 WHERE db_name = 'test_db'"
+        "ALTER TABLE db_management.migrations UPDATE partially_applied_version = 2 WHERE db_name = 'test_db'",
+        settings={"mutations_sync": 2},
     )
 
     # Test end of migration
     migrator._update_migration_status("test_db", 2, is_start=False)
     migrator.ch_client.command.assert_called_with(
-        "ALTER TABLE db_management.migrations UPDATE curr_version = 2, partially_applied_version = NULL WHERE db_name = 'test_db'"
+        "ALTER TABLE db_management.migrations UPDATE curr_version = 2, partially_applied_version = NULL WHERE db_name = 'test_db'",
+        settings={"mutations_sync": 2},
     )
 
 

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -4,7 +4,6 @@ Runs actual SQL against a single-node ClickHouse with embedded Keeper.
 """
 
 import os
-import time
 import uuid
 
 import pytest
@@ -63,19 +62,6 @@ def _get_latest_migration_version(migration_dir: str) -> int:
     ]
     assert versions, f"No up migrations found in {migration_dir}"
     return max(versions)
-
-
-def _sync_mutations(ch_client, db_name: str, table_name: str) -> None:
-    """Wait for all pending mutations to complete on a table."""
-    for _ in range(50):
-        result = ch_client.query(
-            "SELECT count() FROM system.mutations "
-            f"WHERE database = '{db_name}' AND table = '{table_name}' AND is_done = 0"
-        )
-        if result.result_rows[0][0] == 0:
-            return
-        time.sleep(0.1)
-    raise TimeoutError(f"Mutations on {db_name}.{table_name} did not complete")
 
 
 def _table_exists(ch_client, db_name: str, table_name: str) -> bool:
@@ -413,15 +399,12 @@ def test_recent_production_upgrade_path(
     # Seed a real old schema using production migrations, not hand-written DDL.
     seed_migrator = make_migrator(mgmt_db=mgmt_db, use_distributed=use_distributed)
     seed_migrator.apply_migrations(target_db, target_version=seed_version)
-    _sync_mutations(ch_client, mgmt_db, "migrations")
     assert _get_migration_version(ch_client, mgmt_db, target_db) == seed_version
     assert _get_db_engine(ch_client, target_db) == expected_engine
 
     # A new init container starts with an empty engine cache, then upgrades.
     upgrade_migrator = make_migrator(mgmt_db=mgmt_db, use_distributed=use_distributed)
     upgrade_migrator.apply_migrations(target_db)
-    _sync_mutations(ch_client, mgmt_db, "migrations")
-
     assert _get_migration_version(ch_client, mgmt_db, target_db) == latest_version
     assert _get_db_engine(ch_client, target_db) == expected_engine
     assert _table_exists(ch_client, target_db, "object_version_first_seen")
@@ -518,9 +501,6 @@ def test_all_production_down_migrations_replicated(ch_client):
     migrator.apply_migrations(target_db)
     assert _get_db_engine(ch_client, target_db) == "Atomic"
 
-    # ALTER TABLE UPDATE mutations are async; wait for them to settle
-    _sync_mutations(ch_client, mgmt_db, "migrations")
-
     # Migrate all the way back down
     migrator.apply_migrations(target_db, target_version=0)
 
@@ -547,9 +527,6 @@ def test_all_production_down_migrations_distributed(ch_client):
     migrator.apply_migrations(target_db)
     assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
     assert _get_db_engine(ch_client, target_db) == "Atomic"
-
-    # ALTER TABLE UPDATE mutations are async; wait for them to settle
-    _sync_mutations(ch_client, mgmt_db, "migrations")
 
     # Migrate all the way back down
     migrator.apply_migrations(target_db, target_version=0)

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -577,12 +577,15 @@ class BaseClickHouseTraceServerMigrator(ABC):
         self, target_db: str, target_version: int, is_start: bool = True
     ) -> None:
         """Update the migration status in management database migrations table."""
+        # mutations_sync=2 makes the status write durable on every replica before we
+        # return; the async default can leave a finished migration marked partial.
+        sync = {"mutations_sync": 2}
         if is_start:
             command = f"ALTER TABLE {self.management_db}.migrations UPDATE partially_applied_version = {target_version} WHERE db_name = '{target_db}'"
-            self._run_ddl_with_retry(command)
+            self._run_ddl_with_retry(command, settings=sync)
         else:
             command = f"ALTER TABLE {self.management_db}.migrations UPDATE curr_version = {target_version}, partially_applied_version = NULL WHERE db_name = '{target_db}'"
-            self._run_ddl_with_retry(command)
+            self._run_ddl_with_retry(command, settings=sync)
 
     @staticmethod
     def _is_safe_identifier(value: str) -> bool:
@@ -595,7 +598,9 @@ class BaseClickHouseTraceServerMigrator(ABC):
         retry=retry_if_exception(_is_transient_ch_error),
         reraise=True,
     )
-    def _run_ddl_with_retry(self, command: str) -> None:
+    def _run_ddl_with_retry(
+        self, command: str, settings: dict[str, int | str] | None = None
+    ) -> None:
         """Execute a DDL command with retry for transient replication errors.
 
         Retries with exponential backoff for known-transient codes:
@@ -603,7 +608,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
         and 999 (KEEPER_EXCEPTION) when ON CLUSTER DDL hits a transient Keeper
         coordination error.
         """
-        self.ch_client.command(command)
+        self.ch_client.command(command, settings=settings)
 
 
 class CloudClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator):

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -578,7 +578,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
     ) -> None:
         """Update the migration status in management database migrations table."""
         # mutations_sync=2 makes the status write durable on every replica before we
-        # return; the async default can leave a finished migration marked partial.
+        # return; the async default can leave a finished migration marked partial (WB-35755).
         sync = {"mutations_sync": 2}
         if is_start:
             command = f"ALTER TABLE {self.management_db}.migrations UPDATE partially_applied_version = {target_version} WHERE db_name = '{target_db}'"


### PR DESCRIPTION
## Summary
- The migrator writes migration state with async `ALTER ... UPDATE` mutations (`_update_migration_status`) and treats *submitting* them as success. If the "clear partial" mutation stalls on the replicated `db_management.migrations` table (or the process dies in the async window), the row stays `partially_applied_version=N` even though the migration's SQL already succeeded. The next boot's guard then hard-fails forever (crashlooped a managed install for ~2 weeks).
- Fix: run the status `ALTER ... UPDATE`s with `mutations_sync = 2` so they're durably applied before the migrator returns (and fail loudly if they can't).
- Jira: [WB-35755](https://coreweave.atlassian.net/browse/WB-35755)

## Testing
full migrator functional suite (cloud / replicated / distributed / legacy-Replicated-DB) passes with the now-obsolete `_sync_mutations()` test workaround removed; its removal staying green confirms the status writes are synchronous. Root cause confirmed from prod logs: no OOM/timeout/CH error in 30d, only the guard; the 026 backfill is trivially fast, so the SQL succeeded and only the async status-clear was lost.


[WB-35755]: https://coreweave.atlassian.net/browse/WB-35755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ