### PR TITLE
chore(weave_ts): Fix `@typescript-eslint/no-unused-vars` lint errors.

### DIFF
--- a/sdks/node/eslint.config.mjs
+++ b/sdks/node/eslint.config.mjs
@@ -19,7 +19,11 @@ export default defineConfig([
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
       '@typescript-eslint/no-unsafe-function-type': 'off',
-      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      }],
       'prefer-rest-params': 'off',
       'preserve-caught-error': 'off',
     },

--- a/sdks/node/examples/imageGeneration.ts
+++ b/sdks/node/examples/imageGeneration.ts
@@ -2,7 +2,7 @@ import OpenAI from 'openai';
 import * as weave from 'weave';
 
 async function main() {
-  const client = await weave.init('examples');
+  const _client = await weave.init('examples');
   const openai = weave.wrapOpenAI(new OpenAI());
 
   // Generate an image

--- a/sdks/node/scripts/loadTest.ts
+++ b/sdks/node/scripts/loadTest.ts
@@ -1,12 +1,12 @@
 import * as weave from 'weave';
 import type {WeaveClient} from 'weave';
 
-const func = weave.op(async () => 1);
+const _func = weave.op(async () => 1);
 const myFunction = async (a: number = 1, b: string = 'hello', c: boolean = true) => {
   return { first: a, second: b, third: c };
 };
-const func2 = weave.op(myFunction);
-const func3 = weave.op(async () => {
+const _func2 = weave.op(myFunction);
+const _func3 = weave.op(async () => {
   throw new Error('hmm');
 });
 const myFunction2 = async ({ a, b = 'wuh' }: { a?: number; b?: string }) => {

--- a/sdks/node/src/__tests__/call.test.ts
+++ b/sdks/node/src/__tests__/call.test.ts
@@ -1,6 +1,6 @@
 import * as weave from 'weave';
-import {op, type Op} from 'weave';
 import {WeaveClient} from '../weaveClient';
+import type {Op} from 'weave';
 
 const mockOpName = 'weave://test-project-id/op/test-op';
 const mockCallId = 'test-call-id';
@@ -24,10 +24,10 @@ jest.mock('weave/clientApi', () => ({
       createCall: (...args: any) => {
         return WeaveClient.prototype.createCall.apply(weaveClient, args);
       },
-      startCall: (...args: any[]) => {
+      startCall: (..._args: any[]) => {
         return Promise.resolve();
       },
-      saveOp: (op: any, ...rest: any) => {
+      saveOp: (op: any, ..._rest: any) => {
         op.__savedRef = Promise.resolve(op);
         op.uri = () => 'weave://test-project-id/op/test-op';
         return Promise.resolve();

--- a/sdks/node/src/__tests__/helpers/inMemoryTraceServer.ts
+++ b/sdks/node/src/__tests__/helpers/inMemoryTraceServer.ts
@@ -251,7 +251,7 @@ export class InMemoryTraceServer {
   };
 
   feedback = {
-    feedbackCreateFeedbackCreatePost: async (req: any) => {
+    feedbackCreateFeedbackCreatePost: async (_req: any) => {
       // Stub implementation for feedback API (used by scorer feedback attachment)
       return {
         data: {
@@ -261,7 +261,7 @@ export class InMemoryTraceServer {
     },
   };
 
-  private generateDigest(data: any): string {
+  private generateDigest(_data: any): string {
     // In a real implementation, you'd want to use a proper hashing algorithm.
     // For simplicity, we're using uuidv7 here.
     return uuidv7();

--- a/sdks/node/src/__tests__/integrations/anthropic.test.ts
+++ b/sdks/node/src/__tests__/integrations/anthropic.test.ts
@@ -165,7 +165,7 @@ function createMockAnthropic() {
 
   MockMessages.prototype.stream = jest
     .fn()
-    .mockImplementation((options: any) => {
+    .mockImplementation((_options: any) => {
       return new MockAnthropicStream(mockStreamChunks);
     });
 
@@ -196,7 +196,7 @@ describe('Anthropic Integration', () => {
   const testProjectName = 'test-project';
   let mockAnthropic: any;
   let MockMessages: any;
-  let MockBatches: any;
+  let _MockBatches: any;
   let patchedAnthropic: any;
 
   beforeEach(() => {
@@ -206,7 +206,7 @@ describe('Anthropic Integration', () => {
     const mockData = createMockAnthropic();
     mockAnthropic = mockData.mockAnthropic;
     MockMessages = mockData.MockMessages;
-    MockBatches = mockData.MockBatches;
+    _MockBatches = mockData.MockBatches;
 
     // Apply patching
     patchedAnthropic = commonPatchAnthropic(mockAnthropic);

--- a/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
+++ b/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
@@ -121,13 +121,13 @@ describe('OpenAI Integration', () => {
       stream: true,
     });
     let opContent = '';
-    let usageChunkSeen = false;
+    let _usageChunkSeen = false;
     for await (const chunk of opStream) {
       if (chunk.choices && chunk.choices[0]?.delta?.content) {
         opContent += chunk.choices[0].delta.content;
       }
       if ('usage' in chunk) {
-        usageChunkSeen = true;
+        _usageChunkSeen = true;
       }
     }
 

--- a/sdks/node/src/__tests__/integrations/openai2.test.ts
+++ b/sdks/node/src/__tests__/integrations/openai2.test.ts
@@ -52,7 +52,6 @@ describe('OpenAI Integration', () => {
         callStartBatchCallUpsertBatchPost: jest.fn(),
       },
     } as any;
-    mockWandbServerApi = {} as any;
     _weaveClient = new WeaveClient({
       traceServerApi: mockTraceServerApi,
       projectId: 'test-project',

--- a/sdks/node/src/__tests__/integrations/openai2.test.ts
+++ b/sdks/node/src/__tests__/integrations/openai2.test.ts
@@ -5,7 +5,6 @@ import {
   wrapOpenAI,
 } from '../../integrations/openai';
 import {isWeaveImage} from '../../media';
-import {type WandbServerApi} from '../../wandb/wandbServerApi';
 import {WeaveClient} from '../../weaveClient';
 import {makeAPIPromiseShim} from '../openaiMock';
 
@@ -17,8 +16,7 @@ describe('OpenAI Integration', () => {
   let mockOpenAI: any;
   let wrappedOpenAI: any;
   let mockTraceServerApi: jest.Mocked<TraceServerApi<any>>;
-  let mockWandbServerApi: jest.Mocked<WandbServerApi>;
-  let weaveClient: WeaveClient;
+  let _weaveClient: WeaveClient;
 
   beforeEach(() => {
     // Setup mock OpenAI client
@@ -55,7 +53,7 @@ describe('OpenAI Integration', () => {
       },
     } as any;
     mockWandbServerApi = {} as any;
-    weaveClient = new WeaveClient({
+    _weaveClient = new WeaveClient({
       traceServerApi: mockTraceServerApi,
       projectId: 'test-project',
     });
@@ -187,7 +185,7 @@ describe('OpenAI Integration', () => {
 
   describe('wrapOpenAI', () => {
     it('should wrap transparently', async () => {
-      const mockCreate = jest.fn(async params => ({
+      const mockCreate = jest.fn(async _params => ({
         id: 'test-id',
         choices: [{message: {content: 'Hello'}}],
       }));

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -28,7 +28,6 @@ import {
 import {z} from 'zod';
 import * as weave from '../..';
 import {clearWeaveTracerProvider} from '../../genai/provider';
-import {Settings} from '../../settings';
 import {initWithCustomTraceServer} from '../clientMock';
 import {wrapOpenAIChatCompletionsCreate} from '../../integrations/openai';
 import {makeAPIPromiseShim} from '../openaiMock';

--- a/sdks/node/src/__tests__/live/table.test.ts
+++ b/sdks/node/src/__tests__/live/table.test.ts
@@ -33,13 +33,13 @@ describe('Table', () => {
 
     // not sure how to test entity here
     // test that the ref is for the right entity, project
-    const [entity, project] = ref?.projectId.split('/') ?? [];
+    const [_entity, project] = ref?.projectId.split('/') ?? [];
     expect(project).toEqual('test-project');
     expect(ref?.uri()).toContain('test-project');
 
     const row = table.row(0);
     const ref2 = await (row as any).__savedRef; // TODO: This seems wrong... you have to cast to get the ref?  I guess users would rarely do this...
-    const [entity2, project2, digest2] = ref2?.projectId.split('/') ?? [];
+    const [_entity2, project2, _digest2] = ref2?.projectId.split('/') ?? [];
     expect(project2).toEqual('test-project');
     expect(ref2?.uri()).toContain('test-project');
   });

--- a/sdks/node/src/__tests__/modern/op.test.ts
+++ b/sdks/node/src/__tests__/modern/op.test.ts
@@ -164,7 +164,7 @@ describe('op modern decorators', () => {
       }
     }
 
-    const instance = new TestClass();
+    const _instance = new TestClass();
     const descriptor = Object.getOwnPropertyDescriptor(
       TestClass.prototype,
       'method'

--- a/sdks/node/src/__tests__/op.test.ts
+++ b/sdks/node/src/__tests__/op.test.ts
@@ -10,7 +10,7 @@ const createFreshMockClient = () => ({
     parentCall: null,
     newStack: [],
   })),
-  createCall: jest.fn((...args: any[]) => {
+  createCall: jest.fn((..._args: any[]) => {
     // We still need a way to capture this if tests rely on it.
     // Maybe pass a shared object or use a different mechanism?
     // For now, let's remove the direct capture here.

--- a/sdks/node/src/__tests__/openaiMock.ts
+++ b/sdks/node/src/__tests__/openaiMock.ts
@@ -65,7 +65,7 @@ export function makeMockOpenAIChat(responseFn: ResponseFn) {
     stream = false,
     model = 'gpt-4o-2024-05-13',
     stream_options,
-    ...otherOptions
+    ..._otherOptions
   }: {
     messages: any[];
     stream?: boolean;

--- a/sdks/node/src/__tests__/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.test.ts
@@ -2,7 +2,6 @@ import {ReadableStream} from 'stream/web';
 import {type Api as TraceServerApi} from '../generated/traceServerApi';
 import {StringPrompt} from '../prompt';
 import * as registryLinkBindings from '../traceServerBindings/linkAssetToRegistry';
-import {type WandbServerApi} from '../wandb/wandbServerApi';
 import {WeaveClient} from '../weaveClient';
 import {ObjectRef} from '../weaveObject';
 
@@ -50,8 +49,7 @@ type MockedTraceServer = jest.Mocked<TraceServerApi<any>> & {
 describe('WeaveClient', () => {
   let client: WeaveClient;
   let mockTraceServerApi: MockedTraceServer;
-  let mockWandbServerApi: jest.Mocked<WandbServerApi>;
-
+  
   beforeEach(() => {
     mockTraceServerApi = {
       calls: {
@@ -66,7 +64,6 @@ describe('WeaveClient', () => {
         genaiConversationChatAgentsConversationsChatPost: jest.fn(),
       },
     } as any;
-    mockWandbServerApi = {} as any;
     client = new WeaveClient({
       traceServerApi: mockTraceServerApi,
       projectId: 'test-project',
@@ -209,7 +206,6 @@ describe('WeaveClient', () => {
   describe('Batch Processing', () => {
     let client: WeaveClient;
     let mockTraceServerApi: jest.Mocked<TraceServerApi<any>>;
-    let mockWandbServerApi: jest.Mocked<WandbServerApi>;
 
     beforeEach(() => {
       mockTraceServerApi = {
@@ -217,7 +213,6 @@ describe('WeaveClient', () => {
           callStartBatchCallUpsertBatchPost: jest.fn().mockResolvedValue({}),
         },
       } as any;
-      mockWandbServerApi = {} as any;
       client = new WeaveClient({
         traceServerApi: mockTraceServerApi,
         projectId: 'test-project',
@@ -674,14 +669,12 @@ describe('WeaveClient', () => {
   describe('linkPromptToRegistry', () => {
     let client: WeaveClient;
     let mockTraceServerApi: jest.Mocked<TraceServerApi<any>>;
-    let mockWandbServerApi: jest.Mocked<WandbServerApi>;
     let mockTransport: jest.SpyInstance;
 
     beforeEach(() => {
       mockTraceServerApi = {
         request: jest.fn(),
       } as any;
-      mockWandbServerApi = {} as any;
       client = new WeaveClient({
         traceServerApi: mockTraceServerApi,
         projectId: 'current-entity/current-project',

--- a/sdks/node/src/__tests__/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.test.ts
@@ -49,7 +49,7 @@ type MockedTraceServer = jest.Mocked<TraceServerApi<any>> & {
 describe('WeaveClient', () => {
   let client: WeaveClient;
   let mockTraceServerApi: MockedTraceServer;
-  
+
   beforeEach(() => {
     mockTraceServerApi = {
       calls: {

--- a/sdks/node/src/call.ts
+++ b/sdks/node/src/call.ts
@@ -71,7 +71,7 @@ function buildProxyHandlers(
 
       return undefined;
     },
-    set(target: Partial<CallSchema>, prop: string, value: any) {
+    set(_target: Partial<CallSchema>, _prop: string, _value: any) {
       // Disallow setting properties on the call schema
       return false;
     },

--- a/sdks/node/src/clientApi.ts
+++ b/sdks/node/src/clientApi.ts
@@ -43,7 +43,7 @@ export async function login(apiKey: string, host?: string) {
   });
   try {
     await testTraceServerApi.health.readRootHealthGet({});
-  } catch (error) {
+  } catch (_error) {
     throw new Error(
       'Unable to verify connection to the weave trace server with given API Key'
     );
@@ -57,7 +57,7 @@ export async function login(apiKey: string, host?: string) {
       netrc.save();
       console.log(`Successfully logged in. Credentials saved for ${host}`);
     }
-  } catch (error) {
+  } catch (_error) {
     // Log warning but don't fail - the API key can still be used from environment
     console.warn(
       'Could not save credentials to netrc file. You may need to set WANDB_API_KEY environment variable for future sessions.'

--- a/sdks/node/src/evaluationLogger.ts
+++ b/sdks/node/src/evaluationLogger.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 /**
  * Imperative Evaluation Logger
  *

--- a/sdks/node/src/integrations/anthropic.ts
+++ b/sdks/node/src/integrations/anthropic.ts
@@ -202,7 +202,7 @@ const batchStreamReducer: StreamReducer<BatchChunk, ResultState> = {
     }
     return state;
   },
-  finalizeFn: state => {
+  finalizeFn: _state => {
     // no-op
   },
 };

--- a/sdks/node/src/integrations/openai.agent.ts
+++ b/sdks/node/src/integrations/openai.agent.ts
@@ -13,7 +13,7 @@
 
 import type OpenAIAgents from '@openai/agents';
 import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
-import type {SpanData, TracingProcessor} from '@openai/agents';
+import type {TracingProcessor} from '@openai/agents';
 import {getGlobalClient} from '../clientApi';
 import {defaultSettings} from '../settings';
 import {WeaveOtelTracingProcessor} from './openai-agents/weave-otel-tracing-processor';

--- a/sdks/node/src/integrations/openai.ts
+++ b/sdks/node/src/integrations/openai.ts
@@ -827,7 +827,7 @@ function commonProxy(exports: any) {
   const OriginalOpenAIClass = exports.OpenAI;
 
   return new Proxy(OriginalOpenAIClass, {
-    construct(target, args, newTarget) {
+    construct(target, args, _newTarget) {
       const instance = new target(...args);
       return wrapOpenAI(instance);
     },

--- a/sdks/node/src/utils/commonJSLoader.ts
+++ b/sdks/node/src/utils/commonJSLoader.ts
@@ -32,7 +32,7 @@ if (typeof module !== 'undefined' && module.exports) {
     let filename;
     try {
       filename = Module._resolveFilename(request, this);
-    } catch (resolveErr) {
+    } catch (_resolveErr) {
       return originalRequire.apply(this, arguments as any);
     }
 
@@ -79,7 +79,7 @@ if (typeof module !== 'undefined' && module.exports) {
       let packageJson: any;
       try {
         packageJson = requirePackageJson(basedir, module.paths);
-      } catch (e) {
+      } catch (_e) {
         console.log('Cannot find package.json for', name, basedir);
         return originalExports;
       }

--- a/sdks/node/src/utils/npmModuleUtils.ts
+++ b/sdks/node/src/utils/npmModuleUtils.ts
@@ -20,7 +20,7 @@ export function requirePackageJson(baseDir: string, modulePaths: string[]) {
     const candidate = path.join(modulePath, baseDir, 'package.json');
     try {
       return JSON.parse(fs.readFileSync(candidate, 'utf8'));
-    } catch (e) {
+    } catch (_e) {
       continue;
     }
   }

--- a/sdks/node/src/wandb/settings.ts
+++ b/sdks/node/src/wandb/settings.ts
@@ -21,7 +21,7 @@ function getBaseUrlFromConfig(): string | undefined {
         return config.default.wandb_base_url;
       }
     }
-  } catch (error) {
+  } catch (_error) {
     // Silently fail if we can't read the config file
     // This could happen in restricted environments like Deno
   }
@@ -33,7 +33,7 @@ function getApiKeyFromNetrc(host: string): string | undefined {
   try {
     const netrc = new Netrc();
     return netrc.entries.get(host)?.password;
-  } catch (error) {
+  } catch (_error) {
     // Silently fail if we can't read the netrc file
     // This could happen in restricted environments like Deno
     return undefined;

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -966,7 +966,7 @@ export class WeaveClient {
     if (obj.__savedRef) {
       return Promise.resolve(obj.__savedRef);
     }
-    for (const [key, value] of Object.entries(obj)) {
+    for (const [_key, value] of Object.entries(obj)) {
       this.saveWeaveValues(value);
     }
 
@@ -1079,7 +1079,7 @@ export class WeaveClient {
       }
       visited.add(val);
 
-      for (const [key, value] of Object.entries(val)) {
+      for (const [_key, value] of Object.entries(val)) {
         this.saveWeaveValues(value, visited);
       }
     }


### PR DESCRIPTION
## Description

* We currently ignore `no-unused-vars` violations. This change fixes those, and removes the override from our eslint configuration. Uses common convention for allowing unused vars prefixed with `_`.
