### PR TITLE
chore(weave_ts): Remove unnecessary guards against nullish op_name

### DIFF
--- a/sdks/node/src/__tests__/attributes.test.ts
+++ b/sdks/node/src/__tests__/attributes.test.ts
@@ -26,8 +26,8 @@ describe('attributes context', () => {
     });
 
     const calls = await traceServer.getCalls(projectId);
-    const parentCall = calls.find(c => c.op_name?.includes('parentOp'));
-    const childCall = calls.find(c => c.op_name?.includes('childOp'));
+    const parentCall = calls.find(c => c.op_name.includes('parentOp'));
+    const childCall = calls.find(c => c.op_name.includes('childOp'));
 
     expect(parentCall?.attributes?.requestId).toBe('req-123');
     expect(childCall?.attributes?.requestId).toBe('req-123');
@@ -49,8 +49,8 @@ describe('attributes context', () => {
     });
 
     const calls = await traceServer.getCalls(projectId);
-    const parentCall = calls.find(c => c.op_name?.includes('parentOp'));
-    const childCall = calls.find(c => c.op_name?.includes('leafOp'));
+    const parentCall = calls.find(c => c.op_name.includes('parentOp'));
+    const childCall = calls.find(c => c.op_name.includes('leafOp'));
 
     expect(parentCall?.attributes?.scope).toBe('outer');
     expect(parentCall?.attributes?.merged).toBe('parent');
@@ -73,7 +73,7 @@ describe('attributes context', () => {
     });
 
     const calls = await traceServer.getCalls(projectId);
-    const leafCall = calls.find(c => c.op_name?.includes('leafOp'));
+    const leafCall = calls.find(c => c.op_name.includes('leafOp'));
     expect(leafCall?.attributes?.tenant).toBe('acme');
     expect(leafCall?.attributes?.base).toBe('local'); // local overrides global
   });

