### PR TITLE
fix(weave): replace stale version hint in object name validation error message

### DIFF
--- a/tests/trace_server/test_validation.py
+++ b/tests/trace_server/test_validation.py
@@ -1,7 +1,25 @@
 import pytest
 
 from weave.trace_server import validation
-from weave.trace_server.errors import InvalidRequest
+from weave.trace_server.errors import InvalidFieldError, InvalidRequest
+
+
+def test_object_id_validator_invalid_chars():
+    # Invalid characters should raise an error describing the constraint,
+    # not a stale version-upgrade hint.
+    with pytest.raises(InvalidFieldError) as e:
+        validation.object_id_validator("bad name!")
+    msg = str(e.value)
+    assert "alphanumeric" in msg, "Error should describe valid character constraint"
+    assert "0.51" not in msg, "Error must not reference a stale version number"
+    assert "upgrade" not in msg, "Error must not suggest an upgrade"
+
+    # Valid names must pass through unchanged
+    assert validation.object_id_validator("valid-name_1.0") == "valid-name_1.0"
+
+    # Empty name should also raise
+    with pytest.raises(InvalidFieldError):
+        validation.object_id_validator("")
 
 
 def test_validate_dict_one_key():

--- a/weave/trace_server/validation.py
+++ b/weave/trace_server/validation.py
@@ -81,7 +81,7 @@ def _validate_object_name_charset(name: str) -> None:
     if invalid_chars:
         invalid_char_set = list(set(invalid_chars))
         raise InvalidFieldError(
-            f"Invalid object name: {name}. Contains invalid characters: {invalid_char_set}. Please upgrade your `weave` package to `>0.51.0` to prevent this error."
+            f"Invalid object name: {name}. Contains invalid characters: {invalid_char_set}. Object names must only contain alphanumeric characters, dashes, underscores, and periods."
         )
 
     if not name:


### PR DESCRIPTION
## Problem

Fixes #5771

The error message in `weave/trace_server/validation.py` tells users to upgrade to `>0.51.0`:

```
Invalid object name: {name}. Contains invalid characters: {invalid_char_set}. Please upgrade your `weave` package to `>0.51.0` to prevent this error.
```

This is misleading — Weave is already at `0.52+`, so users seeing this are already on a newer version. Version-specific hints in error messages always go stale.

## Fix

Replaced the stale version hint with a clear message that tells users exactly what characters are allowed.

**Before:**
```
...Please upgrade your `weave` package to `>0.51.0` to prevent this error.
```

**After:**
```
...Object names must only contain alphanumeric characters, dashes, underscores, and periods.
```

## Changes

- `weave/trace_server/validation.py` — error message updated to describe the actual constraint
- `tests/trace_server/test_validation.py` — added `test_object_id_validator_invalid_chars` covering: invalid characters raise with a constraint description (not a version hint), valid names pass through, and empty names are rejected