### PR TITLE
fix(weave): apply sortable_datetime prefilter to string datetime filters

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -2421,6 +2421,71 @@ def test_datetime_optimization_simple() -> None:
     )
 
 
+def test_datetime_optimization_string_literal_window() -> None:
+    """ISO/string started_at bounds must still emit the sortable_datetime prefilter.
+
+    Regression (PR #6570): the HAVING path learned to parse ISO / string
+    datetime literals, but the WHERE prefilter stayed numeric-only, so a string
+    started_at range produced a valid HAVING with no granule prune. On
+    calls_merged that forces a full-project GROUP BY and OOMs. Mirrors the
+    scoring-worker "earliest call in window" probe.
+    """
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("started_at")
+    cq.add_condition(
+        tsi_query.AndOperation.model_validate(
+            {
+                "$and": [
+                    {
+                        "$gte": [
+                            {"$getField": "started_at"},
+                            {"$literal": "2024-03-01T00:00:00Z"},
+                        ]
+                    },
+                    {
+                        "$lt": [
+                            {"$getField": "started_at"},
+                            {"$literal": "2024-03-01T01:00:00Z"},
+                        ]
+                    },
+                ]
+            }
+        )
+    )
+    cq.add_order("started_at", "asc")
+    cq.set_limit(1)
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.started_at) AS started_at
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_4:String}
+        WHERE (calls_merged.sortable_datetime >= {pb_2:String}
+            AND calls_merged.sortable_datetime < {pb_3:String})
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((any(calls_merged.started_at) >= {pb_0:String}))
+            AND ((any(calls_merged.started_at) < {pb_1:String}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+        )
+        ORDER BY any(calls_merged.started_at) ASC
+        LIMIT 1
+        """,
+        {
+            "pb_0": "2024-03-01 00:00:00.000000",
+            "pb_1": "2024-03-01 01:00:00.000000",
+            "pb_2": "2024-02-29 23:55:00.000000",
+            "pb_3": "2024-03-01 01:05:00.000000",
+            "pb_4": "project",
+        },
+    )
+
+
 def test_datetime_optimization_lt_simple() -> None:
     """Test basic datetime optimization with a single LT timestamp condition."""
     cq = CallsQuery(project_id="project")

--- a/weave/trace_server/calls_query_builder/optimization_builder.py
+++ b/weave/trace_server/calls_query_builder/optimization_builder.py
@@ -22,7 +22,11 @@ from weave.trace_server.calls_query_builder.utils import (
     param_slot,
 )
 from weave.trace_server.interface import query as tsi_query
-from weave.trace_server.orm import clickhouse_cast, timestamp_to_datetime_str
+from weave.trace_server.orm import (
+    clickhouse_cast,
+    parse_string_to_utc_timestamp,
+    timestamp_to_datetime_str,
+)
 from weave.trace_server.project_version.types import ReadTable, TableConfig
 
 if TYPE_CHECKING:
@@ -680,13 +684,11 @@ def _create_datetime_optimization_sql(
     if not _can_optimize_datetime_field(field_name):
         return None
 
-    literal_value = literal_operand.literal_
-
-    if not literal_value or not isinstance(literal_value, (int, float)):
+    timestamp_seconds = _resolve_datetime_literal_to_timestamp(literal_operand)
+    if timestamp_seconds is None:
         return None
 
-    # convert timestamp to datetime_str
-    timestamp = int(literal_value)
+    timestamp = int(timestamp_seconds)
 
     # Apply buffer in appropriate direction based on context and operator.
     # For normal context:
@@ -708,6 +710,26 @@ def _create_datetime_optimization_sql(
     return (
         f"{table_alias}.sortable_datetime {op_str} {param_slot(param_name, 'String')}"
     )
+
+
+def _resolve_datetime_literal_to_timestamp(
+    literal: tsi_query.LiteralOperation,
+) -> float | None:
+    """Resolve a datetime filter literal to a unix timestamp in seconds.
+
+    Mirrors `maybe_convert_datetime_operands` so the sortable_datetime prefilter
+    matches every literal shape the post-aggregation HAVING accepts: numeric
+    unix timestamps pass through and ISO / `YYYY-MM-DD` strings are parsed. bool
+    (an int subclass) and unparsable values are rejected.
+    """
+    value = literal.literal_
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        return parse_string_to_utc_timestamp(value)
+    return None
 
 
 def _maybe_use_null_check(

--- a/weave/trace_server/calls_query_builder/optimization_builder.py
+++ b/weave/trace_server/calls_query_builder/optimization_builder.py
@@ -24,7 +24,7 @@ from weave.trace_server.calls_query_builder.utils import (
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.orm import (
     clickhouse_cast,
-    parse_string_to_utc_timestamp,
+    datetime_literal_to_timestamp,
     timestamp_to_datetime_str,
 )
 from weave.trace_server.project_version.types import ReadTable, TableConfig
@@ -684,7 +684,7 @@ def _create_datetime_optimization_sql(
     if not _can_optimize_datetime_field(field_name):
         return None
 
-    timestamp_seconds = _resolve_datetime_literal_to_timestamp(literal_operand)
+    timestamp_seconds = datetime_literal_to_timestamp(literal_operand)
     if timestamp_seconds is None:
         return None
 
@@ -710,26 +710,6 @@ def _create_datetime_optimization_sql(
     return (
         f"{table_alias}.sortable_datetime {op_str} {param_slot(param_name, 'String')}"
     )
-
-
-def _resolve_datetime_literal_to_timestamp(
-    literal: tsi_query.LiteralOperation,
-) -> float | None:
-    """Resolve a datetime filter literal to a unix timestamp in seconds.
-
-    Mirrors `maybe_convert_datetime_operands` so the sortable_datetime prefilter
-    matches every literal shape the post-aggregation HAVING accepts: numeric
-    unix timestamps pass through and ISO / `YYYY-MM-DD` strings are parsed. bool
-    (an int subclass) and unparsable values are rejected.
-    """
-    value = literal.literal_
-    if isinstance(value, bool) or value is None:
-        return None
-    if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
-        return parse_string_to_utc_timestamp(value)
-    return None
 
 
 def _maybe_use_null_check(

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -581,6 +581,27 @@ def parse_string_to_utc_timestamp(value: str) -> float | None:
     return dt.timestamp()
 
 
+def datetime_literal_to_timestamp(
+    literal: tsi_query.LiteralOperation,
+) -> float | None:
+    """Resolve a datetime filter literal to a UTC unix timestamp (seconds).
+
+    Single source of truth for the literal shapes a datetime comparison accepts,
+    shared by the post-aggregation HAVING (`maybe_convert_datetime_operands`) and
+    the `sortable_datetime` pre-filter so the two never diverge. Numeric unix
+    timestamps pass through; ISO / `YYYY-MM-DD` strings are parsed; bool (an int
+    subclass) and non-scalar / unparsable values return None.
+    """
+    value = literal.literal_
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        return parse_string_to_utc_timestamp(value)
+    return None
+
+
 def clickhouse_cast(inner_sql: str, cast: tsi_query.CastTo | None = None) -> str:
     """Helper function to cast a sql expression to a clickhouse type."""
     if cast is None:
@@ -781,19 +802,10 @@ def maybe_convert_datetime_operands(
         ):
             field_idx = i
         elif isinstance(op, tsi_query.LiteralOperation):
-            lit = op.literal_
-            # bool is a subclass of int, but comparing a datetime to a bool is
-            # nonsensical -> leave it untouched.
-            if isinstance(lit, bool):
-                continue
-            if isinstance(lit, (int, float)):
+            parsed = datetime_literal_to_timestamp(op)
+            if parsed is not None:
                 literal_idx = i
-                timestamp = float(lit)
-            elif isinstance(lit, str):
-                parsed = parse_string_to_utc_timestamp(lit)
-                if parsed is not None:
-                    literal_idx = i
-                    timestamp = parsed
+                timestamp = parsed
 
     if field_idx is None or literal_idx is None or timestamp is None:
         return operands


### PR DESCRIPTION
## Summary
- `_create_datetime_optimization_sql` only matched numeric `started_at` literals, so a string/ISO datetime bound produced a valid HAVING but no `sortable_datetime` WHERE prefilter -> full-project GROUP BY on calls_merged -> 16 GiB OOM despite `LIMIT 1`.
- Resolve string/ISO/`YYYY-MM-DD` literals to a timestamp before buffering, mirroring the HAVING path's `maybe_convert_datetime_operands`.
- Real example to optimize (`POST /calls/query` -> 502 `MEMORY_LIMIT_EXCEEDED`): [APM trace](https://us5.datadoghq.com/apm/trace/6a32168600000000f1c61b7818052df1?graphType=flamegraph&spanID=11155877239779150371&trace=6a32168600000000f1c61b7818052df111155877239779150371)

BEFORE 
```sql
SELECT
    calls_merged.id AS id,
    any(calls_merged.op_name) AS op_name,
    calls_merged.project_id AS project_id,
    any(calls_merged.started_at) AS started_at,
    any(calls_merged.trace_id) AS trace_id
FROM calls_merged
PREWHERE calls_merged.project_id = 'ProjectInternalId:44150787'
GROUP BY (calls_merged.project_id, calls_merged.id)
HAVING (
    (any(calls_merged.started_at) >= '2026-06-17 02:00:00.000000')
    AND (any(calls_merged.started_at) <  '2026-06-17 03:00:00.000000')
    AND (any(calls_merged.deleted_at) IS NULL)
    AND (NOT (any(calls_merged.op_name) IS NULL))
)
ORDER BY any(calls_merged.started_at) ASC, calls_merged.id ASC
LIMIT 1
```
```
Elapsed: 12.057s
Memory Usage: 35.24 GB
Read: 49,169,472 rows (12.69 GB)
```


AFTER (with the sortable_datetime prefilter the fix emits):
```sql
SELECT
    calls_merged.id AS id,
    any(calls_merged.op_name) AS op_name,
    calls_merged.project_id AS project_id,
    any(calls_merged.started_at) AS started_at,
    any(calls_merged.trace_id) AS trace_id
FROM calls_merged
PREWHERE calls_merged.project_id = 'ProjectInternalId:44150787'
WHERE (
    calls_merged.sortable_datetime >= '2026-06-17 01:55:00.000000'    --<<<<<<<<<<<
    AND calls_merged.sortable_datetime <  '2026-06-17 03:05:00.000000' --<<<<<<<<
)
GROUP BY (calls_merged.project_id, calls_merged.id)
HAVING (
    (any(calls_merged.started_at) >= '2026-06-17 02:00:00.000000')
    AND (any(calls_merged.started_at) <  '2026-06-17 03:00:00.000000')
    AND (any(calls_merged.deleted_at) IS NULL)
    AND (NOT (any(calls_merged.op_name) IS NULL))
)
ORDER BY any(calls_merged.started_at) ASC, calls_merged.id ASC
LIMIT 1
```
```
Elapsed: 0.386s
Memory Usage: 89.61 MiB
Read: 29,734 rows (8.79 MB)
```
