### PR TITLE
feat(weave): wire the agent_conversation_spans endpoint

### DIFF
--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -38,7 +38,6 @@ from weave.trace_server.agents.types import (
 from weave.trace_server.interface.feedback_types import (
     AGENT_MONITOR_FEEDBACK_TYPE,
     AGENT_USER_FEEDBACK_TYPE,
-    NOTE_FEEDBACK_TYPE,
 )
 from weave.trace_server.interface.query import Query
 
@@ -375,8 +374,7 @@ def test_conversation_spans_unknown_id_returns_empty(ch_server):
 def test_conversation_spans_sequence_and_feedback(ch_server):
     """agent_conversation_spans returns an ordered per-span sequence (kinds from
     operation_name, ERROR surfaced via status) plus turn-anchored feedback
-    markers carrying detoned tags and scorer ratings. Only agent_user_feedback
-    and agent_monitor are surfaced; other feedback types are dropped.
+    markers carrying detoned tags and scorer ratings.
     """
     project_id = _make_project_id("conv-spans")
     now = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -428,7 +426,6 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
     _insert_spans(ch_server.ch_client, spans)
 
     # Turn A: a human thumbs-up tag. Turn B: a scorer with a tag + a rating.
-    # Plus an unsupported note on turn B that must be filtered out.
     turn_a_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_a).uri
     turn_b_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_b).uri
     _create_feedback(
@@ -454,10 +451,6 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
         scorer_ratings={"quality": 0.8},
         scorer_rating_reasons={"quality": "clear answer"},
     )
