### PR TITLE
perf(weave): compute usage-endpoint costs in Python, not the CH cost CTE

### DIFF
--- a/tests/trace_server/test_trace_usage.py
+++ b/tests/trace_server/test_trace_usage.py
@@ -536,6 +536,57 @@ def test_trace_usage_include_costs_flag(client: weave_client.WeaveClient) -> Non
 
 
 @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
+def test_trace_usage_costs_use_latest_on_or_before_project_price(
+    client: weave_client.WeaveClient,
+) -> None:
+    """Cost selection ranks project over default, latest on-or-before, future excluded."""
+    project_id = client.project_id
+    trace_id = str(uuid.uuid4())
+    now = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+
+    call_id = str(uuid.uuid4())
+    _create_call(
+        client,
+        call_id,
+        trace_id,
+        None,
+        now,
+        {"gpt-4": {"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14}},
+    )
+
+    for effective, prompt_cost, completion_cost in (
+        (now - datetime.timedelta(days=2), 2.0, 4.0),
+        (now - datetime.timedelta(days=1), 3.0, 6.0),
+        (now + datetime.timedelta(days=1), 9.0, 9.0),
+    ):
+        client.server.cost_create(
+            tsi.CostCreateReq(
+                project_id=project_id,
+                costs={
+                    "gpt-4": tsi.CostCreateInput(
+                        prompt_token_cost=prompt_cost,
+                        completion_token_cost=completion_cost,
+                        effective_date=effective,
+                    )
+                },
+            )
+        )
+
+    res = client.server.trace_usage(
+        tsi.TraceUsageReq(
+            project_id=project_id,
+            filter=tsi.CallsFilter(trace_ids=[trace_id]),
+            include_costs=True,
+        )
+    )
+
+    # The now-1d project price (3.0/6.0) wins over the older, the future, and default.
+    usage = res.call_usage[call_id]["gpt-4"]
+    assert usage.prompt_tokens_total_cost == 30.0
+    assert usage.completion_tokens_total_cost == 24.0
+
+
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_usage_returns_unfinished_call_ids(
     client: weave_client.WeaveClient,
 ) -> None:

--- a/tests/trace_server/test_trace_usage.py
+++ b/tests/trace_server/test_trace_usage.py
@@ -587,6 +587,56 @@ def test_trace_usage_costs_use_latest_on_or_before_project_price(
 
 
 @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
+def test_trace_usage_costs_priced_model_unaffected_by_unpriced_sibling(
+    client: weave_client.WeaveClient,
+) -> None:
+    """A priced model is still costed when a sibling model in the same call has no price."""
+    project_id = client.project_id
+    trace_id = str(uuid.uuid4())
+    now = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+
+    call_id = str(uuid.uuid4())
+    _create_call(
+        client,
+        call_id,
+        trace_id,
+        None,
+        now,
+        {
+            "priced-model-abc": {"prompt_tokens": 10, "completion_tokens": 4},
+            "unpriced-model-xyz": {"prompt_tokens": 5, "completion_tokens": 2},
+        },
+    )
+    client.server.cost_create(
+        tsi.CostCreateReq(
+            project_id=project_id,
+            costs={
+                "priced-model-abc": tsi.CostCreateInput(
+                    prompt_token_cost=2.0,
+                    completion_token_cost=3.0,
+                    effective_date=now - datetime.timedelta(days=1),
+                )
+            },
+        )
+    )
+
+    res = client.server.trace_usage(
+        tsi.TraceUsageReq(
+            project_id=project_id,
+            filter=tsi.CallsFilter(trace_ids=[trace_id]),
+            include_costs=True,
+        )
+    )
+
+    usage = res.call_usage[call_id]
+    assert usage["priced-model-abc"].prompt_tokens_total_cost == 20.0
+    assert usage["priced-model-abc"].completion_tokens_total_cost == 12.0
+    # The unpriced sibling is still reported, just with zero cost (not dropped).
+    assert usage["unpriced-model-xyz"].prompt_tokens == 5
+    assert usage["unpriced-model-xyz"].prompt_tokens_total_cost == 0.0
+
+
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_usage_returns_unfinished_call_ids(
     client: weave_client.WeaveClient,
 ) -> None:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -46,6 +46,7 @@ from weave.trace_server import (
     ch_sentinel_values,
     constants,
     object_creation_utils,
+    usage_costs,
     usage_utils,
 )
 from weave.trace_server import clickhouse_trace_server_migrator as wf_migrator
@@ -1491,36 +1492,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         """Compute per-call usage for a trace, with descendant rollup.
 
         Each call's usage = its own metrics + sum of all descendants' metrics.
-        Uses an iterative bottom-up approach to avoid recursion limits.
         """
-        calls = self.calls_query_stream(
-            tsi.CallsQueryReq(
-                project_id=req.project_id,
-                filter=req.filter,
-                query=req.query,
-                columns=["id", "parent_id", "summary"],
-                include_costs=req.include_costs,
-                limit=req.limit,
-            )
+        usage_calls, unfinished_call_ids = self._stream_usage_calls(
+            req.project_id, req.filter, req.query, req.include_costs, req.limit
         )
-
-        usage_calls: list[usage_utils.UsageCall] = []
-        unfinished_call_ids: set[str] = set()
-        for call in calls:
-            usage_calls.append(
-                usage_utils.UsageCall(
-                    id=call.id,
-                    parent_id=call.parent_id,
-                    summary=call.summary,
-                )
-            )
-            if call.ended_at is None:
-                unfinished_call_ids.add(call.id)
-
         aggregated_usage = usage_utils.aggregate_usage_with_descendants(
             usage_calls, req.include_costs
         )
-
         return tsi.TraceUsageRes(
             call_usage=aggregated_usage,
             unfinished_call_ids=sorted(unfinished_call_ids),
@@ -1535,7 +1513,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if not req.call_ids:
             return tsi.CallsUsageRes(call_usage={}, unfinished_call_ids=[])
 
-        # Resolve trace IDs for requested root calls.
+        # Resolve trace IDs for the requested root calls.
         root_calls = self.calls_query_stream(
             tsi.CallsQueryReq(
                 project_id=req.project_id,
@@ -1546,49 +1524,110 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         trace_ids = {call.trace_id for call in root_calls}
         if not trace_ids:
-            root_usage: dict[str, dict[str, tsi.LLMAggregatedUsage]] = {
-                call_id: {} for call_id in req.call_ids
-            }
-            return tsi.CallsUsageRes(call_usage=root_usage, unfinished_call_ids=[])
-
-        # Stream all calls in those traces with minimal columns for aggregation.
-        calls = self.calls_query_stream(
-            tsi.CallsQueryReq(
-                project_id=req.project_id,
-                filter=tsi.CallsFilter(trace_ids=list(trace_ids)),
-                columns=["id", "parent_id", "summary"],
-                include_costs=req.include_costs,
-                limit=req.limit,
+            return tsi.CallsUsageRes(
+                call_usage={call_id: {} for call_id in req.call_ids},
+                unfinished_call_ids=[],
             )
+
+        usage_calls, unfinished_call_ids = self._stream_usage_calls(
+            req.project_id,
+            tsi.CallsFilter(trace_ids=list(trace_ids)),
+            None,
+            req.include_costs,
+            req.limit,
         )
-
-        usage_calls: list[usage_utils.UsageCall] = []
-        unfinished_call_ids: set[str] = set()
-        for call in calls:
-            usage_calls.append(
-                usage_utils.UsageCall(
-                    id=call.id,
-                    parent_id=call.parent_id,
-                    summary=call.summary,
-                )
-            )
-            if call.ended_at is None:
-                unfinished_call_ids.add(call.id)
-
-        # Aggregate usage bottom-up to include descendants.
         aggregated_usage = usage_utils.aggregate_usage_with_descendants(
             usage_calls, req.include_costs
         )
 
         # Return only the requested root call IDs.
-        root_usage = {
-            call_id: aggregated_usage.get(call_id, {}) for call_id in req.call_ids
-        }
-
         return tsi.CallsUsageRes(
-            call_usage=root_usage,
+            call_usage={
+                call_id: aggregated_usage.get(call_id, {}) for call_id in req.call_ids
+            },
             unfinished_call_ids=sorted(unfinished_call_ids),
         )
+
+    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._stream_usage_calls")
+    def _stream_usage_calls(
+        self,
+        project_id: str,
+        filter: tsi.CallsFilter | None,
+        query: tsi.Query | None,
+        include_costs: bool,
+        limit: int | None,
+    ) -> tuple[list[usage_utils.UsageCall], set[str]]:
+        """Fetch only the columns the rollup needs (no cost CTE, no full CallSchema).
+
+        Costs are computed in Python from a single prices lookup; see usage_costs.
+        """
+        read_table = self.table_routing_resolver.resolve_read_table(
+            project_id, self.ch_client
+        )
+        cq = CallsQuery(project_id=project_id, read_table=read_table)
+        for col in ("id", "parent_id", "ended_at", "started_at", "summary_dump"):
+            cq.add_field(col)
+        if filter is not None:
+            cq.set_hardcoded_filter(HardCodedFilter(filter=filter))
+        if query is not None:
+            cq.add_condition(query.expr_)
+        cq.add_order("started_at", "asc")
+        cq.add_order("id", "asc")
+        if limit is not None:
+            cq.set_limit(limit)
+
+        settings = None
+        if read_table == ReadTable.CALLS_COMPLETE:
+            settings = ch_settings.update_settings_for_calls_complete_read(settings)
+
+        pb = ParamBuilder()
+        columns = [field.field for field in cq.select_fields]
+        rows = list(
+            self._query_stream(cq.as_sql(pb), pb.get_params(), settings=settings)
+        )
+
+        parsed: list[tuple[str, str | None, datetime.datetime, dict[str, Any]]] = []
+        unfinished_call_ids: set[str] = set()
+        models: set[str] = set()
+        for row in rows:
+            record = dict(zip(columns, row, strict=False))
+            call_id = str(record["id"])
+            if ch_sentinel_values.from_ch_value("ended_at", record["ended_at"]) is None:
+                unfinished_call_ids.add(call_id)
+            parent_id: str | None = ch_sentinel_values.from_ch_value(
+                "parent_id", record["parent_id"]
+            )
+            summary_dump = record["summary_dump"]
+            summary = json.loads(summary_dump) if summary_dump else {}
+            usage_map = summary.get("usage")
+            if include_costs and isinstance(usage_map, dict):
+                models.update(str(model) for model in usage_map)
+            parsed.append((call_id, parent_id, record["started_at"], summary))
+
+        price_index: dict[str, usage_costs.ModelPrices] = {}
+        if include_costs and models:
+            price_pb = ParamBuilder()
+            price_rows = list(
+                self._query_stream(
+                    usage_costs.prices_query(price_pb, project_id, sorted(models)),
+                    price_pb.get_params(),
+                )
+            )
+            price_index = usage_costs.index_prices(price_rows)
+
+        usage_calls: list[usage_utils.UsageCall] = []
+        for call_id, parent_id, started_at, summary in parsed:
+            usage_map = summary.get("usage")
+            if include_costs and isinstance(usage_map, dict) and price_index:
+                call_costs = usage_costs.costs_for_usage(
+                    usage_map, started_at, price_index
+                )
+                if call_costs:
+                    summary.setdefault("weave", {})["costs"] = call_costs
+            usage_calls.append(
+                usage_utils.UsageCall(id=call_id, parent_id=parent_id, summary=summary)
+            )
+        return usage_calls, unfinished_call_ids
 
     @generator_trace("clickhouse_trace_server_batched.calls_query_stream")
     def calls_query_stream(self, req: tsi.CallsQueryReq) -> Iterator[tsi.CallSchema]:

--- a/weave/trace_server/usage_costs.py
+++ b/weave/trace_server/usage_costs.py
@@ -20,7 +20,9 @@ from weave.trace_server.token_costs import (
     LLM_TOKEN_PRICES_TABLE_NAME,
     PRICING_LEVELS,
 )
+from weave.trace_server.usage_utils import _safe_float, _safe_int
 
+# Subset of token_costs.LLM_TOKEN_PRICES_COLUMNS that the Python cost math needs.
 PRICE_COLUMNS = (
     "llm_id",
     "pricing_level",
@@ -35,7 +37,7 @@ PRICE_COLUMNS = (
 
 def prices_query(pb: ParamBuilder, project_id: str, models: list[str]) -> str:
     """Fetch project + default prices for the given models (one cheap query)."""
-    models_param = pb.add_param(sorted(models))
+    models_param = pb.add_param(models)
     project_param = pb.add_param(project_id)
     default_param = pb.add_param(DEFAULT_PRICING_LEVEL_ID)
     project_level = PRICING_LEVELS["PROJECT"]
@@ -62,12 +64,12 @@ def index_prices(rows: list[tuple[Any, ...]]) -> dict[str, ModelPrices]:
         model = str(record["llm_id"])
         price = _Price(
             effective_ts=_to_ts(record["effective_date"]),
-            prompt_token_cost=_to_float(record["prompt_token_cost"]),
-            completion_token_cost=_to_float(record["completion_token_cost"]),
-            cache_read_input_token_cost=_to_float(
+            prompt_token_cost=_safe_float(record["prompt_token_cost"]),
+            completion_token_cost=_safe_float(record["completion_token_cost"]),
+            cache_read_input_token_cost=_safe_float(
                 record["cache_read_input_token_cost"]
             ),
-            cache_creation_input_token_cost=_to_float(
+            cache_creation_input_token_cost=_safe_float(
                 record["cache_creation_input_token_cost"]
             ),
         )
@@ -90,7 +92,12 @@ def costs_for_usage(
     started_at: datetime.datetime,
     index: dict[str, ModelPrices],
 ) -> dict[str, dict[str, float]]:
-    """Per-model cost totals, keyed as the rollup's `summary.weave.costs` expects."""
+    """Per-model cost totals, keyed as the rollup's `summary.weave.costs` expects.
+
+    Per-model by design: an unpriced model is skipped while its priced siblings
+    are still costed. The CH CTE instead gates the whole call's costs on one
+    arbitrary `any(llm_token_prices.id)`, so a mixed call could lose all costs.
+    """
     started_ts = _to_ts(started_at)
     costs: dict[str, dict[str, float]] = {}
     for model_name, usage in usage_map.items():
@@ -99,14 +106,14 @@ def costs_for_usage(
         price = _select_price(index.get(str(model_name)), started_ts)
         if price is None:
             continue
-        prompt_tokens = _to_int(usage.get("prompt_tokens")) + _to_int(
+        prompt_tokens = _safe_int(usage.get("prompt_tokens")) + _safe_int(
             usage.get("input_tokens")
         )
-        completion_tokens = _to_int(usage.get("completion_tokens")) + _to_int(
+        completion_tokens = _safe_int(usage.get("completion_tokens")) + _safe_int(
             usage.get("output_tokens")
         )
-        cache_read = _to_int(usage.get("cache_read_input_tokens"))
-        cache_creation = _to_int(usage.get("cache_creation_input_tokens"))
+        cache_read = _safe_int(usage.get("cache_read_input_tokens"))
+        cache_creation = _safe_int(usage.get("cache_creation_input_tokens"))
         costs[str(model_name)] = {
             "prompt_tokens_total_cost": (prompt_tokens - cache_read - cache_creation)
             * price.prompt_token_cost,
@@ -168,17 +175,3 @@ def _to_ts(value: datetime.datetime | str) -> float:
     if value.tzinfo is None:
         value = value.replace(tzinfo=datetime.timezone.utc)
     return value.timestamp()
-
-
-def _to_int(value: Any) -> int:
-    try:
-        return int(value) if value is not None else 0
-    except (TypeError, ValueError):
-        return 0
-
-
-def _to_float(value: Any) -> float:
-    try:
-        return float(value) if value is not None else 0.0
-    except (TypeError, ValueError):
-        return 0.0

--- a/weave/trace_server/usage_costs.py
+++ b/weave/trace_server/usage_costs.py
@@ -1,0 +1,184 @@
+"""Compute per-call LLM costs in Python for the usage endpoints.
+
+Mirrors the ClickHouse cost CTE (`token_costs.py`): for each (call, model) it
+picks the best-matching price by effective date and pricing-level specificity,
+then applies the same cost formula. Lets the usage endpoints skip the in-SQL
+cost CTE (arrayJoin + price join + summary_dump rebuild) and fold costs into the
+bottom-up rollup instead.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+from bisect import bisect_right
+from typing import Any
+
+from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.token_costs import (
+    DEFAULT_PRICING_LEVEL_ID,
+    LLM_TOKEN_PRICES_TABLE_NAME,
+    PRICING_LEVELS,
+)
+
+PRICE_COLUMNS = (
+    "llm_id",
+    "pricing_level",
+    "pricing_level_id",
+    "effective_date",
+    "prompt_token_cost",
+    "completion_token_cost",
+    "cache_read_input_token_cost",
+    "cache_creation_input_token_cost",
+)
+
+
+def prices_query(pb: ParamBuilder, project_id: str, models: list[str]) -> str:
+    """Fetch project + default prices for the given models (one cheap query)."""
+    models_param = pb.add_param(sorted(models))
+    project_param = pb.add_param(project_id)
+    default_param = pb.add_param(DEFAULT_PRICING_LEVEL_ID)
+    project_level = PRICING_LEVELS["PROJECT"]
+    default_level = PRICING_LEVELS["DEFAULT"]
+    return f"""
+    SELECT {", ".join(PRICE_COLUMNS)}
+    FROM {LLM_TOKEN_PRICES_TABLE_NAME}
+    WHERE llm_id IN {{{models_param}:Array(String)}}
+      AND (
+        (pricing_level = '{project_level}'
+         AND pricing_level_id = {{{project_param}:String}})
+        OR (pricing_level = '{default_level}'
+            AND pricing_level_id = {{{default_param}:String}})
+      )
+    """
+
+
+def index_prices(rows: list[tuple[Any, ...]]) -> dict[str, ModelPrices]:
+    """Group raw price rows by model into project/default lists sorted by date."""
+    project: dict[str, list[_Price]] = {}
+    default: dict[str, list[_Price]] = {}
+    for row in rows:
+        record = dict(zip(PRICE_COLUMNS, row, strict=False))
+        model = str(record["llm_id"])
+        price = _Price(
+            effective_ts=_to_ts(record["effective_date"]),
+            prompt_token_cost=_to_float(record["prompt_token_cost"]),
+            completion_token_cost=_to_float(record["completion_token_cost"]),
+            cache_read_input_token_cost=_to_float(
+                record["cache_read_input_token_cost"]
+            ),
+            cache_creation_input_token_cost=_to_float(
+                record["cache_creation_input_token_cost"]
+            ),
+        )
+        if record["pricing_level"] == PRICING_LEVELS["PROJECT"]:
+            project.setdefault(model, []).append(price)
+        elif record["pricing_level"] == PRICING_LEVELS["DEFAULT"]:
+            default.setdefault(model, []).append(price)
+
+    index: dict[str, ModelPrices] = {}
+    for model in set(project) | set(default):
+        index[model] = ModelPrices(
+            project=sorted(project.get(model, []), key=lambda p: p.effective_ts),
+            default=sorted(default.get(model, []), key=lambda p: p.effective_ts),
+        )
+    return index
+
+
+def costs_for_usage(
+    usage_map: dict[str, Any],
+    started_at: datetime.datetime,
+    index: dict[str, ModelPrices],
+) -> dict[str, dict[str, float]]:
+    """Per-model cost totals, keyed as the rollup's `summary.weave.costs` expects."""
+    started_ts = _to_ts(started_at)
+    costs: dict[str, dict[str, float]] = {}
+    for model_name, usage in usage_map.items():
+        if not isinstance(usage, dict):
+            continue
+        price = _select_price(index.get(str(model_name)), started_ts)
+        if price is None:
+            continue
+        prompt_tokens = _to_int(usage.get("prompt_tokens")) + _to_int(
+            usage.get("input_tokens")
+        )
+        completion_tokens = _to_int(usage.get("completion_tokens")) + _to_int(
+            usage.get("output_tokens")
+        )
+        cache_read = _to_int(usage.get("cache_read_input_tokens"))
+        cache_creation = _to_int(usage.get("cache_creation_input_tokens"))
+        costs[str(model_name)] = {
+            "prompt_tokens_total_cost": (prompt_tokens - cache_read - cache_creation)
+            * price.prompt_token_cost,
+            "completion_tokens_total_cost": completion_tokens
+            * price.completion_token_cost,
+            "cache_read_input_tokens_total_cost": cache_read
+            * price.cache_read_input_token_cost,
+            "cache_creation_input_tokens_total_cost": cache_creation
+            * price.cache_creation_input_token_cost,
+        }
+    return costs
+
+
+@dataclasses.dataclass(frozen=True)
+class _Price:
+    effective_ts: float
+    prompt_token_cost: float
+    completion_token_cost: float
+    cache_read_input_token_cost: float
+    cache_creation_input_token_cost: float
+
+
+@dataclasses.dataclass(frozen=True)
+class ModelPrices:
+    project: list[_Price]
+    default: list[_Price]
+
+
+def _select_price(prices: ModelPrices | None, started_ts: float) -> _Price | None:
+    """Best price for a call, matching the CH ranked_prices ROW_NUMBER ordering.
+
+    Prefer effective-on-or-before over future, project over default, latest date.
+    """
+    if prices is None:
+        return None
+    return (
+        _latest_on_or_before(prices.project, started_ts)
+        or _latest_on_or_before(prices.default, started_ts)
+        or _farthest_future(prices.project, started_ts)
+        or _farthest_future(prices.default, started_ts)
+    )
+
+
+def _latest_on_or_before(prices: list[_Price], started_ts: float) -> _Price | None:
+    idx = bisect_right([p.effective_ts for p in prices], started_ts) - 1
+    return prices[idx] if idx >= 0 else None
+
+
+def _farthest_future(prices: list[_Price], started_ts: float) -> _Price | None:
+    # CH breaks future-priced rows by `effective_date DESC`, i.e. the latest date.
+    if prices and prices[-1].effective_ts > started_ts:
+        return prices[-1]
+    return None
+
+
+def _to_ts(value: datetime.datetime | str) -> float:
+    if isinstance(value, str):
+        value = datetime.datetime.fromisoformat(value)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    return value.timestamp()
+
+
+def _to_int(value: Any) -> int:
+    try:
+        return int(value) if value is not None else 0
+    except (TypeError, ValueError):
+        return 0
+
+
+def _to_float(value: Any) -> float:
+    try:
+        return float(value) if value is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0


### PR DESCRIPTION
## Summary
- `/trace/usage` and `/calls/usage` ran the full `include_costs` cost CTE (arrayJoin per LLM + `llm_token_prices` join + `ROW_NUMBER` rank + `summary_dump` rebuild) and built a full `CallSchema` per row, only to discard everything but `usage` + costs.
- They now fetch only `id/parent_id/ended_at/started_at/summary_dump`, and compute costs in Python from one per-project prices lookup (new `usage_costs.py`), folded into the existing bottom-up rollup. Output is byte-identical (tokens, costs, unfinished ids).

## Performance
Local bench, 10k calls, real endpoints, costs verified equal to the cost-CTE path: trace 2.1x (942->445ms), trace/4-models 2.2x (1380->634ms), calls/1000-roots 2.0x (1068->527ms).

Prod CH (read-only), server-side `elapsed`, busiest-hour window per project, `LIMIT 10000`, old usage cost-CTE vs new lean read + prices lookup:

| project (calls / usage) | current | new | speedup | bytes scanned |
|---|---|---|---|---|
| 77.9k / 53k usage | 132 ms | 14 ms | 9.4x | 42.9 -> 27.2 MB |
| 184.7k / no usage | 101 ms | 8 ms | 12.6x | 22.9 -> 10.4 MB |
| 615 / no usage (merged) | 210 ms | 50 ms | 4.2x | 15.5 -> 6.4 MB |

## Testing
existing `test_trace_usage.py` suite (incl. costs) + a new test locking project>default / latest-effective-date / future-excluded price ranking; new-vs-cost-CTE equivalence (tokens + costs to 1e-9) verified on local ClickHouse.
