### PR TITLE
fix(weave): respect explicit non-turn spans

### DIFF
--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -20,6 +20,7 @@ from opentelemetry.proto.trace.v1.trace_pb2 import (
 )
 from opentelemetry.semconv_ai import SpanAttributes as OTSpanAttr
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.constants import MAX_OP_NAME_LENGTH
@@ -607,6 +608,26 @@ class TestPythonSpans:
         # is_turn is truthy via conversation.id, so turn_id should be set
         assert start_call.turn_id == py_span.span_id
 
+    def test_span_to_call_wandb_is_turn_false_overrides_conversation_id(self):
+        """Test that explicit wandb.is_turn=False disables turn inference."""
+        pb_span = create_test_span()
+
+        kv_conv = KeyValue()
+        kv_conv.key = "gen_ai.conversation.id"
+        kv_conv.value.string_value = "conv-xyz"
+        pb_span.attributes.append(kv_conv)
+
+        kv_is_turn = KeyValue()
+        kv_is_turn.key = "wandb.is_turn"
+        kv_is_turn.value.bool_value = False
+        pb_span.attributes.append(kv_is_turn)
+
+        py_span = PySpan.from_proto(pb_span)
+        start_call, _ = py_span.to_call("test_project")
+
+        assert start_call.thread_id == "conv-xyz"
+        assert start_call.turn_id is None
+
     def test_traces_data_from_proto(self):
         """Test converting protobuf TracesData to Python TracesData."""
         export_req = create_test_export_request()
@@ -1061,7 +1082,7 @@ class TestSemanticConventionParsing:
             }
         )
         extracted_false = get_wandb_attributes(attributes_false)
-        assert "is_turn" not in extracted_false.keys()
+        assert extracted_false["is_turn"] is False
         assert extracted_false["thread_id"] == test_thread_id
 
         # Test with only thread_id
@@ -1493,6 +1514,19 @@ class TestSemanticConventionParsing:
         extracted = get_wandb_attributes(attributes)
         assert extracted["thread_id"] == "conv-from-semconv"
 
+    def test_genai_semconv_conversation_id_turn_can_be_disabled(self):
+        """Test that wandb.is_turn=False overrides conversation turn inference."""
+        attributes = create_attributes(
+            {
+                "gen_ai.conversation.id": "conv-from-semconv",
+                "wandb.is_turn": False,
+            }
+        )
+        extracted = get_wandb_attributes(attributes)
+        assert extracted["thread_id"] == "conv-from-semconv"
+        assert extracted["is_turn"] is False
+
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_opentelemetry_cost_calculation(self, client: weave_client.WeaveClient):
         """Test that costs are properly calculated for OTEL spans with usage at query time."""
         project_id = client.project_id

--- a/weave/trace_server/opentelemetry/attributes.py
+++ b/weave/trace_server/opentelemetry/attributes.py
@@ -24,6 +24,12 @@ class SpanEvent(dict):
     dropped_attributes_count: int
 
 
+def _has_attribute_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return True
+    return bool(value)
+
+
 def parse_weave_values(
     attributes: dict[str, Any],
     key_mapping: list[str]
@@ -42,7 +48,7 @@ def parse_weave_values(
             else:
                 attribute_key = attribute_key_or_tuple
             value = get_attribute(attributes, attribute_key)
-            if value:
+            if _has_attribute_value(value):
                 # Handler should never raise - Always use a try in handler and default to passed in value
                 if handler:
                     value = handler(value)
@@ -62,7 +68,7 @@ def parse_weave_values(
                 attribute_key = attribute_key_or_tuple
 
             value = get_attribute(attributes, attribute_key)
-            if value:
+            if _has_attribute_value(value):
                 if handler:
                     # Handler should never raise - Always use a try in handler and default to passed in value
                     value = handler(value)

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -173,9 +173,10 @@ WB_KEYS = {
     "wb_run_step": ["wandb.wb_run_step"],
     "wb_run_step_end": ["wandb.wb_run_step_end"],
     "is_turn": [
+        # Explicit Weave metadata can opt out of semconv turn inference.
+        "wandb.is_turn",
         "gen_ai.conversation.id",  # OpenTelemetry GenAI semconv - presence implies a turn
         "gcp.vertex.agent.session_id",
-        "wandb.is_turn",
     ],  # We just check if this is truthy so we can reuse the id
 }
 


### PR DESCRIPTION
## Summary

Part of #7066.

When OpenTelemetry spans include `gen_ai.conversation.id`, Weave currently uses that conversation id as both the thread id and an implicit turn signal. That is useful as a default, but it also means child spans that correctly belong to the conversation become extra turns even when they explicitly set `wandb.is_turn=false`.

This change lets explicit Weave metadata opt out of that turn inference while keeping the conversation id as the thread id. This is intentionally scoped to the backend ingestion rule; it does not address the separate thread preview or child-span navigation UI crashes also described in the issue.

## Changes

- Preserve explicit boolean `False` values during OTel attribute extraction.
- Resolve `wandb.is_turn` before semconv-derived turn inference.
- Keep `gen_ai.conversation.id` as `thread_id` even when `wandb.is_turn=false`.
- Add regressions for extraction and `Span.to_call()` behavior.

## Verification

```bash
pytest tests/trace_server/test_opentelemetry.py::TestPythonSpans::test_span_to_call_wandb_is_turn_false_overrides_conversation_id tests/trace_server/test_opentelemetry.py::TestSemanticConventionParsing::test_wandb_turn_and_thread_attributes tests/trace_server/test_opentelemetry.py::TestSemanticConventionParsing::test_genai_semconv_conversation_id_turn_can_be_disabled -q
pytest tests/trace_server/test_opentelemetry.py --trace-server=fake -q
ruff check weave/trace_server/opentelemetry/attributes.py weave/trace_server/opentelemetry/constants.py tests/trace_server/test_opentelemetry.py
ruff format --check weave/trace_server/opentelemetry/attributes.py weave/trace_server/opentelemetry/constants.py tests/trace_server/test_opentelemetry.py
git diff --check
```
