### PR TITLE
fix(weave): capture Bedrock Converse cache tokens on the streaming path

### DIFF
--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -102,6 +102,29 @@ MOCK_STREAM_EVENTS = [
     },
 ]
 
+# Converse stream whose final metadata event carries prompt-caching token
+# counts (cacheReadInputTokens / cacheWriteInputTokens), as Bedrock returns
+# when prompt caching is used. These must reach the call summary just like the
+# non-streaming converse path.
+MOCK_STREAM_EVENTS_CACHE = [
+    {"messageStart": {"role": "assistant"}},
+    {"contentBlockDelta": {"delta": {"text": "Hello"}, "contentBlockIndex": 0}},
+    {"contentBlockStop": {"contentBlockIndex": 0}},
+    {"messageStop": {"stopReason": "end_turn"}},
+    {
+        "metadata": {
+            "usage": {
+                "inputTokens": 10,
+                "outputTokens": 5,
+                "totalTokens": 15,
+                "cacheReadInputTokens": 100,
+                "cacheWriteInputTokens": 200,
+            },
+            "metrics": {"latencyMs": 123},
+        }
+    },
+]
+
 # Converse stream emitting a reasoning block followed by a tool-use block.
 # A reasoning-capable, tool-bound Claude model produces these non-text deltas,
 # which the accumulator must not choke on.
@@ -524,6 +547,48 @@ def test_bedrock_converse_stream(
     assert output["usage"]["inputTokens"] == model_usage["prompt_tokens"] == 55
     assert output["usage"]["outputTokens"] == model_usage["completion_tokens"] == 30
     assert output["usage"]["totalTokens"] == model_usage["total_tokens"] == 85
+
+
+@mock_aws
+def test_bedrock_converse_stream_cache_tokens(
+    client: weave.trace.weave_client.WeaveClient,
+) -> None:
+    """Streaming converse must record prompt-caching token counts in the call
+    summary, matching the non-streaming converse path. The accumulator
+    previously dropped cacheReadInputTokens / cacheWriteInputTokens from the
+    metadata event, so they never reached the finish handler.
+    """
+    bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+    patch_client(bedrock_client)
+
+    with patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=converse_stream_make_api_call(MOCK_STREAM_EVENTS_CACHE),
+    ):
+        response = bedrock_client.converse_stream(
+            modelId=model_id,
+            system=[{"text": system_message}],
+            messages=messages,
+            inferenceConfig={"maxTokens": 30},
+        )
+        stream = response.get("stream")
+        assert stream is not None, "Stream not found in response"
+        # Consume the stream so the accumulator runs to completion.
+        list(stream)
+
+    calls = client.get_calls()
+    assert len(calls) == 1, "Expected exactly one trace call for the stream test"
+    call = calls[0]
+    assert call.exception is None
+
+    summary = call.summary
+    assert summary is not None, "Summary should not be None"
+    model_usage = summary["usage"][model_id]
+    assert model_usage["prompt_tokens"] == 10
+    assert model_usage["completion_tokens"] == 5
+    assert model_usage["total_tokens"] == 15
+    assert model_usage["cache_read_input_tokens"] == 100
+    assert model_usage["cache_creation_input_tokens"] == 200
 
 
 @mock_aws

--- a/weave/integrations/bedrock/bedrock_sdk.py
+++ b/weave/integrations/bedrock/bedrock_sdk.py
@@ -34,10 +34,10 @@ def bedrock_on_finish_converse(
             "total_tokens": output_usage["totalTokens"],
         }
         # Bedrock Converse API returns cache tokens when prompt caching is used
-        cache_read = output_usage.get("cacheReadInputTokenCount")
+        cache_read = output_usage.get("cacheReadInputTokens")
         if cache_read is not None:
             tokens_metrics["cache_read_input_tokens"] = cache_read
-        cache_write = output_usage.get("cacheWriteInputTokenCount")
+        cache_write = output_usage.get("cacheWriteInputTokens")
         if cache_write is not None:
             tokens_metrics["cache_creation_input_tokens"] = cache_write
         usage[model_name].update(tokens_metrics)
