### PR TITLE
chore(weave_ts): Clean up duplicated getCalls helper.

### DIFF
--- a/sdks/node/src/__tests__/attributes.test.ts
+++ b/sdks/node/src/__tests__/attributes.test.ts
@@ -72,7 +72,7 @@ describe('attributes context', () => {
       await leafOp();
     });
 
-    const calls = await traceServer.getCalls(projectId)
+    const calls = await traceServer.getCalls(projectId);
     const leafCall = calls.find(c => c.op_name?.includes('leafOp'));
     expect(leafCall?.attributes?.tenant).toBe('acme');
     expect(leafCall?.attributes?.base).toBe('local'); // local overrides global

--- a/sdks/node/src/__tests__/attributes.test.ts
+++ b/sdks/node/src/__tests__/attributes.test.ts
@@ -1,8 +1,6 @@
 import {withAttributes, op} from 'weave';
-
 import {initWithCustomTraceServer} from './clientMock';
 import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
-import {Settings} from '../settings';
 
 describe('attributes context', () => {
   const projectId = 'test-project';
@@ -12,14 +10,6 @@ describe('attributes context', () => {
     traceServer = new InMemoryTraceServer();
     initWithCustomTraceServer(projectId, traceServer);
   });
-
-  const getCalls = async () => {
-    await traceServer.waitForPendingOperations();
-    const result = await traceServer.calls.callsStreamQueryPost({
-      project_id: projectId,
-    });
-    return result.calls;
-  };
 
   test('propagates attributes to parent and child calls', async () => {
     const childOp = op(async function childOp() {
@@ -35,7 +25,7 @@ describe('attributes context', () => {
       await parentOp();
     });
 
-    const calls = await getCalls();
+    const calls = await traceServer.getCalls(projectId);
     const parentCall = calls.find(c => c.op_name?.includes('parentOp'));
     const childCall = calls.find(c => c.op_name?.includes('childOp'));
 
@@ -58,7 +48,7 @@ describe('attributes context', () => {
       await parentOp();
     });
 
-    const calls = await getCalls();
+    const calls = await traceServer.getCalls(projectId);
     const parentCall = calls.find(c => c.op_name?.includes('parentOp'));
     const childCall = calls.find(c => c.op_name?.includes('leafOp'));
 
@@ -82,11 +72,8 @@ describe('attributes context', () => {
       await leafOp();
     });
 
-    await traceServer.waitForPendingOperations();
-    const result = await traceServer.calls.callsStreamQueryPost({
-      project_id: projectId,
-    });
-    const leafCall = result.calls.find(c => c.op_name?.includes('leafOp'));
+    const calls = await traceServer.getCalls(projectId)
+    const leafCall = calls.find(c => c.op_name?.includes('leafOp'));
     expect(leafCall?.attributes?.tenant).toBe('acme');
     expect(leafCall?.attributes?.base).toBe('local'); // local overrides global
   });

--- a/sdks/node/src/__tests__/evaluation.test.ts
+++ b/sdks/node/src/__tests__/evaluation.test.ts
@@ -10,15 +10,6 @@ import {op} from '../op';
 import {initWithCustomTraceServer} from './clientMock';
 import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 
-// Read all recorded calls back from the in-memory trace server (mirrors the
-// helper in evaluationLogger.test.ts).
-async function getCalls(traceServer: InMemoryTraceServer, projectId: string) {
-  await traceServer.waitForPendingOperations();
-  return traceServer.calls
-    .callsStreamQueryPost({project_id: projectId})
-    .then(result => result.calls);
-}
-
 const createMockDataset = () =>
   new Dataset({
     rows: [
@@ -205,7 +196,7 @@ describe('Evaluation - declarative eval metadata', () => {
 
     await evaluation.evaluate({model, nTrials: 2, maxConcurrency: 2});
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const predictAndScoreCalls = calls.filter(c =>
       c.op_name?.includes(EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS)
     );
@@ -247,7 +238,7 @@ describe('Evaluation - declarative eval metadata', () => {
       await evaluation.evaluate({model, maxConcurrency: 2});
     });
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const predictAndScoreCalls = calls.filter(c =>
       c.op_name?.includes(EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS)
     );

--- a/sdks/node/src/__tests__/evaluationLogger.test.ts
+++ b/sdks/node/src/__tests__/evaluationLogger.test.ts
@@ -7,18 +7,6 @@ import {WeaveObject} from '../weaveObject';
 import {initWithCustomTraceServer} from './clientMock';
 import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 
-// Helper function to get calls from trace server
-async function getCalls(traceServer: InMemoryTraceServer, projectId: string) {
-  // Wait for async batch processing to complete
-  await traceServer.waitForPendingOperations();
-
-  return traceServer.calls
-    .callsStreamQueryPost({
-      project_id: projectId,
-    })
-    .then(result => result.calls);
-}
-
 describe('EvaluationLogger - Basic Functionality', () => {
   let traceServer: InMemoryTraceServer;
   const projectId = 'test-project';
@@ -42,7 +30,7 @@ describe('EvaluationLogger - Basic Functionality', () => {
     await scoreLogger.finish();
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     expect(calls.length).toBeGreaterThan(0);
   });
 
@@ -61,7 +49,7 @@ describe('EvaluationLogger - Basic Functionality', () => {
     // logSummary waits for everything to complete internally
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     expect(calls.length).toBeGreaterThan(0);
 
     // Verify scores were logged
@@ -101,7 +89,7 @@ describe('EvaluationLogger - Basic Functionality', () => {
     // logSummary waits for everything to complete internally
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     expect(calls.length).toBeGreaterThan(0);
 
     // Verify scores were logged
@@ -125,7 +113,7 @@ describe('EvaluationLogger - Basic Functionality', () => {
     // logSummary should auto-finish and complete successfully
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const predictAndScoreCall = calls.find(c =>
       c.op_name?.includes('predict_and_score')
     );
@@ -154,7 +142,7 @@ describe('EvaluationLogger - Basic Functionality', () => {
     await scoreLogger.finish();
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
 
     expect(evaluateCall?.attributes?.trial_id).toBe('abc123');
@@ -181,7 +169,7 @@ describe('EvaluationLogger - Call Hierarchy', () => {
     await scoreLogger.finish();
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
     const predictAndScoreCall = calls.find(c =>
       c.op_name?.includes('predict_and_score')
@@ -223,7 +211,7 @@ describe('EvaluationLogger - Attribute Markers', () => {
     await scoreLogger.finish();
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
     const predictCall = calls.find(
       c => c.op_name?.includes('predict') && !c.op_name?.includes('_and_')
@@ -246,7 +234,7 @@ describe('EvaluationLogger - Attribute Markers', () => {
     await scoreLogger.finish();
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const scorerCall = calls.find(c => c.op_name?.includes('accuracy'));
 
     expect(scorerCall?.attributes?._weave_eval_meta?.imperative).toBe(true);
@@ -277,7 +265,7 @@ describe('EvaluationLogger - Summary Generation', () => {
 
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
 
     expect(evaluateCall?.output?.accuracy?.mean).toBeCloseTo(0.95, 2);
@@ -310,7 +298,7 @@ describe('EvaluationLogger - Summary Generation', () => {
 
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
 
     expect(evaluateCall?.output?.passed?.true_count).toBe(2);
@@ -333,7 +321,7 @@ describe('EvaluationLogger - Summary Generation', () => {
       accuracy: {mean: 0.99},
     });
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
 
     expect(evaluateCall?.output?.custom_metric).toBe('custom_value');
@@ -361,7 +349,7 @@ describe('EvaluationLogger - Edge Cases', () => {
 
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const predictAndScoreCall = calls.find(c =>
       c.op_name?.includes('predict_and_score')
     );
@@ -375,7 +363,7 @@ describe('EvaluationLogger - Edge Cases', () => {
 
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
 
     expect(evaluateCall).toBeDefined();
@@ -397,7 +385,7 @@ describe('EvaluationLogger - Edge Cases', () => {
 
     await evalLogger.logSummary();
 
-    const calls = await getCalls(traceServer, projectId);
+    const calls = await traceServer.getCalls(projectId);
     const predictAndScoreCalls = calls.filter(c =>
       c.op_name?.includes('predict_and_score')
     );

--- a/sdks/node/src/__tests__/integrationMetadata.test.ts
+++ b/sdks/node/src/__tests__/integrationMetadata.test.ts
@@ -1,5 +1,4 @@
 import {op} from 'weave';
-
 import {initWithCustomTraceServer} from './clientMock';
 import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 import {
@@ -67,14 +66,6 @@ describe('op-level attributes', () => {
     initWithCustomTraceServer(projectId, traceServer);
   });
 
-  const getCalls = async () => {
-    await traceServer.waitForPendingOperations();
-    const result = await traceServer.calls.callsStreamQueryPost({
-      project_id: projectId,
-    });
-    return result.calls;
-  };
-
   test('op attributes stamp integration provenance on the call', async () => {
     const tracedOp = op(
       async function tracedOp() {
@@ -85,7 +76,7 @@ describe('op-level attributes', () => {
 
     await tracedOp();
 
-    const calls = await getCalls();
+    const calls = await traceServer.getCalls(projectId);
     const call = calls.find(c => c.op_name?.includes('tracedOp'));
     expect(call?.attributes?.integration?.name).toBe('demo');
     expect(call?.attributes?.integration?.version).toBe(packageVersion);
@@ -102,7 +93,7 @@ describe('op-level attributes', () => {
 
     await tracedOp();
 
-    const calls = await getCalls();
+    const calls = await traceServer.getCalls(projectId);
     const call = calls.find(c => c.op_name?.includes('kindOp'));
     expect(call?.attributes?.kind).toBe('llm');
   });

--- a/sdks/node/src/__tests__/integrations/anthropic.test.ts
+++ b/sdks/node/src/__tests__/integrations/anthropic.test.ts
@@ -2,17 +2,6 @@ import {InMemoryTraceServer} from '../helpers/inMemoryTraceServer';
 import {commonPatchAnthropic} from '../../integrations/anthropic';
 import {initWithCustomTraceServer} from '../clientMock';
 
-// Helper function to get calls
-async function getCalls(traceServer: InMemoryTraceServer, projectId: string) {
-  const calls = await traceServer.calls
-    .callsStreamQueryPost({
-      project_id: projectId,
-      limit: 100,
-    })
-    .then(result => result.calls);
-  return calls;
-}
-
 // Mock Anthropic SDK
 function createMockAnthropic() {
   const mockMessages = {
@@ -203,7 +192,7 @@ function createMockAnthropic() {
 }
 
 describe('Anthropic Integration', () => {
-  let inMemoryTraceServer: InMemoryTraceServer;
+  let traceServer: InMemoryTraceServer;
   const testProjectName = 'test-project';
   let mockAnthropic: any;
   let MockMessages: any;
@@ -211,8 +200,8 @@ describe('Anthropic Integration', () => {
   let patchedAnthropic: any;
 
   beforeEach(() => {
-    inMemoryTraceServer = new InMemoryTraceServer();
-    initWithCustomTraceServer(testProjectName, inMemoryTraceServer);
+    traceServer = new InMemoryTraceServer();
+    initWithCustomTraceServer(testProjectName, traceServer);
 
     const mockData = createMockAnthropic();
     mockAnthropic = mockData.mockAnthropic;
@@ -239,9 +228,6 @@ describe('Anthropic Integration', () => {
     const anthropic = new patchedAnthropic.Anthropic.Messages();
     const result = await anthropic.create(options);
 
-    // Wait for pending operations to complete
-    await inMemoryTraceServer.waitForPendingOperations();
-
     // Check results
     expect(result).toMatchObject({
       id: 'msg_123',
@@ -257,7 +243,7 @@ describe('Anthropic Integration', () => {
     });
 
     // Check logged Call values
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('create');
     // Integration-tracking metadata is stamped on every patched call. The
@@ -302,14 +288,11 @@ describe('Anthropic Integration', () => {
       }
     }
 
-    // Wait for pending operations to complete
-    await inMemoryTraceServer.waitForPendingOperations();
-
     // Check results
     expect(collectedText).toBe('Hello! How can I help you today?');
 
     // Check logged Call values
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('create');
     expect(calls[0].inputs).toEqual({arg0: options, self: {}});
@@ -367,14 +350,11 @@ describe('Anthropic Integration', () => {
       }
     }
 
-    // Wait for pending operations to complete
-    await inMemoryTraceServer.waitForPendingOperations();
-
     // Check results
     expect(collectedText).toBe('Hello! How can I help you today?');
 
     // Check logged Call values
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('stream');
     expect(calls[0].inputs).toMatchObject({arg1: options, self: {}});
@@ -417,9 +397,6 @@ describe('Anthropic Integration', () => {
     const batches = new patchedAnthropic.Anthropic.Messages.Batches();
     const result = await batches.create(batchOptions);
 
-    // Wait for pending operations to complete
-    await inMemoryTraceServer.waitForPendingOperations();
-
     // Check results
     expect(result).toMatchObject({
       id: 'batch_123',
@@ -428,7 +405,7 @@ describe('Anthropic Integration', () => {
     });
 
     // Check logged Call values
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('create');
     expect(calls[0].inputs).toEqual({arg0: batchOptions, self: {}});
@@ -442,9 +419,6 @@ describe('Anthropic Integration', () => {
     const batches = new patchedAnthropic.Anthropic.Messages.Batches();
     const result = await batches.retrieve(batchId);
 
-    // Wait for pending operations to complete
-    await inMemoryTraceServer.waitForPendingOperations();
-
     // Check results
     expect(result).toMatchObject({
       id: 'batch_123',
@@ -453,7 +427,7 @@ describe('Anthropic Integration', () => {
     });
 
     // Check logged Call values
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('retrieve');
     expect(calls[0].inputs).toEqual({arg0: batchId, self: {}});
@@ -482,14 +456,11 @@ describe('Anthropic Integration', () => {
       }
     }
 
-    // Wait for pending operations to complete
-    await inMemoryTraceServer.waitForPendingOperations();
-
     // Check results
     expect(resultCount).toBe(1);
 
     // Check logged Call values
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('results');
     expect(calls[0].inputs).toEqual({arg0: batchId, self: {}});
@@ -530,11 +501,8 @@ describe('Anthropic Integration', () => {
 
     await expect(anthropic.create(options)).rejects.toThrow('API Error');
 
-    // Wait for pending operations to complete
-    await inMemoryTraceServer.waitForPendingOperations();
-
     // Check logged Call values
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('create');
     expect(calls[0].inputs).toEqual({arg0: options, self: {}});
@@ -583,11 +551,8 @@ describe('Anthropic Integration', () => {
     await anthropic.create(options1);
     await anthropic.create(options2);
 
-    // Wait for pending operations to complete
-    await inMemoryTraceServer.waitForPendingOperations();
-
     // Check logged Call values
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(2);
 
     // Check first call

--- a/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
+++ b/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
@@ -3,28 +3,17 @@ import {wrapOpenAI} from '../../integrations/openai';
 import {initWithCustomTraceServer} from '../clientMock';
 import {makeAPIPromiseShim, makeMockOpenAIChat} from '../openaiMock';
 
-// Helper function to get calls
-async function getCalls(traceServer: InMemoryTraceServer, projectId: string) {
-  const calls = await traceServer.calls
-    .callsStreamQueryPost({
-      project_id: projectId,
-      limit: 100,
-    })
-    .then(result => result.calls);
-  return calls;
-}
-
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 describe('OpenAI Integration', () => {
-  let inMemoryTraceServer: InMemoryTraceServer;
+  let traceServer: InMemoryTraceServer;
   const testProjectName = 'test-project';
   let mockOpenAI: any;
   let patchedOpenAI: any;
 
   beforeEach(() => {
-    inMemoryTraceServer = new InMemoryTraceServer();
-    initWithCustomTraceServer(testProjectName, inMemoryTraceServer);
+    traceServer = new InMemoryTraceServer();
+    initWithCustomTraceServer(testProjectName, traceServer);
 
     const mockOpenAIChat = makeMockOpenAIChat(messages => ({
       content: messages[messages.length - 1].content.toUpperCase(),
@@ -81,7 +70,7 @@ describe('OpenAI Integration', () => {
     expect(opResult.choices[0].message.content).toBe('HELLO, AI!');
 
     // Check logged Call values
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('openai.chat.completions.create');
     // Integration-tracking metadata is stamped on every patched call.
@@ -153,7 +142,7 @@ describe('OpenAI Integration', () => {
     // expect(usageChunkSeen).toBe(false);  // Ensure no usage chunk is seen in the user-facing stream
 
     // Check logged Call values
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('openai.chat.completions.create');
     expect(calls[0].inputs).toEqual({messages, stream: true});
@@ -197,7 +186,7 @@ describe('OpenAI Integration', () => {
       expect(result.choices[0].message.content).toBe('HELLO!');
 
       await wait(300);
-      const calls = await getCalls(inMemoryTraceServer, testProjectName);
+      const calls = await traceServer.getCalls(testProjectName);
       // Fail-fast: no half-started call on the trace server.
       expect(calls).toHaveLength(0);
     } finally {
@@ -228,7 +217,7 @@ describe('OpenAI Integration', () => {
 
     await wait(300);
 
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     // The key assertion: output is populated, which means finishCall
     // fired. Without the .withResponse() → traced-data substitution,
@@ -269,7 +258,7 @@ describe('OpenAI Integration', () => {
     expect(usageChunkSeen).toBe(true); // Ensure usage chunk is seen when explicitly requested
 
     // Check logged Call values
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].summary).toEqual({
       usage: {
@@ -342,7 +331,7 @@ describe('OpenAI Integration', () => {
     });
 
     // Check logged Call values
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('openai.chat.completions.create');
     expect(calls[0].inputs).toEqual({messages, functions});
@@ -467,7 +456,7 @@ describe('OpenAI Integration', () => {
     // Wait for any pending batch processing
     await wait(300);
 
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('create');
     expect(calls[0].inputs).toMatchObject(options);
@@ -510,7 +499,7 @@ describe('OpenAI Integration', () => {
 
     await wait(300);
 
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     // The trace records the exception rather than declaring success
     // with partial output.

--- a/sdks/node/src/__tests__/opFlow.test.ts
+++ b/sdks/node/src/__tests__/opFlow.test.ts
@@ -4,29 +4,13 @@ import {op} from '../op';
 import {initWithCustomTraceServer} from './clientMock';
 import {makeMockOpenAIChat} from './openaiMock';
 
-// Helper function to get calls
-async function getCalls(
-  traceServer: InMemoryTraceServer,
-  projectId: string,
-  limit?: number,
-  filters?: any
-) {
-  return traceServer.calls
-    .callsStreamQueryPost({
-      project_id: projectId,
-      limit,
-      filters,
-    })
-    .then(result => result.calls);
-}
-
 describe('Op Flow', () => {
-  let inMemoryTraceServer: InMemoryTraceServer;
+  let traceServer: InMemoryTraceServer;
   const testProjectName = 'test-project';
 
   beforeEach(() => {
-    inMemoryTraceServer = new InMemoryTraceServer();
-    initWithCustomTraceServer(testProjectName, inMemoryTraceServer);
+    traceServer = new InMemoryTraceServer();
+    initWithCustomTraceServer(testProjectName, traceServer);
   });
 
   test('end-to-end op flow', async () => {
@@ -51,7 +35,7 @@ describe('Op Flow', () => {
     await new Promise(resolve => setTimeout(resolve, 300));
 
     // Fetch the logged calls using the helper function
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
 
     // Assertions
     expect(calls).toHaveLength(6); // 2 outer calls + 4 inner calls
@@ -117,7 +101,7 @@ describe('Op Flow', () => {
     await new Promise(resolve => setTimeout(resolve, 300));
 
     // Fetch the logged calls using the helper function
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
 
     // Assertions
     expect(calls).toHaveLength(6); // 2 outer calls + 4 inner calls
@@ -188,7 +172,7 @@ describe('Op Flow', () => {
     // Wait for any pending batch processing
     await new Promise(resolve => setTimeout(resolve, 300));
 
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
 
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('customSummaryOp');
@@ -212,7 +196,7 @@ describe('Op Flow', () => {
     // Wait for any pending batch processing
     await new Promise(resolve => setTimeout(resolve, 300));
 
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
 
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('testOpenAIChat');
@@ -289,7 +273,7 @@ describe('Op Flow', () => {
     // Wait for any pending batch processing
     await new Promise(resolve => setTimeout(resolve, 300));
 
-    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    const calls = await traceServer.getCalls(testProjectName);
 
     expect(calls).toHaveLength(5); // 1 root + 1 mid + 3 leaf calls
 
@@ -357,14 +341,14 @@ describe('Op Flow', () => {
     // server merges end fields onto the start record, and the start already
     // carries trace_id, so a merged read would pass even without the fix.
     const batchSpy = jest.spyOn(
-      inMemoryTraceServer.call,
+      traceServer.call,
       'callStartBatchCallUpsertBatchPost'
     );
 
     const myOp = op((x: number) => x * 2, {name: 'myOp'});
     await myOp(21);
 
-    await inMemoryTraceServer.waitForPendingOperations();
+    await traceServer.waitForPendingOperations();
 
     const items = batchSpy.mock.calls.flatMap(([batchReq]) => batchReq.batch);
     const startItem = items.find(item => item.mode === 'start');


### PR DESCRIPTION
## Description

* Followup from https://github.com/wandb/weave/pull/7286/changes#r3436612143

* Removes unnecessary `getCalls` helper that was duplicated in 7 places.