### PR TITLE
fix(weave): surface interleaved reasoning between tool calls in agent chat

### DIFF
--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -532,6 +532,148 @@ def test_reasoning_part_not_duplicated_in_assistant_text() -> None:
     assert payload.reasoning_content == reasoning
 
 
+def _tool_call_part(name: str, arguments: str) -> dict:
+    return {"type": "tool_call", "id": "tc1", "name": name, "arguments": arguments}
+
+
+def test_interleaved_reasoning_before_tool_call_is_surfaced() -> None:
+    """Reasoning that precedes a tool call (an LLM step whose only output is a
+    tool call, no assistant text) must still surface as a reasoning-only
+    message, in order before the tool call — not be dropped because the step
+    produced no final text.
+    """
+
+    def at(seconds: int) -> datetime.datetime:
+        return datetime.datetime(
+            2026, 1, 1, 0, 0, seconds, tzinfo=datetime.timezone.utc
+        )
+
+    step_reasoning = "Deciding to inspect the workspace"
+    final_reasoning = "Summarizing what I found"
+    answer = "The eval suite has 17 scenarios."
+
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="wb-agent",
+            input_messages=[{"role": "user", "content": "How many scenarios?"}],
+            started_at=at(0),
+        ),
+        # LLM step that reasons then calls a tool: reasoning + tool_call parts,
+        # no text part.
+        _span(
+            span_id="llm1",
+            parent_span_id="agent",
+            operation_name="chat",
+            output_messages=[
+                {
+                    "role": "assistant",
+                    "content": _parts(
+                        {"type": "reasoning", "content": step_reasoning},
+                        _tool_call_part("shell", '{"command": "ls"}'),
+                    ),
+                }
+            ],
+            reasoning_content=step_reasoning,
+            started_at=at(1),
+        ),
+        _span(
+            span_id="tool1",
+            parent_span_id="agent",
+            operation_name="execute_tool",
+            span_name="execute_tool shell",
+            tool_name="shell",
+            tool_call_arguments='{"command": "ls"}',
+            tool_call_result="17 files",
+            started_at=at(2),
+        ),
+        # Final LLM step: reasoning + the answer text.
+        _span(
+            span_id="llm2",
+            parent_span_id="agent",
+            operation_name="chat",
+            output_messages=[
+                {
+                    "role": "assistant",
+                    "content": _parts(
+                        {"type": "reasoning", "content": final_reasoning},
+                        _text_part(answer),
+                    ),
+                }
+            ],
+            reasoning_content=final_reasoning,
+            started_at=at(3),
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+    types = [m.type for m in messages]
+
+    # The interleaved reasoning step is emitted before its tool call, and the
+    # final answer (with its own reasoning) comes last.
+    assert types == [
+        "user_message",
+        "agent_start",
+        "assistant_message",  # reasoning-only step
+        "tool_call",
+        "assistant_message",  # final answer
+    ]
+
+    step = _assistant_payload(messages[2])
+    assert step.text == ""
+    assert step.reasoning_content == step_reasoning
+
+    final = _assistant_payload(messages[4])
+    assert final.text == answer
+    assert final.reasoning_content == final_reasoning
+
+
+def test_tool_call_step_without_reasoning_emits_no_assistant_message() -> None:
+    """A tool-calling LLM step that carries neither assistant text nor
+    reasoning must not produce an empty assistant bubble.
+    """
+
+    def at(seconds: int) -> datetime.datetime:
+        return datetime.datetime(
+            2026, 1, 1, 0, 0, seconds, tzinfo=datetime.timezone.utc
+        )
+
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="wb-agent",
+            input_messages=[{"role": "user", "content": "run it"}],
+            started_at=at(0),
+        ),
+        _span(
+            span_id="llm1",
+            parent_span_id="agent",
+            operation_name="chat",
+            output_messages=[
+                {
+                    "role": "assistant",
+                    "content": _parts(_tool_call_part("shell", "{}")),
+                }
+            ],
+            started_at=at(1),
+        ),
+        _span(
+            span_id="tool1",
+            parent_span_id="agent",
+            operation_name="execute_tool",
+            span_name="execute_tool shell",
+            tool_name="shell",
+            tool_call_result="done",
+            started_at=at(2),
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+    assert [m.type for m in messages if m.type == "assistant_message"] == []
+
+
 def test_subagent_spans_render_inline_with_agent_label_inheritance() -> None:
     def at(seconds: int) -> datetime.datetime:
         return datetime.datetime(

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -328,7 +328,14 @@ class ChatTraversal:
     def _walk_content_span(
         self, node: SpanNode, nearest_agent: str | None, depth: int
     ) -> bool:
-        """Walk a regular content span and emit its assistant text if present."""
+        """Walk a regular content span and emit its assistant text if present.
+
+        A span that produced reasoning but no assistant text (an LLM step that
+        only emitted a tool call) still emits a reasoning-only message, so
+        thinking interleaved between tool calls is surfaced rather than dropped.
+        Such a step is not the turn's final assistant text, so it does not
+        suppress a mirrored final message on the enclosing `invoke_agent` span.
+        """
         span = node.span
         agent_name = _agent_label(span, nearest_agent)
         subtree_emitted_assistant = self._walk_children(
@@ -336,10 +343,12 @@ class ChatTraversal:
         )
 
         msg = _emit_assistant_message(span, agent_name)
-        if msg:
-            self.messages.append(msg)
-            return True
-        return subtree_emitted_assistant
+        if msg is None:
+            return subtree_emitted_assistant
+        self.messages.append(msg)
+        assistant = msg.assistant_message
+        emitted_text = bool(assistant and assistant.text)
+        return emitted_text or subtree_emitted_assistant
 
     def _walk_children(
         self, node: SpanNode, nearest_agent: str | None, depth: int
@@ -671,12 +680,19 @@ def _emit_assistant_message(
     descendant LLM span. Callers pass `aggregate_node` only when the invoke span
     itself needs to emit because no descendant already did; in that case token
     usage is summed across the subtree so the emitted message reflects the
-    whole agent turn. Returns None when there is no non-user output text.
+    whole agent turn.
+
+    A span that produced reasoning but no assistant text (e.g. an LLM step that
+    only emitted a tool call) still yields a message carrying that reasoning, so
+    thinking interleaved between tool calls is surfaced rather than dropped.
+    Returns None only when there is neither output text nor reasoning content.
     """
-    if not span.output_messages:
-        return None
-    text = _extract_non_user_output_text(span.output_messages)
-    if not text:
+    text = (
+        _extract_non_user_output_text(span.output_messages)
+        if span.output_messages
+        else ""
+    )
+    if not text and not span.reasoning_content:
         return None
 
     if aggregate_node:


### PR DESCRIPTION
## Problem

In the Agents UI, an assistant turn's reasoning ("thinking") showed up **only when it immediately preceded the final text response** — reasoning that happened **between tool calls** was silently dropped.

Root cause is in the chat-view projection, not in instrumentation, ingest, or storage:

- `reasoning_content` is only ever attached to an `assistant_message`.
- An `assistant_message` is only emitted when a span produced output **text** (`_emit_assistant_message` returned `None` when `_extract_non_user_output_text` was empty).
- An LLM step whose output is a tool call carries `reasoning + tool_call` parts but **no text**, so it produced no `assistant_message` — and its reasoning was discarded. The actual tool call is rendered from a separate `execute_tool` span, which has no reasoning field.

Net effect: reasoning survived only on the final, text-producing step of a turn.

## Fix

Emit a **reasoning-only** assistant message for content spans that carry reasoning but no text, ordered right before the resulting tool call:

- `_emit_assistant_message` gains an `include_reasoning_only` flag. When set, a span with `reasoning_content` but no output text still yields a message (empty `text`, populated `reasoning_content`).
- `_walk_content_span` passes `include_reasoning_only=True`. Crucially, a reasoning-only step is **not** counted as the turn's final assistant text, so it does not suppress the mirrored-final-message logic on the enclosing `invoke_agent` span.

**No frontend change needed:** the chat view already renders the reasoning block independently of body text, and an empty text body renders nothing (`CollapsibleSmartText` returns `null` for empty input).

## Validation

- Unit tests: full `test_genai_chat_view.py` suite passes (22), plus two new tests:
  - interleaved reasoning surfaces as a reasoning-only step, in order before its tool call;
  - a tool-calling step with neither text nor reasoning emits no (empty) assistant bubble.
- **Real data:** replayed a production `wb-agent-prod` conversation through the patched projection. Reasoning went from surfacing on **2 of 9** assistant turns to **all 19** reasoning-bearing LLM steps (17 previously-dropped interleaved steps + 2 final), matching the reasoning content captured at ingest exactly.

## Scope / risk

- Pure projection change; no schema, ingest, or migration impact. The reasoning data was already stored in `reasoning_content` — this only stops the read path from dropping it.
- The mirror/aggregation path for `invoke_agent` is unchanged (reasoning-only steps deliberately don't flip the "emitted final text" signal).
