### PR TITLE
fix(weave): add numeric then string fallback to eval input output sort

### DIFF
--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -10,6 +10,7 @@ from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.eval_results_query_builder import (
     build_eval_results_cte_chain,
     build_eval_results_query,
+    build_sort_expression,
 )
 
 
@@ -1106,4 +1107,191 @@ def test_full_query_calls_complete() -> None:
             "pb_4": SENTINEL_EPOCH,
             "pb_5": "proj-1",
         },
+    )
+
+
+def test_sort_output_numeric_then_string_fallback_asc() -> None:
+    """An output column sorts numerically (with a string fallback), not lexically.
+
+    Three terms mirror OrderField in the calls query: a fixed-DESC existence term
+    so numeric rows precede NULL/text rows in both directions, then the numeric
+    key, then the string key for non-numeric values.
+    """
+    pb = ParamBuilder("pb")
+    order_by = build_sort_expression(
+        [tsi.EvalResultsSortBy(field="output.predicted", direction="asc")],
+        ["eval-1"],
+        pb,
+    )
+    assert_raw_sql(
+        order_by,
+        """
+        (toFloat64OrNull(any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))) IS NOT NULL) DESC,
+        toFloat64OrNull(any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))) ASC,
+        any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '')) ASC,
+        row_digest ASC
+        """,
+        pb.get_params(),
+        {"pb_0": '$."predicted"'},
+    )
+
+
+def test_sort_output_numeric_then_string_fallback_desc() -> None:
+    """On DESC, only the numeric and string terms flip; the existence term stays DESC."""
+    pb = ParamBuilder("pb")
+    order_by = build_sort_expression(
+        [tsi.EvalResultsSortBy(field="output.predicted", direction="desc")],
+        ["eval-1"],
+        pb,
+    )
+    assert_raw_sql(
+        order_by,
+        """
+        (toFloat64OrNull(any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))) IS NOT NULL) DESC,
+        toFloat64OrNull(any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))) DESC,
+        any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '')) DESC,
+        row_digest ASC
+        """,
+        pb.get_params(),
+        {"pb_0": '$."predicted"'},
+    )
+
+
+def test_sort_inputs_numeric_then_string_fallback() -> None:
+    """An input column gets the same numeric-then-string fallback, on resolved_inputs."""
+    pb = ParamBuilder("pb")
+    order_by = build_sort_expression(
+        [tsi.EvalResultsSortBy(field="inputs.truth_x2", direction="asc")],
+        ["eval-1"],
+        pb,
+    )
+    assert_raw_sql(
+        order_by,
+        """
+        (toFloat64OrNull(any(coalesce(nullIf(JSON_VALUE(resolved_inputs, {pb_0:String}), 'null'), ''))) IS NOT NULL) DESC,
+        toFloat64OrNull(any(coalesce(nullIf(JSON_VALUE(resolved_inputs, {pb_0:String}), 'null'), ''))) ASC,
+        any(coalesce(nullIf(JSON_VALUE(resolved_inputs, {pb_0:String}), 'null'), '')) ASC,
+        row_digest ASC
+        """,
+        pb.get_params(),
+        {"pb_0": '$."truth_x2"'},
+    )
+
+
+def test_sort_scores_unchanged() -> None:
+    """Scores keep the existing single-term numeric avg (with bool coercion)."""
+    pb = ParamBuilder("pb")
+    order_by = build_sort_expression(
+        [
+            tsi.EvalResultsSortBy(
+                field="scores.accuracy",
+                direction="desc",
+                evaluation_call_id="eval-1",
+            )
+        ],
+        ["eval-1"],
+        pb,
+    )
+    assert_raw_sql(
+        order_by,
+        """
+        avg(toFloat64OrNull(CASE WHEN eval_call_id = {pb_1:String}
+            THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') = 'true', '1',
+                coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') = 'false', '0',
+                coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))
+            ELSE NULL END)) DESC,
+        row_digest ASC
+        """,
+        pb.get_params(),
+        {"pb_0": '$."scores"."accuracy"', "pb_1": "eval-1"},
+    )
+
+
+def test_sort_difference_mode_is_numeric() -> None:
+    """Difference-mode sort on an output column subtracts numeric scalars, not strings."""
+    pb = ParamBuilder("pb")
+    order_by = build_sort_expression(
+        [
+            tsi.EvalResultsSortBy(
+                field="output.predicted", direction="desc", mode="difference"
+            )
+        ],
+        ["eval-1", "eval-2"],
+        pb,
+    )
+    assert_raw_sql(
+        order_by,
+        """
+        greatest(
+            toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_1:String} THEN coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') ELSE NULL END)),
+            toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_2:String} THEN coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') ELSE NULL END))
+        ) - least(
+            toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_1:String} THEN coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') ELSE NULL END)),
+            toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_2:String} THEN coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') ELSE NULL END))
+        ) DESC,
+        row_digest ASC
+        """,
+        pb.get_params(),
+        {"pb_0": '$."predicted"', "pb_1": "eval-1", "pb_2": "eval-2"},
+    )
+
+
+def test_sort_row_digest_value_mode() -> None:
+    """row_digest is the GROUP BY key, sorted bare (plus the stable tie-breaker)."""
+    pb = ParamBuilder("pb")
+    order_by = build_sort_expression(
+        [tsi.EvalResultsSortBy(field="row_digest", direction="asc")],
+        ["eval-1"],
+        pb,
+    )
+    assert_raw_sql(
+        order_by,
+        "row_digest ASC, row_digest ASC",
+        pb.get_params(),
+        {},
+    )
+
+
+def test_sort_difference_mode_scores_is_numeric() -> None:
+    """Difference-mode sort on a score diffs the numeric avg scalar per eval."""
+    pb = ParamBuilder("pb")
+    order_by = build_sort_expression(
+        [
+            tsi.EvalResultsSortBy(
+                field="scores.accuracy", direction="desc", mode="difference"
+            )
+        ],
+        ["eval-1", "eval-2"],
+        pb,
+    )
+    assert_raw_sql(
+        order_by,
+        """
+        greatest(
+            avg(toFloat64OrNull(CASE WHEN eval_call_id = {pb_1:String}
+                THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') = 'true', '1',
+                    coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') = 'false', '0',
+                    coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))
+                ELSE NULL END)),
+            avg(toFloat64OrNull(CASE WHEN eval_call_id = {pb_2:String}
+                THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') = 'true', '1',
+                    coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') = 'false', '0',
+                    coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))
+                ELSE NULL END))
+        ) - least(
+            avg(toFloat64OrNull(CASE WHEN eval_call_id = {pb_1:String}
+                THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') = 'true', '1',
+                    coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') = 'false', '0',
+                    coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))
+                ELSE NULL END)),
+            avg(toFloat64OrNull(CASE WHEN eval_call_id = {pb_2:String}
+                THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') = 'true', '1',
+                    coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '') = 'false', '0',
+                    coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))
+                ELSE NULL END))
+        ) DESC,
+        row_digest ASC
+        """,
+        pb.get_params(),
+        {"pb_0": '$."scores"."accuracy"', "pb_1": "eval-1", "pb_2": "eval-2"},
     )

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.trace_server.query_builder.utils import assert_raw_sql
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ch_sentinel_values import SENTINEL_EPOCH
@@ -1110,48 +1112,30 @@ def test_full_query_calls_complete() -> None:
     )
 
 
