### PR TITLE
feat(weave): send client-capability header on ingest (Python + Node)

### DIFF
--- a/sdks/node/src/__tests__/clientApi.test.ts
+++ b/sdks/node/src/__tests__/clientApi.test.ts
@@ -3,6 +3,7 @@ import {getWandbConfigs} from '../wandb/settings';
 import {WandbServerApi} from '../wandb/wandbServerApi';
 import {Api as TraceServerApi} from '../generated/traceServerApi';
 import {Netrc} from '../utils/netrc';
+import {CLIENT_CAPABILITIES, CLIENT_CAPABILITIES_HEADER} from '../constants';
 
 jest.mock('../wandb/wandbServerApi');
 jest.mock('../wandb/settings');
@@ -74,6 +75,20 @@ describe('Client API', () => {
         'mock-api-key'
       );
       expect(gottenClient.projectId).toBe('custom-entity/test-project');
+    });
+
+    test('sends the client-capability header on the ingest client', async () => {
+      await init('test-project');
+
+      expect(TraceServerApi).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseApiParams: expect.objectContaining({
+            headers: expect.objectContaining({
+              [CLIENT_CAPABILITIES_HEADER]: CLIENT_CAPABILITIES,
+            }),
+          }),
+        })
+      );
     });
   });
 

--- a/sdks/node/src/__tests__/helpers/withCassette.ts
+++ b/sdks/node/src/__tests__/helpers/withCassette.ts
@@ -1,6 +1,7 @@
 import {join} from 'node:path';
 import {DefaultRequestMatcher, FileStorage, VCR} from 'vcr-test';
 import type {HttpRequest} from 'vcr-test';
+import {CLIENT_CAPABILITIES_HEADER} from '../../constants';
 
 const vcr = new VCR(new FileStorage(join(__dirname, '..', '__cassettes__')));
 
@@ -50,11 +51,27 @@ function normalizeMultipartBoundary(req: HttpRequest): HttpRequest {
   };
 }
 
