### PR TITLE
feat(weave_ts): tag declarative evaluation child calls with eval metadata

### DIFF
--- a/sdks/node/src/__tests__/evaluation.test.ts
+++ b/sdks/node/src/__tests__/evaluation.test.ts
@@ -229,12 +229,13 @@ describe('Evaluation - declarative eval metadata', () => {
       expect(call.attributes?._weave_eval_meta?.declarative).toBe(true);
     }
 
-    // The root evaluate call is recognized by op_name, so it is not tagged.
-    const rootCall = calls.find(c =>
+    // Exactly one root evaluate call; recognized by op_name, so it is
+    // intentionally not tagged (its attributes are read before the wrapper runs).
+    const rootCalls = calls.filter(c =>
       c.op_name?.includes(EVALUATION_RUN_OP_NAME)
     );
-    expect(rootCall).toBeDefined();
-    expect(rootCall?.attributes?._weave_eval_meta).toBeUndefined();
+    expect(rootCalls).toHaveLength(1);
+    expect(rootCalls[0].attributes?._weave_eval_meta).toBeUndefined();
   });
 
   // A flat overwrite would drop the outer marker; deep-merge keeps both keys.

--- a/sdks/node/src/__tests__/evaluation.test.ts
+++ b/sdks/node/src/__tests__/evaluation.test.ts
@@ -226,7 +226,7 @@ describe('Evaluation - declarative eval metadata', () => {
       ...modelCalls,
       ...scorerCalls,
     ]) {
-      expect(call.attributes?._weave_eval_meta?.declarative).toBe(true);
+      expect(call.attributes?._weave_eval_meta).toEqual({declarative: true});
     }
 
     // Exactly one root evaluate call; recognized by op_name, so it is
@@ -248,16 +248,27 @@ describe('Evaluation - declarative eval metadata', () => {
     });
 
     const calls = await getCalls(traceServer, projectId);
