### PR TITLE
feat(weave): add predict-only token total to eval results summary

### DIFF
--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -846,6 +846,214 @@ def test_eval_results_include_predict_and_score_children(client):
     assert trial_without.scores["children_test_scorer"] == 0.8
 
 
+def test_eval_results_summary_predict_total_tokens(client):
+    """Summary predict_total_tokens sums per-trial model tokens, excluding scorer tokens."""
+    project_id = client.project_id
+    model_ref = "model://predict-tokens"
+    run = client.server.evaluation_run_create(
+        EvaluationRunCreateReq(
+            project_id=project_id,
+            evaluation="eval://predict-tokens",
+            model=model_ref,
+        )
+    )
+
+    # Two trials. Each has a model predict child (30 tokens) and an LLM-judge
+    # scorer child (100 tokens); the predict_and_score rollup carries both (130).
+    for i in range(2):
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        pas_id = generate_id()
+        client.server.call_start(
+            CallStartReq(
+                start=StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=pas_id,
+                    trace_id=run.evaluation_run_id,
+                    parent_id=run.evaluation_run_id,
+                    op_name="Evaluation.predict_and_score",
+                    started_at=now,
+                    attributes={},
+                    inputs={"example": {"idx": i}, "model": model_ref},
+                )
+            )
+        )
+        predict_id = generate_id()
+        client.server.call_start(
+            CallStartReq(
+                start=StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=predict_id,
+                    trace_id=run.evaluation_run_id,
+                    parent_id=pas_id,
+                    op_name="Model.predict",
+                    started_at=now,
+                    attributes={},
+                    inputs={"self": model_ref, "example": {"idx": i}},
+                )
+            )
+        )
+        client.server.call_end(
+            CallEndReq(
+                end=EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=predict_id,
+                    ended_at=now + datetime.timedelta(seconds=1),
+                    output=f"answer_{i}",
+                    summary={"usage": {"gpt-4o-mini": {"total_tokens": 30}}},
+                )
+            )
+        )
+        scorer_id = generate_id()
+        client.server.call_start(
+            CallStartReq(
+                start=StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=scorer_id,
+                    trace_id=run.evaluation_run_id,
+                    parent_id=pas_id,
+                    op_name="my_scorer.score",
+                    started_at=now + datetime.timedelta(seconds=1),
+                    attributes={},
+                    inputs={"output": f"answer_{i}"},
+                )
+            )
+        )
+        client.server.call_end(
+            CallEndReq(
+                end=EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=scorer_id,
+                    ended_at=now + datetime.timedelta(seconds=2),
+                    output={"score": 1},
+                    summary={"usage": {"judge": {"total_tokens": 100}}},
+                )
+            )
+        )
+        client.server.call_end(
+            CallEndReq(
+                end=EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=pas_id,
+                    ended_at=now + datetime.timedelta(seconds=3),
+                    output={"output": f"answer_{i}", "scores": {"my_scorer": 1}},
+                    summary={
+                        "usage": {
+                            "gpt-4o-mini": {"total_tokens": 30},
+                            "judge": {"total_tokens": 100},
+                        }
+                    },
+                )
+            )
+        )
+
+    res = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=project_id,
+            evaluation_call_ids=[run.evaluation_run_id],
+            include_rows=False,
+            include_summary=True,
+            include_predict_and_score_children=True,
+        )
+    )
+    assert res.summary is not None
+    # 2 trials x 30 model tokens = 60; the 2 x 100 judge tokens are excluded.
+    assert res.summary.evaluations[0].predict_total_tokens == 60
+
+
+def test_eval_results_summary_predict_total_tokens_none_when_absent(client):
+    """predict_total_tokens is None when no trial carries token usage (caller falls back)."""
+    eval_id, _ = _create_eval_with_scores(
+        client, [{"accuracy": 0.5}], eval_name="no-tokens"
+    )
+    res = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=client.project_id,
+            evaluation_call_ids=[eval_id],
+            include_rows=False,
+            include_summary=True,
+        )
+    )
+    assert res.summary is not None
+    assert res.summary.evaluations[0].predict_total_tokens is None
+
+
+def test_eval_results_summary_predict_total_tokens_counts_zero(client):
+    """A trial whose model usage is 0 still counts: the field is 0, not None."""
+    project_id = client.project_id
+    model_ref = "model://zero-tokens"
+    run = client.server.evaluation_run_create(
+        EvaluationRunCreateReq(
+            project_id=project_id,
+            evaluation="eval://zero-tokens",
+            model=model_ref,
+        )
+    )
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    pas_id = generate_id()
+    client.server.call_start(
+        CallStartReq(
+            start=StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=pas_id,
+                trace_id=run.evaluation_run_id,
+                parent_id=run.evaluation_run_id,
+                op_name="Evaluation.predict_and_score",
+                started_at=now,
+                attributes={},
+                inputs={"example": {"idx": 0}, "model": model_ref},
+            )
+        )
+    )
+    predict_id = generate_id()
+    client.server.call_start(
+        CallStartReq(
+            start=StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=predict_id,
+                trace_id=run.evaluation_run_id,
+                parent_id=pas_id,
+                op_name="Model.predict",
+                started_at=now,
+                attributes={},
+                inputs={"self": model_ref, "example": {"idx": 0}},
+            )
+        )
+    )
+    client.server.call_end(
+        CallEndReq(
+            end=EndedCallSchemaForInsert(
+                project_id=project_id,
+                id=predict_id,
+                ended_at=now + datetime.timedelta(seconds=1),
+                output="result",
+                summary={"usage": {"gpt-4o-mini": {"total_tokens": 0}}},
+            )
+        )
+    )
+    client.server.call_end(
+        CallEndReq(
+            end=EndedCallSchemaForInsert(
+                project_id=project_id,
+                id=pas_id,
+                ended_at=now + datetime.timedelta(seconds=2),
+                output={"output": "result", "scores": {}},
+                summary={},
+            )
+        )
+    )
+    res = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=project_id,
+            evaluation_call_ids=[run.evaluation_run_id],
+            include_rows=False,
+            include_summary=True,
+            include_predict_and_score_children=True,
+        )
+    )
+    assert res.summary is not None
+    assert res.summary.evaluations[0].predict_total_tokens == 0
+
+
 def test_eval_results_resolved_inputs_inline(client):
     """Inline inputs should be available as dicts in raw_data_row."""
     project_id = client.project_id

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -784,6 +784,10 @@ def compute_summary_from_rows(
 
             for trial in eval_entry.trials:
                 eval_summary_map[eval_call_id].trial_count += 1
+                if trial.total_tokens is not None:
+                    eval_summary_map[eval_call_id].predict_total_tokens = (
+                        eval_summary_map[eval_call_id].predict_total_tokens or 0
+                    ) + trial.total_tokens
                 for scorer_key, scorer_val in trial.scores.items():
                     _process_scorer_output(
                         scorer_val,

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3227,6 +3227,7 @@ class EvalResultsScorerStats(BaseModel):
 class EvalResultsEvaluationSummary(BaseModel):
     evaluation_call_id: str
     trial_count: int = 0
+    predict_total_tokens: int | None = None
     scorer_stats: list[EvalResultsScorerStats] = Field(default_factory=list)
     evaluation_ref: str | None = None
     model_ref: str | None = None

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3227,8 +3227,15 @@ class EvalResultsScorerStats(BaseModel):
 class EvalResultsEvaluationSummary(BaseModel):
     evaluation_call_id: str
     trial_count: int = 0
-    predict_total_tokens: int | None = None
     scorer_stats: list[EvalResultsScorerStats] = Field(default_factory=list)
+    predict_total_tokens: int | None = Field(
+        default=None,
+        description=(
+            "Sum of per-trial predict-only token usage for this evaluation "
+            "(the model's predict() tokens only, excluding LLM-as-a-judge "
+            "scorer usage); None when no trial reports usage."
+        ),
+    )
     evaluation_ref: str | None = None
     model_ref: str | None = None
     display_name: str | None = None


### PR DESCRIPTION
See https://github.com/wandb/core/pull/45031 for the context/screenshots to understand why we need this change. Short version - the API should expose the per-evaluation predict-only token total as one number, so the frontend can read it instead of pulling every row and summing them in the browser.

The bug: in Compare Evaluations a model's Total Tokens is too high when the eval has an LLM judge - the judge's tokens get counted as the model's. Same model and dataset, but the number jumps from 97 to 243 once you add two LLM scorers. It should only count the model's own predict() tokens.

The per-trial number is already predict-only; the API just never summed it per evaluation. That's why #45031 had to fetch all the rows and add them up on the client, which is slow on an already heavy page. So here I do the sum on the server and return it as `predict_total_tokens` on each evaluation in the summary. The summary code already loops over the trials, so I just add them up in the same place - no extra query. It's null when there's no token data, so the caller falls back to the old value and nothing breaks.

Backend only. The frontend PR comes next - it reads this field and drops the row fetch.

Jira: https://coreweave.atlassian.net/browse/WB-35134

Testing: three tests - judge tokens excluded (60, not 260), null when there are no tokens, and a real 0 stays 0 (not null).
