### PR TITLE
fix(weave): disable replicated insert block-dedup on CI clickhouse clusters

### DIFF
--- a/tests/trace_server/conftest_lib/keeper_1s3r.xml
+++ b/tests/trace_server/conftest_lib/keeper_1s3r.xml
@@ -64,4 +64,17 @@
             </shard>
         </weave_cluster>
     </remote_servers>
+
+    <!-- Disable ReplicatedMergeTree insert block-dedup. CI inserts are
+         synchronous (test_overrides.xml sets async_insert=0 for
+         read-after-write determinism), and a sync re-insert of a
+         byte-identical block is silently dropped by Keeper dedup. Weave
+         legitimately re-inserts identical rows (delete+recreate an object,
+         republish-to-promote "latest", re-tag, re-set a call display_name)
+         because the per-row created_at is a server-side DEFAULT, not part
+         of the insert block. Prod inserts asynchronously, where dedup is
+         off by default, so 0 matches prod's effective behavior. -->
+    <merge_tree>
+        <replicated_deduplication_window>0</replicated_deduplication_window>
+    </merge_tree>
 </clickhouse>

--- a/tests/trace_server/conftest_lib/keeper_2s2r.xml
+++ b/tests/trace_server/conftest_lib/keeper_2s2r.xml
@@ -73,4 +73,17 @@
             </shard>
         </weave_cluster>
     </remote_servers>
+
+    <!-- Disable ReplicatedMergeTree insert block-dedup. CI inserts are
+         synchronous (test_overrides.xml sets async_insert=0 for
+         read-after-write determinism), and a sync re-insert of a
+         byte-identical block is silently dropped by Keeper dedup. Weave
+         legitimately re-inserts identical rows (delete+recreate an object,
+         republish-to-promote "latest", re-tag, re-set a call display_name)
+         because the per-row created_at is a server-side DEFAULT, not part
+         of the insert block. Prod inserts asynchronously, where dedup is
+         off by default, so 0 matches prod's effective behavior. -->
+    <merge_tree>
+        <replicated_deduplication_window>0</replicated_deduplication_window>
+    </merge_tree>
 </clickhouse>


### PR DESCRIPTION
## Summary
- WB-35378: the `1s3r` nightly leg fails 7 object/tag/call tests (`test_objs_query_delete_and_recreate`, `test_republish_*`, `test_sdk_tag_lifecycle`, `test_call_display_name`) with `assert 0 == 1`.
- Cause: CI inserts are synchronous (`test_overrides.xml` `async_insert=0`); on a `ReplicatedMergeTree` a sync re-insert of a byte-identical block is silently dropped by Keeper dedup. Weave re-inserts identical rows on delete+recreate / republish-to-promote / re-tag / re-set display_name because the per-row `created_at` is a server-side `DEFAULT`, not part of the insert block. Single-node `MergeTree` ignores the knob; prod inserts async, where dedup is off.
- Fix: `replicated_deduplication_window=0` in the `1s3r`/`2s2r` keeper configs (`config.d`), matching prod's effective behavior.

## Testing
reproduced `assert 0 == 1` on a local 1s3r cluster, then confirmed all 7 tests pass with the setting. replicated-only (non-replicated CI ignores the knob), so no normal-CI test applies.