### PR TITLE
feat(weave_ts): Add `gen_ai.agent.name` as attribute on all spans in `@openai/agents` integration

### DIFF
--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -423,6 +423,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     )!;
     expect(executeToolSpan.attributes).toMatchObject({
       'gen_ai.operation.name': 'execute_tool',
+      'gen_ai.agent.name': 'test-agent',
       'gen_ai.conversation.id': 'some-conversation-id',
       'gen_ai.tool.name': 'test-function',
       'gen_ai.tool.call.arguments': '{"city":"Tokyo"}',
@@ -433,6 +434,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     const resp = spans.find(s => s.name === 'chat gpt-4o-mini')!;
     expect(resp.attributes).toMatchObject({
       'gen_ai.operation.name': 'chat',
+      'gen_ai.agent.name': 'test-agent',
       'gen_ai.conversation.id': 'some-conversation-id',
       'gen_ai.provider.name': 'openai',
       'gen_ai.output.type': 'text',
@@ -454,6 +456,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     const gen = spans.find(s => s.name === 'chat gpt-3.5-turbo')!;
     expect(gen.attributes).toMatchObject({
       'gen_ai.operation.name': 'chat',
+      'gen_ai.agent.name': 'test-agent',
       'gen_ai.conversation.id': 'some-conversation-id',
       'gen_ai.provider.name': 'openai',
       'gen_ai.output.type': 'text',
@@ -481,6 +484,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
 
     const handoff = spans.find(s => s.name === 'handoff Triage -> Specialist')!;
     expect(handoff.attributes).toMatchObject({
+      'gen_ai.agent.name': 'test-agent',
       'gen_ai.conversation.id': 'some-conversation-id',
       'weave.openai_agents.handoff.from_agent': 'Triage',
       'weave.openai_agents.handoff.to_agent': 'Specialist',
@@ -490,6 +494,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
 
     const guard = spans.find(s => s.name === 'guardrail test-guardrail')!;
     expect(guard.attributes).toMatchObject({
+      'gen_ai.agent.name': 'test-agent',
       'gen_ai.conversation.id': 'some-conversation-id',
       'weave.openai_agents.guardrail.name': 'test-guardrail',
       'weave.openai_agents.guardrail.triggered': false,
@@ -499,6 +504,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
 
     const transcription = spans.find(s => s.name === 'transcription')!;
     expect(transcription.attributes).toMatchObject({
+      'gen_ai.agent.name': 'test-agent',
       'gen_ai.conversation.id': 'some-conversation-id',
       'weave.openai_agents.transcription.model': 'whisper-1',
       'weave.openai_agents.transcription.input': 'base64audio',
@@ -510,6 +516,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
 
     const speech = spans.find(s => s.name === 'speech')!;
     expect(speech.attributes).toMatchObject({
+      'gen_ai.agent.name': 'test-agent',
       'gen_ai.conversation.id': 'some-conversation-id',
       'weave.openai_agents.speech.model': 'tts-1',
       'weave.openai_agents.speech.input': 'say hello',
@@ -521,6 +528,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
 
     const speechGroup = spans.find(s => s.name === 'speech_group')!;
     expect(speechGroup.attributes).toMatchObject({
+      'gen_ai.agent.name': 'test-agent',
       'gen_ai.conversation.id': 'some-conversation-id',
       'weave.openai_agents.speech_group.input': 'narration script',
       'weave.openai_agents.span_id': 'span-speech-group',
@@ -529,6 +537,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
 
     const mcp = spans.find(s => s.name === 'mcp_list_tools')!;
     expect(mcp.attributes).toMatchObject({
+      'gen_ai.agent.name': 'test-agent',
       'gen_ai.conversation.id': 'some-conversation-id',
       'weave.openai_agents.mcp.server': 'http://localhost:9000',
       'weave.openai_agents.mcp.result': ['search', 'fetch'],
@@ -539,6 +548,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     // CustomSpan uses the user-supplied name with no prefix.
     const custom = spans.find(s => s.name === 'my_step')!;
     expect(custom.attributes).toMatchObject({
+      'gen_ai.agent.name': 'test-agent',
       'gen_ai.conversation.id': 'some-conversation-id',
       'weave.openai_agents.custom.kind': 'cache_lookup',
       'weave.openai_agents.custom.hits': 3,
@@ -625,6 +635,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     expect(executeToolSpan).toBeDefined();
     expect(executeToolSpan.attributes).toMatchObject({
       'gen_ai.operation.name': 'execute_tool',
+      'gen_ai.agent.name': 'Assistant',
       'gen_ai.conversation.id': 'some-conversation-id',
       'gen_ai.tool.name': 'get_weather',
       // The Agents SDK serializes the tool's JSON args/result as strings

--- a/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
+++ b/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
@@ -427,6 +427,11 @@ type TraceInfo = {
   openSpanIds: string[];
 };
 
+type SpanInfo = {
+  otelSpan: OtelSpan;
+  agentName: string | undefined;
+};
+
 /**
  * OTel-emitting TracingProcessor for the OpenAI Agents SDK.
  *
@@ -449,7 +454,7 @@ type TraceInfo = {
  * - `{custom}`
  */
 export class WeaveOtelTracingProcessor implements TracingProcessor {
-  private spansById = new Map<string, OtelSpan>();
+  private spansById = new Map<string, SpanInfo>();
   private tracesById = new Map<string, TraceInfo>();
 
   private getTraceInfo(traceId: string): TraceInfo {
@@ -476,7 +481,7 @@ export class WeaveOtelTracingProcessor implements TracingProcessor {
     if (!span.parentId) return undefined;
     const parent = this.spansById.get(span.parentId);
     if (!parent) return undefined;
-    return otelTrace.setSpan(otelContext.active(), parent);
+    return otelTrace.setSpan(otelContext.active(), parent.otelSpan);
   }
 
   async onTraceStart(trace: Trace): Promise<void> {
@@ -489,12 +494,12 @@ export class WeaveOtelTracingProcessor implements TracingProcessor {
     const openSpanIds = traceInfo.openSpanIds;
     // Sweep in LIFO order so child spans end before their parents.
     for (const spanId of openSpanIds.reverse()) {
-      const otelSpan = this.spansById.get(spanId);
-      if (!otelSpan) continue;
+      const span = this.spansById.get(spanId);
+      if (!span) continue;
 
       this.spansById.delete(spanId);
-      if (otelSpan.isRecording()) {
-        otelSpan.end();
+      if (span.otelSpan.isRecording()) {
+        span.otelSpan.end();
       }
     }
     this.tracesById.delete(trace.traceId);
@@ -509,16 +514,35 @@ export class WeaveOtelTracingProcessor implements TracingProcessor {
     );
     otelSpan.setAttribute(`${WEAVE_ATTR_PREFIX}.span_id`, span.spanId);
     otelSpan.setAttribute(`${WEAVE_ATTR_PREFIX}.trace_id`, span.traceId);
-    this.spansById.set(span.spanId, otelSpan);
+
+    this.spansById.set(span.spanId, {
+      otelSpan,
+      agentName: this.resolveAgentName(span),
+    });
 
     const traceInfo = this.getTraceInfo(span.traceId);
     traceInfo.openSpanIds.push(span.spanId);
   }
 
+  private resolveAgentName(span: Span<SpanData>): string | undefined {
+    if (span.spanData.type === 'agent') {
+      return span.spanData.name;
+    }
+
+    if (span.parentId) {
+      const parentSpanInfo = this.spansById.get(span.parentId);
+      if (parentSpanInfo) {
+        return parentSpanInfo.agentName;
+      }
+    }
+  }
+
   async onSpanEnd(span: Span<SpanData>): Promise<void> {
-    const otelSpan = this.spansById.get(span.spanId);
+    const spanInfo = this.spansById.get(span.spanId);
+    if (!spanInfo) return;
+    const {otelSpan, agentName} = spanInfo;
+
     this.spansById.delete(span.spanId);
-    if (!otelSpan) return;
 
     const traceInfo = this.getTraceInfo(span.traceId);
 
@@ -540,6 +564,7 @@ export class WeaveOtelTracingProcessor implements TracingProcessor {
       otelSpan.setAttributes({
         ...attrsForSpan(span),
         [ATTR_GEN_AI_CONVERSATION_ID]: traceInfo.conversationId,
+        [ATTR_GEN_AI_AGENT_NAME]: agentName,
       });
 
       if (span.error) {
@@ -573,7 +598,7 @@ export class WeaveOtelTracingProcessor implements TracingProcessor {
   }
 
   private endOpenSpans(): void {
-    for (const otelSpan of this.spansById.values()) {
+    for (const {otelSpan} of this.spansById.values()) {
       if (otelSpan.isRecording()) {
         otelSpan.end();
       }


### PR DESCRIPTION
## Description

* We currently require this attribute on all children spans in order for certain pieces of data to populate in the Weave UI.

* This change starts including `gen_ai.agent.name` as attrs on all span types, instead of only a select few.

