### PR TITLE
feat(weave): support session-level span attributes

### DIFF
--- a/tests/session/test_span_attributes.py
+++ b/tests/session/test_span_attributes.py
@@ -13,7 +13,15 @@ import logging
 import pytest
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from weave.session.session import LLM, Session, SubAgent, Tool, Turn, log_turn
+from weave.session.session import (
+    LLM,
+    Session,
+    SubAgent,
+    Tool,
+    Turn,
+    log_session,
+    log_turn,
+)
 
 # (class_label, factory, otel_span_name) — span_name is the full emitted name
 # (not a prefix) so SubAgent and Turn (both "invoke_agent") don't collide.
@@ -172,9 +180,16 @@ def test_session_attributes_on_every_streaming_span(
                 pass
             with turn.tool(name="Edit"):
                 pass
+            with turn.subagent(name="researcher"):
+                pass
     spans = otel_spans.get_finished_spans()
     names = {span.name for span in spans}
-    assert {"invoke_agent bot", "chat gpt-4o", "execute_tool Edit"} <= names
+    assert {
+        "invoke_agent bot",
+        "chat gpt-4o",
+        "execute_tool Edit",
+        "invoke_agent researcher",
+    } <= names
     for span in spans:
         assert span.attributes["weave.integration.name"] == "wb-agent"
         assert span.attributes["custom.tier"] == "gold"
@@ -192,6 +207,24 @@ def test_session_attributes_on_every_batch_span(
     )
     spans = otel_spans.get_finished_spans()
     assert len(spans) == 3
+    for span in spans:
+        assert span.attributes["weave.integration.name"] == "wb-agent"
+
+
+def test_session_attributes_on_every_log_session_span(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    """log_session applies attributes to every turn root and child span."""
+    log_session(
+        turns=[
+            Turn(agent_name="bot", spans=[LLM(model="gpt-4o")]),
+            Turn(agent_name="bot", spans=[Tool(name="Edit")]),
+        ],
+        session_id="s",
+        attributes={"weave.integration.name": "wb-agent"},
+    )
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) == 4  # two turn roots + one child each
     for span in spans:
         assert span.attributes["weave.integration.name"] == "wb-agent"
 

--- a/tests/session/test_span_attributes.py
+++ b/tests/session/test_span_attributes.py
@@ -13,7 +13,7 @@ import logging
 import pytest
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from weave.session.session import LLM, Session, SubAgent, Tool, Turn
+from weave.session.session import LLM, Session, SubAgent, Tool, Turn, log_turn
 
 # (class_label, factory, otel_span_name) — span_name is the full emitted name
 # (not a prefix) so SubAgent and Turn (both "invoke_agent") don't collide.
@@ -153,3 +153,54 @@ def test_warns_when_span_already_ended(caplog: pytest.LogCaptureFixture) -> None
     messages = [record.message for record in caplog.records]
     assert any("set_attributes" in m and "span already ended" in m for m in messages)
     assert any("add_event" in m and "span already ended" in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# Session attributes (stamped on every span)
+# ---------------------------------------------------------------------------
+
+
+def test_session_attributes_on_every_streaming_span(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    """A session's attributes land on the turn root and every child span."""
+    attrs = {"weave.integration.name": "wb-agent", "custom.tier": "gold"}
+    with Session(session_id="s", attributes=attrs) as session:
+        turn = session.start_turn(agent_name="bot")
+        with turn:
+            with turn.llm(model="gpt-4o"):
+                pass
+            with turn.tool(name="Edit"):
+                pass
+    spans = otel_spans.get_finished_spans()
+    names = {span.name for span in spans}
+    assert {"invoke_agent bot", "chat gpt-4o", "execute_tool Edit"} <= names
+    for span in spans:
+        assert span.attributes["weave.integration.name"] == "wb-agent"
+        assert span.attributes["custom.tier"] == "gold"
+
+
+def test_session_attributes_on_every_batch_span(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    """log_turn applies attributes to the turn and its child spans."""
+    log_turn(
+        session_id="s",
+        agent_name="bot",
+        spans=[LLM(model="gpt-4o"), Tool(name="Edit")],
+        attributes={"weave.integration.name": "wb-agent"},
+    )
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) == 3
+    for span in spans:
+        assert span.attributes["weave.integration.name"] == "wb-agent"
+
+
+def test_no_session_attributes_by_default(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    with Session(session_id="s") as session:
+        with session.start_turn(agent_name="bot"):
+            pass
+    span = _only_span(otel_spans.get_finished_spans(), "invoke_agent bot")
+    assert "weave.integration.name" not in (span.attributes or {})

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -63,6 +63,7 @@ except ImportError:
 if TYPE_CHECKING:
     from opentelemetry.context import Token as _OTelToken
     from opentelemetry.trace import Span as _OTelSpan
+    from opentelemetry.util.types import AttributeValue
 
 
 # Re-export types for backwards compatibility with existing imports of
@@ -157,6 +158,12 @@ class _SpanBase(BaseModel):
         self._otel_token = otel_context.attach(
             otel_trace.set_span_in_context(self._otel_span)
         )
+        # Stamp the active session's attributes on every span. Read from the
+        # session contextvar (not OTel context) so they reach the root turn
+        # span too, which starts in a fresh OTel Context to force a new trace.
+        session = get_current_session()
+        if session is not None and session.attributes:
+            self._otel_span.set_attributes(session.attributes)
 
     def _end_otel_span(
         self, attrs: dict[str, Any], *, end_time_ns: int | None = None
@@ -952,6 +959,10 @@ class Session(BaseModel):
     model: str = ""
     include_content: bool = True
     continue_parent_trace: bool = False
+    # Attributes stamped on every span this session emits (e.g. an integration
+    # identity). dict[str, Any] like set_attributes — AttributeValue is a
+    # TYPE_CHECKING-only import, but Pydantic resolves field types at runtime.
+    attributes: dict[str, Any] = Field(default_factory=dict)
 
     _ended: bool = PrivateAttr(default=False)
     _token: Token[Session | None] | None = PrivateAttr(default=None)
@@ -1036,8 +1047,13 @@ def start_session(
     session_name: str = "",
     include_content: bool = True,
     continue_parent_trace: bool = False,
+    attributes: dict[str, AttributeValue] | None = None,
 ) -> Session:
-    """Create and activate a session. Sets the contextvar for cross-module access."""
+    """Create and activate a session. Sets the contextvar for cross-module access.
+
+    ``attributes`` are stamped on every span this session emits (e.g. an
+    integration identity like ``weave.integration.*``).
+    """
     session = Session(
         agent_name=agent_name,
         model=model,
@@ -1045,6 +1061,7 @@ def start_session(
         session_name=session_name,
         include_content=include_content,
         continue_parent_trace=continue_parent_trace,
+        attributes=attributes or {},
     )
     session._token = _current_session.set(session)
     return session
@@ -1268,6 +1285,7 @@ def log_turn(
     ended_at: datetime | None = None,
     include_content: bool = True,
     continue_parent_trace: bool = False,
+    attributes: dict[str, AttributeValue] | None = None,
 ) -> LogResult:
     """Imperatively emit one turn and its child spans to OTel.
 
@@ -1276,6 +1294,9 @@ def log_turn(
     ``ended_at`` set; the emitted OTel span timestamps come from those fields.
     Falls back to the earliest/latest child timestamp, then ``now()``, when
     the turn doesn't supply its own.
+
+    ``attributes`` are stamped on every emitted span; the streaming path reads
+    these from the active session instead.
     """
     if not _OTEL_AVAILABLE or should_disable_weave():
         return LogResult(session_id=session_id)
@@ -1301,6 +1322,8 @@ def log_turn(
         session_name=session_name,
         include_content=include_content,
     )
+    if attributes:
+        turn_attrs.update(attributes)
 
     parent_ctx = Context() if not continue_parent_trace else None
     turn_span = _emit_span_now(
@@ -1321,6 +1344,8 @@ def log_turn(
             session_name=session_name,
             include_content=include_content,
         )
+        if attributes:
+            attrs.update(attributes)
         _emit_span_now(
             name,
             parent_ctx=child_ctx,
@@ -1346,11 +1371,14 @@ def log_session(
     model: str = "",
     include_content: bool = True,
     continue_parent_trace: bool = False,
+    attributes: dict[str, AttributeValue] | None = None,
 ) -> LogResult:
     """Imperatively emit a complete session.
 
     Each Turn's ``.spans`` attribute provides its children. Auto-generates
     ``session_id`` if empty. By default each turn gets its own OTel trace.
+
+    ``attributes`` are stamped on every emitted span.
     """
     sid = session_id or str(uuid.uuid4())
     if not _OTEL_AVAILABLE or should_disable_weave():
@@ -1371,6 +1399,7 @@ def log_session(
             ended_at=turn.ended_at,
             include_content=include_content,
             continue_parent_trace=continue_parent_trace,
+            attributes=attributes,
         )
         trace_ids.extend(result.trace_ids)
         root_span_ids.extend(result.root_span_ids)

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -1052,7 +1052,11 @@ def start_session(
     """Create and activate a session. Sets the contextvar for cross-module access.
 
     ``attributes`` are stamped on every span this session emits (e.g. an
-    integration identity like ``weave.integration.*``).
+    integration identity like ``weave.integration.*``). Use custom,
+    non-semconv keys: set semantic-convention fields via the typed params
+    (``session_name``, ``model``, ...). A key that collides with a span's
+    own ``gen_ai.*`` / ``weave.*`` attribute is unsupported; which value
+    wins is path-dependent (streaming vs ``log_turn``).
     """
     session = Session(
         agent_name=agent_name,
@@ -1296,7 +1300,9 @@ def log_turn(
     the turn doesn't supply its own.
 
     ``attributes`` are stamped on every emitted span; the streaming path reads
-    these from the active session instead.
+    these from the active session instead. Use custom, non-semconv keys: a
+    key that collides with a span's own ``gen_ai.*`` / ``weave.*`` attribute
+    is unsupported (which value wins is path-dependent).
     """
     if not _OTEL_AVAILABLE or should_disable_weave():
         return LogResult(session_id=session_id)
@@ -1378,7 +1384,9 @@ def log_session(
     Each Turn's ``.spans`` attribute provides its children. Auto-generates
     ``session_id`` if empty. By default each turn gets its own OTel trace.
 
-    ``attributes`` are stamped on every emitted span.
+    ``attributes`` are stamped on every emitted span. Use custom, non-semconv
+    keys: a key that collides with a span's own ``gen_ai.*`` / ``weave.*``
+    attribute is unsupported (which value wins is path-dependent).
     """
     sid = session_id or str(uuid.uuid4())
     if not _OTEL_AVAILABLE or should_disable_weave():

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -63,7 +63,7 @@ except ImportError:
 if TYPE_CHECKING:
     from opentelemetry.context import Token as _OTelToken
     from opentelemetry.trace import Span as _OTelSpan
-    from opentelemetry.util.types import AttributeValue
+    from opentelemetry.util.types import Attributes
 
 
 # Re-export types for backwards compatibility with existing imports of
@@ -960,7 +960,7 @@ class Session(BaseModel):
     include_content: bool = True
     continue_parent_trace: bool = False
     # Attributes stamped on every span this session emits (e.g. an integration
-    # identity). dict[str, Any] like set_attributes — AttributeValue is a
+    # identity). dict[str, Any] like set_attributes — Attributes is a
     # TYPE_CHECKING-only import, but Pydantic resolves field types at runtime.
     attributes: dict[str, Any] = Field(default_factory=dict)
 
@@ -1047,7 +1047,7 @@ def start_session(
     session_name: str = "",
     include_content: bool = True,
     continue_parent_trace: bool = False,
-    attributes: dict[str, AttributeValue] | None = None,
+    attributes: Attributes = None,
 ) -> Session:
     """Create and activate a session. Sets the contextvar for cross-module access.
 
@@ -1289,7 +1289,7 @@ def log_turn(
     ended_at: datetime | None = None,
     include_content: bool = True,
     continue_parent_trace: bool = False,
-    attributes: dict[str, AttributeValue] | None = None,
+    attributes: Attributes = None,
 ) -> LogResult:
     """Imperatively emit one turn and its child spans to OTel.
 
@@ -1377,7 +1377,7 @@ def log_session(
     model: str = "",
     include_content: bool = True,
     continue_parent_trace: bool = False,
-    attributes: dict[str, AttributeValue] | None = None,
+    attributes: Attributes = None,
 ) -> LogResult:
     """Imperatively emit a complete session.
 


### PR DESCRIPTION
Add an `attributes` mapping to the Session SDK, stamped on every span a session emits — the turn root and all chat / tool / subagent children.

- `start_session(attributes={...})` (streaming) — read from the active session in `_start_otel_span`, so they reach the root turn span (which starts in a fresh OTel context).
- `log_turn(attributes={...})` / `log_session(attributes={...})` (batch).

`attributes` is for your own custom, non-semconv keys (e.g. `weave.integration.*` or any custom namespace); these land in the backend's queryable `custom_attrs_string`. Set semantic-convention fields via the typed params (`session_name`, `model`, ...) — a key that collides with a span's own `gen_ai.*` / `weave.*` attribute is unsupported, and which value wins is path-dependent (streaming vs `log_turn`). First consumer: wb_agent stamps `{"weave.integration.name": "wb-agent", ...}` to group/filter conversations by integration.

## Test
`tests/session/test_span_attributes.py`: every-span streaming (turn root + chat / tool / subagent children), every-span batch (`log_turn`), every-span `log_session` across multiple turns, and default-off. Full session suite green.
