### PR TITLE
fix(weave): reject agent span group_by on payload-bearing custom attrs

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -962,6 +962,28 @@ class TestResolveGroupBy:
                 pb, [AgentGroupByRef(source="column", key="raw_span_dump")]
             )
 
+    def test_rejects_payload_bearing_custom_attr_keys(self) -> None:
+        """Grouping on a full input/output payload attribute makes the GROUP BY
+        key near-unique and large per span, so ClickHouse builds an enormous
+        aggregation hash table and OOMs. Reject these keys instead.
+        """
+        # The client sends a hashed, identifier-safe alias (e.g.
+        # ``custom_string_mk1e43``), so the raw key reaches the custom-attr
+        # branch; the guard must key off ``ref.key``, not the alias.
+        for key in ("input.value", "output.value"):
+            pb = ParamBuilder("genai")
+            with pytest.raises(ValueError, match="free-form payload"):
+                resolve_group_by(
+                    pb,
+                    [
+                        AgentGroupByRef(
+                            source="custom_attrs_string",
+                            key=key,
+                            alias="custom_string_x",
+                        )
+                    ],
+                )
+
     def test_rejects_duplicate_alias(self) -> None:
         pb = ParamBuilder("genai")
         with pytest.raises(ValueError, match="duplicate group_by alias"):

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -124,6 +124,18 @@ _IDENT_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _CUSTOM_ATTR_SOURCES: frozenset[str] = frozenset(AGENT_CUSTOM_ATTR_SOURCE_VALUE_TYPES)
 _FIELD_GROUP_BY_SOURCES: frozenset[str] = frozenset({"field", "column"})
 
+# Custom-attribute keys that hold a span's full input/output payload
+# (OpenInference `input.value` / `output.value`). Their values are large and
+# near-unique per span, so a GROUP BY on one produces ~one group per row: the
+# aggregation hash table grows with the scan and OOMs ClickHouse. They are never
+# meaningful grouping dimensions, so reject them up front.
+GROUP_BY_DENYLISTED_CUSTOM_ATTR_KEYS: frozenset[str] = frozenset(
+    {
+        "input.value",
+        "output.value",
+    }
+)
+
 _VALUE_TYPE_STRING: AgentSpanStatsValueType = "string"
 _VALUE_TYPE_NUMBER: AgentSpanStatsValueType = "number"
 _VALUE_TYPE_BOOLEAN: AgentSpanStatsValueType = "boolean"
@@ -539,6 +551,11 @@ def resolve_group_by(
                 raise ValueError(f"group_by field {ref.key!r} is not in the allowlist")
             sql_expr = f"{table_alias}.{column}"
         elif ref.source in _CUSTOM_ATTR_SOURCES:
+            if ref.key in GROUP_BY_DENYLISTED_CUSTOM_ATTR_KEYS:
+                raise ValueError(
+                    f"group_by on custom attribute {ref.key!r} is not allowed: it "
+                    "holds a free-form payload whose value is near-unique per span"
+                )
             key_slot = pb.add(str(ref.key), param_type="String")
             sql_expr = custom_attr_value_or_null(table_alias, ref.source, key_slot)
         else:


### PR DESCRIPTION
## Problem

The agents/spans view OOMs ClickHouse when a custom attribute holding a full payload - OpenInference `input.value` / `output.value` - is used as a group-by. The frontend surfaces every custom-attr key as a groupable facet, so selecting one fires `GROUP BY custom_attrs_string['input.value']`.

`input.value` is the raw input payload: near-unique and large per span. Grouping on it yields ~one group per row, so ClickHouse's GROUP BY hash table grows with the scan (hundreds of millions of rows over a multi-day window) and the node OOMs before `LIMIT` ever applies. EXPLAIN confirms a full aggregation over the scanned set ahead of the sort/limit.

## Fix

Reject group-by on these payload-bearing keys in `resolve_group_by` with a clear error, the same way out-of-allowlist columns are already rejected. `GROUP_BY_DENYLISTED_CUSTOM_ATTR_KEYS` holds the set and is easy to extend.

## Test

`TestResolveGroupBy::test_rejects_payload_bearing_custom_attr_keys`. The client sends a hashed, identifier-safe alias, so the guard keys off `ref.key`, not the alias.

## Follow-ups (separate PRs)

- Bound the grouped aggregate state (`uniqExact`/`groupUniqArray`).
- Frontend: drop these keys from the facet/column candidate set and cut the per-facet query fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)