### PR TITLE
chore(weave): Decouple `weave.prompt` from `trace_server`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -635,7 +635,6 @@ ignore_imports = [
   "weave.trace_server.interface.builtin_object_classes.llm_structured_model -> weave.utils.project_id",
   "weave.trace_server.isolated_client_executor -> weave.trace.context.weave_client_context",
   "weave.trace_server.isolated_client_executor -> weave.trace.weave_client",
-  "weave.trace_server.llm_completion -> weave.prompt.prompt",
   "weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker -> weave.evaluation.eval",
   "weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker -> weave.scorers.llm_as_a_judge_scorer",
   "weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker -> weave.trace.context.weave_client_context",

--- a/weave/trace_server/llm_completion.py
+++ b/weave/trace_server/llm_completion.py
@@ -7,7 +7,6 @@ from cachetools import TTLCache
 from litellm import CustomStreamWrapper
 from pydantic import BaseModel
 
-from weave.prompt.prompt import format_message_with_template_vars
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import (
     InvalidRequest,
@@ -36,6 +35,45 @@ _custom_provider_cache: TTLCache[tuple[str, str, str], "CustomProviderInfo"] = T
     ttl=CUSTOM_PROVIDER_CACHE_TTL_SECONDS,
 )
 _custom_provider_cache_lock = threading.Lock()
+
+
+# Vendored from weave.prompt.prompt to keep the trace server free of client-SDK
+# imports (the client keeps its own copy). The logic is small and the two are
+# deliberately not shared via a common module.
+class IncorrectPromptVarError(Exception):
+    """Raised when prompt template variables are incorrect or missing."""
+
+
+def format_message_with_template_vars(message: dict, **kwargs: Any) -> dict:
+    """Format a message dictionary by replacing template variables.
+
+    Recursively processes message dictionaries, replacing template variables in
+    string values using Python's ``.format()`` syntax, including nested
+    multimodal content lists.
+
+    Raises:
+        IncorrectPromptVarError: If a template variable is not found in kwargs.
+    """
+    formatted: dict[str, Any] = {}
+    for key, value in message.items():
+        if isinstance(value, str):
+            try:
+                formatted[key] = value.format(**kwargs)
+            except KeyError as e:
+                missing_key = e.args[0] if e.args else str(e).strip("'\"")
+                available_keys = ", ".join(sorted(kwargs.keys()))
+                raise IncorrectPromptVarError(
+                    f"Prompt template variable '{missing_key}' not found. "
+                    f"Available variables: {available_keys}"
+                ) from e
+        elif isinstance(value, list) and all(isinstance(d, dict) for d in value):
+            # Recursively format nested dicts in lists
+            formatted[key] = [
+                format_message_with_template_vars(d, **kwargs) for d in value
+            ]
+        else:
+            formatted[key] = value
+    return formatted
 
 
 def parse_prompt_reference(prompt: str) -> tuple[str, str, str | None]:


### PR DESCRIPTION
Decouples `weave.prompt` from `trace_server` by vendoring `format_message_with_template_vars` into `weave/trace_server/llm_completion.py` instead of importing it from `weave.prompt.prompt`.