-    const childCalls = calls.filter(
+    const predictAndScoreCalls = calls.filter(c =>
+      c.op_name?.includes(EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS)
+    );
+    const modelCalls = calls.filter(c => c.op_name?.includes('mockPrediction'));
+    const scorerCalls = calls.filter(
       c =>
-        c.op_name?.includes(EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS) ||
-        c.op_name?.includes('mockPrediction') ||
         c.op_name?.includes('lengthScorer') ||
         c.op_name?.includes('inclusionScorer')
     );
-    expect(childCalls.length).toBeGreaterThan(0);
 
-    for (const call of childCalls) {
+    // dataset rows (5), and scorers also * scorer count (2).
+    expect(predictAndScoreCalls).toHaveLength(5);
+    expect(modelCalls).toHaveLength(5);
+    expect(scorerCalls).toHaveLength(10);
+
+    // Both the outer marker and ours survive (flat overwrite would drop foo).
+    for (const call of [
+      ...predictAndScoreCalls,
+      ...modelCalls,
+      ...scorerCalls,
+    ]) {
       expect(call.attributes?._weave_eval_meta).toEqual({
         foo: true,
         declarative: true,

--- a/sdks/node/src/__tests__/evaluation.test.ts
+++ b/sdks/node/src/__tests__/evaluation.test.ts
@@ -1,7 +1,23 @@
+import {withAttributes} from '../clientApi';
+import {
+  EVALUATION_RUN_OP_NAME,
+  EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
+} from '../constants';
 import {Dataset} from '../dataset';
 import {Evaluation} from '../evaluation';
 import {type ColumnMapping} from '../fn';
 import {op} from '../op';
+import {initWithCustomTraceServer} from './clientMock';
+import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
+
+// Read all recorded calls back from the in-memory trace server (mirrors the
+// helper in evaluationLogger.test.ts).
+async function getCalls(traceServer: InMemoryTraceServer, projectId: string) {
+  await traceServer.waitForPendingOperations();
+  return traceServer.calls
+    .callsStreamQueryPost({project_id: projectId})
+    .then(result => result.calls);
+}
 
 const createMockDataset = () =>
   new Dataset({
@@ -167,5 +183,84 @@ describe('Evaluation', () => {
       model_success: {true_count: 0, true_fraction: 0},
       model_latency: {mean: expect.any(Number)},
     });
+  });
+});
+
+describe('Evaluation - declarative eval metadata', () => {
+  let traceServer: InMemoryTraceServer;
+  const projectId = 'test-project';
+
+  beforeEach(() => {
+    traceServer = new InMemoryTraceServer();
+    initWithCustomTraceServer(projectId, traceServer);
+  });
+
+  // Every child of the declarative path must carry the marker, including
+  // children of later examples under concurrency (the marker rides the
+  // AsyncLocalStorage context, so nTrials > 1 + maxConcurrency > 1 is the real
+  // test). Non-failing mocks so every model+scorer call actually runs.
+  test('tags every child call of every example', async () => {
+    const evaluation = createMockEvaluation(false);
+    const model = createMockModel(false);
+
+    await evaluation.evaluate({model, nTrials: 2, maxConcurrency: 2});
+
+    const calls = await getCalls(traceServer, projectId);
+    const predictAndScoreCalls = calls.filter(c =>
+      c.op_name?.includes(EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS)
+    );
+    const modelCalls = calls.filter(c => c.op_name?.includes('mockPrediction'));
+    const scorerCalls = calls.filter(
+      c =>
+        c.op_name?.includes('lengthScorer') ||
+        c.op_name?.includes('inclusionScorer')
+    );
+
+    // nTrials (2) * dataset rows (5), and scorers also * scorer count (2).
+    expect(predictAndScoreCalls).toHaveLength(10);
+    expect(modelCalls).toHaveLength(10);
+    expect(scorerCalls).toHaveLength(20);
+
+    for (const call of [
+      ...predictAndScoreCalls,
+      ...modelCalls,
+      ...scorerCalls,
+    ]) {
+      expect(call.attributes?._weave_eval_meta?.declarative).toBe(true);
+    }
+
+    // The root evaluate call is recognized by op_name, so it is not tagged.
+    const rootCall = calls.find(c =>
+      c.op_name?.includes(EVALUATION_RUN_OP_NAME)
+    );
+    expect(rootCall).toBeDefined();
+    expect(rootCall?.attributes?._weave_eval_meta).toBeUndefined();
+  });
+
+  // A flat overwrite would drop the outer marker; deep-merge keeps both keys.
+  test('deep-merges declarative meta into an existing _weave_eval_meta', async () => {
+    const evaluation = createMockEvaluation(false);
+    const model = createMockModel(false);
+
+    await withAttributes({_weave_eval_meta: {foo: true}}, async () => {
+      await evaluation.evaluate({model, maxConcurrency: 2});
+    });
+
+    const calls = await getCalls(traceServer, projectId);
+    const childCalls = calls.filter(
+      c =>
+        c.op_name?.includes(EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS) ||
+        c.op_name?.includes('mockPrediction') ||
+        c.op_name?.includes('lengthScorer') ||
+        c.op_name?.includes('inclusionScorer')
+    );
+    expect(childCalls.length).toBeGreaterThan(0);
+
+    for (const call of childCalls) {
+      expect(call.attributes?._weave_eval_meta).toEqual({
+        foo: true,
+        declarative: true,
+      });
+    }
   });
 });

--- a/sdks/node/src/constants.ts
+++ b/sdks/node/src/constants.ts
@@ -12,6 +12,15 @@ export const EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAMES = [
   EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
 ] as const;
 
+/**
+ * Call-attribute key for evaluation metadata. Reserved internal Weave key:
+ * user ops must not write to it. Both eval paths — declarative
+ * `Evaluation.evaluate` and imperative `EvaluationLogger` — tag their calls
+ * with it so consumers (eval-results rendering, server-side ingest sampling)
+ * can recognize eval calls.
+ */
+export const EVAL_META_KEY = '_weave_eval_meta';
+
 export const WEAVE_ATTRIBUTES_NAMESPACE = 'weave';
 export const GENAI_SPAN_REF_ATTR_KEY = 'genai_span_ref';
 

--- a/sdks/node/src/evaluation.ts
+++ b/sdks/node/src/evaluation.ts
@@ -1,4 +1,6 @@
 import cliProgress from 'cli-progress';
+import {getGlobalClient, withAttributes} from './clientApi';
+import {EVAL_META_KEY} from './constants';
 import {type Dataset, type DatasetRow} from './dataset';
 import {type ColumnMapping, mapArgs} from './fn';
 import {isMedia} from './media';
@@ -169,63 +171,74 @@ export class Evaluation<
     nTrials?: number;
     maxConcurrency?: number;
   }) {
-    const results: Array<{
-      model_output: M;
-      model_success: boolean;
-      model_latency: number;
-      [key: string]: any;
-    }> = [];
+    // Tag every eval child call (predictAndScore, model, scorers) so a
+    // server-side ingest sampler can recognize eval calls from each child's own
+    // attributes; children reach the server before the root op. Mirrors the
+    // imperative path; merge so an outer _weave_eval_meta is kept, not clobbered.
+    const prevMeta =
+      getGlobalClient()?.getCurrentAttributes()?.[EVAL_META_KEY] ?? {};
+    return withAttributes(
+      {[EVAL_META_KEY]: {...prevMeta, declarative: true}},
+      async () => {
+        const results: Array<{
+          model_output: M;
+          model_success: boolean;
+          model_latency: number;
+          [key: string]: any;
+        }> = [];
 
-    const progressBar = new cliProgress.SingleBar({
-      format:
-        'Evaluating |{bar}| {percentage}% | ETA: {eta}s | {modelErrors} errors | {value}/{total} examples | {running} running',
-      barCompleteChar: '\u2588',
-      barIncompleteChar: '\u2591',
-      hideCursor: true,
-    });
+        const progressBar = new cliProgress.SingleBar({
+          format:
+            'Evaluating |{bar}| {percentage}% | ETA: {eta}s | {modelErrors} errors | {value}/{total} examples | {running} running',
+          barCompleteChar: '\u2588',
+          barIncompleteChar: '\u2591',
+          hideCursor: true,
+        });
 
-    if (PROGRESS_BAR) {
-      progressBar.start(this.dataset.length * nTrials, 0, {
-        running: 0,
-        modelErrors: 0,
-      });
-    }
+        if (PROGRESS_BAR) {
+          progressBar.start(this.dataset.length * nTrials, 0, {
+            running: 0,
+            modelErrors: 0,
+          });
+        }
 
-    let modelErrors = 0;
-    let datasetExamples = this.dataset;
-    if (nTrials > 1) {
-      // @ts-ignore
-      datasetExamples = repeatAsyncIterator(this.dataset, nTrials);
-    }
+        let modelErrors = 0;
+        let datasetExamples = this.dataset;
+        if (nTrials > 1) {
+          // @ts-ignore
+          datasetExamples = repeatAsyncIterator(this.dataset, nTrials);
+        }
 
-    for await (const {result, nRunning, nDone} of asyncParallelMap(
-      datasetExamples,
-      this.predictAndScore,
-      item => [{model, example: item, columnMapping: this.columnMapping}],
-      maxConcurrency
-    )) {
-      const {scores} = result;
-      results.push({
-        model_success: result.model_success,
-        model_output: result.model_output,
-        ...scores,
-        model_latency: result.model_latency,
-      });
-      modelErrors += result.model_success ? 0 : 1;
-      if (PROGRESS_BAR) {
-        progressBar.update(nDone, {running: nRunning, modelErrors});
-      } else {
-        console.log(
-          `Evaluating ${nDone}/${this.dataset.length * nTrials} examples (${nRunning} running, ${modelErrors} errors)`
-        );
+        for await (const {result, nRunning, nDone} of asyncParallelMap(
+          datasetExamples,
+          this.predictAndScore,
+          item => [{model, example: item, columnMapping: this.columnMapping}],
+          maxConcurrency
+        )) {
+          const {scores} = result;
+          results.push({
+            model_success: result.model_success,
+            model_output: result.model_output,
+            ...scores,
+            model_latency: result.model_latency,
+          });
+          modelErrors += result.model_success ? 0 : 1;
+          if (PROGRESS_BAR) {
+            progressBar.update(nDone, {running: nRunning, modelErrors});
+          } else {
+            console.log(
+              `Evaluating ${nDone}/${this.dataset.length * nTrials} examples (${nRunning} running, ${modelErrors} errors)`
+            );
+          }
+        }
+
+        if (PROGRESS_BAR) {
+          progressBar.stop();
+        }
+
+        return this.summarizeResults(results);
       }
-    }
-
-    if (PROGRESS_BAR) {
-      progressBar.stop();
-    }
-
-    return this.summarizeResults(results);
+    );
   }
 
   async predictAndScore({

--- a/sdks/node/src/evaluationLogger.ts
+++ b/sdks/node/src/evaluationLogger.ts
@@ -20,6 +20,7 @@ import {WeaveObject, type WeaveObjectParameters} from './weaveObject';
 import {type Dataset, type DatasetRow} from './dataset';
 import {op} from './op';
 import {requireGlobalClient} from './clientApi';
+import {EVAL_META_KEY} from './constants';
 import {InternalCall} from './call';
 import {type CallStackEntry, type WeaveClient} from './weaveClient';
 import {type Op, type OpRef, type ParameterNamesOption} from './opType';
@@ -33,14 +34,14 @@ import {uuidv7} from 'uuidv7';
  * Attribute marker for imperative evaluation calls.
  * Applied to: evaluate, predict_and_score, predict, summarize calls.
  */
-const IMPERATIVE_EVAL_MARKER = {_weave_eval_meta: {imperative: true}};
+const IMPERATIVE_EVAL_MARKER = {[EVAL_META_KEY]: {imperative: true}};
 
 /**
  * Attribute marker for scorer calls in imperative evaluation.
  * Applied to: scorer.score calls.
  */
 const IMPERATIVE_SCORE_MARKER = {
-  _weave_eval_meta: {imperative: true, score: true},
+  [EVAL_META_KEY]: {imperative: true, score: true},
 };
 
 // ============================================================================


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-35811 — TypeScript sibling of #7260 (the Python change, WB-35748).

## Description

The imperative evaluation path (`EvaluationLogger`) already tags every call it emits with the `_weave_eval_meta` attribute, but the declarative path (`Evaluation.evaluate`) tagged nothing on its children — they were identifiable only by the op name on the root call. This change brings the two paths to parity by wrapping the `evaluate` body in a single `withAttributes` context, so `predictAndScore`, the model call, and every scorer inherit `{declarative: true}`.

This is groundwork for a server-side ingest sampler that needs to keep evaluation traces intact. The sampler decides per message, and a child call reaches the server before its root, so the marker has to ride on every child rather than only the root. The value is merged into any existing `_weave_eval_meta` rather than replacing it, so an outer marker is preserved. The attribute key now lives in one place (`constants.ts`) and is reused by both paths instead of being hardcoded twice. This mirrors the merged Python change in #7260; the sampler that reads the marker is a separate, later change.

## Testing

Two new unit tests in `evaluation.test.ts`, using the same in-memory trace-server harness as the existing imperative-marker tests. The first runs a declarative eval with `nTrials: 2` and `maxConcurrency: 2` and asserts the marker lands on every `predictAndScore`, model, and scorer call (with exact counts), while the root stays unmarked. The second wraps the eval in an outer `_weave_eval_meta` and asserts both keys survive the merge. Full Node suite is green (284 tests); cjs+esm typecheck and prettier-check are clean.

## Backward compatibility

Purely additive: declarative children now carry one extra key inside the free-form `attributes` dict. No schema or endpoint change. Existing readers of `_weave_eval_meta` only act on `.imperative` / `.score`, so `{declarative: true}` is inert to them.
