### PR TITLE
fix(weave): skip declarative eval-meta tests on the in-memory fake backend

### DIFF
--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -193,6 +193,7 @@ async def test_basic_evaluation(client):
     assert len(inputs) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_declarative_eval_marks_child_calls_with_eval_meta(client):
     # The declarative path must tag every eval call (predict_and_score, model,
@@ -245,6 +246,7 @@ async def test_declarative_eval_marks_child_calls_with_eval_meta(client):
     assert "_weave_eval_meta" not in root.attributes
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_declarative_eval_meta_merges_with_existing(client):
     # An outer wrapper (e.g. the evaluate_model_worker) may already set


### PR DESCRIPTION
## JIRA Issue(s)

[WB-35748](https://coreweave.atlassian.net/browse/WB-35748) (follow-up)

## Description

Two recently added tests in `tests/trace/test_evaluations.py` run a full `Evaluation.evaluate()` and read the calls back via `calls_query`. The in-memory fake trace server doesn't implement that path yet, so on the fake backend they fail with `AttributeError: 'NoneType' object has no attribute 'calls'`. Every other `client` eval test in the file already carries `@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, ...)`; these two were missing it. This adds the same guard. The tests still run on ClickHouse, so coverage is unchanged and no production code is touched.

How master went red while each PR was green on its own:

```
#7145  added the fake (in-memory) CI job + skip-guard infra   [green]
#7260  added these 2 tests; branch was cut before #7145, so   [green]
       the fake job never ran on the PR -> tests left unguarded
       ----------------- merge skew -----------------
master #7260 merges onto #7145; fake job runs the 2 tests     [red]
#7286  unrelated TS-only PR inherits the red master           [red]
```

## Testing

Fake backend: the two tests now skip, file green (`7 passed, 12 skipped`, was `2 failed, 2 errors`). ClickHouse: the two tests still run and pass (`2 passed`).


[WB-35748]: https://coreweave.atlassian.net/browse/WB-35748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