### PR TITLE
fix(weave): validate agent signal filters against the agent-spans schema

### DIFF
--- a/tests/trace_server/calls_query_builder/test_monitor_query_validation.py
+++ b/tests/trace_server/calls_query_builder/test_monitor_query_validation.py
@@ -1,0 +1,146 @@
+"""Unit tests for saved-Monitor query validation.
+
+Agent monitors (op_names include an agent-span op) validate against the
+agent-spans schema, so logical fields like `operation_name` are accepted there
+but still rejected on a regular monitor (validated against the calls schema).
+"""
+
+import pytest
+
+from weave.flow.monitor import AGENT_SPAN_OP_NAMES as FLOW_AGENT_SPAN_OP_NAMES
+from weave.trace_server.agents.constants import AGENT_SPAN_OP_NAMES
+from weave.trace_server.calls_query_builder.monitor_query_validation import (
+    validate_monitor_query_fields,
+)
+from weave.trace_server.errors import InvalidFieldError, InvalidRequest
+
+AGENT_OP = next(iter(AGENT_SPAN_OP_NAMES))
+# A normalized (non-agent) op-name ref, as a regular monitor stores them.
+CALL_OP_REF = "weave:///entity/project/op/my_op:abc123"
+
+
+def _eq(field: str, value: object) -> dict:
+    return {"$expr": {"$eq": [{"$getField": field}, {"$literal": value}]}}
+
+
+def _monitor_val(*, op_names: list[str], query: object) -> dict:
+    return {
+        "_type": "Monitor",
+        "_class_name": "Monitor",
+        "_bases": ["Monitor", "Object", "BaseModel"],
+        "op_names": op_names,
+        "query": query,
+    }
+
+
+def _validate(val: dict) -> None:
+    validate_monitor_query_fields("Monitor", "Monitor", val)
+
+
+class TestConstantInSync:
+    def test_agent_span_op_names_mirror_flow(self) -> None:
+        # The trace-server copy is mirrored from weave/flow/monitor.py so the
+        # trace server can detect agent monitors without importing weave.flow.
+        assert AGENT_SPAN_OP_NAMES == FLOW_AGENT_SPAN_OP_NAMES
+
+
+class TestAgentMonitorQuery:
+    def test_operation_name_filter_accepted(self) -> None:
+        # The reported bug: an agent signal filtering on Operation name = "chat"
+        # was rejected with a 422 because it was validated against calls_merged.
+        _validate(
+            _monitor_val(op_names=[AGENT_OP], query=_eq("operation_name", "chat"))
+        )
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("agent_name", "my-agent"),
+            ("agent_version", "v1"),
+            ("provider_name", "openai"),
+            ("request_model", "gpt-4"),
+            ("response_model", "gpt-4"),
+            ("tool_name", "search"),
+            ("tool_type", "function"),
+            ("conversation_id", "conv-1"),
+            ("status_code", "OK"),
+            ("error_type", "timeout"),
+            ("span_kind", "agent"),
+            ("wb_run_id", "run-1"),
+        ],
+    )
+    def test_logical_agent_fields_accepted(self, field: str, value: str) -> None:
+        _validate(_monitor_val(op_names=[AGENT_OP], query=_eq(field, value)))
+
+    def test_anded_filters_accepted(self) -> None:
+        query = {
+            "$expr": {
+                "$and": [
+                    {"$eq": [{"$getField": "operation_name"}, {"$literal": "chat"}]},
+                    {"$eq": [{"$getField": "agent_name"}, {"$literal": "bot"}]},
+                ]
+            }
+        }
+        _validate(_monitor_val(op_names=[AGENT_OP], query=query))
+
+    def test_agent_monitor_alongside_other_op_names(self) -> None:
+        # Membership is enough; a mixed op_names list still counts as agent.
+        _validate(
+            _monitor_val(
+                op_names=[CALL_OP_REF, AGENT_OP],
+                query=_eq("operation_name", "chat"),
+            )
+        )
+
+    def test_unresolvable_agent_field_rejected(self) -> None:
+        # Field-compared-to-field offers no literal type to infer a custom-attr
+        # map from, so it can't resolve to a column -> fail loudly.
+        query = {
+            "$expr": {
+                "$eq": [
+                    {"$getField": "totally_unknown"},
+                    {"$getField": "also_unknown"},
+                ]
+            }
+        }
+        with pytest.raises(InvalidRequest):
+            _validate(_monitor_val(op_names=[AGENT_OP], query=query))
+
+
+class TestRegularMonitorQuery:
+    def test_calls_field_accepted(self) -> None:
+        _validate(_monitor_val(op_names=[CALL_OP_REF], query=_eq("op_name", "foo")))
+
+    def test_attributes_path_accepted(self) -> None:
+        _validate(
+            _monitor_val(
+                op_names=[CALL_OP_REF],
+                query=_eq("attributes.weave.operation.name", "chat"),
+            )
+        )
+
+    def test_logical_agent_field_still_rejected(self) -> None:
+        # A non-agent monitor must keep rejecting agent-span logical names; the
+        # error carries the allowed-calls-field list (InvalidFieldError).
+        with pytest.raises(InvalidFieldError):
+            _validate(
+                _monitor_val(
+                    op_names=[CALL_OP_REF], query=_eq("operation_name", "chat")
+                )
+            )
+
+
+class TestNoQuery:
+    def test_agent_monitor_without_query_is_noop(self) -> None:
+        _validate(_monitor_val(op_names=[AGENT_OP], query=None))
+
+    def test_regular_monitor_without_query_is_noop(self) -> None:
+        _validate(_monitor_val(op_names=[CALL_OP_REF], query=None))
+
+    def test_non_monitor_object_ignored(self) -> None:
+        # Non-Monitor objects are never validated, even with a Monitor-ish val.
+        validate_monitor_query_fields(
+            "Scorer",
+            "Scorer",
+            _monitor_val(op_names=[AGENT_OP], query=_eq("not_a_field", 1)),
+        )

