### PR TITLE
chore(weave): Decouple `weave.flow` from `trace_server`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -627,7 +627,6 @@ allow_indirect_imports = true
 # forbidding trace_server's internal imports; every file that does so also
 # leaks via a client subpackage below, so none escape the contract.
 ignore_imports = [
-  "weave.trace_server.agents.kafka_events -> weave.flow.monitor",
   "weave.trace_server.base64_content_conversion -> weave.type_wrappers.Content.content",
   "weave.trace_server.image_completion -> weave.type_wrappers.Content.content",
   "weave.trace_server.interface.builtin_object_classes.llm_structured_model -> weave.prompt.prompt",

--- a/weave/trace_server/agents/kafka_events.py
+++ b/weave/trace_server/agents/kafka_events.py
@@ -7,8 +7,11 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-from weave.flow.monitor import AgentSpanOpName
-from weave.trace_server.agents.schema import AgentSpanCHInsertable, StatusCodeLiteral
+from weave.trace_server.agents.schema import (
+    AgentSpanCHInsertable,
+    AgentSpanOpName,
+    StatusCodeLiteral,
+)
 from weave.trace_server.ch_sentinel_values import SENTINEL_EPOCH as SENTINEL_EPOCH_UTC
 
 if TYPE_CHECKING:

--- a/weave/trace_server/agents/schema.py
+++ b/weave/trace_server/agents/schema.py
@@ -10,7 +10,7 @@ extraction logic that applies those conventions lives in
 """
 
 import datetime
-from typing import Literal
+from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, Field
 
@@ -25,6 +25,13 @@ SpanKindLiteral = Literal[
     "CONSUMER",
 ]
 StatusCodeLiteral = Literal["UNSET", "OK", "ERROR"]
+
+# Operation names of agent spans the server emits scoring events for. This is a
+# server/wire concept (the span op-name the server produces and matches on), so
+# the trace server owns it here. `weave.flow.monitor` keeps an independent copy
+# of the same literal for the client-side `Monitor.op_names` field; the two are
+# deliberately not shared, to keep the trace server free of client imports.
+AgentSpanOpName: TypeAlias = Literal["weave.genai.turn_ended"]
 # Empty string means the provider did not specify an output modality; it
 # mirrors the ClickHouse string-column default for newly inserted spans.
 OutputTypeLiteral = Literal["", "text", "json", "image", "speech"]


### PR DESCRIPTION
Decouples `weave.flow` from `trace_server` by moving the `AgentSpanOpName` literal into the trace server (`weave/trace_server/agents/schema.py`) instead of importing it from `weave.flow.monitor`.