### PR TITLE
chore(weave_ts): Fix `no-empty` lint errors.

### DIFF
--- a/sdks/node/eslint.config.mjs
+++ b/sdks/node/eslint.config.mjs
@@ -23,7 +23,6 @@ export default defineConfig([
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-wrapper-object-types': 'off',
       'no-case-declarations': 'off',
-      'no-empty': 'off',
       'no-useless-assignment': 'off',
       'no-undef': 'off',
       'prefer-const': 'off',

--- a/sdks/node/src/utils/urlToMediaPart.ts
+++ b/sdks/node/src/utils/urlToMediaPart.ts
@@ -1,4 +1,4 @@
-import {type MessagePart} from '../genai';
+import type {MessagePart} from '../genai';
 import {parseDataUrl} from './parseDataUrl';
 
 export type MediaPart = Extract<MessagePart, {type: 'blob' | 'uri' | 'file'}>;

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -998,7 +998,9 @@ export class WeaveClient {
     } else if (val instanceof Table) {
       this.saveTable(val);
     } else if (isWeaveImage(val)) {
+      // no-op
     } else if (isWeaveAudio(val)) {
+      // no-op
     } else if (isOp(val)) {
       this.saveOp(val);
     } else if (typeof val === 'object' && val !== null) {


### PR DESCRIPTION
## Description

* We currently ignore `no-empty` violations. This change fixes those, and removes the override from our eslint configuration.

