### PR TITLE
chore(weave): Decouple `weave.type_wrappers` from `trace_server`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -635,7 +635,6 @@ ignore_imports = [
   "weave.trace_server.interface.builtin_object_classes.llm_structured_model -> weave.utils.project_id",
   "weave.trace_server.isolated_client_executor -> weave.trace.context.weave_client_context",
   "weave.trace_server.isolated_client_executor -> weave.trace.weave_client",
-  "weave.trace_server.llm_completion -> weave.prompt.prompt",
   "weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker -> weave.evaluation.eval",
   "weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker -> weave.scorers.llm_as_a_judge_scorer",
   "weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker -> weave.trace.context.weave_client_context",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -627,8 +627,6 @@ allow_indirect_imports = true
 # forbidding trace_server's internal imports; every file that does so also
 # leaks via a client subpackage below, so none escape the contract.
 ignore_imports = [
-  "weave.trace_server.base64_content_conversion -> weave.type_wrappers.Content.content",
-  "weave.trace_server.image_completion -> weave.type_wrappers.Content.content",
   "weave.trace_server.interface.builtin_object_classes.llm_structured_model -> weave.prompt.prompt",
   "weave.trace_server.interface.builtin_object_classes.llm_structured_model -> weave.trace.context.weave_client_context",
   "weave.trace_server.interface.builtin_object_classes.llm_structured_model -> weave.trace.vals",

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -11,6 +11,7 @@ from typing import Any, TypeVar
 
 import ddtrace
 
+from weave.trace_server.content.content import Content
 from weave.trace_server.trace_server_interface import (
     CallEndReq,
     CallEndV2Req,
@@ -19,7 +20,6 @@ from weave.trace_server.trace_server_interface import (
     FileCreateReq,
     TraceServerInterface,
 )
-from weave.type_wrappers.Content.content import Content
 
 logger = logging.getLogger(__name__)
 

--- a/weave/trace_server/content/__init__.py
+++ b/weave/trace_server/content/__init__.py
@@ -1,0 +1,7 @@
+"""Server-side, client-free copy of the Content decode/MIME utilities.
+
+Vendored from weave.type_wrappers.Content so the trace server can detect and
+decode base64 / data-URI / URL payloads without importing the client SDK. The
+client keeps its own copy; the two are deliberately not shared (no shared
+module), per the trace-server <-> client import boundary.
+"""

--- a/weave/trace_server/content/content.py
+++ b/weave/trace_server/content/content.py
@@ -1,0 +1,249 @@
+"""Server-side, client-free copy of weave.type_wrappers.Content.Content.
+
+Only the decode/construction surface the trace server actually uses is kept:
+``from_base64``, ``from_data_url``, ``from_url`` and the public fields. The
+client SDK keeps the full implementation (ref tracking, save/open, data-URL
+emission); this copy is intentionally not shared with it, so the trace server
+stays free of client imports.
+
+The pydantic field set is kept byte-identical to the client's Content so that
+``model_dump(exclude={"data"})`` produces the same ``metadata.json`` the client
+reads back when deserializing a stored Content object (see
+weave/type_handlers/Content/content.py).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import re
+from pathlib import Path
+from typing import Annotated, Any, Generic
+from urllib.parse import urlparse
+
+import httpx
+from pydantic import BaseModel, Field
+from typing_extensions import Self, TypeVar
+
+from weave.trace_server.content.content_types import (
+    ContentType,
+    ResolvedContentArgs,
+)
+from weave.trace_server.content.utils import (
+    default_filename,
+    full_name,
+    get_mime_and_extension,
+    try_parse_data_url,
+)
+
+logger = logging.getLogger(__name__)
+
+# Dummy typevar to allow for passing mimetype/extension through annotated content
+# e.x. Content["pdf"] or Content["application/pdf"]
+T = TypeVar("T", bound=str)
+
+
+class Content(BaseModel, Generic[T]):
+    """Byte-oriented content with associated metadata.
+
+    Must be instantiated through one of the ``from_*`` classmethods.
+    """
+
+    # This is required due to some attribute setting done by our serialization layer
+    # Without it, it is hard to know if it was processed properly
+    data: bytes
+    size: int
+    mimetype: str
+    digest: str
+    filename: str
+    content_type: ContentType
+    input_type: str
+
+    encoding: str = Field(
+        "utf-8", description="Encoding to use when decoding bytes to string"
+    )
+
+    metadata: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description="metadata metadata to associate with the content",
+            examples=[{"number of cats": 1}],
+        ),
+    ] = None
+    extension: str | None = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Direct initialization is disabled.
+        Please use a classmethod like `Content.from_base64()` to create an instance.
+        """
+        raise NotImplementedError(
+            "Content objects cannot be initialized directly. "
+            "Use a classmethod: from_base64, from_data_url, or from_url."
+        )
+
+    @classmethod
+    def from_base64(
+        cls: type[Self],
+        b64_data: str | bytes,
+        /,
+        extension: str | None = None,
+        mimetype: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Self:
+        """Initializes Content from a base64 encoded string or bytes."""
+        if len(b64_data) == 0:
+            logger.warning("Content.from_base64 received empty input")
+
+        input_type = full_name(b64_data)
+        if isinstance(b64_data, str):
+            b64_data = b64_data.encode("ascii")
+        try:
+            if len(b64_data) == 0:
+                data = b""
+            else:
+                data = base64.b64decode(b64_data, validate=True)
+        except (ValueError, TypeError) as e:
+            raise ValueError("Invalid base64 data provided.") from e
+
+        digest = hashlib.sha256(data).hexdigest()
+        size = len(data)
+        mimetype, extension = get_mime_and_extension(
+            mimetype=mimetype, extension=extension, filename=None, buffer=data
+        )
+        filename = default_filename(
+            extension=extension, mimetype=mimetype, digest=digest
+        )
+
+        resolved_args: ResolvedContentArgs = {
+            "data": data,
+            "size": size,
+            "mimetype": mimetype,
+            "digest": digest,
+            "filename": filename,
+            "content_type": "base64",
+            "input_type": input_type,
+            "extension": extension,
+            "encoding": "base64",
+        }
+
+        if metadata:
+            resolved_args["metadata"] = metadata
+
+        # Use model_construct to bypass our custom __init__
+        return cls.model_construct(**resolved_args)
+
+    @classmethod
+    def from_data_url(
+        cls: type[Self], url: str, /, metadata: dict[str, Any] | None = None
+    ) -> Self:
+        """Initializes Content from a data URL."""
+        parsed = try_parse_data_url(url)
+        if not parsed:
+            raise ValueError("Invalid data URL provided.")
+
+        content_type = parsed.params.content_type
+        encoding = parsed.params.encoding
+        data = parsed.params.data
+        mimetype = parsed.params.mimetype
+
+        digest = hashlib.sha256(data).hexdigest()
+        size = len(data)
+
+        mimetype, extension = get_mime_and_extension(
+            mimetype=mimetype, extension=None, filename=None, buffer=data
+        )
+        filename = default_filename(
+            extension=extension, mimetype=mimetype, digest=digest
+        )
+
+        resolved_args: ResolvedContentArgs = {
+            "data": data,
+            "size": size,
+            "mimetype": mimetype,
+            "digest": digest,
+            "filename": filename,
+            "content_type": content_type,
+            "input_type": full_name(url),
+            "extension": extension,
+            "encoding": encoding,
+        }
+
+        if metadata:
+            resolved_args["metadata"] = metadata
+
+        # Use model_construct to bypass our custom __init__
+        return cls.model_construct(**resolved_args)
+
+    @classmethod
+    def from_url(
+        cls: type[Self],
+        url: str,
+        /,
+        headers: dict[str, Any] | None = None,
+        timeout: int | None = 30,
+        metadata: dict[str, Any] | None = None,
+    ) -> Self:
+        """Initializes Content by fetching bytes from an HTTP(S) URL.
+
+        Downloads the content, infers mimetype/extension from headers, URL path,
+        and data, and constructs a Content object from the resulting bytes.
+        """
+        # Use httpx directly (a hard server dependency) rather than the client's
+        # weave.utils.http_requests, to keep the trace server free of client
+        # imports. Callers gate this on an SSRF check before fetching.
+        resp = httpx.get(url, headers=headers, timeout=timeout, follow_redirects=True)
+        resp.raise_for_status()
+
+        data = resp.content or b""
+        digest = hashlib.sha256(data).hexdigest()
+        size = len(data)
+
+        # Try to get mimetype from header (strip any charset)
+        header_ct = resp.headers.get("Content-Type", "")
+        mimetype_from_header = header_ct.split(";")[0].strip() if header_ct else None
+
+        # Try to get filename from Content-Disposition or URL path
+        filename_from_header = None
+        cd = resp.headers.get("Content-Disposition", "")
+        if "filename=" in cd:
+            # naive extraction; handles filename="..." or filename=...
+            match = re.search(
+                r"filename\*=.*?''([^;\r\n]+)|filename=\"?([^;\r\n\"]+)\"?", cd
+            )
+            if match:
+                filename_from_header = match.group(1) or match.group(2)
+
+        parsed_url = urlparse(url)
+        url_basename = Path(parsed_url.path).name if parsed_url.path else None
+        filename_hint = filename_from_header or url_basename
+
+        mimetype, extension = get_mime_and_extension(
+            mimetype=mimetype_from_header,
+            extension=Path(filename_hint).suffix if filename_hint else None,
+            filename=filename_hint,
+            buffer=data,
+        )
+
+        filename = (
+            filename_hint
+            if filename_hint
+            else default_filename(extension, mimetype, digest)
+        )
+
+        resolved_args: ResolvedContentArgs = {
+            "data": data,
+            "size": size,
+            "mimetype": mimetype,
+            "digest": digest,
+            "filename": filename,
+            "content_type": "bytes",
+            "input_type": full_name(url),
+            # Use the response-detected encoding if present, else utf-8
+            "encoding": resp.encoding or "utf-8",
+        }
+
+        if metadata:
+            resolved_args["metadata"] = metadata
+
+        return cls.model_construct(**resolved_args)

--- a/weave/trace_server/content/content_types.py
+++ b/weave/trace_server/content/content_types.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+from typing import Any, Literal, TypedDict
+
+from pydantic import BaseModel, Field
+from typing_extensions import NotRequired
+
+DataUrlContentType = Literal[
+    "data_url", "data_url:base64", "data_url:encoding", "data_url:encoding:base64"
+]
+
+ContentType = Literal["bytes", "text", "base64", "file", "url", DataUrlContentType]
+
+ValidContentInputs = bytes | str | Path
+
+
+# This is what is saved to the 'metadata.json' file by serialization layer
+# It is used to 'restore' an existing content object
+class ResolvedContentArgsWithoutData(TypedDict):
+    # Required Fields
+    size: int
+    mimetype: str
+    digest: str
+    filename: str
+    content_type: ContentType
+    input_type: str
+    encoding: str
+
+    # Optional fields - can be omitted
+    metadata: NotRequired[dict[str, Any]]
+    extension: NotRequired[str]
+
+
+class ResolvedContentArgs(ResolvedContentArgsWithoutData):
+    # Required Fields
+    data: bytes
+
+
+class DataUrlParamsBase(BaseModel):
+    mimetype: str
+    data: bytes
+    encoding: str = "us-ascii"
+
+
+class DataUrlSimple(DataUrlParamsBase):
+    content_type: Literal["data_url"]
+
+
+class DataUrlBase64(DataUrlParamsBase):
+    content_type: Literal["data_url:base64"]
+
+
+class DataUrlWithEncoding(DataUrlParamsBase):
+    content_type: Literal["data_url:encoding"]
+
+
+class DataUrlBase64WithEncoding(DataUrlParamsBase):
+    content_type: Literal["data_url:encoding:base64"]
+
+
+class DataUrl(BaseModel):
+    params: (
+        DataUrlSimple | DataUrlBase64 | DataUrlWithEncoding | DataUrlBase64WithEncoding
+    ) = Field(discriminator="content_type")

--- a/weave/trace_server/content/polyfile_magic_resolver.py
+++ b/weave/trace_server/content/polyfile_magic_resolver.py
@@ -1,0 +1,53 @@
+"""MIME type detection using polyfile (pure Python libmagic implementation).
+
+Polyfile only supports buffer-based detection and does not provide
+file extension information.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    pass
+
+
+def is_available() -> bool:
+    """Check whether polyfile is installed and usable."""
+    matcher = None
+    try:
+        from polyfile.magic import MagicMatcher
+
+        matcher = MagicMatcher
+    except (ImportError, ModuleNotFoundError):
+        pass
+    return matcher is not None
+
+
+def detect(
+    *, filename: str | None, buffer: bytes | None
+) -> tuple[str | None, str | None]:
+    """Detect MIME type from a byte buffer using polyfile.
+
+    Polyfile does not support file-based detection or extension detection,
+    so the filename parameter is ignored and extension is always None.
+
+    Returns (mimetype, None) tuple; mimetype may be None.
+    """
+    if buffer is None or len(buffer) == 0:
+        return None, None
+
+    if not is_available():
+        return None, None
+
+    from polyfile.magic import MagicMatcher
+
+    try:
+        mimetype = next(MagicMatcher.DEFAULT_INSTANCE.match(buffer)).mimetypes[0]
+    except (IndexError, StopIteration):
+        return None, None
+    else:
+        return mimetype, None

--- a/weave/trace_server/content/python_magic_resolver.py
+++ b/weave/trace_server/content/python_magic_resolver.py
@@ -1,0 +1,196 @@
+"""MIME type and extension detection using python-magic (libmagic wrapper).
+
+Provides detection from both file paths (magic.from_file) and byte buffers
+(magic.from_buffer). Uses thread-local Magic instances so each thread gets
+its own libmagic cookie — no cross-thread contention, no per-call overhead.
+"""
+
+from __future__ import annotations
+
+import logging
+import mimetypes
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Cached availability flags.  Set once on first call; read-only afterwards.
+# Because Python's GIL protects simple attribute reads/writes, and the worst
+# case of a race is redundant initialisation (idempotent), no lock is needed.
+_magic_available: bool | None = None
+_magic_has_extension: bool = False
+
+# Thread-local storage for Magic instances.  Each thread lazily creates its
+# own pair of instances on first use and reuses them for subsequent calls.
+_thread_local = threading.local()
+
+
+def _check_availability() -> tuple[bool, bool]:
+    """One-time check for python-magic availability."""
+    global _magic_available, _magic_has_extension  # noqa: PLW0603
+    if _magic_available is not None:
+        return _magic_available, _magic_has_extension
+    try:
+        import magic
+
+        magic.Magic(mime=True)
+        _magic_available = True
+    except (ImportError, Exception) as e:
+        logger.debug("python-magic is not available: %s", e)
+        _magic_available = False
+        return False, False
+    try:
+        magic.Magic(extension=True)  # type: ignore[call-overload]
+        _magic_has_extension = True
+    except (NotImplementedError, TypeError):
+        logger.warning(
+            "libmagic version out of date, upgrade libmagic to version above 524 for extension detection."
+        )
+    return _magic_available, _magic_has_extension
+
+
+def _get_magic_instances() -> tuple[Any, Any]:
+    """Return thread-local Magic instances, creating them on first access.
+
+    Each thread gets its own libmagic cookie so concurrent callers never
+    share C-level state.
+    """
+    mime_inst = getattr(_thread_local, "mime", None)
+    if mime_inst is not None:
+        return mime_inst, getattr(_thread_local, "ext", None)
+
+    available, has_extension = _check_availability()
+    if not available:
+        return None, None
+
+    import magic
+
+    _thread_local.mime = magic.Magic(mime=True)
+    _thread_local.ext = magic.Magic(extension=True) if has_extension else None  # type: ignore[call-overload]
+    return _thread_local.mime, _thread_local.ext
+
+
+def _normalize_magic_extension(raw_ext: str | None) -> str | None:
+    """Normalize the extension string returned by python-magic.
+
+    python-magic with extension=True returns values like:
+    - "png" for a single match
+    - "jpeg/jpg/jpe/jfif" for multiple alternatives (slash-separated)
+    - "???" when the type is unknown
+
+    Returns a normalized extension with a leading dot (e.g. ".png"), or None.
+    """
+    if not raw_ext or raw_ext.strip() == "???" or not raw_ext.strip():
+        return None
+    # Take the first alternative if multiple are returned
+    ext = raw_ext.split("/")[0].strip()
+    if not ext:
+        return None
+    if not ext.startswith("."):
+        ext = f".{ext}"
+    return ext
+
+
+def _resolve_extension(raw_ext: str | None, mimetype: str) -> str | None:
+    """Normalize a libmagic extension, falling back to stdlib mimetypes."""
+    extension = _normalize_magic_extension(raw_ext)
+    if extension is None:
+        extension = mimetypes.guess_extension(mimetype)
+    return extension
+
+
+def is_available() -> bool:
+    """Check whether python-magic is installed and usable.
+
+    Only requires the MIME-detection instance; extension detection is optional
+    (it needs a newer libmagic that may not be bundled on Windows).
+    """
+    available, _ = _check_availability()
+    return available
+
+
+# Leading magic bytes of a WAV file. WAV is a RIFF container, so the bytes we
+# match live at fixed, little-endian offsets defined by the RIFF spec.
+_RIFF_MARKER = b"RIFF"  # offset 0: generic RIFF container marker (ChunkID)
+_WAVE_FORM = b"WAVE"  # offset 8: form type that marks this RIFF as WAVE audio
+
+
+def _is_wav_buffer(buffer: bytes) -> bool:
+    """Return True if the buffer's magic bytes identify it as a WAV file.
+
+    This works around a libmagic limitation: some builds only recognise the
+    generic RIFF container when classifying a WAV from an in-memory buffer
+    (``magic.from_buffer`` returns ``application/octet-stream``), even though
+    ``magic.from_file`` on the identical bytes correctly returns
+    ``audio/x-wav``. Content frequently detects from buffers (e.g. base64
+    payloads decoded in memory), so without this check WAV audio silently fails
+    to be recognised on the affected builds.
+
+    RIFF/WAVE header layout (fixed by the spec, little-endian)::
+
+        offset 0   4 bytes   "RIFF"   ChunkID   -- generic container marker
+        offset 4   4 bytes   <size>   ChunkSize
+        offset 8   4 bytes   "WAVE"   Format    -- the *form type*
+
+    The form type at offset 8 is what distinguishes WAV from every other RIFF
+    container ("AVI " video, "WEBP" image, "ANI " cursor, ...), so we require
+    BOTH the "RIFF" marker at offset 0 and the "WAVE" form at offset 8;
+    matching on "RIFF" alone would misclassify those as audio. These offsets
+    never move regardless of the audio payload, so a 12-byte prefix suffices.
+    """
+    return (
+        len(buffer) >= 12 and buffer[:4] == _RIFF_MARKER and buffer[8:12] == _WAVE_FORM
+    )
+
+
+def detect(
+    *, filename: str | None, buffer: bytes | None
+) -> tuple[str | None, str | None]:
+    """Detect MIME type and extension using python-magic.
+
+    When filename is set to a valid value, tries magic.from_file first.
+    If from_file fails because the file is not found, falls back to
+    from_buffer when buffer is available.
+
+    Extension detection uses libmagic's extension mode when available,
+    otherwise falls back to stdlib mimetypes.guess_extension().
+
+    Returns (mimetype, extension) tuple; either value may be None.
+    """
+    mime_magic, ext_magic = _get_magic_instances()
+    if mime_magic is None:
+        return None, None
+
+    # Try from_file when filename is provided
+    if filename is not None:
+        try:
+            mimetype = mime_magic.from_file(filename)
+            if mimetype:
+                raw_ext = ext_magic.from_file(filename) if ext_magic else None
+                return mimetype, _resolve_extension(raw_ext, mimetype)
+        except FileNotFoundError:
+            # File not found — fall through to from_buffer
+            pass
+        except Exception as e:
+            logger.debug("magic.from_file failed for %r: %s", filename, e)
+
+    # Fall back to from_buffer
+    if buffer is not None:
+        try:
+            mimetype = mime_magic.from_buffer(buffer)
+            # Some libmagic builds cannot identify WAV from an in-memory buffer
+            # and report the generic octet-stream type (see _is_wav_buffer).
+            # Sniff the RIFF/WAVE signature and override so buffer-based
+            # detection matches what from_file would return. This is a no-op on
+            # builds that already classify WAV correctly.
+            if mimetype in {None, "application/octet-stream"} and _is_wav_buffer(
+                buffer
+            ):
+                return "audio/x-wav", ".wav"
+            if mimetype:
+                raw_ext = ext_magic.from_buffer(buffer) if ext_magic else None
+                return mimetype, _resolve_extension(raw_ext, mimetype)
+        except Exception as e:
+            logger.debug("magic.from_buffer failed: %s", e)
+
+    return None, None

--- a/weave/trace_server/content/utils.py
+++ b/weave/trace_server/content/utils.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import base64
+import logging
+import re
+from pathlib import Path
+
+# The types module is imported here as it has no external dependencies
+# and is used in the `_get_mimetypes_module` helper.
+from types import ModuleType
+from typing import Any
+from urllib.parse import unquote_to_bytes
+
+from weave.trace_server.content.content_types import (
+    DataUrl,
+    DataUrlBase64,
+    DataUrlBase64WithEncoding,
+    DataUrlSimple,
+    DataUrlWithEncoding,
+)
+
+logger = logging.getLogger(__name__)
+
+# See: https://mimesniff.spec.whatwg.org/
+# Buffer size should be >= 1445 for deterministic results in most cases
+# Most documentation uses 2048 to slightly exceed this requirement
+# If the data is smaller than 2048 just use the entire thing
+MIME_DETECTION_BUFFER_SIZE = 2048
+
+# A global variable to hold the lazily imported mimetypes module.
+_mimetypes_module: ModuleType | None = None
+
+# Lazily resolved magic backend (python_magic_resolver or polyfile_magic_resolver).
+_UNSET: Any = object()
+_resolver: Any = _UNSET
+
+DATA_URL_PATTERN = re.compile(
+    r"^data:(?P<media_type>[\w\/\-\+\.]+(?:;[\w\-]+\=[\w\-\.]+)*)?(?P<base64>;base64)?,(?P<data>.*)$"
+)
+
+
+def _get_mimetypes_module() -> ModuleType:
+    """Lazily import and initialize the mimetypes module.
+
+    This ensures the module is only loaded into memory when it's first needed
+    and that its custom types are only added once.
+    """
+    global _mimetypes_module  # noqa: PLW0603
+    if _mimetypes_module is None:
+        import mimetypes as _m
+
+        _m.add_type("text/markdown", ".md")
+        _m.add_type("audio/wav", ".wav")
+        _mimetypes_module = _m
+    return _mimetypes_module
+
+
+def _get_resolver() -> Any:
+    """Lazily resolve the magic backend.
+
+    Prefers python-magic (faster, supports from_file + extension detection),
+    falls back to polyfile (pure Python, buffer-only MIME detection).
+    Returns None if neither library is available.
+    """
+    global _resolver  # noqa: PLW0603
+    if _resolver is not _UNSET:
+        return _resolver
+
+    from weave.trace_server.content import python_magic_resolver
+
+    if python_magic_resolver.is_available():
+        _resolver = python_magic_resolver
+        return _resolver
+
+    from weave.trace_server.content import polyfile_magic_resolver
+
+    if polyfile_magic_resolver.is_available():
+        _resolver = polyfile_magic_resolver
+        return _resolver
+
+    _resolver = None
+    return None
+
+
+# libmagic reports WAV as audio/x-wav; normalize detected types to the canonical
+# audio/wav so buffer- and filename-based detection agree. Caller-supplied
+# mimetypes don't pass through here and are preserved as-is.
+_DETECTED_MIMETYPE_ALIASES = {
+    "audio/x-wav": "audio/wav",
+}
+
+
+def _detect_from_resolver(
+    *, filename: str | None, buffer: bytes | None
+) -> tuple[str | None, str | None]:
+    """Dispatch detection to the available magic backend.
+
+    Returns (mimetype, extension) tuple; either value may be None.
+    Logs a warning when no backend is available and buffer was provided.
+    """
+    resolver = _get_resolver()
+    if resolver is not None:
+        mimetype, extension = resolver.detect(filename=filename, buffer=buffer)
+        if mimetype is not None:
+            mimetype = _DETECTED_MIMETYPE_ALIASES.get(mimetype, mimetype)
+        return mimetype, extension
+
+    if buffer is not None:
+        logger.warning(
+            "Failed to determine MIME type from file extension and cannot infer from data\n"
+            "MIME type detection from raw data requires python-magic or polyfile\n"
+            "Install one by running: `pip install python-magic` or `pip install polyfile`\n"
+            "python-magic requires libmagic: `apt-get install libmagic1` (Linux), "
+            "`brew install libmagic` (macOS), or `pip install python-magic-bin` (Windows)"
+        )
+    return None, None
+
+
+def full_name(obj: Any) -> str:
+    cls = obj.__class__
+    module = cls.__module__
+    if module == "builtins":
+        return cls.__qualname__  # avoid outputs like 'builtins.str'
+    return f"{module}.{cls.__qualname__}"
+
+
+def is_valid_b64(input: str | bytes) -> bool:
+    if len(input) == 0:
+        return False
+
+    # Normalize to bytes and verify it is not unicode
+    if isinstance(input, str):
+        try:
+            input = input.encode("ascii")
+        except UnicodeEncodeError:
+            return False
+    try:
+        base64.b64decode(input, validate=True)
+
+    except (ValueError, TypeError) as _:
+        return False
+
+    return True
+
+
+def is_valid_path(input: str | Path) -> bool:
+    if isinstance(input, str):
+        input = Path(input)
+    try:
+        return input.exists() and input.is_file()
+    except Exception:
+        return False
+
+
+def default_filename(
+    extension: str | None,
+    mimetype: str,
+    digest: str,
+) -> str:
+    type_name, _ = mimetype.split("/")
+    if type_name == "application":
+        # This seems a bit more 'presentable'
+        type_name = "file"
+
+    digest_suffix = digest[:4]
+    return f"{type_name}-{digest_suffix}{extension}"
+
+
+def get_extension_from_mimetype(mimetype: str) -> str | None:
+    mimetypes = _get_mimetypes_module()
+    extension = mimetypes.guess_extension(mimetype)
+    if not extension:
+        logger.warning(
+            "Got mime-type %s but failed to resolve a valid extension", mimetype
+        )
+    return extension
+
+
+def guess_from_buffer(buffer: bytes) -> str | None:
+    """Guess the mimetype from a byte buffer using the available magic backend."""
+    if len(buffer) == 0:
+        return None
+
+    resolver = _get_resolver()
+    if resolver is None:
+        logger.warning(
+            "Failed to determine MIME type from file extension and cannot infer from data\n"
+            "MIME type detection from raw data requires python-magic or polyfile\n"
+            "Install one by running: `pip install python-magic` or `pip install polyfile`\n"
+            "python-magic requires libmagic: `apt-get install libmagic1` (Linux), "
+            "`brew install libmagic` (macOS), or `pip install python-magic-bin` (Windows)\n"
+            "See: https://pypi.org/project/python-magic for detailed instructions"
+        )
+        return None
+
+    mimetype, _ = resolver.detect(filename=None, buffer=buffer)
+    if mimetype is not None:
+        mimetype = _DETECTED_MIMETYPE_ALIASES.get(mimetype, mimetype)
+    return mimetype
+
+
+def guess_from_filename(filename: str) -> str | None:
+    mimetypes = _get_mimetypes_module()
+    return mimetypes.guess_type(filename)[0]
+
+
+def guess_from_extension(extension: str) -> str | None:
+    filename = f"file.{extension.lstrip('.')}"
+    return guess_from_filename(filename)
+
+
+def guess_from_path(path: str | Path) -> str | None:
+    path = Path(path)
+    mimetype = guess_from_filename(path.name)
+    return mimetype
+
+
+def get_mime_and_extension(
+    *,
+    mimetype: str | None,
+    extension: str | None,
+    filename: str | None,
+    buffer: bytes | None,
+    default_mimetype: str = "application/octet-stream",
+    default_extension: str = "",
+) -> tuple[str, str]:
+    # Set it to none if empty
+    if buffer and len(buffer) == 0:
+        buffer = None
+
+    if extension is not None and len(extension) > 0:
+        extension = f".{extension.lstrip('.')}"
+    if mimetype and extension:
+        return mimetype, extension
+
+    elif (
+        mimetype
+        and not extension
+        and (guessed_ext := get_extension_from_mimetype(mimetype))
+    ):
+        return mimetype, guessed_ext
+
+    elif (
+        extension and not mimetype and (guessed_type := guess_from_extension(extension))
+    ):
+        return guessed_type, extension
+
+    # Stdlib mimetypes-based detection from filename / extension
+    if filename is not None:
+        mimetype = guess_from_filename(filename)
+
+    if not mimetype and extension is not None:
+        mimetype = guess_from_extension(extension)
+
+    # Content-based detection via magic backend (python-magic or polyfile).
+    # python-magic: tries magic.from_file first, falls back to from_buffer.
+    # polyfile: buffer-only detection, extension always None.
+    if not mimetype or not extension:
+        magic_mime, magic_ext = _detect_from_resolver(
+            filename=filename,
+            buffer=buffer[:MIME_DETECTION_BUFFER_SIZE] if buffer else None,
+        )
+        if not mimetype and magic_mime:
+            mimetype = magic_mime
+        if not extension and magic_ext:
+            extension = magic_ext
+
+    if mimetype and extension:
+        return mimetype, extension
+
+    elif (
+        mimetype
+        and not extension
+        and (extension := get_extension_from_mimetype(mimetype))
+    ):
+        return mimetype, extension
+
+    if filename is not None:
+        idx = filename.rfind(".")
+        if idx != -1:
+            extension = filename[idx:]
+
+    return mimetype or default_mimetype, extension or default_extension
+
+
+def match_data_url(url: str) -> re.Match[str] | None:
+    return DATA_URL_PATTERN.match(url)
+
+
+def try_parse_data_url(url: str) -> DataUrl | None:
+    """Parses a data URI, extracting the media type, encoding (charset),
+    base64 flag, and data.
+    """
+    match = match_data_url(url)
+
+    if not match:
+        return None
+
+    groups = match.groupdict()
+    data_str = groups.get("data")
+    if data_str is None:
+        return None
+
+    full_media_type = groups.get("media_type")
+    is_base64 = groups.get("base64") is not None
+
+    # Initialize default values as per RFC 2397
+    base_media_type = "text/plain"
+    encoding = None  # Default for data URIs
+
+    # If a media type is present, parse it
+    if full_media_type:
+        parts = [p.strip() for p in full_media_type.split(";")]
+        base_media_type = str(parts[0].lower()) if parts[0] else "text/plain"
+
+        # Find the charset parameter and override the default
+        for param in parts[1:]:
+            if param.lower().startswith("charset="):
+                charset = param.split("=", 1)[1]
+                if charset and isinstance(charset, str):
+                    encoding = charset
+                # Map to a Python-compatible encoding name (lowercase)
+                break
+
+    data_bytes: bytes
+    if is_base64:
+        try:
+            data_bytes = base64.b64decode(data_str)
+        except (ValueError, TypeError):
+            logger.warning("Invalid base64 data in data URL.")
+            return None
+    else:
+        # It's percent-encoded
+        data_bytes = unquote_to_bytes(data_str)
+
+    if encoding and is_base64:
+        return DataUrl(
+            params=DataUrlBase64WithEncoding(
+                mimetype=base_media_type,
+                data=data_bytes,
+                content_type="data_url:encoding:base64",
+                encoding=encoding,
+            )
+        )
+    elif encoding:
+        return DataUrl(
+            params=DataUrlWithEncoding(
+                mimetype=base_media_type,
+                data=data_bytes,
+                content_type="data_url:encoding",
+                encoding=encoding,
+            )
+        )
+    elif is_base64:
+        return DataUrl(
+            params=DataUrlBase64(
+                mimetype=base_media_type,
+                data=data_bytes,
+                content_type="data_url:base64",
+            )
+        )
+    return DataUrl(
+        params=DataUrlSimple(
+            mimetype=base_media_type,
+            data=data_bytes,
+            content_type="data_url",
+        )
+    )

--- a/weave/trace_server/image_completion.py
+++ b/weave/trace_server/image_completion.py
@@ -3,11 +3,11 @@ from typing import Any
 
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.base64_content_conversion import store_content_object
+from weave.trace_server.content.content import Content
 from weave.trace_server.errors import (
     InvalidRequest,
 )
 from weave.trace_server.helpers.url_safety import is_publicly_routable_url
-from weave.type_wrappers.Content.content import Content
 
 logger = logging.getLogger(__name__)
 

--- a/weave/trace_server/llm_completion.py
+++ b/weave/trace_server/llm_completion.py
@@ -7,7 +7,6 @@ from cachetools import TTLCache
 from litellm import CustomStreamWrapper
 from pydantic import BaseModel
 
-from weave.prompt.prompt import format_message_with_template_vars
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import (
     InvalidRequest,
@@ -36,6 +35,45 @@ _custom_provider_cache: TTLCache[tuple[str, str, str], "CustomProviderInfo"] = T
     ttl=CUSTOM_PROVIDER_CACHE_TTL_SECONDS,
 )
 _custom_provider_cache_lock = threading.Lock()
+
+
+# Vendored from weave.prompt.prompt to keep the trace server free of client-SDK
+# imports (the client keeps its own copy). The logic is small and the two are
+# deliberately not shared via a common module.
+class IncorrectPromptVarError(Exception):
+    """Raised when prompt template variables are incorrect or missing."""
+
+
+def format_message_with_template_vars(message: dict, **kwargs: Any) -> dict:
+    """Format a message dictionary by replacing template variables.
+
+    Recursively processes message dictionaries, replacing template variables in
+    string values using Python's ``.format()`` syntax, including nested
+    multimodal content lists.
+
+    Raises:
+        IncorrectPromptVarError: If a template variable is not found in kwargs.
+    """
+    formatted: dict[str, Any] = {}
+    for key, value in message.items():
+        if isinstance(value, str):
+            try:
+                formatted[key] = value.format(**kwargs)
+            except KeyError as e:
+                missing_key = e.args[0] if e.args else str(e).strip("'\"")
+                available_keys = ", ".join(sorted(kwargs.keys()))
+                raise IncorrectPromptVarError(
+                    f"Prompt template variable '{missing_key}' not found. "
+                    f"Available variables: {available_keys}"
+                ) from e
+        elif isinstance(value, list) and all(isinstance(d, dict) for d in value):
+            # Recursively format nested dicts in lists
+            formatted[key] = [
+                format_message_with_template_vars(d, **kwargs) for d in value
+            ]
+        else:
+            formatted[key] = value
+    return formatted
 
 
 def parse_prompt_reference(prompt: str) -> tuple[str, str, str | None]:


### PR DESCRIPTION
Decouples `weave.type_wrappers` from `trace_server` by vendoring a client-free Content decoder under `weave/trace_server/content/` instead of importing `weave.type_wrappers.Content`.