### PR TITLE
chore(weave): skip llm judge publish test on fake trace server

### DIFF
--- a/tests/trace/test_llm_as_a_judge_scorer.py
+++ b/tests/trace/test_llm_as_a_judge_scorer.py
@@ -154,6 +154,7 @@ def test_llm_as_a_judge_scorer_record_excludes_op_methods():
     assert "summarize" in plain_record.__dict__
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_llm_as_a_judge_scorer_publish_has_no_op_refs(client):
     """The published payload must carry no op refs, so the scoring worker accepts it.
 


### PR DESCRIPTION
## Summary
- `test_llm_as_a_judge_scorer_publish_has_no_op_refs` publishes objects via `weave.publish()`, but the new in-memory fake backend (skeleton from #7145) has no `obj_create` yet, so the call returns `None` and the test fails deterministically on the fake job (not a flake).
- The fake stack gates such tests with `@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, ...)`; this test (added in #7183) slipped through. The same gate already sits on `test_publish_and_load_scorer_with_prompt_ref` in this file. Drop it when the fake implements objects.

Original failure ([CI job](https://github.com/wandb/weave/actions/runs/27664896940/job/81816735280)):
```
AttributeError: 'NoneType' object has no attribute 'digest'
```

## Testing
test only change.