### PR TITLE
feat(weave_ts): Include integration OTel attrs in `@openai/agents` integration

### DIFF
--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -34,6 +34,7 @@ import {wrapOpenAIChatCompletionsCreate} from '../../integrations/openai';
 import {makeAPIPromiseShim} from '../openaiMock';
 import {InMemoryTraceServer, type Call} from '../helpers/inMemoryTraceServer';
 import state from 'weave/state';
+import {packageVersion} from 'weave/utils/packageVersion';
 
 describe('OpenAI Agents Integration', () => {
   withEnv({WEAVE_USE_OTEL_V2: false});
@@ -416,6 +417,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.agent.handoffs': ['h1'],
       'weave.openai_agents.agent.output_type': 'text',
       'weave.openai_agents.span_id': 'span-agent',
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
 
     const executeToolSpan = spans.find(
@@ -429,6 +433,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.tool.call.arguments': '{"city":"Tokyo"}',
       'gen_ai.tool.call.result': 'sunny, 22C',
       'weave.openai_agents.span_id': 'span-function',
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
 
     const resp = spans.find(s => s.name === 'chat gpt-4o-mini')!;
@@ -445,6 +452,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.usage.output_tokens': 7,
       'gen_ai.usage.cache_read.input_tokens': 4,
       'gen_ai.usage.reasoning.output_tokens': 3,
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
     expect(resp.attributes['gen_ai.input.messages']).toMatchInlineSnapshot(
       `"[{"role":"user","parts":[{"type":"text","content":"What is the weather in Tokyo?"}]}]"`
@@ -473,6 +483,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.request.seed': 42,
       'gen_ai.request.stop_sequences': ['STOP'],
       'gen_ai.request.choice.count': 3,
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
     expect(gen.attributes['gen_ai.input.messages']).toMatchInlineSnapshot(
       `"[{"role":"user","parts":[{"type":"text","content":"hi"}]}]"`
@@ -489,6 +502,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.handoff.from_agent': 'Triage',
       'weave.openai_agents.handoff.to_agent': 'Specialist',
       'weave.openai_agents.span_id': 'span-handoff',
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
     expect(handoff.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -499,6 +515,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.guardrail.name': 'test-guardrail',
       'weave.openai_agents.guardrail.triggered': false,
       'weave.openai_agents.span_id': 'span-guardrail',
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
     expect(guard.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -511,6 +530,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.transcription.input_format': 'pcm',
       'weave.openai_agents.transcription.output': 'hello world',
       'weave.openai_agents.span_id': 'span-transcription',
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
     expect(transcription.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -523,6 +545,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.speech.output': 'base64audio',
       'weave.openai_agents.speech.output_format': 'pcm',
       'weave.openai_agents.span_id': 'span-speech',
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
     expect(speech.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -532,6 +557,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.conversation.id': 'some-conversation-id',
       'weave.openai_agents.speech_group.input': 'narration script',
       'weave.openai_agents.span_id': 'span-speech-group',
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
     expect(speechGroup.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -542,6 +570,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.mcp.server': 'http://localhost:9000',
       'weave.openai_agents.mcp.result': ['search', 'fetch'],
       'weave.openai_agents.span_id': 'span-mcp',
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
     expect(mcp.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -553,6 +584,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.custom.kind': 'cache_lookup',
       'weave.openai_agents.custom.hits': 3,
       'weave.openai_agents.span_id': 'span-custom',
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
     // Null values dropped — `miss: null` doesn't produce an attribute.
     expect(
@@ -627,6 +661,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.conversation.id': 'some-conversation-id',
       'gen_ai.provider.name': 'openai',
       'weave.openai_agents.agent.tools': ['get_weather'],
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
 
     const executeToolSpan = spans.find(
@@ -642,6 +679,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       // on the FunctionSpanData, which we lift straight to semconv.
       'gen_ai.tool.call.arguments': '{"city":"Tokyo"}',
       'gen_ai.tool.call.result': 'Tokyo: Sunny, 22°C',
+      'integration.meta.package_name': '@openai/agents',
+      'integration.name': 'openai_agents',
+      'integration.version': packageVersion,
     });
     // Span is a child of the agent span.
     expect(executeToolSpan.parentSpanId).toBe(agentSpan!.spanContext().spanId);

--- a/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
+++ b/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
@@ -65,11 +65,18 @@ import type {
 } from '@openai/agents';
 import type OpenAI from 'openai';
 import type {GenerationUsageData} from '@openai/agents';
+import {asOtelAttributes, libraryIntegration} from '../integrationMetadata';
 
 const TRACER_NAME = 'weave.openai_agents';
 const WEAVE_ATTR_PREFIX = 'weave.openai_agents';
 const PROVIDER_NAME = 'openai';
 const DEFAULT_CHAT_OUTPUT_TYPE = 'text';
+
+const OPENAI_AGENTS_INTEGRATION_OTEL_ATTRS = asOtelAttributes(
+  libraryIntegration('openai_agents', {
+    packageName: '@openai/agents',
+  })
+);
 
 function otelSpanName(span: Span<SpanData>): string {
   switch (span.spanData.type) {
@@ -563,6 +570,7 @@ export class WeaveOtelTracingProcessor implements TracingProcessor {
 
       otelSpan.setAttributes({
         ...attrsForSpan(span),
+        ...OPENAI_AGENTS_INTEGRATION_OTEL_ATTRS,
         [ATTR_GEN_AI_CONVERSATION_ID]: traceInfo.conversationId,
         [ATTR_GEN_AI_AGENT_NAME]: agentName,
       });


### PR DESCRIPTION
## Description

* Followup from https://github.com/wandb/weave/issues/7103. This change stamps our custom integration attrs onto OTel spans in the `@openai/agents` integration.

