### PR TITLE
chore(weave): skip weekend nightly test runs

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -2,8 +2,8 @@ name: nightly-tests
 
 on:
   schedule:
-    # Run at midnight UTC
-    - cron: "0 0 * * *"
+    # Run at midnight UTC, Monday-Friday only (skip weekends)
+    - cron: "0 0 * * 1-5"
   # Allow manual triggering
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- Nightly suite runs daily against `master` HEAD. When nothing merges over the weekend (the common case), the Sat/Sun runs re-test Friday's commit and only generate redundant CI cost + a Slack page nobody acts on until Monday.
- Restrict the cron from `0 0 * * *` to `0 0 * * 1-5` (Mon-Fri UTC). The Mon 00:00 UTC firing (~Sun 5pm PT) still covers the weekend's state before Monday morning.

## Testing
non-functional change (cron schedule only).