### PR TITLE
fix(weave): resolve recursive LiteralOperation schema to fix Mintlify warnings

### DIFF
--- a/sdks/node/weave.openapi.json
+++ b/sdks/node/weave.openapi.json
@@ -14423,15 +14423,11 @@
                 "type": "boolean"
               },
               {
-                "additionalProperties": {
-                  "$ref": "#/components/schemas/LiteralOperation"
-                },
+                "additionalProperties": true,
                 "type": "object"
               },
               {
-                "items": {
-                  "$ref": "#/components/schemas/LiteralOperation"
-                },
+                "items": {},
                 "type": "array"
               },
               {


### PR DESCRIPTION
## Problem

Fixes #5619

The `LiteralOperation` schema in `sdks/node/weave.openapi.json` contains recursive self-references:

```json
"additionalProperties": { "$ref": "#/components/schemas/LiteralOperation" }
"items": { "$ref": "#/components/schemas/LiteralOperation" }
```

Static OpenAPI tooling (including Mintlify) cannot resolve infinite recursive schemas and emits warnings during documentation builds.

## Root cause

`LiteralOperation` represents a JSON literal — a value that can be a string, number, boolean, object, array, or null. Objects and arrays within a literal can themselves contain arbitrary values, but the schema modelled this as a recursive reference to `LiteralOperation`. Static tools cannot follow infinite recursion, unlike a runtime parser.

## Fix

Replaced the recursive `$ref` entries with open schemas that are semantically equivalent for a JSON literal:

- `"additionalProperties": true` — object values are unconstrained
- `"items": {}` — array elements are unconstrained

This matches the runtime behaviour (any JSON value is valid) while remaining resolvable by static tooling.

> **Note:** This change only affects the generated OpenAPI schema used for documentation. It does not touch any runtime validation logic.

## Changes

- `sdks/node/weave.openapi.json` — 2 lines changed