@@ -417,6 +417,17 @@ def bedrock_stream_accumulator(
             acc["usage"]["inputTokens"] = metadata["usage"].get("inputTokens", 0)
             acc["usage"]["outputTokens"] = metadata["usage"].get("outputTokens", 0)
             acc["usage"]["totalTokens"] = metadata["usage"].get("totalTokens", 0)
+            # Carry the prompt-caching token counts so the shared finish handler
+            # (bedrock_on_finish_converse) records them, matching the
+            # non-streaming converse path.
+            if "cacheReadInputTokens" in metadata["usage"]:
+                acc["usage"]["cacheReadInputTokens"] = metadata["usage"][
+                    "cacheReadInputTokens"
+                ]
+            if "cacheWriteInputTokens" in metadata["usage"]:
+                acc["usage"]["cacheWriteInputTokens"] = metadata["usage"][
+                    "cacheWriteInputTokens"
+                ]
         if "metrics" in metadata:
             acc["latency_ms"] = metadata["metrics"].get("latencyMs", 0)
 


### PR DESCRIPTION
## Summary

Thanks again for the Bedrock integration! This makes prompt-caching token counts on the Converse API actually get recorded.

Closes #7326.

Bedrock's Converse / ConverseStream `usage` object reports prompt-caching tokens as `cacheReadInputTokens` / `cacheWriteInputTokens` (confirmed against the `bedrock-runtime` botocore service model and the AWS [prompt-caching docs](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html)). Two things prevented them from being recorded:

1. `bedrock_on_finish_converse` read `cacheReadInputTokenCount` / `cacheWriteInputTokenCount` (a `*Count` suffix the API does not return), so `.get(...)` always returned `None`.
2. The streaming accumulator (`bedrock_stream_accumulator`) copied only `inputTokens` / `outputTokens` / `totalTokens` from the `metadata` event, so cache tokens never reached the shared finish handler on the `converse_stream` path.

The streaming accumulator already carries the other usage fields through to the shared finish handler — this just adds the two cache fields it was missing, matching the non-streaming path.

## Before / After

| Path | Cache tokens in call summary (Before) | After |
|------|----------------------------------------|-------|
| `converse` (non-streaming) | ❌ never (reads non-existent `*Count` key) | ✅ `cache_read_input_tokens` / `cache_creation_input_tokens` |
| `converse_stream` (streaming) | ❌ never (accumulator drops them) | ✅ recorded |
| `inputTokens` / `outputTokens` / `totalTokens` | ✅ | unchanged ✅ |
| Non-cached calls (no cache fields) | no cache keys in summary | unchanged ✅ (keys omitted, not zeroed) |

## Changes

- `weave/integrations/bedrock/bedrock_sdk.py`:
  - Finish handler reads `cacheReadInputTokens` / `cacheWriteInputTokens` (the service-model field names).
  - `bedrock_stream_accumulator` carries those two fields from the `metadata` event into the accumulated usage, only when present (so non-cached streams are unaffected).
- `tests/integrations/bedrock/bedrock_test.py`: streaming regression test that feeds a `metadata` event with cache tokens and asserts they reach the call summary.

## Test (before / after the fix)

Reverting only the source fix (keeping the new test) makes it fail — the streamed cache tokens never reach the summary:

```
self = WeaveDict({'prompt_tokens': 10, 'completion_tokens': 5, 'requests': 1, 'total_tokens': 15})
key = 'cache_read_input_tokens'
>       v = super().__getitem__(key)
E       KeyError: 'cache_read_input_tokens'
```

With the fix, the full Bedrock suite passes (in-memory backend):

```
$ pytest tests/integrations/bedrock/bedrock_test.py --trace-server=fake -q
12 passed
```

`ruff check` is clean on the changed lines.

## Verification of field names

```
$ python -c "import botocore.session as s; m=s.get_session().get_service_model('bedrock-runtime'); print(list(m.shape_for('TokenUsage').members.keys()))"
['inputTokens', 'outputTokens', 'totalTokens', 'cacheReadInputTokens', 'cacheWriteInputTokens']
```

---
This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, its rationale, and the test results before submitting.
