### PR TITLE
fix(weave): opt out of clickhouse insert dedup on replicated deployments

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1093,6 +1093,36 @@ def test_insert_retries_empty_query_error():
         assert mock_ch_client.insert.call_count == 2  # Retried once
 
 
+def test_insert_deduplication_token_gated_on_replicated():
+    """Replicated/distributed inserts carry a unique dedup-opt-out token; non-replicated is untouched."""
+
+    def capture_settings(replicated: bool) -> list[dict]:
+        mock_client = MagicMock()
+        with (
+            patch(
+                "weave.trace_server.environment.wf_clickhouse_replicated",
+                return_value=replicated,
+            ),
+            patch.object(
+                chts.ClickHouseTraceServer, "_mint_client", return_value=mock_client
+            ),
+        ):
+            server = chts.ClickHouseTraceServer(host="h")
+            server._insert("t", data=[[1]], column_names=["a"])
+            server._insert("t", data=[[1]], column_names=["a"])
+        return [
+            c.kwargs.get("settings") or {} for c in mock_client.insert.call_args_list
+        ]
+
+    tokens = [s.get("insert_deduplication_token") for s in capture_settings(True)]
+    assert all(tokens), "replicated inserts must carry a dedup token"
+    assert tokens[0] != tokens[1], "each insert must get a unique token"
+
+    assert all(
+        "insert_deduplication_token" not in s for s in capture_settings(False)
+    ), "non-replicated inserts must be unchanged (SharedMergeTree/CH Cloud)"
+
+
 def test_insert_with_empty_query_retry_contract():
     """The shared direct-insert helper retries empty query, exhausts, and passes through."""
     summary = MagicMock()

--- a/tests/trace_server/test_trace_server_conftest.py
+++ b/tests/trace_server/test_trace_server_conftest.py
@@ -43,6 +43,7 @@ KNOWN_SERVER_ATTRS = frozenset(
         "_table_routing_resolver",
         "_thread_local",
         "_use_async_insert",
+        "_use_replicated_tables",
         "_user",
     }
 )

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -395,6 +395,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self._password = password
         self._database = database
         self._use_async_insert = use_async_insert
+        self._use_replicated_tables = wf_env.wf_clickhouse_replicated()
         self._model_to_provider_info_map = read_model_to_provider_info_map()
         self._init_lock = threading.Lock()
         self._file_storage_client: FileStorageClient | None = None
@@ -7281,6 +7282,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     "clickhouse_trace_server_batched._insert.async_insert": True,
                 }
             )
+
+        # Replicated/distributed engines block-dedup byte-identical inserts;
+        # a unique token opts out (non-replicated CH Cloud is unaffected).
+        if self._use_replicated_tables:
+            settings = {**(settings or {}), "insert_deduplication_token": generate_id()}
 
         start = time.monotonic()
         sanitized_invalid_utf8 = False


### PR DESCRIPTION
## Summary
- WB-35378: on replicated/distributed ClickHouse, byte-identical inserts are silently dropped by Keeper block-dedup. Weave re-inserts identical rows by design (republish-to-promote, re-tag, display_name reset, delete+recreate) because `created_at` is a server-side `DEFAULT`, not in the insert block. Breaks the 1s3r/2s2r nightly legs (7 tests, `assert 0 == 1`).
- Fix: set a unique `insert_deduplication_token` per insert, gated on `wf_clickhouse_replicated()`. Replicated/distributed deployments (incl. CI legs) opt out; non-replicated SharedMergeTree (CH Cloud prod) is byte-for-byte untouched.
- `replicated_deduplication_window=0` only disables *sync*-insert dedup; the token is the only lever that also covers the *async* path (prod). Supersedes #7297.

## Testing
nightly dispatched on this branch ([run](https://github.com/wandb/weave/actions/runs/27975716334)): `trace` shard (the dedup tests) green on single-node + replicated 1s3r + 2s2r-distributed across py3.10-3.13; all 6 previously-failing dedup tests run and pass on the 2s2r distributed leg. added a unit test pinning the gate (token present iff replicated); also verified on a local 1s3r cluster that `window=0` fixes only sync inserts while a unique token fixes both sync and async.

the lone red, 2s2r `trace_server`, is a pre-existing distributed calls_complete-v2 read-your-write class (`no start found`) unrelated to this PR: it also fails on the [master nightly baseline](https://github.com/wandb/weave/actions/runs/27923554551) and only when `use_distributed=true` (1s3r passes, though the token applies to both legs).