--- a/weave/trace_server/agents/constants.py
+++ b/weave/trace_server/agents/constants.py
@@ -116,3 +116,13 @@ MAX_INGEST_ERRORS_REPORTED = 20
 # Other operation names are treated as regular content spans.
 OP_INVOKE_AGENT = "invoke_agent"
 OP_EXECUTE_TOOL = "execute_tool"
+
+# ---------------------------------------------------------------------------
+# Agent-span monitor op names
+# ---------------------------------------------------------------------------
+
+# Op-name literals a Monitor lists in `op_names` to target agent turns. Mirrors
+# `AGENT_SPAN_OP_NAMES` in `weave/flow/monitor.py` (kept here as plain strings so
+# the trace server needn't import `weave.flow`; a test asserts they stay equal),
+# and drives agent vs. calls query validation in `monitor_query_validation`.
+AGENT_SPAN_OP_NAMES: frozenset[str] = frozenset({"weave.genai.turn_ended"})

--- a/weave/trace_server/calls_query_builder/monitor_query_validation.py
+++ b/weave/trace_server/calls_query_builder/monitor_query_validation.py
@@ -1,19 +1,20 @@
-"""Server-side validation for saved Monitor object queries.
+"""Server-side validation for saved Monitor object queries at obj_create time.
 
-A Monitor carries a `query` over call fields that the scoring worker runs every
-cycle. We reject queries referencing disallowed fields or that are structurally
-invalid at obj_create time, so a bad monitor fails loudly on save instead of
-silently erroring per scoring cycle.
+Regular monitors validate against the `calls_merged` schema; agent monitors
+(op_names include an agent-span op) against the agent-spans schema, so logical
+fields like `operation_name` aren't wrongly rejected (the agent-signal 422).
 """
 
 from pydantic import ValidationError
 
+from weave.trace_server.agents.constants import AGENT_SPAN_OP_NAMES
 from weave.trace_server.calls_query_builder.calls_query_builder import (
     process_query_to_conditions,
 )
 from weave.trace_server.errors import InvalidRequest
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.query_builder.agent_query_compiler import compile_agent_query
 
 
 def validate_monitor_query_fields(
@@ -27,7 +28,10 @@ def validate_monitor_query_fields(
     query = _monitor_query(val)
     if query is None:
         return
-    _validate_calls_query(query)
+    if _is_agent_monitor(val):
+        _validate_agent_spans_query(query)
+    else:
+        _validate_calls_query(query)
 
 
 def _validate_calls_query(query: tsi_query.Query) -> None:
@@ -40,6 +44,18 @@ def _validate_calls_query(query: tsi_query.Query) -> None:
     """
     try:
         process_query_to_conditions(query, ParamBuilder(), "calls_merged")
+    except (ValueError, TypeError) as e:
+        raise InvalidRequest(f"Invalid query: {e}") from e
+
+
+def _validate_agent_spans_query(query: tsi_query.Query) -> None:
+    """Like `_validate_calls_query`, but compiles against the agent-spans schema.
+
+    Accepts logical agent-span fields (`operation_name`, ...) while still failing
+    loudly on unknown ones; `compile_agent_query` raises a ValueError remapped here.
+    """
+    try:
+        compile_agent_query(query, ParamBuilder())
     except (ValueError, TypeError) as e:
         raise InvalidRequest(f"Invalid query: {e}") from e
 
