### PR TITLE
chore(weave_ts): Fix `prefer-const` lint errors.

### DIFF
--- a/sdks/node/eslint.config.mjs
+++ b/sdks/node/eslint.config.mjs
@@ -23,7 +23,6 @@ export default defineConfig([
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-wrapper-object-types': 'off',
       'no-case-declarations': 'off',
-      'prefer-const': 'off',
       'prefer-rest-params': 'off',
       'preserve-caught-error': 'off',
     },

--- a/sdks/node/src/__tests__/integrations/openaiMock.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiMock.test.ts
@@ -54,7 +54,7 @@ describe('OpenAI Mock', () => {
       stream: true,
     })) as AsyncIterable<any>;
 
-    let chunks = [];
+    const chunks = [];
     for await (const chunk of stream) {
       chunks.push(chunk);
     }
@@ -101,7 +101,7 @@ describe('OpenAI Mock', () => {
       stream_options: {include_usage: true},
     })) as AsyncIterable<any>;
 
-    let chunks = [];
+    const chunks = [];
     for await (const chunk of stream) {
       chunks.push(chunk);
     }

--- a/sdks/node/src/integrations/anthropic.ts
+++ b/sdks/node/src/integrations/anthropic.ts
@@ -127,7 +127,7 @@ function patchAnthropicMessagesCreate(exports: any) {
 
       let result: any;
 
-      let weaveOp = op(() => {
+      const weaveOp = op(() => {
         result = originalCreate.apply(thisArg, args);
         return result;
       }, weaveOpOptions);

--- a/sdks/node/src/op.ts
+++ b/sdks/node/src/op.ts
@@ -172,7 +172,7 @@ function createOpWrapper<T extends (...args: any[]) => any>(
     );
 
     try {
-      let result = await client.runWithCallStack(newStack, async () => {
+      const result = await client.runWithCallStack(newStack, async () => {
         return await fn.apply(thisArg, params);
       });
 

--- a/sdks/node/src/utils/commonJSLoader.ts
+++ b/sdks/node/src/utils/commonJSLoader.ts
@@ -16,7 +16,7 @@ const parse: (filePath: string) => {
 
 export let reset = () => {};
 
-let patching = Object.create(null);
+const patching = Object.create(null);
 
 const cachedModules = new Map<string, CacheEntry>();
 const passThroughModules = new Set<string>();

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -539,7 +539,7 @@ export class WeaveClient {
 
     this.isBatchProcessing = true;
 
-    let batchToProcess = [];
+    const batchToProcess = [];
     let currentBatchSize = 0;
 
     while (
@@ -774,7 +774,7 @@ export class WeaveClient {
 
       const {content, description, name} = val;
 
-      let obj = new StringPrompt({
+      const obj = new StringPrompt({
         name,
         description,
         content,
@@ -790,7 +790,7 @@ export class WeaveClient {
 
       const {description, messages, name} = val;
 
-      let obj = new MessagesPrompt({
+      const obj = new MessagesPrompt({
         name,
         description,
         messages,
@@ -807,7 +807,7 @@ export class WeaveClient {
 
       const {description, rows, name} = val;
 
-      let obj = new Dataset({
+      const obj = new Dataset({
         name: name || dataObj.id,
         description,
         rows,
@@ -821,7 +821,7 @@ export class WeaveClient {
       return obj;
     } else if (t == 'Table') {
       const {rows} = val;
-      let obj = new Table(rows);
+      const obj = new Table(rows);
       obj.__savedRef = ref;
 
       // Load table rows if they are a ref
@@ -831,7 +831,7 @@ export class WeaveClient {
     } else if (t == 'CustomWeaveType') {
       const typeName = val.weave_type.type;
       if (typeName == 'PIL.Image.Image') {
-        let loadedFiles: {[key: string]: Buffer} = {};
+        const loadedFiles: {[key: string]: Buffer} = {};
         for (const [name, digest] of Object.entries(val.files)) {
           try {
             const fileContent =
@@ -847,7 +847,7 @@ export class WeaveClient {
         // TODO: Implement getting img back as buffer
         return 'Coming soon!';
       } else if (typeName == 'wave.Wave_read') {
-        let loadedFiles: {[key: string]: Buffer} = {};
+        const loadedFiles: {[key: string]: Buffer} = {};
         for (const [name, digest] of Object.entries(val.files)) {
           try {
             const fileContent =
@@ -1539,7 +1539,7 @@ function processSummary(
   currentCall: CallStackEntry,
   parentCall: CallStackEntry | undefined
 ) {
-  let ownSummary = summarize && result != null ? summarize(result) : {};
+  const ownSummary = summarize && result != null ? summarize(result) : {};
 
   if (ownSummary.usage) {
     for (const model in ownSummary.usage) {


### PR DESCRIPTION
## Description

* We currently ignore `prefer-const` violations. This change fixes those, and removes the override from our eslint configuration.
