### PR TITLE
fix(weave): return 400 not 500 on feedback with malformed annotation spec

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -214,6 +214,38 @@ def test_annotation_feedback(client: WeaveClient) -> None:
     }
 
 
+@pytest.mark.parametrize(
+    "bad_spec",
+    [None, {"field_schema": None}, "not-a-spec"],
+    ids=["null_spec", "null_field_schema", "scalar"],
+)
+def test_annotation_feedback_malformed_spec_is_invalid_request(
+    client: WeaveClient, bad_spec: object
+) -> None:
+    """A malformed annotation spec yields InvalidRequest, not an unhandled 500 (WB-35940)."""
+    project_id = client.project_id
+    column_name = "malformed_spec"
+    digest = client.server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=project_id, object_id=column_name, val=bad_spec
+            )
+        )
+    ).digest
+    annotation_ref = f"weave:///{project_id}/object/{column_name}:{digest}"
+
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=f"weave:///{project_id}/call/call_id_123",
+                feedback_type=f"wandb.annotation.{column_name}",
+                payload={"value": 1},
+                annotation_ref=annotation_ref,
+            )
+        )
+
+
 def test_runnable_feedback(client: WeaveClient) -> None:
     """Test feedback creation with runnable references."""
     project_id = client.project_id

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -221,8 +221,13 @@ def validate_feedback_create_req(
         # 3. Validate the payload against the annotation spec
         value = req.payload["value"]
         spec = data.vals[0]
-        is_valid = AnnotationSpec.model_validate(spec).value_is_valid(value)
-        if not is_valid:
+        try:
+            annotation_spec = AnnotationSpec.model_validate(spec)
+        except ValidationError as e:
+            raise InvalidRequest(
+                f"Annotation ref {req.annotation_ref} is not a valid annotation spec"
+            ) from e
+        if not annotation_spec.value_is_valid(value):
             raise InvalidRequest("Feedback payload does not match annotation spec")
     if req.runnable_ref:
         ensure_ref_is_valid(req.runnable_ref, (ri.InternalOpRef, ri.InternalObjectRef))

--- a/weave/trace_server/interface/builtin_object_classes/annotation_spec.py
+++ b/weave/trace_server/interface/builtin_object_classes/annotation_spec.py
@@ -45,8 +45,8 @@ class AnnotationSpec(base_object_def.BaseObject):
 
     @model_validator(mode="before")
     @classmethod
-    def preprocess_field_schema(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if "field_schema" not in data:
+    def preprocess_field_schema(cls, data: Any) -> Any:
+        if not isinstance(data, dict) or "field_schema" not in data:
             return data
 
         field_schema = data["field_schema"]


### PR DESCRIPTION
## Summary
- Jira: [WB-35940](https://coreweave.atlassian.net/browse/WB-35940)
- `/feedback/create` 500s with `TypeError: argument of type 'NoneType' is not iterable` when `annotation_ref` resolves to a malformed spec (null spec or null `field_schema`): `preprocess_field_schema` ran `"field_schema" not in data` on a non-dict, and the error escaped unhandled.
- Guard non-dict input in `preprocess_field_schema`, and wrap `AnnotationSpec.model_validate` so a bad spec raises `InvalidRequest` instead. The 422->400 mapping for that `InvalidRequest` lands in the paired core PR: https://github.com/wandb/core/pull/46439

## Testing
parametrized functional test in test_feedback.py; fails on master (TypeError/ValidationError), passes here.

[WB-35940]: https://coreweave.atlassian.net/browse/WB-35940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