-    _create_feedback(
-        ch_server, project_id, turn_b_ref, NOTE_FEEDBACK_TYPE, {"note": "nice"}
-    )
-
     res = ch_server.agent_conversation_spans(
         AgentConversationSpansReq(
             project_id=project_id,
@@ -478,8 +471,8 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
     assert row.spans[-1].trace_id == trace_b
     assert any(e.span_id == tool_span for e in row.spans)
 
-    # Markers are keyed by turn (trace_id); the note is dropped, so each turn
-    # has exactly one marker. Emoji tags come back as the detoned glyph.
+    # Markers are keyed by turn (trace_id). Emoji tags come back as the detoned
+    # glyph; scorer ratings come back as scores.
     by_trace = {f.trace_id: f for f in row.spans_feedback}
     assert by_trace[trace_a].feedback_type == AGENT_USER_FEEDBACK_TYPE
     assert by_trace[trace_a].tags == ["\U0001f44d"]

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -459,12 +459,13 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
     )
     row = {c.conversation_id: c for c in res.conversations}[conv]
 
-    # Ordered by started_at: agent, tool, tool(ERROR), assistant.
-    assert [(e.kind, e.status) for e in row.spans] == [
-        ("agent", "OK"),
-        ("tool", "OK"),
-        ("tool", "ERROR"),
-        ("assistant", "OK"),
+    # Spans carry the raw operation_name (the client classifies), ordered by
+    # started_at; ERROR surfaces via status.
+    assert [(e.operation_name, e.status) for e in row.spans] == [
+        ("invoke_agent", "OK"),
+        ("execute_tool", "OK"),
+        ("execute_tool", "ERROR"),
+        ("chat", "OK"),
     ]
     # Each span carries its turn (trace_id) and its own span_id.
     assert row.spans[0].trace_id == trace_a
@@ -472,17 +473,21 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
     assert any(e.span_id == tool_span for e in row.spans)
 
     # Markers are keyed by turn (trace_id). Emoji tags come back as the detoned
-    # glyph; scorer ratings come back as scores.
+    # glyph; scorer ratings come back as ratings.
     by_trace = {f.trace_id: f for f in row.spans_feedback}
     assert by_trace[trace_a].feedback_type == AGENT_USER_FEEDBACK_TYPE
-    assert by_trace[trace_a].tags == ["\U0001f44d"]
-    assert by_trace[trace_a].scores == []
+    assert by_trace[trace_a].tags == ["👍"]
+    assert by_trace[trace_a].ratings == []
 
     assert by_trace[trace_b].feedback_type == AGENT_MONITOR_FEEDBACK_TYPE
     assert by_trace[trace_b].tags == ["helpful"]
-    assert len(by_trace[trace_b].scores) == 1
-    score = by_trace[trace_b].scores[0]
-    assert (score.name, score.value, score.reason) == ("quality", 0.8, "clear answer")
+    assert len(by_trace[trace_b].ratings) == 1
+    rating = by_trace[trace_b].ratings[0]
+    assert (rating.name, rating.value, rating.reason) == (
+        "quality",
+        0.8,
+        "clear answer",
+    )
 
 
 def test_group_by_conversation_id_filters_numeric_aggregates(ch_server):

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -10,6 +10,8 @@ import uuid
 import pytest
 
 from tests.trace_server.helpers import make_project_id as _make_project_id
+from weave.shared import refs_internal as ri
+from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents.helpers import genai_span_to_row
 from weave.trace_server.agents.schema import (
     ALL_SPAN_INSERT_COLUMNS,
@@ -18,6 +20,7 @@ from weave.trace_server.agents.schema import (
 )
 from weave.trace_server.agents.types import (
     AgentConversationChatReq,
+    AgentConversationSpansReq,
     AgentCustomAttrsSchemaReq,
     AgentGroupByRef,
     AgentSearchReq,
@@ -31,6 +34,10 @@ from weave.trace_server.agents.types import (
     AgentSpanStatsReq,
     AgentSpanValueRef,
     AgentsQueryReq,
+)
+from weave.trace_server.interface.feedback_types import (
+    NOTE_FEEDBACK_TYPE,
+    REACTION_FEEDBACK_TYPE,
 )
 from weave.trace_server.interface.query import Query
 
@@ -325,6 +332,134 @@ def test_group_by_conversation_id_message_previews(ch_server):
     assert row.last_message is not None
     assert row.last_message.role == "assistant_message"
     assert row.last_message.text == "final reply"
+
+
+def _create_feedback(
+    ch_server,
+    project_id: str,
+    weave_ref: str,
+    feedback_type: str,
+    payload: dict,
+) -> None:
+    ch_server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=weave_ref,
+            feedback_type=feedback_type,
+            payload=payload,
+            wb_user_id="test-user",
+        )
+    )
+
+
+def test_conversation_spans_unknown_id_returns_empty(ch_server):
+    """The endpoint returns one entry per requested conversation; an id with no
+    matching spans comes back with empty sequences rather than being dropped.
+    """
+    project_id = _make_project_id("conv-spans-empty")
+    res = ch_server.agent_conversation_spans(
+        AgentConversationSpansReq(
+            project_id=project_id,
+            conversation_ids=["conv-does-not-exist"],
+        )
+    )
+    assert len(res.conversations) == 1
+    assert res.conversations[0].conversation_id == "conv-does-not-exist"
+    assert res.conversations[0].spans == []
+    assert res.conversations[0].spans_feedback == []
+
+
+def test_conversation_spans_sequence_and_feedback(ch_server):
+    """agent_conversation_spans returns an ordered per-span sequence (kinds from
+    operation_name, ERROR surfaced via status) plus turn-anchored feedback
+    markers carrying the feedback_type and any detoned tags.
+    """
+    project_id = _make_project_id("conv-spans")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    conv = f"conv-{uuid.uuid4().hex[:8]}"
+    trace_a = uuid.uuid4().hex
+    trace_b = uuid.uuid4().hex
+    tool_span = uuid.uuid4().hex[:16]
+
+    spans = [
+        # Turn A: an agent invocation, then two tool calls (the second errored).
+        _make_span(
+            project_id,
+            conversation_id=conv,
+            trace_id=trace_a,
+            operation_name="invoke_agent",
+            started_at=now,
+            ended_at=now + datetime.timedelta(seconds=1),
+        ),
+        _make_span(
+            project_id,
+            conversation_id=conv,
+            trace_id=trace_a,
+            span_id=tool_span,
+            operation_name="execute_tool",
+            tool_name="search",
+            started_at=now + datetime.timedelta(seconds=2),
+            ended_at=now + datetime.timedelta(seconds=3),
+        ),
+        _make_span(
+            project_id,
+            conversation_id=conv,
+            trace_id=trace_a,
+            operation_name="execute_tool",
+            tool_name="broken",
+            status_code="ERROR",
+            started_at=now + datetime.timedelta(seconds=4),
+            ended_at=now + datetime.timedelta(seconds=5),
+        ),
+        # Turn B: a later content span -> classified assistant.
+        _make_span(
+            project_id,
+            conversation_id=conv,
+            trace_id=trace_b,
+            operation_name="chat",
+            started_at=now + datetime.timedelta(seconds=6),
+            ended_at=now + datetime.timedelta(seconds=7),
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    # Turn-level reaction (👍 -> positive) on turn A; a note on turn B.
+    turn_a_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_a).uri
+    turn_b_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_b).uri
+    _create_feedback(
+        ch_server, project_id, turn_a_ref, REACTION_FEEDBACK_TYPE, {"emoji": "👍"}
+    )
+    _create_feedback(
+        ch_server, project_id, turn_b_ref, NOTE_FEEDBACK_TYPE, {"note": "nice"}
+    )
+
+    res = ch_server.agent_conversation_spans(
+        AgentConversationSpansReq(
+            project_id=project_id,
+            conversation_ids=[conv],
+        )
+    )
+    row = {c.conversation_id: c for c in res.conversations}[conv]
+
+    # Ordered by started_at: agent, tool, tool(ERROR), assistant.
+    assert [(e.kind, e.status) for e in row.spans] == [
+        ("agent", "OK"),
+        ("tool", "OK"),
+        ("tool", "ERROR"),
+        ("assistant", "OK"),
+    ]
+    # Each span carries its turn (trace_id) and its own span_id.
+    assert row.spans[0].trace_id == trace_a
+    assert row.spans[-1].trace_id == trace_b
+    assert any(e.span_id == tool_span for e in row.spans)
+
+    # Feedback markers are keyed by turn (trace_id) and carry the feedback_type
+    # plus any detoned tags (empty for a note). An emoji tag is the glyph itself.
+    by_trace = {f.trace_id: f for f in row.spans_feedback}
+    assert by_trace[trace_a].feedback_type == REACTION_FEEDBACK_TYPE
+    assert by_trace[trace_a].tags == ["\U0001f44d"]
+    assert by_trace[trace_b].feedback_type == NOTE_FEEDBACK_TYPE
+    assert by_trace[trace_b].tags == []
 
 
 def test_group_by_conversation_id_filters_numeric_aggregates(ch_server):

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -36,8 +36,9 @@ from weave.trace_server.agents.types import (
     AgentsQueryReq,
 )
 from weave.trace_server.interface.feedback_types import (
+    AGENT_MONITOR_FEEDBACK_TYPE,
+    AGENT_USER_FEEDBACK_TYPE,
     NOTE_FEEDBACK_TYPE,
-    REACTION_FEEDBACK_TYPE,
 )
 from weave.trace_server.interface.query import Query
 
@@ -339,15 +340,17 @@ def _create_feedback(
     project_id: str,
     weave_ref: str,
     feedback_type: str,
-    payload: dict,
+    payload: dict | None = None,
+    **scorer_fields,
 ) -> None:
     ch_server.feedback_create(
         tsi.FeedbackCreateReq(
             project_id=project_id,
             weave_ref=weave_ref,
             feedback_type=feedback_type,
-            payload=payload,
+            payload=payload or {},
             wb_user_id="test-user",
+            **scorer_fields,
         )
     )
 
@@ -372,7 +375,8 @@ def test_conversation_spans_unknown_id_returns_empty(ch_server):
 def test_conversation_spans_sequence_and_feedback(ch_server):
     """agent_conversation_spans returns an ordered per-span sequence (kinds from
     operation_name, ERROR surfaced via status) plus turn-anchored feedback
-    markers carrying the feedback_type and any detoned tags.
+    markers carrying detoned tags and scorer ratings. Only agent_user_feedback
+    and agent_monitor are surfaced; other feedback types are dropped.
     """
     project_id = _make_project_id("conv-spans")
     now = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -423,11 +427,32 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
     ]
     _insert_spans(ch_server.ch_client, spans)
 
-    # Turn-level reaction (👍 -> positive) on turn A; a note on turn B.
+    # Turn A: a human thumbs-up tag. Turn B: a scorer with a tag + a rating.
+    # Plus an unsupported note on turn B that must be filtered out.
     turn_a_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_a).uri
     turn_b_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_b).uri
     _create_feedback(
-        ch_server, project_id, turn_a_ref, REACTION_FEEDBACK_TYPE, {"emoji": "👍"}
+        ch_server,
+        project_id,
+        turn_a_ref,
+        AGENT_USER_FEEDBACK_TYPE,
+        scorer_tags=["\U0001f44d"],
+    )
+    _create_feedback(
+        ch_server,
+        project_id,
+        turn_b_ref,
+        AGENT_MONITOR_FEEDBACK_TYPE,
+        runnable_ref=ri.InternalOpRef(
+            project_id=project_id, name="quality_scorer", version="v1"
+        ).uri,
+        call_ref=ri.InternalCallRef(project_id=project_id, id=trace_b).uri,
+        trigger_ref=ri.InternalObjectRef(
+            project_id=project_id, name="quality_scorer_trigger", version="v1"
+        ).uri,
+        scorer_tags=["helpful"],
+        scorer_ratings={"quality": 0.8},
+        scorer_rating_reasons={"quality": "clear answer"},
     )
     _create_feedback(
         ch_server, project_id, turn_b_ref, NOTE_FEEDBACK_TYPE, {"note": "nice"}
@@ -453,13 +478,18 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
     assert row.spans[-1].trace_id == trace_b
     assert any(e.span_id == tool_span for e in row.spans)
 
-    # Feedback markers are keyed by turn (trace_id) and carry the feedback_type
-    # plus any detoned tags (empty for a note). An emoji tag is the glyph itself.
+    # Markers are keyed by turn (trace_id); the note is dropped, so each turn
+    # has exactly one marker. Emoji tags come back as the detoned glyph.
     by_trace = {f.trace_id: f for f in row.spans_feedback}
-    assert by_trace[trace_a].feedback_type == REACTION_FEEDBACK_TYPE
+    assert by_trace[trace_a].feedback_type == AGENT_USER_FEEDBACK_TYPE
     assert by_trace[trace_a].tags == ["\U0001f44d"]
-    assert by_trace[trace_b].feedback_type == NOTE_FEEDBACK_TYPE
-    assert by_trace[trace_b].tags == []
+    assert by_trace[trace_a].scores == []
+
+    assert by_trace[trace_b].feedback_type == AGENT_MONITOR_FEEDBACK_TYPE
+    assert by_trace[trace_b].tags == ["helpful"]
+    assert len(by_trace[trace_b].scores) == 1
+    score = by_trace[trace_b].scores[0]
+    assert (score.name, score.value, score.reason) == ("quality", 0.8, "clear answer")
 
 
 def test_group_by_conversation_id_filters_numeric_aggregates(ch_server):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -62,6 +62,8 @@ from weave.trace_server.agents.kafka_events import ScoreAgentSpansEvent
 from weave.trace_server.agents.types import (
     AgentConversationChatReq,
     AgentConversationChatRes,
+    AgentConversationSpansReq,
+    AgentConversationSpansRes,
     AgentCustomAttrsSchemaReq,
     AgentCustomAttrsSchemaRes,
     AgentSearchReq,
@@ -6939,6 +6941,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self, req: AgentConversationChatReq
     ) -> AgentConversationChatRes:
         return AgentQueryHandler(self._query, self.feedback_query).conversation_chat(
+            req
+        )
+
+    def agent_conversation_spans(
+        self, req: AgentConversationSpansReq
+    ) -> AgentConversationSpansRes:
+        return AgentQueryHandler(self._query, self.feedback_query).conversation_spans(
             req
         )
 

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1369,6 +1369,16 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             req.project_id,
         )
 
