### PR TITLE
fix(weave): detone emoji scorer tags at write time

### DIFF
--- a/tests/trace/test_client_feedback.py
+++ b/tests/trace/test_client_feedback.py
@@ -202,6 +202,29 @@ def test_feedback_apis(client):
 
 
 @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
+def test_agent_user_feedback_emoji_tag_is_detoned(client):
+    def create(scorer_tags):
+        return client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=client.project_id,
+                wb_user_id="VXNlcjoxOQ==",
+                weave_ref="weave:///entity/project/object/name:digest",
+                feedback_type="wandb.agent_user_feedback",
+                payload={},
+                scorer_tags=scorer_tags,
+            )
+        )
+
+    # The emoji thumb is detoned (skin-tone variants collapse to one alias).
+    res = create(["👍🏽"])
+    assert res.payload["detoned_alias"] == ":thumbs_up:"
+
+    # A non-emoji tag gets no alias.
+    res = create(["looks-good"])
+    assert "detoned_alias" not in res.payload
+
+
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_payload(client):
     project_id = client.project_id
 

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -92,6 +92,13 @@ def process_feedback_payload(
         processed_payload["detoned"] = detoned
         processed_payload["detoned_alias"] = emoji.demojize(detoned)
 
+    # Detone an agent user feedback's emoji scorer tag the same way we already
+    # detone reaction emojis.
+    if feedback_type_is_agent_user_feedback(feedback_req.feedback_type):
+        tag = feedback_req.scorer_tags[0] if feedback_req.scorer_tags else ""
+        if emoji.emoji_count(tag) == 1:
+            processed_payload["detoned_alias"] = emoji.demojize(detone_emojis(tag))
+
     # Validate payload size
     payload = json.dumps(processed_payload)
     if len(payload) > ch_settings.CLICKHOUSE_MAX_FEEDBACK_PAYLOAD_SIZE:


### PR DESCRIPTION
## Description

`wandb.agent_user_feedback` (the agents thumbs up/down) records its value as an emoji in `scorer_tags`, e.g. `["👍"]`.

Reactions (`wandb.reaction.1`) are already detoned at write time — their emoji is stored alongside a `detoned_alias` (e.g. `:thumbs_up:`) so skin-tone variants (👍🏻/👍🏽/👍🏿) collapse to one stable key. Agent user feedback's emoji tag wasn't, so downstream consumers couldn't reliably match it (a 👍🏽 wouldn't equal a plain 👍).

This detones an agent user feedback's emoji scorer tag the same way, storing `detoned_alias` in the payload — mirroring the existing reaction handling. Other feedback types are untouched.

### Behavior (feedback_type `wandb.agent_user_feedback`)

| `scorer_tags` | stored `detoned_alias` |
|---|---|
| `["👍"]` | `:thumbs_up:` |
| `["👍🏽"]` (skin tone) | `:thumbs_up:` |
| `["👎"]` | `:thumbs_down:` |
| `["looks-good"]` | _(key omitted)_ |

This hasn't gone GA, so no migration/backfill is needed — only new feedback rows are affected.

## Testing

- [x] Manual
- [x] Unit
- [x] QA
