### PR TITLE
chore(weave_ts): Fix `@typescript-eslint/no-wrapper-object-types` lint errors.

### DIFF
--- a/sdks/node/eslint.config.mjs
+++ b/sdks/node/eslint.config.mjs
@@ -21,7 +21,6 @@ export default defineConfig([
       '@typescript-eslint/no-require-imports': 'off',
       '@typescript-eslint/no-unsafe-function-type': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
-      '@typescript-eslint/no-wrapper-object-types': 'off',
       'no-case-declarations': 'off',
       'prefer-rest-params': 'off',
       'preserve-caught-error': 'off',

--- a/sdks/node/src/op.ts
+++ b/sdks/node/src/op.ts
@@ -38,7 +38,7 @@ function isModernDecorator(
  */
 function isLegacyDecorator(
   args: any[]
-): args is [Object, string | symbol, TypedPropertyDescriptor<any>] {
+): args is [object, string | symbol, TypedPropertyDescriptor<any>] {
   return (
     args.length === 3 &&
     (typeof args[0] === 'object' || typeof args[0] === 'function') &&
@@ -294,7 +294,7 @@ function handleModernDecorator<T extends (...args: any[]) => any>(
 }
 
 function handleLegacyDecorator<T extends (...args: any[]) => any>(
-  target: Object,
+  target: object,
   propertyKey: string | symbol,
   descriptor: TypedPropertyDescriptor<T>,
   factoryOptions?: Partial<OpOptions<T>>
@@ -343,7 +343,7 @@ function handleDecoratorFactory<T extends (...args: any[]) => any>(
     // Legacy Factory Usage
     if (isLegacyDecorator(decoratorArgs)) {
       const [target, propertyKey, descriptor] = decoratorArgs as [
-        Object,
+        object,
         string | symbol,
         TypedPropertyDescriptor<(...args: any[]) => any>,
       ];
@@ -389,7 +389,7 @@ export function op<T extends (...args: any[]) => any>(
 ): Op<T>;
 // Legacy decorator usage (experimentalDecorators in tsconfig.json): @weave.op
 export function op(
-  target: Object,
+  target: object,
   propertyKey: string | symbol,
   descriptor: TypedPropertyDescriptor<any>
 ): TypedPropertyDescriptor<any>;

--- a/sdks/node/src/opType.ts
+++ b/sdks/node/src/opType.ts
@@ -45,7 +45,7 @@ export type OpDecorator<T extends (...args: any[]) => any> = ((
 ) => T | void) &
   ((
     // Legacy signature
-    target: Object,
+    target: object,
     propertyKey: string | symbol,
     descriptor: TypedPropertyDescriptor<T>
   ) => TypedPropertyDescriptor<T> | void);


### PR DESCRIPTION
## Description

* We currently ignore `no-wrapper-object-types` violations. This change fixes those, and removes the override from our eslint configuration.