+/**
+ * Drop the client-capabilities header so cassettes recorded before it existed
+ * still match. Like the `client_version` body field above, it is SDK-identity
+ * metadata, not part of a request's logical identity.
+ */
+function stripClientCapabilitiesHeader(req: HttpRequest): HttpRequest {
+  const key = CLIENT_CAPABILITIES_HEADER.toLowerCase();
+  if (!(key in req.headers)) {
+    return req;
+  }
+  const headers = {...req.headers};
+  delete headers[key];
+  return {...req, headers};
+}
+
 function normalizeRequest(req: HttpRequest): HttpRequest {
-  return [normalizeMultipartBoundary, normalizeVolatileBodyFields].reduce(
-    (req, normalizer) => normalizer(req),
-    req
-  );
+  return [
+    normalizeMultipartBoundary,
+    normalizeVolatileBodyFields,
+    stripClientCapabilitiesHeader,
+  ].reduce((req, normalizer) => normalizer(req), req);
 }
 
 class Matcher extends DefaultRequestMatcher {

--- a/sdks/node/src/clientApi.ts
+++ b/sdks/node/src/clientApi.ts
@@ -1,4 +1,5 @@
 import {Api as TraceServerApi} from './generated/traceServerApi';
+import {CLIENT_CAPABILITIES, CLIENT_CAPABILITIES_HEADER} from './constants';
 import {registerEvalLinkSpanProcessor} from './evalLinkSpanProcessor';
 import {makeSettings, type Settings} from './settings';
 import {defaultHost, getUrls, setGlobalDomain} from './urls';
@@ -121,6 +122,7 @@ export async function init(
       baseApiParams: {
         headers: {
           'User-Agent': `W&B Weave JS Client ${process.env.VERSION || 'unknown'}`,
+          [CLIENT_CAPABILITIES_HEADER]: CLIENT_CAPABILITIES,
           Authorization: `Basic ${Buffer.from(`api:${apiKey}`).toString('base64')}`,
         },
       },

--- a/sdks/node/src/constants.ts
+++ b/sdks/node/src/constants.ts
@@ -28,3 +28,13 @@ export const EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR =
   'weave.eval.predict_and_score_call_id';
 export const EVAL_PROJECT_ID_SPAN_ATTR = 'weave.eval.project_id';
 export const EVAL_EVALUATION_NAME_SPAN_ATTR = 'weave.eval.evaluation_name';
+
+/**
+ * Request header advertising the sampling-relevant capabilities this SDK build
+ * guarantees, so a future server-side ingest sampler can tell a sampling-safe
+ * client from an older one and leave unsupported traffic unsampled. Sent on
+ * every ingest request (it describes the client, not one trace); a
+ * comma-separated, forward-compatible token list.
+ */
+export const CLIENT_CAPABILITIES_HEADER = 'X-Weave-Client-Capabilities';
+export const CLIENT_CAPABILITIES = 'trace_id_on_end,eval_child_meta';

--- a/tests/trace_server_bindings/test_http_behavior_remote.py
+++ b/tests/trace_server_bindings/test_http_behavior_remote.py
@@ -27,6 +27,8 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
 from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
 from weave.trace_server_bindings.http_utils import (
+    CLIENT_CAPABILITIES,
+    CLIENT_CAPABILITIES_HEADER,
     ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED,
     TRACE_ID_HEADER,
 )
@@ -632,6 +634,66 @@ def test_legacy_upsert_batch_end_carries_trace_id_in_body(mock_post):
         ]
         assert end_items, "expected an end item in the posted batch"
         assert end_items[0]["req"]["end"]["trace_id"] == "trace-batch"
+    finally:
+        if server.call_processor:
+            server.call_processor.stop_accepting_new_work_and_flush_queue()
+        if server.feedback_processor:
+            server.feedback_processor.stop_accepting_new_work_and_flush_queue()
+
+
+# =============================================================================
+# X-Weave-Client-Capabilities on every ingest request
+#
+# Unlike the per-trace X-Weave-Trace-Id header, the capability header describes
+# the client build itself, so it rides every request -- single calls AND
+# batches -- letting a future server-side ingest sampler recognize a
+# sampling-safe client even on the batch path, which cannot carry a per-trace
+# trace_id header.
+# =============================================================================
+
+
+@patch("weave.utils.http_requests.post")
+def test_single_call_sends_client_capabilities_header(mock_post, unbatched_server):
+    """Every single-call request advertises the client's capabilities."""
+    call_id = generate_id()
+    mock_post.return_value = httpx.Response(
+        200,
+        json=dict(tsi.CallStartRes(id=call_id, trace_id="test_trace_id")),
+        request=httpx.Request("POST", "http://test.com"),
+    )
+
+    unbatched_server.call_start(tsi.CallStartReq(start=generate_start(call_id)))
+
+    assert (
+        _request_headers(mock_post.call_args)[CLIENT_CAPABILITIES_HEADER]
+        == CLIENT_CAPABILITIES
+    )
+
+
+@patch("weave.utils.http_requests.post")
+def test_batch_upsert_sends_client_capabilities_header(mock_post):
+    """The batch path carries the capability header too (it describes the
+    client, not a trace), unlike the per-trace X-Weave-Trace-Id header.
+    """
+    server = RemoteHTTPTraceServer("http://example.com", should_batch=True)
+    mock_post.return_value = httpx.Response(
+        200, json={}, request=httpx.Request("POST", "http://example.com")
+    )
+
+    call_id = "call-id"
+    start = StartBatchItem(
+        req=tsi.CallStartReq(start=generate_start(call_id, "entity/project"))
+    )
+
+    try:
+        server._flush_calls([start])
+
+        assert mock_post.call_args_list
+        for call in mock_post.call_args_list:
+            assert (
+                _request_headers(call)[CLIENT_CAPABILITIES_HEADER]
+                == CLIENT_CAPABILITIES
+            )
     finally:
         if server.call_processor:
             server.call_processor.stop_accepting_new_work_and_flush_queue()

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -30,6 +30,14 @@ ROW_COUNT_CHUNKING_THRESHOLD = 1000
 # parsed, the same cheap-header pattern RequestSizeLimitMiddleware already uses.
 TRACE_ID_HEADER = "X-Weave-Trace-Id"
 
+# Request header advertising the sampling-relevant capabilities this SDK build
+# guarantees, so a future server-side ingest sampler can tell a sampling-safe
+# client from an older one and leave unsupported traffic unsampled. Sent on
+# every request (it describes the client, not one trace); a comma-separated,
+# forward-compatible token list.
+CLIENT_CAPABILITIES_HEADER = "X-Weave-Client-Capabilities"
+CLIENT_CAPABILITIES = "trace_id_on_end,eval_child_meta"
+
 # Fixed wait between 404 retries. Short, because eventual-consistency windows
 # on reads-after-write are typically sub-second; longer waits just pad latency
 # when the object is genuinely missing.

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -24,6 +24,8 @@ from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcesso
 from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
 from weave.trace_server_bindings.client_interface import TraceServerClientInterface
 from weave.trace_server_bindings.http_utils import (
+    CLIENT_CAPABILITIES,
+    CLIENT_CAPABILITIES_HEADER,
     REMOTE_REQUEST_BYTES_LIMIT,
     TRACE_ID_HEADER,
     CallsCompleteModeRequired,
@@ -113,13 +115,16 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
     def _build_dynamic_request_headers(
         self, trace_id: str | None = None
     ) -> dict[str, str]:
-        """Build headers for HTTP requests, including extra headers and retry ID.
+        """Build headers for HTTP requests: extra headers, capabilities, IDs.
 
-        When ``trace_id`` is provided (single-call ingest requests), it is
-        attached as ``X-Weave-Trace-Id`` so a server-side ingest sampler can
-        decide keep/drop per trace without parsing the body.
+        Every request carries ``X-Weave-Client-Capabilities`` (the capabilities
+        this SDK build guarantees) so a future server-side ingest sampler can
+        recognize a sampling-safe client. When ``trace_id`` is provided
+        (single-call ingest requests) it is also attached as ``X-Weave-Trace-Id``
+        so the sampler can decide keep/drop per trace without parsing the body.
         """
         headers = dict(self._extra_headers) if self._extra_headers else {}
+        headers[CLIENT_CAPABILITIES_HEADER] = CLIENT_CAPABILITIES
         if retry_id := get_current_retry_id():
             headers["X-Weave-Retry-Id"] = retry_id
         if trace_id is not None:


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-35951

## Description

Both the Python and Node SDKs now send an `X-Weave-Client-Capabilities` header on every request they make to the Weave trace server. The value is a small comma-separated list of the sampling-relevant capabilities this SDK build guarantees — today `trace_id_on_end,eval_child_meta`, matching the two recent changes that put `trace_id` on every call message and tag evaluation child calls with eval metadata.

The header is groundwork for a future server-side ingest sampler. To sample the calls model safely the server has to drop whole traces consistently and never shred evaluations, which is only true once a client sends `trace_id` everywhere and marks its eval calls. The server cannot infer that from the data alone — an unmarked call is ambiguous (a normal call, or an eval child from an older client) — so the client states it directly, and the sampler leaves traffic without the header unsampled. Nothing reads the header yet; this mirrors the `X-Weave-Trace-Id` header added recently for the same future sampler.

## Why this approach

A capability list rather than an SDK version keeps the server out of mapping versions to behavior: the Python and Node SDKs version independently, and the relevant behavior landed across several releases. It is advisory, not a gate — a missing or unknown capability just means "don't sample," never a rejected request. It is set once in the shared request-header builder, so it rides every request (it describes the client, not one trace); a future sampler simply reads it on the ingest paths.

## Testing

Python: new tests assert the header is present on single-call and on batch upsert requests; the full `trace_server_bindings` suite passes (64). Node: a new `clientApi` test asserts `init()` wires the header onto the trace-server client; the full suite passes (313). The VCR cassette matcher now ignores this header the same way it already ignores the volatile `client_version` body field, so the recorded `live/` cassettes still match. Lint, format and typecheck (cjs + esm) are clean.

## Backward compatibility

Additive and safe both ways: an older server ignores the unknown header, and an older client simply doesn't send it. The Stainless transport and the one-shot login health check are out of scope, matching the `X-Weave-Trace-Id` change. One follow-up to track: if the Stainless transport later becomes the default, this header and `X-Weave-Trace-Id` must be ported to it together, otherwise the sampler would see header-less traffic from the new default client.