-def test_sort_output_numeric_then_string_fallback_asc() -> None:
+@pytest.mark.parametrize("direction", ["asc", "desc"])
+def test_sort_output_numeric_then_string_fallback(direction: str) -> None:
     """An output column sorts numerically (with a string fallback), not lexically.
 
     Three terms mirror OrderField in the calls query: a fixed-DESC existence term
     so numeric rows precede NULL/text rows in both directions, then the numeric
-    key, then the string key for non-numeric values.
+    key and the string fallback in the requested direction.
     """
     pb = ParamBuilder("pb")
     order_by = build_sort_expression(
-        [tsi.EvalResultsSortBy(field="output.predicted", direction="asc")],
+        [tsi.EvalResultsSortBy(field="output.predicted", direction=direction)],
         ["eval-1"],
         pb,
     )
-    assert_raw_sql(
-        order_by,
-        """
-        (toFloat64OrNull(any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))) IS NOT NULL) DESC,
-        toFloat64OrNull(any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))) ASC,
-        any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '')) ASC,
-        row_digest ASC
-        """,
-        pb.get_params(),
-        {"pb_0": '$."predicted"'},
-    )
-
-
-def test_sort_output_numeric_then_string_fallback_desc() -> None:
-    """On DESC, only the numeric and string terms flip; the existence term stays DESC."""
-    pb = ParamBuilder("pb")
-    order_by = build_sort_expression(
-        [tsi.EvalResultsSortBy(field="output.predicted", direction="desc")],
-        ["eval-1"],
-        pb,
+    d = direction.upper()
+    extract = (
+        "any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))"
     )
     assert_raw_sql(
         order_by,
-        """
-        (toFloat64OrNull(any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))) IS NOT NULL) DESC,
-        toFloat64OrNull(any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), ''))) DESC,
-        any(coalesce(nullIf(JSON_VALUE(output_dump, {pb_0:String}), 'null'), '')) DESC,
-        row_digest ASC
-        """,
+        f"(toFloat64OrNull({extract}) IS NOT NULL) DESC, "
+        f"toFloat64OrNull({extract}) {d}, "
+        f"{extract} {d}, "
+        "row_digest ASC",
         pb.get_params(),
         {"pb_0": '$."predicted"'},
     )

--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -8,6 +8,7 @@ import pytest
 
 import weave
 from tests.conftest import LATENCY_TOL
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from tests.trace_server.completions_util import with_simple_mock_litellm_completion
 from weave.trace.refs import ObjectRef
 from weave.trace.serialization.custom_objs import UnsafeDeserializationError
@@ -1309,6 +1310,12 @@ def test_eval_results_sort_by_output(client):
     assert sorted_labels == ["apple", "banana", "cherry"]
 
 
+# TODO: remove the skip once the in-memory fake sorts output/input numerically
+# (it currently orders them lexicographically); ClickHouse already does.
+@pytest.mark.skipif(
+    FAKE_NOT_IMPLEMENTED,
+    reason="fake: output/input sort is lexicographic, not numeric, yet",
+)
 def test_eval_results_sort_by_numeric_output(client):
     """Numeric output columns sort by value, not lexicographically.
 
@@ -1383,6 +1390,12 @@ def test_eval_results_sort_by_numeric_output(client):
     assert sorted_predictions("desc") == [10, 2, 1]
 
 
+# TODO: remove the skip once the in-memory fake sorts output/input numerically
+# (it currently orders them lexicographically); ClickHouse already does.
+@pytest.mark.skipif(
+    FAKE_NOT_IMPLEMENTED,
+    reason="fake: output/input sort is lexicographic, not numeric, yet",
+)
 def test_eval_results_sort_by_numeric_input(client):
     """Numeric input columns sort by value, not lexicographically.
 

--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -1309,6 +1309,145 @@ def test_eval_results_sort_by_output(client):
     assert sorted_labels == ["apple", "banana", "cherry"]
 
 
+def test_eval_results_sort_by_numeric_output(client):
+    """Numeric output columns sort by value, not lexicographically.
+
+    Regression test for the ClickHouse ORDER BY: previously `output.*` fields
+    were ordered as the raw `JSON_VALUE` String, so e.g. 10 sorted before 2.
+    Executed against ClickHouse so we exercise the actual generated SQL.
+    """
+    project_id = client.project_id
+    run = client.server.evaluation_run_create(
+        EvaluationRunCreateReq(
+            project_id=project_id,
+            evaluation="eval://numeric-output-sort",
+            model="model://numeric-output-sort",
+        )
+    )
+    # Chosen so lexicographic and numeric orderings differ:
+    # lexicographic asc -> [1, 10, 2]; numeric asc -> [1, 2, 10].
+    values = [2, 10, 1]
+    for i, value in enumerate(values):
+        call_id = generate_id()
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        client.server.call_start(
+            CallStartReq(
+                start=StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=call_id,
+                    trace_id=run.evaluation_run_id,
+                    parent_id=run.evaluation_run_id,
+                    op_name="Evaluation.predict_and_score",
+                    started_at=now,
+                    attributes={},
+                    inputs={
+                        "example": {"idx": i},
+                        "model": "model://numeric-output-sort",
+                    },
+                )
+            )
+        )
+        client.server.call_end(
+            CallEndReq(
+                end=EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=call_id,
+                    ended_at=now + datetime.timedelta(seconds=1),
+                    output={
+                        "output": {"predicted": value},
+                        "scores": {"accuracy": float(i)},
+                    },
+                    summary={},
+                )
+            )
+        )
+
+    def sorted_predictions(direction: str) -> list:
+        res = client.server.eval_results_query(
+            EvalResultsQueryReq(
+                project_id=project_id,
+                evaluation_call_ids=[run.evaluation_run_id],
+                include_raw_data_rows=True,
+                sort_by=[
+                    EvalResultsSortBy(
+                        field="output.output.predicted", direction=direction
+                    )
+                ],
+            )
+        )
+        return [
+            row.evaluations[0].trials[0].model_output["predicted"] for row in res.rows
+        ]
+
+    assert sorted_predictions("asc") == [1, 2, 10]
+    assert sorted_predictions("desc") == [10, 2, 1]
+
+
+def test_eval_results_sort_by_numeric_input(client):
+    """Numeric input columns sort by value, not lexicographically.
+
+    Inputs resolve via a different path than outputs (the `resolved_inputs`
+    CTE / inline `example` fallback), so cover them separately. Executed
+    against ClickHouse so we exercise the actual generated SQL.
+    """
+    project_id = client.project_id
+    run = client.server.evaluation_run_create(
+        EvaluationRunCreateReq(
+            project_id=project_id,
+            evaluation="eval://numeric-input-sort",
+            model="model://numeric-input-sort",
+        )
+    )
+    # Chosen so lexicographic and numeric orderings differ:
+    # lexicographic asc -> [1, 10, 2]; numeric asc -> [1, 2, 10].
+    values = [2, 10, 1]
+    for value in values:
+        call_id = generate_id()
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        client.server.call_start(
+            CallStartReq(
+                start=StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=call_id,
+                    trace_id=run.evaluation_run_id,
+                    parent_id=run.evaluation_run_id,
+                    op_name="Evaluation.predict_and_score",
+                    started_at=now,
+                    attributes={},
+                    inputs={
+                        "example": {"x": value},
+                        "model": "model://numeric-input-sort",
+                    },
+                )
+            )
+        )
+        client.server.call_end(
+            CallEndReq(
+                end=EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=call_id,
+                    ended_at=now + datetime.timedelta(seconds=1),
+                    output={"output": {"label": "x"}, "scores": {"accuracy": 1.0}},
+                    summary={},
+                )
+            )
+        )
+
+    def sorted_inputs(direction: str) -> list:
+        res = client.server.eval_results_query(
+            EvalResultsQueryReq(
+                project_id=project_id,
+                evaluation_call_ids=[run.evaluation_run_id],
+                include_raw_data_rows=True,
+                sort_by=[EvalResultsSortBy(field="inputs.x", direction=direction)],
+            )
+        )
+        return [row.raw_data_row["x"] for row in res.rows]
+
+    assert sorted_inputs("asc") == [1, 2, 10]
+    assert sorted_inputs("desc") == [10, 2, 1]
+
+
 def test_eval_results_summary_with_filter(client):
     """Summary reflects filtered rows, not all rows."""
     eval_id, _ = _create_eval_with_scores(

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -263,6 +263,25 @@ def _make_field_resolver(
     return partial(resolve_eval_field_to_sql, evaluation_call_id=evaluation_call_id)
 
 
+def _sort_numeric_scalar(
+    field_path: str,
+    pb: ParamBuilder,
+    evaluation_call_id: str | None,
+) -> str:
+    """Return a single numeric scalar for a field (no direction, no multi-term).
+
+    Safe to embed inside greatest()/least() for difference-mode sorting. Scores
+    carry their bool coercion via _build_json_field_inner; inputs/output are
+    coerced to float here so numeric values sort numerically rather than
+    lexicographically. (Only ever called for scores/inputs/output fields --
+    difference mode never targets row_digest.)
+    """
+    inner, _ = _build_json_field_inner(field_path, pb, evaluation_call_id)
+    if field_path.startswith("scores."):
+        return _score_sort_numeric(inner)
+    return f"toFloat64OrNull(any({inner}))"
+
+
 def build_sort_expression(
     sort_by: list[tsi.EvalResultsSortBy] | None,
     eval_root_ids: list[str],
@@ -280,10 +299,11 @@ def build_sort_expression(
     for s in sort_by:
         direction = "DESC" if s.direction == "desc" else "ASC"
         if s.mode == "difference" and len(eval_root_ids) > 1:
-            expr = _build_difference_sort(s.field, eval_root_ids, pb)
+            parts.append(_build_difference_sort(s.field, eval_root_ids, pb, direction))
         else:
-            expr = _build_sort_aggregate(s.field, pb, s.evaluation_call_id)
-        parts.append(f"{expr} {direction}")
+            parts.append(
+                _build_sort_aggregate(s.field, pb, s.evaluation_call_id, direction)
+            )
 
     parts.append("row_digest ASC")
     return ", ".join(parts)
@@ -293,31 +313,46 @@ def _build_sort_aggregate(
     field_path: str,
     pb: ParamBuilder,
     evaluation_call_id: str | None,
+    direction: str,
 ) -> str:
-    """Build the per-field sort expression, applying the right aggregate.
+    """Build the per-field ORDER BY fragment, including its direction(s).
 
-    Scores get numeric avg (with bool coercion); other fields get any().
-    row_digest is used bare (it's the GROUP BY key).
+    - row_digest: bare GROUP BY key.
+    - scores.*: numeric avg (with bool coercion), single term.
+    - inputs.*/output.*: a three-term existence -> numeric -> string fallback,
+      mirroring OrderField in the calls query
+      (calls_query_builder._build_standard_order_sql). The existence term is
+      fixed DESC so rows with a numeric value precede NULL/text rows in BOTH
+      sort directions -- ClickHouse places NULLs first on DESC by default and
+      these builders use no explicit NULLS clauses. The numeric term sorts
+      numeric values; the string term orders the remaining (text) rows.
     """
     inner, _ = _build_json_field_inner(field_path, pb, evaluation_call_id)
     if field_path == "row_digest":
-        return inner
+        return f"{inner} {direction}"
     if field_path.startswith("scores."):
-        return _score_sort_numeric(inner)
-    return f"any({inner})"
+        return f"{_score_sort_numeric(inner)} {direction}"
+    numeric = f"toFloat64OrNull(any({inner}))"
+    string = f"any({inner})"
+    return f"({numeric} IS NOT NULL) DESC, {numeric} {direction}, {string} {direction}"
 
 
 def _build_difference_sort(
     field_path: str,
     eval_root_ids: list[str],
     pb: ParamBuilder,
+    direction: str,
 ) -> str:
-    """Build greatest(...) - least(...) expression for difference mode sorting."""
+    """Build greatest(...) - least(...) expression for difference mode sorting.
+
+    Uses the numeric scalar per eval so the subtraction is numeric; sorting an
+    output column in difference mode previously subtracted raw strings.
+    """
     per_eval_exprs: list[str] = []
     for eval_id in eval_root_ids:
-        per_eval_exprs.append(_build_sort_aggregate(field_path, pb, eval_id))
+        per_eval_exprs.append(_sort_numeric_scalar(field_path, pb, eval_id))
     joined = ", ".join(per_eval_exprs)
-    return f"greatest({joined}) - least({joined})"
+    return f"greatest({joined}) - least({joined}) {direction}"
 
 
 def _build_having_clause(


### PR DESCRIPTION
## Description

- Fixes [WB-35949](https://coreweave.atlassian.net/browse/WB-35949)

This PR fixes input and output sorting on eval results by adding numeric aware ordering to `inputs.*` and `output.*` columns in the eval results query, so columns are sorted by value instead of lexicographically.

**Problem**

We noticed that input and output columns were being sorted lexicographically. Looking at the trace calls, the values were numbers, so we diagnosed that it was an issue with the backend and not our SDK write path.

The backend creates a query, via `build_sort_expression`:
1. Scores are numerically coerced for sorting
2. inputs.* and output.* were ordered as the raw JSON_VALUE String via `any(...)`, so ch sorted them lexicographically. 

**Solution**

Make the input and output column sorting numeric aware with a string fallback so these columns sort as expected. All changes are in `eval_results_query_builder.py`:
* `_build_sort_aggregate` now gives `inputs.*/output.*` a three term existence → numeric → string ordering:
1. `(toFloat64OrNull(any(x)) IS NOT NULL) DESC` — group rows that have a numeric value ahead of non-numeric/missing rows. It's pinned DESC (regardless of the requested direction) so that grouping holds for both ascending and descending sorts.
2. `toFloat64OrNull(any(x)) {dir}` — sort the numeric values by their actual number, in the requested direction.
3. `any(x) {dir}` — fall back to alphabetical order for the remaining non-numeric (text) values.
* `_build_difference_sort` now uses a new `_sort_numeric_scalar` helper, so it subtracts numeric scalars instead of raw strings.

## Testing
**Before**
Sorting on inputs:
<img width="171" height="424" alt="image" src="https://github.com/user-attachments/assets/f068c5c1-6ff1-4b01-95a9-bce05604ce74" />


Sorting on outputs:
<img width="241" height="430" alt="image" src="https://github.com/user-attachments/assets/e97b9bbc-e182-406d-83fb-b3be4163e32c" />



**After**
Sorting on inputs:
<img width="167" height="413" alt="image" src="https://github.com/user-attachments/assets/a05406d0-8e57-4cfb-9fb6-b4b3d9c373b5" />

Sorting on outputs:
<img width="247" height="423" alt="image" src="https://github.com/user-attachments/assets/c3a3cbde-83fb-493f-9eee-a0087db9d724" />



- [x] Added unit tests
- [x] Added clickhouse tests 
- [x] Tested on dev_mtsaas 

Follow-up PR for the in-memory test backend: https://github.com/wandb/weave/pull/7354

[WB-35949]: https://coreweave.atlassian.net/browse/WB-35949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