+    def agent_conversation_spans(
+        self, req: tsi.agent_types.AgentConversationSpansReq
+    ) -> tsi.agent_types.AgentConversationSpansRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(
+            self._internal_trace_server.agent_conversation_spans,
+            req,
+            req.project_id,
+        )
+
     def projects_info(self, req: tsi.ProjectsInfoReq) -> list[tsi.ProjectsInfoRes]:
         req = req.model_copy(deep=True)
         """Resolve external project IDs to internal project IDs."""

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3264,6 +3264,9 @@ class TraceServerInterface(Protocol):
     def agent_conversation_chat(
         self, req: agent_types.AgentConversationChatReq
     ) -> agent_types.AgentConversationChatRes: ...
+    def agent_conversation_spans(
+        self, req: agent_types.AgentConversationSpansReq
+    ) -> agent_types.AgentConversationSpansRes: ...
 
     # Call API
     def call_start(self, req: CallStartReq) -> CallStartRes: ...


### PR DESCRIPTION
## JIRA Issue(s)

- [Turns / Events Minimap in Sessions list (Notion)](https://www.notion.so/wandbai/Turns-Minimap-in-Sessions-list-375e2f5c7ef380ec8e5fd994696125b2)

## Description

Wiring half of the spans minimap backend, stacked on wandb/weave#7223 (the feature). Exposes `AgentQueryHandler.conversation_spans` as the `agent_conversation_spans` endpoint across the trace-server layers:

- `trace_server_interface.py` — the Protocol method,
- `external_to_internal_trace_server_adapter.py` — project-id translation,
- `clickhouse_trace_server_batched.py` — the delegate.

Plus through-server endpoint tests (the FastAPI route + HTTP auth tests live in wandb/core#45791).

## Testing

- [x] Manual
- [x] Unit
- [x] QA