### PR TITLE
perf(weave): batch traced completion-call span writes

### DIFF
--- a/tests/trace_server/test_async_clickhouse_trace_server.py
+++ b/tests/trace_server/test_async_clickhouse_trace_server.py
@@ -12,10 +12,14 @@ import pytest_asyncio
 from tests.trace_server.conftest_lib.trace_server_external_adapter import (
     DummyIdConverter,
 )
+from tests.trace_server.helpers import make_project_id
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.agents.types import AgentSpansQueryReq
 from weave.trace_server.async_clickhouse_trace_server import (
     AsyncClickHouseTraceServer,
+    CompletionSpanBuffer,
 )
+from weave.trace_server.clickhouse_trace_server_batched import BuiltCompletionSpan
 from weave.trace_server.datadog import _db_insert_path
 from weave.trace_server.external_to_internal_trace_server_adapter import (
     ExternalTraceServer,
@@ -27,7 +31,11 @@ LITELLM_ACOMPLETION_PATCH = (
 
 
 def _make_req(
-    *, track_llm_call: bool, model: str = "gpt-4o-mini", prompt: str | None = None
+    *,
+    track_llm_call: bool,
+    model: str = "gpt-4o-mini",
+    prompt: str | None = None,
+    project_id: str = "p1",
 ) -> tsi.CompletionsCreateReq:
     inputs_kwargs: dict[str, object] = {
         "model": model,
@@ -36,7 +44,7 @@ def _make_req(
     if prompt is not None:
         inputs_kwargs["prompt"] = prompt
     return tsi.CompletionsCreateReq(
-        project_id="p1",
+        project_id=project_id,
         wb_user_id="u1",
         track_llm_call=track_llm_call,
         inputs=tsi.CompletionsCreateRequestInputs(**inputs_kwargs),
@@ -116,7 +124,7 @@ async def test_span_sink_defers_insert_to_caller() -> None:
     srv = AsyncClickHouseTraceServer(host="test_host", ch_executor=ch_executor)
     fake_span = object()
     buffered = tsi.CompletionsCreateRes(response={"ok": True}, weave_call_id="call-1")
-    sink: list[object] = []
+    sink = CompletionSpanBuffer()
     try:
         with (
             patch(
@@ -126,7 +134,9 @@ async def test_span_sink_defers_insert_to_caller() -> None:
                 ),
             ),
             patch.object(
-                srv, "_build_completion_call_span", return_value=(fake_span, buffered)
+                srv,
+                "_build_completion_call_span",
+                return_value=BuiltCompletionSpan(fake_span, buffered),
             ) as build_mock,
             patch.object(srv, "_log_completion_call") as log_mock,
         ):
@@ -134,7 +144,7 @@ async def test_span_sink_defers_insert_to_caller() -> None:
                 _make_req(track_llm_call=True), span_sink=sink
             )
         assert res is buffered
-        assert sink == [fake_span]
+        assert sink.spans == [fake_span]
         assert build_mock.call_count == 1
         assert log_mock.call_count == 0
     finally:
@@ -166,6 +176,47 @@ async def test_ainsert_completion_spans_bulk_writes_on_executor() -> None:
         assert observed["path"] == "completions_create_batch"
     finally:
         ch_executor.shutdown(wait=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_mock_secret_fetcher")
+async def test_deferred_span_flow_lands_queryable_spans(ch_server) -> None:
+    """End-to-end: two traced completions buffer into a `CompletionSpanBuffer`,
+    the drained spans bulk-insert via `ainsert_completion_spans`, and both are
+    readable back from ClickHouse by the call ids the deferred path returned.
+    """
+    project_id = make_project_id("deferred_flow")
+    ch_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ch-pool")
+    srv = AsyncClickHouseTraceServer(
+        host=ch_server._host,
+        port=ch_server._port,
+        database=ch_server._database,
+        ch_executor=ch_executor,
+    )
+    buf = CompletionSpanBuffer()
+    try:
+        with patch(
+            LITELLM_ACOMPLETION_PATCH,
+            new=AsyncMock(
+                return_value=tsi.CompletionsCreateRes(response={"choices": [{"x": 1}]})
+            ),
+        ):
+            res1 = await srv.acompletions_create(
+                _make_req(track_llm_call=True, project_id=project_id), span_sink=buf
+            )
+            res2 = await srv.acompletions_create(
+                _make_req(track_llm_call=True, project_id=project_id), span_sink=buf
+            )
+            # Buffered, not yet inserted: both spans wait in the sink.
+            assert len(buf.spans) == 2
+            await srv.ainsert_completion_spans(buf.drain())
+        assert buf.spans == []
+    finally:
+        ch_executor.shutdown(wait=True)
+
+    res = ch_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
+    assert res.total_count == 2
+    assert {res1.span_id, res2.span_id} == {s.span_id for s in res.spans}
 
 
 @pytest.mark.asyncio

--- a/tests/trace_server/test_async_clickhouse_trace_server.py
+++ b/tests/trace_server/test_async_clickhouse_trace_server.py
@@ -142,6 +142,21 @@ async def test_span_sink_defers_insert_to_caller() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ainsert_completion_spans_bulk_writes_on_executor() -> None:
+    """Collected spans are bulk-written once via the CH executor; empty no-ops."""
+    ch_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ch-pool")
+    srv = AsyncClickHouseTraceServer(host="test_host", ch_executor=ch_executor)
+    spans = [object(), object()]
+    try:
+        with patch.object(srv, "_insert_spans_sync") as insert_mock:
+            await srv.ainsert_completion_spans([])
+            await srv.ainsert_completion_spans(spans)
+        insert_mock.assert_called_once_with(spans)
+    finally:
+        ch_executor.shutdown(wait=True)
+
+
+@pytest.mark.asyncio
 async def test_prep_short_circuit_returns_without_calling_litellm(
     server: AsyncClickHouseTraceServer,
 ) -> None:

--- a/tests/trace_server/test_async_clickhouse_trace_server.py
+++ b/tests/trace_server/test_async_clickhouse_trace_server.py
@@ -143,15 +143,27 @@ async def test_span_sink_defers_insert_to_caller() -> None:
 
 @pytest.mark.asyncio
 async def test_ainsert_completion_spans_bulk_writes_on_executor() -> None:
-    """Collected spans are bulk-written once via the CH executor; empty no-ops."""
+    """Collected spans are bulk-written once via the CH executor, tagged with the
+    `completions_create_batch` insert path; empty input no-ops.
+    """
     ch_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ch-pool")
     srv = AsyncClickHouseTraceServer(host="test_host", ch_executor=ch_executor)
     spans = [object(), object()]
+    observed = {"thread_id": None, "path": None}
+
+    def _capture_insert(_spans: object) -> None:
+        observed["thread_id"] = threading.get_ident()
+        observed["path"] = _db_insert_path.get()
+
     try:
-        with patch.object(srv, "_insert_spans_sync") as insert_mock:
+        with patch.object(
+            srv, "_insert_spans_sync", side_effect=_capture_insert
+        ) as insert_mock:
             await srv.ainsert_completion_spans([])
             await srv.ainsert_completion_spans(spans)
         insert_mock.assert_called_once_with(spans)
+        assert observed["thread_id"] != threading.get_ident()
+        assert observed["path"] == "completions_create_batch"
     finally:
         ch_executor.shutdown(wait=True)
 

--- a/tests/trace_server/test_async_clickhouse_trace_server.py
+++ b/tests/trace_server/test_async_clickhouse_trace_server.py
@@ -107,6 +107,41 @@ async def test_tracking_routes_through_log_completion_call(
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("_mock_secret_fetcher")
+async def test_span_sink_defers_insert_to_caller() -> None:
+    """With a `span_sink`, the traced-call span is appended for a later bulk
+    insert instead of inserted per call; the per-call insert path is skipped.
+    """
+    ch_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ch-pool")
+    srv = AsyncClickHouseTraceServer(host="test_host", ch_executor=ch_executor)
+    fake_span = object()
+    buffered = tsi.CompletionsCreateRes(response={"ok": True}, weave_call_id="call-1")
+    sink: list[object] = []
+    try:
+        with (
+            patch(
+                LITELLM_ACOMPLETION_PATCH,
+                new=AsyncMock(
+                    return_value=tsi.CompletionsCreateRes(response={"ok": True})
+                ),
+            ),
+            patch.object(
+                srv, "_build_completion_call_span", return_value=(fake_span, buffered)
+            ) as build_mock,
+            patch.object(srv, "_log_completion_call") as log_mock,
+        ):
+            res = await srv.acompletions_create(
+                _make_req(track_llm_call=True), span_sink=sink
+            )
+        assert res is buffered
+        assert sink == [fake_span]
+        assert build_mock.call_count == 1
+        assert log_mock.call_count == 0
+    finally:
+        ch_executor.shutdown(wait=True)
+
+
+@pytest.mark.asyncio
 async def test_prep_short_circuit_returns_without_calling_litellm(
     server: AsyncClickHouseTraceServer,
 ) -> None:

--- a/tests/trace_server/test_async_clickhouse_trace_server.py
+++ b/tests/trace_server/test_async_clickhouse_trace_server.py
@@ -4,7 +4,7 @@ import asyncio
 import threading
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 import pytest_asyncio
@@ -14,12 +14,12 @@ from tests.trace_server.conftest_lib.trace_server_external_adapter import (
 )
 from tests.trace_server.helpers import make_project_id
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.agents.schema import AgentSpanCHInsertable
 from weave.trace_server.agents.types import AgentSpansQueryReq
 from weave.trace_server.async_clickhouse_trace_server import (
     AsyncClickHouseTraceServer,
-    CompletionSpanBuffer,
 )
-from weave.trace_server.clickhouse_trace_server_batched import BuiltCompletionSpan
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.datadog import _db_insert_path
 from weave.trace_server.external_to_internal_trace_server_adapter import (
     ExternalTraceServer,
@@ -116,36 +116,48 @@ async def test_tracking_routes_through_log_completion_call(
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("_mock_secret_fetcher")
-async def test_span_sink_defers_insert_to_caller() -> None:
-    """With a `span_sink`, the traced-call span is appended for a later bulk
-    insert instead of inserted per call; the per-call insert path is skipped.
+async def test_deferred_returns_real_span_without_inserting() -> None:
+    """The deferred path builds a real, fully populated span and returns it for
+    the caller to bulk-insert; nothing is written per call. An untracked call
+    returns no span.
     """
     ch_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ch-pool")
     srv = AsyncClickHouseTraceServer(host="test_host", ch_executor=ch_executor)
-    fake_span = object()
-    buffered = tsi.CompletionsCreateRes(response={"ok": True}, weave_call_id="call-1")
-    sink = CompletionSpanBuffer()
     try:
         with (
             patch(
                 LITELLM_ACOMPLETION_PATCH,
                 new=AsyncMock(
-                    return_value=tsi.CompletionsCreateRes(response={"ok": True})
+                    return_value=tsi.CompletionsCreateRes(
+                        response={"choices": [{"x": 1}]}
+                    )
                 ),
             ),
+            # The project-retention lookup is the only CH read in the build; stub
+            # it (and the client it reads through) so a real span is built
+            # without a live ClickHouse.
+            patch(
+                "weave.trace_server.clickhouse_trace_server_batched.get_project_retention_days",
+                return_value=0,
+            ),
             patch.object(
-                srv,
-                "_build_completion_call_span",
-                return_value=BuiltCompletionSpan(fake_span, buffered),
-            ) as build_mock,
+                ClickHouseTraceServer,
+                "ch_client",
+                new_callable=PropertyMock,
+                return_value=MagicMock(),
+            ),
             patch.object(srv, "_log_completion_call") as log_mock,
         ):
-            res = await srv.acompletions_create(
-                _make_req(track_llm_call=True), span_sink=sink
+            result, span = await srv.acompletions_create_deferred(
+                _make_req(track_llm_call=True, project_id="p1")
             )
-        assert res is buffered
-        assert sink.spans == [fake_span]
-        assert build_mock.call_count == 1
+            untracked = await srv.acompletions_create_deferred(
+                _make_req(track_llm_call=False)
+            )
+        assert isinstance(span, AgentSpanCHInsertable)
+        assert span.project_id == "p1"
+        assert span.span_id == result.span_id == result.weave_call_id
+        assert untracked.span is None
         assert log_mock.call_count == 0
     finally:
         ch_executor.shutdown(wait=True)
@@ -181,9 +193,9 @@ async def test_ainsert_completion_spans_bulk_writes_on_executor() -> None:
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("_mock_secret_fetcher")
 async def test_deferred_span_flow_lands_queryable_spans(ch_server) -> None:
-    """End-to-end: two traced completions buffer into a `CompletionSpanBuffer`,
-    the drained spans bulk-insert via `ainsert_completion_spans`, and both are
-    readable back from ClickHouse by the call ids the deferred path returned.
+    """End-to-end: two traced completions go through the deferred path, the spans
+    they return bulk-insert via `ainsert_completion_spans`, and both read back
+    from ClickHouse by the call ids the deferred path returned.
     """
     project_id = make_project_id("deferred_flow")
     ch_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ch-pool")
@@ -193,7 +205,6 @@ async def test_deferred_span_flow_lands_queryable_spans(ch_server) -> None:
         database=ch_server._database,
         ch_executor=ch_executor,
     )
-    buf = CompletionSpanBuffer()
     try:
         with patch(
             LITELLM_ACOMPLETION_PATCH,
@@ -201,22 +212,21 @@ async def test_deferred_span_flow_lands_queryable_spans(ch_server) -> None:
                 return_value=tsi.CompletionsCreateRes(response={"choices": [{"x": 1}]})
             ),
         ):
-            res1 = await srv.acompletions_create(
-                _make_req(track_llm_call=True, project_id=project_id), span_sink=buf
+            d1 = await srv.acompletions_create_deferred(
+                _make_req(track_llm_call=True, project_id=project_id)
             )
-            res2 = await srv.acompletions_create(
-                _make_req(track_llm_call=True, project_id=project_id), span_sink=buf
+            d2 = await srv.acompletions_create_deferred(
+                _make_req(track_llm_call=True, project_id=project_id)
             )
-            # Buffered, not yet inserted: both spans wait in the sink.
-            assert len(buf.spans) == 2
-            await srv.ainsert_completion_spans(buf.drain())
-        assert buf.spans == []
+            spans = [d.span for d in (d1, d2) if d.span is not None]
+            assert len(spans) == 2  # built, not yet inserted
+            await srv.ainsert_completion_spans(spans)
     finally:
         ch_executor.shutdown(wait=True)
 
     res = ch_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
     assert res.total_count == 2
-    assert {res1.span_id, res2.span_id} == {s.span_id for s in res.spans}
+    assert {d1.result.span_id, d2.result.span_id} == {s.span_id for s in res.spans}
 
 
 @pytest.mark.asyncio

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -10,6 +10,7 @@ import uuid
 import pytest
 
 from tests.trace_server.helpers import make_project_id as _make_project_id
+from weave.trace_server.agents.clickhouse import AgentWriteHandler
 from weave.trace_server.agents.helpers import genai_span_to_row
 from weave.trace_server.agents.schema import (
     ALL_SPAN_INSERT_COLUMNS,
@@ -117,6 +118,29 @@ def test_spans_insert_and_query(ch_server):
     )
     assert res_filtered.total_count == 2
     assert all(s.agent_name == "agent-A" for s in res_filtered.spans)
+
+
+def test_insert_spans_bulk_writes_all_in_one_call(ch_server):
+    """`AgentWriteHandler.insert_spans` bulk-writes every span in one insert
+    (the scoring-worker batch path); empty input is a no-op.
+    """
+    project_id = _make_project_id("bulk_spans")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    spans = [
+        _make_span(project_id, agent_name="bulk-A", started_at=now),
+        _make_span(
+            project_id,
+            agent_name="bulk-B",
+            started_at=now + datetime.timedelta(seconds=1),
+        ),
+    ]
+    handler = AgentWriteHandler(ch_server.ch_client)
+    handler.insert_spans([])  # no-op
+    handler.insert_spans(spans)
+
+    res = ch_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
+    assert res.total_count == 2
+    assert {s.agent_name for s in res.spans} == {"bulk-A", "bulk-B"}
 
 
 # ---------------------------------------------------------------------------

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -686,7 +686,7 @@ class AgentWriteHandler:
                     accepted += 1
 
         if span_rows:
-            self._insert_spans(span_rows)
+            self.insert_spans(span_rows)
 
         if failure_counts:
             logger.warning(
@@ -713,11 +713,17 @@ class AgentWriteHandler:
         GenAI extraction — the caller is responsible for constructing a
         fully populated ``AgentSpanCHInsertable``.
         """
-        self._insert_spans([span])
+        self.insert_spans([span])
 
     @ddtrace.tracer.wrap(name="agents.clickhouse.insert_spans")
-    def _insert_spans(self, span_rows: list[AgentSpanCHInsertable]) -> None:
-        """Insert pre-built span rows; traced so spans-table writes show in APM."""
+    def insert_spans(self, span_rows: list[AgentSpanCHInsertable]) -> None:
+        """Bulk-insert pre-built span rows in one round-trip; traced for APM.
+
+        Shared by `insert_span`, OTel ingest, and the scoring worker's batch
+        span-write path. Empty input is a no-op.
+        """
+        if not span_rows:
+            return
         set_root_span_dd_tags(
             {
                 "weave_trace_server.insert.table": "spans",

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -5,8 +5,7 @@ import contextvars
 import datetime
 from collections.abc import Callable
 from concurrent.futures import Executor
-from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, NamedTuple, TypeVar
 
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents.clickhouse import AgentWriteHandler
@@ -18,20 +17,7 @@ from weave.trace_server.clickhouse_trace_server_batched import (
 from weave.trace_server.datadog import tag_db_insert_path
 from weave.trace_server.llm_completion import lite_llm_acompletion
 
-
-@dataclass
-class CompletionSpanBuffer:
-    """Accumulates deferred completion-call spans for one bulk insert."""
-
-    spans: list[AgentSpanCHInsertable] = field(default_factory=list)
-
-    def add(self, span: AgentSpanCHInsertable) -> None:
-        self.spans.append(span)
-
-    def drain(self) -> list[AgentSpanCHInsertable]:
-        """Return the buffered spans and reset, so a re-flush can't double-insert."""
-        drained, self.spans = self.spans, []
-        return drained
+_T = TypeVar("_T")
 
 
 class AsyncClickHouseTraceServer(ClickHouseTraceServer):
@@ -45,16 +31,67 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
 
     @tag_db_insert_path("completions_create")
     async def acompletions_create(
-        self,
-        req: tsi.CompletionsCreateReq,
-        *,
-        span_sink: CompletionSpanBuffer | None = None,
+        self, req: tsi.CompletionsCreateReq
     ) -> tsi.CompletionsCreateRes:
-        """Async twin of `completions_create`.
+        """Async twin of `completions_create`."""
+        call = await self._acompletion_call(req)
+        if isinstance(call, tsi.CompletionsCreateRes):
+            return call
+        return await self._run_on_ch_executor(
+            self._log_completion_call,
+            req,
+            call.prep,
+            call.res,
+            call.start_time,
+            call.end_time,
+        )
 
-        When `span_sink` is given, the traced-call span is added to it instead of
-        inserted, so a batch caller can bulk-write all spans in one round-trip via
-        `ainsert_completion_spans(span_sink.drain())`.
+    @tag_db_insert_path("completions_create")
+    async def acompletions_create_deferred(
+        self, req: tsi.CompletionsCreateReq
+    ) -> "DeferredCompletion":
+        """Run the completion and return its traced-call span instead of inserting
+        it, so a batch caller can bulk-write every span in one round-trip via
+        `ainsert_completion_spans`.
+
+        `span` is `None` when there is nothing to write (tracking disabled or a
+        short-circuited request).
+        """
+        call = await self._acompletion_call(req)
+        if isinstance(call, tsi.CompletionsCreateRes):
+            return DeferredCompletion(call, None)
+        built = await self._run_on_ch_executor(
+            self._build_completion_call_span,
+            req,
+            call.prep,
+            call.res,
+            call.start_time,
+            call.end_time,
+        )
+        return DeferredCompletion(built.result, built.span)
+
+    @tag_db_insert_path("completions_create_batch")
+    async def ainsert_completion_spans(
+        self, spans: list[AgentSpanCHInsertable]
+    ) -> None:
+        """Bulk-insert spans returned by `acompletions_create_deferred` in one CH
+        round-trip.
+
+        All-or-nothing: a failed insert drops the whole batch's spans, so the
+        caller must reprocess on error.
+        """
+        if not spans:
+            return
+        await self._run_on_ch_executor(self._insert_spans_sync, spans)
+
+    async def _acompletion_call(
+        self, req: tsi.CompletionsCreateReq
+    ) -> "tsi.CompletionsCreateRes | _CompletionCall":
+        """Prep the request and run the LLM call.
+
+        Returns a `CompletionsCreateRes` directly when there is no span to write
+        (short-circuited request or tracking disabled), else the post-call inputs
+        for building the traced-call span.
         """
         prep = await asyncio.to_thread(self._prepare_completion_request, req)
         if isinstance(prep, tsi.CompletionsCreateRes):
@@ -72,73 +109,37 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         )
         end_time = datetime.datetime.now()
 
-        # Untracked calls do no CH work; skip the executor hop entirely.
         if not req.track_llm_call:
             return tsi.CompletionsCreateRes(response=res.response)
+        return _CompletionCall(prep, res, start_time, end_time)
 
-        if span_sink is not None:
-            return await self._run_ch_insert(
-                self._buffer_completion_call,
-                span_sink,
-                req,
-                prep,
-                res,
-                start_time,
-                end_time,
-            )
-        return await self._run_ch_insert(
-            self._log_completion_call, req, prep, res, start_time, end_time
-        )
+    async def _run_on_ch_executor(self, fn: Callable[..., _T], *args: object) -> _T:
+        """Run `fn(*args)` on `_ch_executor`.
 
-    def _buffer_completion_call(
-        self,
-        span_sink: CompletionSpanBuffer,
-        req: tsi.CompletionsCreateReq,
-        prep: CompletionPrepResult,
-        res: tsi.CompletionsCreateRes,
-        start_time: datetime.datetime,
-        end_time: datetime.datetime,
-    ) -> tsi.CompletionsCreateRes:
-        """Build the traced-call span and add it to `span_sink` (no insert).
-
-        Runs on `_ch_executor` because `_build_completion_call_span` reads CH
-        (project retention) via the thread-local `ch_client`.
+        Copies contextvars so `@tag_db_insert_path` survives the thread hop, and
+        `self.ch_client` resolves to that thread's (thread-local) client there.
         """
-        # `acompletions_create` already gates on `track_llm_call` before here.
-        built = self._build_completion_call_span(req, prep, res, start_time, end_time)
-        span_sink.add(built.span)
-        return built.result
-
-    async def _run_ch_insert(
-        self,
-        fn: Callable[..., tsi.CompletionsCreateRes],
-        *args: object,
-    ) -> tsi.CompletionsCreateRes:
-        # contextvars don't cross run_in_executor; copy so `@tag_db_insert_path`
-        # tags survive on the executor thread.
         ctx = contextvars.copy_context()
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(self._ch_executor, lambda: ctx.run(fn, *args))
-
-    @tag_db_insert_path("completions_create_batch")
-    async def ainsert_completion_spans(
-        self, spans: list[AgentSpanCHInsertable]
-    ) -> None:
-        """Bulk-insert spans collected via `span_sink` in one CH round-trip.
-
-        Runs on `_ch_executor` so `self.ch_client` resolves to that thread's
-        client (it is thread-local). All-or-nothing: a failed insert drops the
-        whole batch's spans, so the caller must reprocess on error.
-        """
-        if not spans:
-            return
-        ctx = contextvars.copy_context()
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            self._ch_executor, lambda: ctx.run(self._insert_spans_sync, spans)
-        )
 
     def _insert_spans_sync(self, spans: list[AgentSpanCHInsertable]) -> None:
         AgentWriteHandler(self.ch_client, self._async_insert_settings()).insert_spans(
             spans
         )
+
+
+class DeferredCompletion(NamedTuple):
+    """Call result plus the span to bulk-insert later (`None` if nothing to write)."""
+
+    result: tsi.CompletionsCreateRes
+    span: AgentSpanCHInsertable | None
+
+
+class _CompletionCall(NamedTuple):
+    """Post-LLM-call inputs to `_build_completion_call_span`."""
+
+    prep: CompletionPrepResult
+    res: tsi.CompletionsCreateRes
+    start_time: datetime.datetime
+    end_time: datetime.datetime

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -8,7 +8,12 @@ from concurrent.futures import Executor
 from typing import Any
 
 from weave.trace_server import trace_server_interface as tsi
-from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.agents.clickhouse import AgentWriteHandler
+from weave.trace_server.agents.schema import AgentSpanCHInsertable
+from weave.trace_server.clickhouse_trace_server_batched import (
+    ClickHouseTraceServer,
+    CompletionPrepResult,
+)
 from weave.trace_server.datadog import tag_db_insert_path
 from weave.trace_server.llm_completion import lite_llm_acompletion
 
@@ -24,9 +29,17 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
 
     @tag_db_insert_path("completions_create")
     async def acompletions_create(
-        self, req: tsi.CompletionsCreateReq
+        self,
+        req: tsi.CompletionsCreateReq,
+        *,
+        span_sink: list[AgentSpanCHInsertable] | None = None,
     ) -> tsi.CompletionsCreateRes:
-        """Async twin of `completions_create`."""
+        """Async twin of `completions_create`.
+
+        When `span_sink` is given, the traced-call span is appended to it
+        instead of inserted, so a batch caller can bulk-write all spans in one
+        round-trip (see `AgentWriteHandler.insert_spans`).
+        """
         prep = await asyncio.to_thread(self._prepare_completion_request, req)
         if isinstance(prep, tsi.CompletionsCreateRes):
             return prep
@@ -47,9 +60,41 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         if not req.track_llm_call:
             return tsi.CompletionsCreateRes(response=res.response)
 
+        if span_sink is not None:
+            return await self._run_ch_insert(
+                self._buffer_completion_call,
+                span_sink,
+                req,
+                prep,
+                res,
+                start_time,
+                end_time,
+            )
         return await self._run_ch_insert(
             self._log_completion_call, req, prep, res, start_time, end_time
         )
+
+    def _buffer_completion_call(
+        self,
+        span_sink: list[AgentSpanCHInsertable],
+        req: tsi.CompletionsCreateReq,
+        prep: CompletionPrepResult,
+        res: tsi.CompletionsCreateRes,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+    ) -> tsi.CompletionsCreateRes:
+        """Build the traced-call span and append it to `span_sink` (no insert).
+
+        Runs on `_ch_executor`; `list.append` is atomic under the GIL so
+        concurrent judges can share one sink safely.
+        """
+        if not req.track_llm_call:
+            return tsi.CompletionsCreateRes(response=res.response)
+        span, result = self._build_completion_call_span(
+            req, prep, res, start_time, end_time
+        )
+        span_sink.append(span)
+        return result
 
     async def _run_ch_insert(
         self,
@@ -61,3 +106,22 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         ctx = contextvars.copy_context()
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(self._ch_executor, lambda: ctx.run(fn, *args))
+
+    async def ainsert_completion_spans(
+        self, spans: list[AgentSpanCHInsertable]
+    ) -> None:
+        """Bulk-insert spans collected via `span_sink` in one CH round-trip.
+
+        Runs on `_ch_executor` so `self.ch_client` resolves to that thread's
+        client (it is thread-local).
+        """
+        if not spans:
+            return
+        ctx = contextvars.copy_context()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            self._ch_executor, lambda: ctx.run(self._insert_spans_sync, spans)
+        )
+
+    def _insert_spans_sync(self, spans: list[AgentSpanCHInsertable]) -> None:
+        AgentWriteHandler(self.ch_client).insert_spans(spans)

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -5,6 +5,7 @@ import contextvars
 import datetime
 from collections.abc import Callable
 from concurrent.futures import Executor
+from dataclasses import dataclass, field
 from typing import Any
 
 from weave.trace_server import trace_server_interface as tsi
@@ -16,6 +17,21 @@ from weave.trace_server.clickhouse_trace_server_batched import (
 )
 from weave.trace_server.datadog import tag_db_insert_path
 from weave.trace_server.llm_completion import lite_llm_acompletion
+
+
+@dataclass
+class CompletionSpanBuffer:
+    """Accumulates deferred completion-call spans for one bulk insert."""
+
+    spans: list[AgentSpanCHInsertable] = field(default_factory=list)
+
+    def add(self, span: AgentSpanCHInsertable) -> None:
+        self.spans.append(span)
+
+    def drain(self) -> list[AgentSpanCHInsertable]:
+        """Return the buffered spans and reset, so a re-flush can't double-insert."""
+        drained, self.spans = self.spans, []
+        return drained
 
 
 class AsyncClickHouseTraceServer(ClickHouseTraceServer):
@@ -32,13 +48,13 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         self,
         req: tsi.CompletionsCreateReq,
         *,
-        span_sink: list[AgentSpanCHInsertable] | None = None,
+        span_sink: CompletionSpanBuffer | None = None,
     ) -> tsi.CompletionsCreateRes:
         """Async twin of `completions_create`.
 
-        When `span_sink` is given, the traced-call span is appended to it
-        instead of inserted, so a batch caller can bulk-write all spans in one
-        round-trip (see `AgentWriteHandler.insert_spans`).
+        When `span_sink` is given, the traced-call span is added to it instead of
+        inserted, so a batch caller can bulk-write all spans in one round-trip via
+        `ainsert_completion_spans(span_sink.drain())`.
         """
         prep = await asyncio.to_thread(self._prepare_completion_request, req)
         if isinstance(prep, tsi.CompletionsCreateRes):
@@ -76,24 +92,22 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
 
     def _buffer_completion_call(
         self,
-        span_sink: list[AgentSpanCHInsertable],
+        span_sink: CompletionSpanBuffer,
         req: tsi.CompletionsCreateReq,
         prep: CompletionPrepResult,
         res: tsi.CompletionsCreateRes,
         start_time: datetime.datetime,
         end_time: datetime.datetime,
     ) -> tsi.CompletionsCreateRes:
-        """Build the traced-call span and append it to `span_sink` (no insert).
+        """Build the traced-call span and add it to `span_sink` (no insert).
 
-        Runs on `_ch_executor`; `list.append` is atomic under the GIL so
-        concurrent judges can share one sink safely.
+        Runs on `_ch_executor` because `_build_completion_call_span` reads CH
+        (project retention) via the thread-local `ch_client`.
         """
         # `acompletions_create` already gates on `track_llm_call` before here.
-        span, result = self._build_completion_call_span(
-            req, prep, res, start_time, end_time
-        )
-        span_sink.append(span)
-        return result
+        built = self._build_completion_call_span(req, prep, res, start_time, end_time)
+        span_sink.add(built.span)
+        return built.result
 
     async def _run_ch_insert(
         self,

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -88,8 +88,7 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         Runs on `_ch_executor`; `list.append` is atomic under the GIL so
         concurrent judges can share one sink safely.
         """
-        if not req.track_llm_call:
-            return tsi.CompletionsCreateRes(response=res.response)
+        # `acompletions_create` already gates on `track_llm_call` before here.
         span, result = self._build_completion_call_span(
             req, prep, res, start_time, end_time
         )
@@ -107,13 +106,15 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(self._ch_executor, lambda: ctx.run(fn, *args))
 
+    @tag_db_insert_path("completions_create_batch")
     async def ainsert_completion_spans(
         self, spans: list[AgentSpanCHInsertable]
     ) -> None:
         """Bulk-insert spans collected via `span_sink` in one CH round-trip.
 
         Runs on `_ch_executor` so `self.ch_client` resolves to that thread's
-        client (it is thread-local).
+        client (it is thread-local). All-or-nothing: a failed insert drops the
+        whole batch's spans, so the caller must reprocess on error.
         """
         if not spans:
             return

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -125,4 +125,6 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         )
 
     def _insert_spans_sync(self, spans: list[AgentSpanCHInsertable]) -> None:
-        AgentWriteHandler(self.ch_client).insert_spans(spans)
+        AgentWriteHandler(self.ch_client, self._async_insert_settings()).insert_spans(
+            spans
+        )

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -59,6 +59,7 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents.clickhouse import AgentQueryHandler, AgentWriteHandler
 from weave.trace_server.agents.completion_spans import build_completion_span
 from weave.trace_server.agents.kafka_events import ScoreAgentSpansEvent
+from weave.trace_server.agents.schema import AgentSpanCHInsertable
 from weave.trace_server.agents.types import (
     AgentConversationChatReq,
     AgentConversationChatRes,
@@ -6513,18 +6514,19 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return CompletionPrepResult(initial_messages, completion_model_info)
 
-    def _log_completion_call(
+    def _build_completion_call_span(
         self,
         req: tsi.CompletionsCreateReq,
         prep: "CompletionPrepResult",
         res: tsi.CompletionsCreateRes,
         start_time: datetime.datetime,
         end_time: datetime.datetime,
-    ) -> tsi.CompletionsCreateRes:
-        """Post-LLM-call CH insert. Called via `run_in_executor` from the async path."""
-        if not req.track_llm_call:
-            return tsi.CompletionsCreateRes(response=res.response)
+    ) -> tuple[AgentSpanCHInsertable, tsi.CompletionsCreateRes]:
+        """Build the traced-call span and result without inserting it.
 
+        Split out from `_log_completion_call` so callers that score many calls
+        can batch the span write via `AgentWriteHandler.insert_spans`.
+        """
         retention_days = get_project_retention_days(req.project_id, self.ch_client)
 
         req.inputs.messages = prep.initial_messages
@@ -6553,17 +6555,34 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             error=error,
             source=req.source,
         )
-        AgentWriteHandler(self.ch_client, self._async_insert_settings()).insert_span(
-            span
-        )
-
-        return tsi.CompletionsCreateRes(
+        result = tsi.CompletionsCreateRes(
             response=res.response,
             weave_call_id=span_id,
             span_id=span_id,
             trace_id=trace_id,
             conversation_id=conversation_id,
         )
+        return span, result
+
+    def _log_completion_call(
+        self,
+        req: tsi.CompletionsCreateReq,
+        prep: "CompletionPrepResult",
+        res: tsi.CompletionsCreateRes,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+    ) -> tsi.CompletionsCreateRes:
+        """Post-LLM-call CH insert. Called via `run_in_executor` from the async path."""
+        if not req.track_llm_call:
+            return tsi.CompletionsCreateRes(response=res.response)
+
+        span, result = self._build_completion_call_span(
+            req, prep, res, start_time, end_time
+        )
+        AgentWriteHandler(self.ch_client, self._async_insert_settings()).insert_span(
+            span
+        )
+        return result
 
     # -------------------------------------------------------------------
     # Streaming variant

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6521,7 +6521,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         res: tsi.CompletionsCreateRes,
         start_time: datetime.datetime,
         end_time: datetime.datetime,
-    ) -> tuple[AgentSpanCHInsertable, tsi.CompletionsCreateRes]:
+    ) -> "BuiltCompletionSpan":
         """Build the traced-call span and result without inserting it.
 
         Split out from `_log_completion_call` so callers that score many calls
@@ -6562,7 +6562,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             trace_id=trace_id,
             conversation_id=conversation_id,
         )
-        return span, result
+        return BuiltCompletionSpan(span=span, result=result)
 
     def _log_completion_call(
         self,
@@ -6576,13 +6576,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if not req.track_llm_call:
             return tsi.CompletionsCreateRes(response=res.response)
 
-        span, result = self._build_completion_call_span(
-            req, prep, res, start_time, end_time
-        )
+        built = self._build_completion_call_span(req, prep, res, start_time, end_time)
         AgentWriteHandler(self.ch_client, self._async_insert_settings()).insert_span(
-            span
+            built.span
         )
-        return result
+        return built.result
 
     # -------------------------------------------------------------------
     # Streaming variant
@@ -7823,6 +7821,16 @@ class CompletionPrepResult(NamedTuple):
 
     initial_messages: list[dict[str, Any]]
     completion_model_info: CompletionModelInfo
+
+
+class BuiltCompletionSpan(NamedTuple):
+    """Output of `_build_completion_call_span`: the span to write + the call result.
+
+    Named so a future field reorder is a type error, not a silent positional bug.
+    """
+
+    span: AgentSpanCHInsertable
+    result: tsi.CompletionsCreateRes
 
 
 def _setup_completion_model_info(


### PR DESCRIPTION
## Summary
- Batch the per-judge traced completion-call span write: add bulk `AgentWriteHandler.insert_spans` + a new `acompletions_create_deferred` that returns the built span (instead of inserting it) so a batch caller (the scoring worker) writes all spans in one ClickHouse insert.
- Per-call `acompletions_create` is unchanged.

## Testing
unit test asserts the deferred path returns a real span and skips the per-call insert; end-to-end test bulk-inserts and reads the spans back. scoring-worker consumer + QA load test land in the paired core PR.