### PR TITLE
chore(weave_ts): Fix `@typescript-eslint/no-require-imports` lint errors.

### DIFF
--- a/sdks/node/eslint.config.mjs
+++ b/sdks/node/eslint.config.mjs
@@ -18,7 +18,6 @@ export default defineConfig([
       '@typescript-eslint/no-empty-object-type': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
-      '@typescript-eslint/no-require-imports': 'off',
       '@typescript-eslint/no-unsafe-function-type': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
       'prefer-rest-params': 'off',

--- a/sdks/node/jest.setup.ts
+++ b/sdks/node/jest.setup.ts
@@ -1,4 +1,4 @@
-const path = require('path');
+import path from 'path';
 
 const liveTestTimeout = 20000; // 20 seconds
 

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -101,6 +101,7 @@ export {MessagesPrompt, StringPrompt} from './prompt';
 // is emitted, the `require()` call here is dead code, and the typeof
 // check prevents the missing module from ever being requested.
 if (typeof require === 'function' && typeof module === 'object') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   require('./utils/commonJSLoader');
 }
 

--- a/sdks/node/src/utils/commonJSLoader.ts
+++ b/sdks/node/src/utils/commonJSLoader.ts
@@ -12,6 +12,7 @@ const parse: (filePath: string) => {
   name: string;
   basedir: string;
   path: string;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
 } = require('module-details-from-path');
 
 export let reset = () => {};
@@ -23,6 +24,7 @@ const passThroughModules = new Set<string>();
 
 if (typeof module !== 'undefined' && module.exports) {
   // CommonJS environment
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const Module = require('module');
   const originalRequire = Module.prototype.require;
 


### PR DESCRIPTION
## Description

* We currently ignore `no-require-imports` violations. This change fixes those, and removes the override from our eslint configuration.
