### PR TITLE
test(weave): fix two flaky trace tests

### DIFF
--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -232,6 +232,9 @@ def slow_operation():
 
 
 def speed_test(client, count=5):
+    # Warm the pool so lazy worker-thread spawning isn't charged to queue_time.
+    for fut in [client.future_executor.defer(slow_operation) for _ in range(count)]:
+        fut.result()
     start = time.time()
     futs = [client.future_executor.defer(slow_operation) for _ in range(count)]
     queue_time = time.time()

--- a/tests/trace/test_tracing_resilience.py
+++ b/tests/trace/test_tracing_resilience.py
@@ -8,6 +8,7 @@ We should never be breaking the user's program with an error.
 from __future__ import annotations
 
 import gc
+import time
 import weakref
 from collections import Counter
 from unittest.mock import MagicMock
@@ -119,6 +120,11 @@ def test_resilience_to_obj_create_failure_does_not_pin_payload(
         pass
     client_with_throwing_server.future_executor.flush()
 
+    # flush() can return before the future's failure done-callback clears the
+    # ref, so wait for the eventual release rather than racing it.
+    deadline = time.monotonic() + 5.0
+    while obj.ref is not None and time.monotonic() < deadline:
+        time.sleep(0.005)
     assert obj.ref is None
 
     del obj


### PR DESCRIPTION
## Summary
- From a 7-day audit of the `#weave-test-flake` monitor. Two of the three real flaky tests (the third, `test_call_batch_uploads_files_to_bucket_in_parallel`, was already fixed on master in #7247).
- `test_client_parallelism_setting`: warm the pool in `speed_test` so lazy worker-thread spawning isn't charged to the measured `queue_time`; that startup spike (~0.5s) is what blew the `approx(abs=0.5)` check.
- `test_resilience_to_obj_create_failure_does_not_pin_payload`: `flush()` can return before the failure done-callback clears `obj.ref` (active-set removal is registered before the ref-clear), so wait for the eventual release instead of racing it.

## Testing
ran both locally many times (stable). ref-pin race is a nanosecond window between two done-callbacks, so it surfaces under CI contention, not on a quiet box; confirmed by source analysis.
