### PR TITLE
chore(weave_ts): Fix `no-useless-assignment` lint errors.

### DIFF
--- a/sdks/node/eslint.config.mjs
+++ b/sdks/node/eslint.config.mjs
@@ -23,7 +23,6 @@ export default defineConfig([
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-wrapper-object-types': 'off',
       'no-case-declarations': 'off',
-      'no-useless-assignment': 'off',
       'prefer-const': 'off',
       'prefer-rest-params': 'off',
       'preserve-caught-error': 'off',

--- a/sdks/node/src/integrations/openai.realtime.agent.ts
+++ b/sdks/node/src/integrations/openai.realtime.agent.ts
@@ -366,7 +366,7 @@ export class WeaveRealtimeTracingAdapter {
     const toolName: string | undefined = tool?.name;
     if (!callId || !toolName) return;
 
-    let inputs: Record<string, any> = {};
+    let inputs: Record<string, any>;
     try {
       inputs = JSON.parse(details.toolCall.arguments ?? '{}');
     } catch {

--- a/sdks/node/src/op.ts
+++ b/sdks/node/src/op.ts
@@ -86,7 +86,7 @@ function deriveOpName<T extends (...args: any[]) => any>(
   context?: MethodDecoratorContext
 ): string {
   const fnName = options?.originalFunction?.name || fn.name || 'anonymous';
-  let calculatedName = 'anonymous';
+  let calculatedName: string;
 
   if (options?.name) {
     calculatedName = options.name;
@@ -305,7 +305,7 @@ function handleLegacyDecorator<T extends (...args: any[]) => any>(
   }
 
   // Derive default legacy name
-  let className = 'anonymous';
+  let className: string;
   if (target.constructor === Function) {
     // Static method
     className = (target as Function).name || 'anonymous';


### PR DESCRIPTION
## Description

* We currently ignore `no-useless-assignment` violations. This change fixes those, and removes the override from our eslint configuration.