@@ -57,6 +73,20 @@ def _is_monitor_object(
         base_object_class in MONITOR_OBJECT_CLASSES
         or leaf_object_class in MONITOR_OBJECT_CLASSES
     )
+
+
+def _is_agent_monitor(val: object) -> bool:
+    """Whether a Monitor targets agent spans, by its serialized `op_names`.
+
+    Agent-span op literals are stored verbatim (not normalized to `weave:///`
+    refs), so a plain membership check against `AGENT_SPAN_OP_NAMES` suffices.
+    """
+    if not isinstance(val, dict):
+        return False
+    op_names = val.get("op_names")
+    if not isinstance(op_names, list):
+        return False
+    return any(op in AGENT_SPAN_OP_NAMES for op in op_names)
 
 
 def _monitor_query(val: object) -> tsi_query.Query | None:


### PR DESCRIPTION
## Problem

In the new **Agents → Signals** tab, changing the "Only score turns matching" filter on an agent signal (e.g. `Operation name = "chat"`) failed to save with a **422 Unprocessable Content** from `POST /obj/create`:

```
Field operation_name is not allowed. Allowed fields: attributes, display_name, ended_at, ...
op_name, ... Allowed dynamic prefixes: attributes.*, feedback.*, inputs.*, output.*, summary.*, ...
```

(Same error for `agent_name`, `provider_name`, etc.)

## Root cause

An agent signal persists a `Monitor` whose `query` is a Mongo-style `$expr` built from the filter editor. The filter editor uses **logical agent-span field names** — `operation_name`, `agent_name`, `provider_name`, `request_model`, `conversation_id`, `tool_name`, … — which is correct: those are exactly the fields the agent **Spans** tab and the agent scoring worker's `agent_spans_query` understand (resolved by `compile_agent_query` against the denormalized agent-spans schema).

But at `obj_create` time, `validate_monitor_query_fields` validated **every** monitor query against the raw **`calls_merged`** schema via `process_query_to_conditions`. That schema only allows `op_name`, `attributes.*`, `inputs.*`, `output.*`, `summary.*`, etc. — so the agent-span logical fields were rejected and the save 422'd.

The two consumers of a monitor `query` want **different schemas**:

| Monitor kind | Scored over | Valid fields |
| --- | --- | --- |
| Regular monitor | raw calls (`calls_merged`) | `op_name`, `attributes.*`, `inputs.*`, … |
| Agent monitor (`op_names` ⊇ `weave.genai.turn_ended`) | agent spans (`agent_spans_query`) | `operation_name`, `agent_name`, … |

Validating an agent query against `calls_merged` was simply the wrong schema. (Conversely, a frontend-side rewrite to `attributes.weave.*` raw paths would have cleared the 422 but broken the scoring worker, which passes the stored query verbatim into `agent_spans_query` — so the fix belongs here, on the validation side.)

## Change

- `validate_monitor_query_fields` now branches on whether the monitor is an **agent monitor** (its `op_names` include an agent-span op literal). Agent-monitor queries are validated with `compile_agent_query` (the agent-spans schema); regular-monitor queries keep using `process_query_to_conditions` against `calls_merged`. Unknown fields still fail loudly on both paths.
- Added `AGENT_SPAN_OP_NAMES` to `weave/trace_server/agents/constants.py`, mirroring `weave/flow/monitor.AGENT_SPAN_OP_NAMES`, so the trace server can detect agent monitors **without importing `weave.flow`** (the validation module deliberately avoids that dependency). A test asserts the two stay in sync.

## Tests

New `tests/trace_server/calls_query_builder/test_monitor_query_validation.py` (23 cases):
- agent monitors accept `operation_name` and all the other logical agent-span fields, single and AND-ed;
- regular monitors still accept calls fields (`op_name`, `attributes.*`) and **still reject** agent logical names;
- unresolvable agent fields raise `InvalidRequest`; null query / non-Monitor objects are no-ops;
- the mirrored constant equals `weave.flow`'s.

```
tests/trace_server/calls_query_builder/test_monitor_query_validation.py .... 23 passed
tests/trace_server/query_builder/test_agent_query_compiler.py + test_calls_query_builder.py .... 162 passed
```

`ruff check` / `ruff format --check` clean on the changed files.

## Scope / notes

- Backend-only fix; no frontend (`wandb/core`) change is needed — the filter editor already emits the correct logical field names.
- The second issue from the bug report (empty `{output_messages}` in the scorer prompt) is **not** addressed here, per the request to focus on the 422.
- Could not run the full trace-server suite locally (it needs ClickHouse/Kafka infra); CI covers that. The unit tests above run standalone.

---
Re-opens #7345, which was authored by the Fixit bot and could not pass the CLA check under a bot account.