--- a/sdks/node/src/__tests__/evalLinkSpanProcessor.test.ts
+++ b/sdks/node/src/__tests__/evalLinkSpanProcessor.test.ts
@@ -183,7 +183,7 @@ describe('EvalLinkSpanProcessor', () => {
 
     const calls = await traceServer.getCalls(projectId);
     const predictAndScoreCall = calls.find(c =>
-      c.op_name?.includes('Evaluation.predictAndScore')
+      c.op_name.includes('Evaluation.predictAndScore')
     );
 
     expect(predictAndScoreCall?.summary?.weave?.genai_span_ref).toEqual([

--- a/sdks/node/src/__tests__/evaluation.test.ts
+++ b/sdks/node/src/__tests__/evaluation.test.ts
@@ -217,7 +217,7 @@ describe('Evaluation - declarative eval metadata', () => {
       ...modelCalls,
       ...scorerCalls,
     ]) {
-      expect(call.attributes?._weave_eval_meta).toEqual({declarative: true});
+      expect(call.attributes._weave_eval_meta).toEqual({declarative: true});
     }
 
     // Exactly one root evaluate call; recognized by op_name, so it is
@@ -260,7 +260,7 @@ describe('Evaluation - declarative eval metadata', () => {
       ...modelCalls,
       ...scorerCalls,
     ]) {
-      expect(call.attributes?._weave_eval_meta).toEqual({
+      expect(call.attributes._weave_eval_meta).toEqual({
         foo: true,
         declarative: true,
       });

--- a/sdks/node/src/__tests__/evaluation.test.ts
+++ b/sdks/node/src/__tests__/evaluation.test.ts
@@ -198,13 +198,13 @@ describe('Evaluation - declarative eval metadata', () => {
 
     const calls = await traceServer.getCalls(projectId);
     const predictAndScoreCalls = calls.filter(c =>
-      c.op_name?.includes(EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS)
+      c.op_name.includes(EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS)
     );
-    const modelCalls = calls.filter(c => c.op_name?.includes('mockPrediction'));
+    const modelCalls = calls.filter(c => c.op_name.includes('mockPrediction'));
     const scorerCalls = calls.filter(
       c =>
-        c.op_name?.includes('lengthScorer') ||
-        c.op_name?.includes('inclusionScorer')
+        c.op_name.includes('lengthScorer') ||
+        c.op_name.includes('inclusionScorer')
     );
 
     // nTrials (2) * dataset rows (5), and scorers also * scorer count (2).
@@ -223,7 +223,7 @@ describe('Evaluation - declarative eval metadata', () => {
     // Exactly one root evaluate call; recognized by op_name, so it is
     // intentionally not tagged (its attributes are read before the wrapper runs).
     const rootCalls = calls.filter(c =>
-      c.op_name?.includes(EVALUATION_RUN_OP_NAME)
+      c.op_name.includes(EVALUATION_RUN_OP_NAME)
     );
     expect(rootCalls).toHaveLength(1);
     expect(rootCalls[0].attributes?._weave_eval_meta).toBeUndefined();
@@ -240,13 +240,13 @@ describe('Evaluation - declarative eval metadata', () => {
 
     const calls = await traceServer.getCalls(projectId);
     const predictAndScoreCalls = calls.filter(c =>
-      c.op_name?.includes(EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS)
+      c.op_name.includes(EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS)
     );
-    const modelCalls = calls.filter(c => c.op_name?.includes('mockPrediction'));
+    const modelCalls = calls.filter(c => c.op_name.includes('mockPrediction'));
     const scorerCalls = calls.filter(
       c =>
-        c.op_name?.includes('lengthScorer') ||
-        c.op_name?.includes('inclusionScorer')
+        c.op_name.includes('lengthScorer') ||
+        c.op_name.includes('inclusionScorer')
     );
 
     // dataset rows (5), and scorers also * scorer count (2).

--- a/sdks/node/src/__tests__/evaluationLogger.test.ts
+++ b/sdks/node/src/__tests__/evaluationLogger.test.ts
@@ -54,7 +54,7 @@ describe('EvaluationLogger - Basic Functionality', () => {
 
     // Verify scores were logged
     const predictAndScoreCall = calls.find(c =>
-      c.op_name?.includes('predict_and_score')
+      c.op_name.includes('predict_and_score')
     );
     expect(predictAndScoreCall?.output?.scores?.accuracy).toBe(0.95);
     expect(predictAndScoreCall?.output?.scores?.f1).toBe(0.88);
@@ -93,7 +93,7 @@ describe('EvaluationLogger - Basic Functionality', () => {
     expect(calls.length).toBeGreaterThan(0);
 
     // Verify scores were logged
-    const summarizeCall = calls.find(c => c.op_name?.includes('summarize'));
+    const summarizeCall = calls.find(c => c.op_name.includes('summarize'));
     const output = summarizeCall?.output;
     expect(output?.accuracy?.mean).toBeCloseTo(0.4, 2);
     expect(output?.f1?.mean).toBeCloseTo(0.8, 2);
@@ -115,7 +115,7 @@ describe('EvaluationLogger - Basic Functionality', () => {
 
     const calls = await traceServer.getCalls(projectId);
     const predictAndScoreCall = calls.find(c =>
-      c.op_name?.includes('predict_and_score')
+      c.op_name.includes('predict_and_score')
     );
 
     // Verify the prediction was properly finished
@@ -143,7 +143,7 @@ describe('EvaluationLogger - Basic Functionality', () => {
     await evalLogger.logSummary();
 
     const calls = await traceServer.getCalls(projectId);
-    const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
+    const evaluateCall = calls.find(c => c.op_name.includes('evaluate'));
 
     expect(evaluateCall?.attributes?.trial_id).toBe('abc123');
   });
@@ -170,15 +170,15 @@ describe('EvaluationLogger - Call Hierarchy', () => {
     await evalLogger.logSummary();
 
     const calls = await traceServer.getCalls(projectId);
-    const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
+    const evaluateCall = calls.find(c => c.op_name.includes('evaluate'));
     const predictAndScoreCall = calls.find(c =>
-      c.op_name?.includes('predict_and_score')
+      c.op_name.includes('predict_and_score')
     );
     const predictCall = calls.find(
-      c => c.op_name?.includes('predict') && !c.op_name?.includes('_and_')
+      c => c.op_name.includes('predict') && !c.op_name.includes('_and_')
     );
-    const scorerCall = calls.find(c => c.op_name?.includes('accuracy'));
-    const summarizeCall = calls.find(c => c.op_name?.includes('summarize'));
+    const scorerCall = calls.find(c => c.op_name.includes('accuracy'));
+    const summarizeCall = calls.find(c => c.op_name.includes('summarize'));
 
     // evaluate is root
     expect(evaluateCall?.parent_id).toBeUndefined();
@@ -212,11 +212,11 @@ describe('EvaluationLogger - Attribute Markers', () => {
     await evalLogger.logSummary();
 
     const calls = await traceServer.getCalls(projectId);
-    const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
+    const evaluateCall = calls.find(c => c.op_name.includes('evaluate'));
     const predictCall = calls.find(
-      c => c.op_name?.includes('predict') && !c.op_name?.includes('_and_')
+      c => c.op_name.includes('predict') && !c.op_name.includes('_and_')
     );
-    const summarizeCall = calls.find(c => c.op_name?.includes('summarize'));
+    const summarizeCall = calls.find(c => c.op_name.includes('summarize'));
 
     expect(evaluateCall?.attributes?._weave_eval_meta?.imperative).toBe(true);
     expect(predictCall?.attributes?._weave_eval_meta?.imperative).toBe(true);
@@ -235,7 +235,7 @@ describe('EvaluationLogger - Attribute Markers', () => {
     await evalLogger.logSummary();
 
     const calls = await traceServer.getCalls(projectId);
-    const scorerCall = calls.find(c => c.op_name?.includes('accuracy'));
+    const scorerCall = calls.find(c => c.op_name.includes('accuracy'));
 
     expect(scorerCall?.attributes?._weave_eval_meta?.imperative).toBe(true);
     expect(scorerCall?.attributes?._weave_eval_meta?.score).toBe(true);
@@ -266,7 +266,7 @@ describe('EvaluationLogger - Summary Generation', () => {
     await evalLogger.logSummary();
 
     const calls = await traceServer.getCalls(projectId);
-    const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
+    const evaluateCall = calls.find(c => c.op_name.includes('evaluate'));
 
     expect(evaluateCall?.output?.accuracy?.mean).toBeCloseTo(0.95, 2);
   });
@@ -299,7 +299,7 @@ describe('EvaluationLogger - Summary Generation', () => {
     await evalLogger.logSummary();
 
     const calls = await traceServer.getCalls(projectId);
-    const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
+    const evaluateCall = calls.find(c => c.op_name.includes('evaluate'));
 
     expect(evaluateCall?.output?.passed?.true_count).toBe(2);
     expect(evaluateCall?.output?.passed?.true_fraction).toBeCloseTo(2 / 3, 2);
@@ -322,7 +322,7 @@ describe('EvaluationLogger - Summary Generation', () => {
     });
 
     const calls = await traceServer.getCalls(projectId);
-    const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
+    const evaluateCall = calls.find(c => c.op_name.includes('evaluate'));
 
     expect(evaluateCall?.output?.custom_metric).toBe('custom_value');
     expect(evaluateCall?.output?.accuracy?.mean).toBe(0.99);
@@ -351,7 +351,7 @@ describe('EvaluationLogger - Edge Cases', () => {
 
     const calls = await traceServer.getCalls(projectId);
     const predictAndScoreCall = calls.find(c =>
-      c.op_name?.includes('predict_and_score')
+      c.op_name.includes('predict_and_score')
     );
 
     expect(predictAndScoreCall?.output?.scores).toEqual({});
@@ -364,7 +364,7 @@ describe('EvaluationLogger - Edge Cases', () => {
     await evalLogger.logSummary();
 
     const calls = await traceServer.getCalls(projectId);
-    const evaluateCall = calls.find(c => c.op_name?.includes('evaluate'));
+    const evaluateCall = calls.find(c => c.op_name.includes('evaluate'));
 
     expect(evaluateCall).toBeDefined();
     expect(evaluateCall?.output).toEqual({});
@@ -387,7 +387,7 @@ describe('EvaluationLogger - Edge Cases', () => {
 
     const calls = await traceServer.getCalls(projectId);
     const predictAndScoreCalls = calls.filter(c =>
-      c.op_name?.includes('predict_and_score')
+      c.op_name.includes('predict_and_score')
     );
 
     expect(predictAndScoreCalls.length).toBe(5);

--- a/sdks/node/src/__tests__/integrationMetadata.test.ts
+++ b/sdks/node/src/__tests__/integrationMetadata.test.ts
@@ -77,7 +77,7 @@ describe('op-level attributes', () => {
     await tracedOp();
 
     const calls = await traceServer.getCalls(projectId);
-    const call = calls.find(c => c.op_name?.includes('tracedOp'));
+    const call = calls.find(c => c.op_name.includes('tracedOp'));
     expect(call?.attributes?.integration?.name).toBe('demo');
     expect(call?.attributes?.integration?.version).toBe(packageVersion);
     expect(call?.attributes?.integration?.meta?.package_name).toBe('demo');
@@ -94,7 +94,7 @@ describe('op-level attributes', () => {
     await tracedOp();
 
     const calls = await traceServer.getCalls(projectId);
-    const call = calls.find(c => c.op_name?.includes('kindOp'));
+    const call = calls.find(c => c.op_name.includes('kindOp'));
     expect(call?.attributes?.kind).toBe('llm');
   });
 });

--- a/sdks/node/src/__tests__/integrations/openaiAgent.realtime.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.realtime.test.ts
@@ -41,7 +41,7 @@ describe('WeaveRealtimeTracingAdapter', () => {
     // Integration-tracking metadata is stamped on calls this adapter
     // produces. Match by name rather than by index, since a realtime trace
     // can contain other calls.
-    const stamped = calls.map(c => c.attributes?.integration).filter(Boolean);
+    const stamped = calls.map(c => c.attributes.integration).filter(Boolean);
     const mine = stamped.filter(i => i.name === 'openai_agents_realtime');
     expect(mine.length).toBeGreaterThan(0);
     expect(

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -100,7 +100,7 @@ describe('OpenAI Agents Integration', () => {
     const calls = await inMemoryTraceServer.getCalls(testProjectName);
 
     for (const {id, expectedKind} of spans) {
-      const call = calls.find(c => c.attributes?.agent_span_id === id);
+      const call = calls.find(c => c.attributes.agent_span_id === id);
       expect(call?.attributes?.kind).toBe(expectedKind);
     }
   });
@@ -114,9 +114,7 @@ describe('OpenAI Agents Integration', () => {
     expect(calls).toHaveLength(2);
 
     const traceCall = calls.find(c => c.op_name === 'openai_agent_trace');
-    const spanCall = calls.find(
-      c => c.attributes?.agent_span_id === 'span-123'
-    );
+    const spanCall = calls.find(c => c.attributes.agent_span_id === 'span-123');
 
     expect(spanCall!.parent_id).toBe(traceCall!.id);
     expect(spanCall!.trace_id).toBe(traceCall!.trace_id);
@@ -213,7 +211,7 @@ describe('OpenAI Agents Integration', () => {
     // Integration-tracking metadata is stamped on calls this processor
     // produces. The trace also contains nested OpenAI SDK calls with their
     // own integration block, so match by name rather than by index.
-    const stamped = calls.map(c => c.attributes?.integration).filter(Boolean);
+    const stamped = calls.map(c => c.attributes.integration).filter(Boolean);
     const mine = stamped.filter(i => i.name === 'openai_agents');
     expect(mine.length).toBeGreaterThan(0);
     expect(mine.every(i => i.meta?.package_name === '@openai/agents')).toBe(


### PR DESCRIPTION
## Description

* Followup from https://github.com/wandb/weave/pull/7286/changes#r3436623803

* Removes unnecessary null guards against `Call`'s `op_name`, which is typed as a `string`.
