### PR TITLE
chore(weave): expose dataset_sources over the remote-HTTP trace server

### DIFF
--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -1288,6 +1288,47 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             tsi.AnnotatorQueueItemsProgressUpdateRes,
         )
 
+    # Dataset Sources API
+    def dataset_sources_link(
+        self, req: tsi.DatasetSourcesLinkReq
+    ) -> tsi.DatasetSourcesLinkRes:
+        return self._generic_request(
+            "/dataset_sources/link",
+            req,
+            tsi.DatasetSourcesLinkReq,
+            tsi.DatasetSourcesLinkRes,
+        )
+
+    def dataset_sources_link_delete(
+        self, req: tsi.DatasetSourcesLinkDeleteReq
+    ) -> tsi.DatasetSourcesLinkDeleteRes:
+        return self._generic_request(
+            "/dataset_sources/link_delete",
+            req,
+            tsi.DatasetSourcesLinkDeleteReq,
+            tsi.DatasetSourcesLinkDeleteRes,
+        )
+
+    def dataset_sources_query(
+        self, req: tsi.DatasetSourcesQueryReq
+    ) -> tsi.DatasetSourcesQueryRes:
+        return self._generic_request(
+            "/dataset_sources/query",
+            req,
+            tsi.DatasetSourcesQueryReq,
+            tsi.DatasetSourcesQueryRes,
+        )
+
+    def source_datasets_query(
+        self, req: tsi.SourceDatasetsQueryReq
+    ) -> tsi.SourceDatasetsQueryRes:
+        return self._generic_request(
+            "/dataset_sources/source_datasets_query",
+            req,
+            tsi.SourceDatasetsQueryReq,
+            tsi.SourceDatasetsQueryRes,
+        )
+
     def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
         raise NotImplementedError("evaluate_model is not implemented")
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Exposes `dataset_sources` over the remote-HTTP trace server so the Python SDK client
(`RemoteHTTPTraceServer`) can reach the endpoints.

    Adds the four bindings (`dataset_sources_link`, `dataset_sources_link_delete`,
`dataset_sources_query`, `source_datasets_query`) as thin `_generic_request` passthroughs to the
`/dataset_sources/*` routes.