### PR TITLE
feat(weave): OTel-native OpenAI Realtime exporter and agent chat-view fixes

### DIFF
--- a/tests/integrations/openai_realtime/test_connection.py
+++ b/tests/integrations/openai_realtime/test_connection.py
@@ -91,7 +91,7 @@ def test_weave_media_connection_wrapping_sends_and_receives(monkeypatch):
     mc.wrapped_on_message(mc.ws, json.dumps(server_msg))
 
     # Verify session propagated into state
-    assert mc.conversation_manager.state.session_span is not None
+    assert mc.conversation_manager.state_exporter.session_span is not None
 
     # Prevent atexit handler from firing after monkeypatch restores require_weave_client
     mc._exit_ran = True
@@ -148,7 +148,7 @@ async def test_async_wrapper_basic(monkeypatch):
     except Exception:
         pass
     # Session should be set from received message
-    assert conn.conversation_manager.state.session_span is not None
+    assert conn.conversation_manager.state_exporter.session_span is not None
 
     # Prevent atexit handler from firing after monkeypatch restores require_weave_client
     conn._exit_ran = True

--- a/tests/integrations/openai_realtime/test_conversation_manager.py
+++ b/tests/integrations/openai_realtime/test_conversation_manager.py
@@ -35,6 +35,9 @@ class DummyState:
     def handle_item_created(self, msg):
         self.calls.append(msg["type"])
 
+    def handle_item_done(self, msg):
+        self.calls.append(msg["type"])
+
     def handle_item_deleted(self, msg):
         self.calls.append(msg["type"])
 
@@ -53,11 +56,19 @@ class DummyState:
     def handle_response_audio_done(self, msg):
         self.calls.append(msg["type"])
 
+    def handle_response_text_delta(self, msg):
+        self.calls.append(msg["type"])
+
+    def handle_function_call_arguments_delta(self, msg):
+        self.calls.append(msg["type"])
+
 
 def test_conversation_manager_dispatch_sync(monkeypatch):
-    # Patch StateExporter used by ConversationManager to our dummy
+    # Patch StateExporter used by ConversationManager to our dummy. use_otel is
+    # pinned False so the legacy (patchable) StateExporter branch is taken; the
+    # OTel branch imports OTelStateExporter directly and ignores this patch.
     monkeypatch.setattr(cm_mod, "StateExporter", DummyState)
-    mgr = cm_mod.ConversationManager()
+    mgr = cm_mod.ConversationManager(use_otel=False)
 
     msg = {
         "type": "session.updated",
@@ -85,7 +96,7 @@ def test_conversation_manager_dispatch_sync(monkeypatch):
 @pytest.mark.asyncio
 async def test_conversation_manager_worker_queue(monkeypatch):
     monkeypatch.setattr(cm_mod, "StateExporter", DummyState)
-    mgr = cm_mod.ConversationManager()
+    mgr = cm_mod.ConversationManager(use_otel=False)
 
     msg = {"type": "input_audio_buffer.cleared", "event_id": "event_1"}
 

--- a/tests/integrations/openai_realtime/test_conversation_manager.py
+++ b/tests/integrations/openai_realtime/test_conversation_manager.py
@@ -66,7 +66,7 @@ class DummyState:
 def test_conversation_manager_dispatch_sync(monkeypatch):
     # Patch StateExporter used by ConversationManager to our dummy. use_otel is
     # pinned False so the legacy (patchable) StateExporter branch is taken; the
-    # OTel branch imports OTelStateExporter directly and ignores this patch.
+    # OTel branch instantiates OTelStateExporter and ignores this patch.
     monkeypatch.setattr(cm_mod, "StateExporter", DummyState)
     mgr = cm_mod.ConversationManager(use_otel=False)
 
@@ -90,7 +90,7 @@ def test_conversation_manager_dispatch_sync(monkeypatch):
         },
     }
     mgr.process_event(msg)
-    assert "session.updated" in mgr.state.calls
+    assert "session.updated" in mgr.state_exporter.calls
 
 
 @pytest.mark.asyncio
@@ -104,4 +104,4 @@ async def test_conversation_manager_worker_queue(monkeypatch):
     # Wait until worker drains queue
     mgr._queue.join()
 
-    assert "input_audio_buffer.cleared" in mgr.state.calls
+    assert "input_audio_buffer.cleared" in mgr.state_exporter.calls

--- a/tests/integrations/openai_realtime/test_otel_state_exporter.py
+++ b/tests/integrations/openai_realtime/test_otel_state_exporter.py
@@ -62,12 +62,14 @@ class _FakeRef:
 
 @pytest.fixture
 def fake_publish(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
-    """Stub ``weave.trace.api.publish`` so audio publishing needs no client.
+    """Stub ``publish`` so audio publishing needs no client.
 
-    Returns the list of published Content objects (for assertions) and hands
-    back a deterministic ``weave://`` ref per call.
+    The exporter imports ``publish`` into its own namespace, so patch the name
+    there (where it is looked up) rather than on ``weave.trace.api``. Returns
+    the list of published Content objects (for assertions) and hands back a
+    deterministic ``weave://`` ref per call.
     """
-    from weave.trace import api
+    from weave.integrations.openai_realtime import otel_state_exporter
 
     published: list[Any] = []
 
@@ -75,7 +77,7 @@ def fake_publish(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
         published.append(obj)
         return _FakeRef(f"weave:///entity/proj/object/content:{len(published)}")
 
-    monkeypatch.setattr(api, "publish", _publish)
+    monkeypatch.setattr(otel_state_exporter, "publish", _publish)
     return published
 
 
@@ -190,8 +192,8 @@ def part_types(msgs: list[dict[str, Any]]) -> set[str]:
 
 def test_conversation_manager_selects_exporter_by_flag() -> None:
     """The dispatcher flag picks the destination; legacy path is untouched."""
-    assert isinstance(ConversationManager(use_otel=True).state, OTelStateExporter)
-    legacy = ConversationManager(use_otel=False).state
+    assert isinstance(ConversationManager(use_otel=True).state_exporter, OTelStateExporter)
+    legacy = ConversationManager(use_otel=False).state_exporter
     assert isinstance(legacy, StateExporter)
     assert not isinstance(legacy, OTelStateExporter)
 

--- a/tests/integrations/openai_realtime/test_otel_state_exporter.py
+++ b/tests/integrations/openai_realtime/test_otel_state_exporter.py
@@ -1,0 +1,526 @@
+"""Tests for the OTel GenAI variant of the OpenAI Realtime integration.
+
+Sibling of ``test_state_exporter.py`` — same delta-driven state machine, but
+asserts on emitted OTel GenAI spans (and their normalization into the
+``spans`` ClickHouse schema) instead of legacy Weave calls.
+
+Two layers of validation:
+
+1. Span shape — drive the exporter with realtime events and assert the
+   emitted invoke_agent / chat / execute_tool spans carry the right semconv
+   attributes, parenting, audio refs, and timing (via an in-memory exporter).
+2. Schema population — round-trip the emitted spans through the *real* ingest
+   path (OTLP protobuf -> ``Span.from_proto`` -> ``extract_genai_span``) and
+   assert they populate ``AgentSpanCHInsertable`` columns correctly.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from weave.integrations.openai_realtime.conversation_manager import ConversationManager
+from weave.integrations.openai_realtime.otel_state_exporter import OTelStateExporter
+from weave.integrations.openai_realtime.state_exporter import StateExporter
+
+_MODEL = "gpt-4o-realtime-preview"
+_SESSION_ID = "sess_1"
+
+
+# --- fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture
+def otel_spans(monkeypatch: pytest.MonkeyPatch) -> Generator[InMemorySpanExporter]:
+    """Install an in-memory OTel exporter as the global provider.
+
+    Mirrors the claude_agent_sdk / openai_agents OTel fixtures: overrides the
+    private ``_TRACER_PROVIDER`` so prior state restores cleanly.
+    """
+    exporter = InMemorySpanExporter()
+    provider = SDKTracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", provider)
+    yield exporter
+    provider.shutdown()
+
+
+@dataclass
+class _FakeRef:
+    uri: str
+
+
+@pytest.fixture
+def fake_publish(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Stub ``weave.trace.api.publish`` so audio publishing needs no client.
+
+    Returns the list of published Content objects (for assertions) and hands
+    back a deterministic ``weave://`` ref per call.
+    """
+    from weave.trace import api
+
+    published: list[Any] = []
+
+    def _publish(obj: Any, *args: Any, **kwargs: Any) -> _FakeRef:
+        published.append(obj)
+        return _FakeRef(f"weave:///entity/proj/object/content:{len(published)}")
+
+    monkeypatch.setattr(api, "publish", _publish)
+    return published
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def make_session(*, modalities: list[str] | None = None) -> dict:
+    return {
+        "id": _SESSION_ID,
+        "model": _MODEL,
+        "modalities": modalities or ["audio"],
+        "voice": "alloy",
+        "temperature": 0.8,
+        "max_response_output_tokens": 4096,
+        "input_audio_format": "pcm16",
+        "output_audio_format": "pcm16",
+        "turn_detection": {"type": "server_vad"},
+    }
+
+
+def make_user_audio_item(item_id: str, transcript: str | None = None) -> dict:
+    return {
+        "id": item_id,
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_audio", "audio": "", "transcript": transcript}],
+    }
+
+
+def make_assistant_audio_item(item_id: str, transcript: str) -> dict:
+    return {
+        "id": item_id,
+        "type": "message",
+        "status": "completed",
+        "role": "assistant",
+        "content": [{"type": "audio", "transcript": transcript}],
+    }
+
+
+def make_function_call_item(item_id: str, name: str, arguments: str, call_id: str) -> dict:
+    return {
+        "id": item_id,
+        "type": "function_call",
+        "name": name,
+        "call_id": call_id,
+        "arguments": arguments,
+        "status": "completed",
+    }
+
+
+def make_response(
+    resp_id: str,
+    output: list[dict],
+    *,
+    conversation_id: str | None = None,
+    usage: dict | None = None,
+    status: str = "completed",
+) -> dict:
+    return {
+        "id": resp_id,
+        "status": status,
+        "status_details": None,
+        "output": output,
+        "usage": usage,
+        "conversation_id": conversation_id,
+    }
+
+
+def drive_response(
+    exp: OTelStateExporter,
+    response: dict,
+    *,
+    input_items: list[dict] | None = None,
+    response_audio: dict[str, bytes] | None = None,
+) -> None:
+    """Register input items, link the output to them, and run a full turn."""
+    output_items = response.get("output", [])
+    for item in input_items or []:
+        exp.items[item["id"]] = item
+    # Link the (single) output item to the most recent input item so
+    # _get_input_item_list can walk the thread back to it.
+    if output_items and input_items:
+        exp.prev_by_item[output_items[0]["id"]] = input_items[-1]["id"]
+    for item_id, audio in (response_audio or {}).items():
+        exp.response_audio[item_id] = audio
+
+    exp.handle_response_created(
+        {"type": "response.created", "response": response}
+    )
+    exp.handle_response_done({"type": "response.done", "response": response})
+
+
+def get_attrs(span: Any) -> dict[str, Any]:
+    return dict(span.attributes) if span.attributes is not None else {}
+
+
+def by_op(spans: list[Any], op: str) -> list[Any]:
+    return [s for s in spans if get_attrs(s).get("gen_ai.operation.name") == op]
+
+
+def messages(span: Any, key: str) -> list[dict[str, Any]]:
+    raw = get_attrs(span).get(key)
+    return json.loads(raw) if raw else []
+
+
+def part_types(msgs: list[dict[str, Any]]) -> set[str]:
+    return {p.get("type") for m in msgs for p in m.get("parts", [])}
+
+
+# --- exporter selection -----------------------------------------------------
+
+
+def test_conversation_manager_selects_exporter_by_flag() -> None:
+    """The dispatcher flag picks the destination; legacy path is untouched."""
+    assert isinstance(ConversationManager(use_otel=True).state, OTelStateExporter)
+    legacy = ConversationManager(use_otel=False).state
+    assert isinstance(legacy, StateExporter)
+    assert not isinstance(legacy, OTelStateExporter)
+
+
+# --- span shape -------------------------------------------------------------
+
+
+def test_basic_response_emits_invoke_agent_chat_tree(
+    otel_spans: InMemorySpanExporter, fake_publish: list[Any]
+) -> None:
+    exp = OTelStateExporter()
+    exp.handle_session_updated(
+        {"type": "session.updated", "session": make_session()}
+    )
+
+    user = make_user_audio_item("item_u1", transcript="What's the weather?")
+    out = make_assistant_audio_item("item_a1", transcript="It's sunny.")
+    resp = make_response("resp_1", [out], conversation_id="conv_abc")
+    drive_response(
+        exp, resp, input_items=[user], response_audio={"item_a1": b"\x10\x20\x30\x40"}
+    )
+
+    time.sleep(0.12)
+    exp.on_exit()
+    spans = otel_spans.get_finished_spans()
+
+    agents = by_op(spans, "invoke_agent")
+    chats = by_op(spans, "chat")
+    assert len(agents) == 1
+    assert len(chats) == 1
+
+    root = agents[0]
+    chat = chats[0]
+    assert root.name == "invoke_agent openai_realtime"
+    root_attrs = get_attrs(root)
+    assert root_attrs["gen_ai.agent.name"] == "openai_realtime"
+    assert root_attrs["gen_ai.provider.name"] == "openai"
+    # conversation.id is the realtime conversation_id, not the session id.
+    assert root_attrs["gen_ai.conversation.id"] == "conv_abc"
+
+    chat_attrs = get_attrs(chat)
+    assert chat.name == f"chat {_MODEL}"
+    assert chat_attrs["gen_ai.provider.name"] == "openai"
+    assert chat_attrs["gen_ai.request.model"] == _MODEL
+    assert chat_attrs["gen_ai.conversation.id"] == "conv_abc"
+    # Audio output -> speech modality + published ref.
+    assert chat_attrs["gen_ai.output.type"] == "speech"
+    assert list(chat_attrs["weave.content_refs"]) == [
+        "weave:///entity/proj/object/content:1"
+    ]
+
+    # Output message carries the transcript (text) + audio (uri) parts.
+    out_msgs = messages(chat, "gen_ai.output.messages")
+    assert part_types(out_msgs) == {"text", "uri"}
+    uri_part = next(
+        p for m in out_msgs for p in m["parts"] if p["type"] == "uri"
+    )
+    assert uri_part["modality"] == "audio"
+    assert uri_part["mime_type"] == "audio/wav"
+    assert uri_part["uri"] == "weave:///entity/proj/object/content:1"
+
+    # Input transcript is captured as a user text part.
+    in_msgs = messages(chat, "gen_ai.input.messages")
+    assert any(
+        p.get("content") == "What's the weather?"
+        for m in in_msgs
+        for p in m.get("parts", [])
+    )
+
+    # chat nests under the invoke_agent root, same trace.
+    assert chat.parent.span_id == root.context.span_id
+    assert chat.context.trace_id == root.context.trace_id
+
+
+def test_input_audio_published_as_uri(
+    otel_spans: InMemorySpanExporter, fake_publish: list[Any]
+) -> None:
+    """User speech is sliced from the input buffer and published as a uri."""
+    exp = OTelStateExporter()
+    exp.handle_session_updated(
+        {"type": "session.updated", "session": make_session()}
+    )
+
+    user = make_user_audio_item("item_u1")
+    # 20ms @ 24kHz/16-bit mono = 960 bytes.
+    exp.handle_speech_started({"item_id": "item_u1", "audio_start_ms": 0})
+    exp.handle_input_audio_append({"audio": base64.b64encode(b"\x01" * 960).decode()})
+    exp.handle_speech_stopped({"item_id": "item_u1", "audio_end_ms": 20})
+
+    out = make_assistant_audio_item("item_a1", transcript="ok")
+    resp = make_response("resp_1", [out], conversation_id="conv_x")
+    drive_response(
+        exp, resp, input_items=[user], response_audio={"item_a1": b"\xaa\xbb"}
+    )
+
+    time.sleep(0.12)
+    exp.on_exit()
+    chat = by_op(otel_spans.get_finished_spans(), "chat")[0]
+
+    in_msgs = messages(chat, "gen_ai.input.messages")
+    uri_parts = [p for m in in_msgs for p in m.get("parts", []) if p["type"] == "uri"]
+    assert len(uri_parts) == 1
+    assert uri_parts[0]["modality"] == "audio"
+    # Both input and output audio were published (2 refs total).
+    assert len(fake_publish) == 2
+    assert len(get_attrs(chat)["weave.content_refs"]) == 2
+
+
+def test_function_call_emits_execute_tool_span(
+    otel_spans: InMemorySpanExporter, fake_publish: list[Any]
+) -> None:
+    exp = OTelStateExporter()
+    exp.handle_session_updated(
+        {"type": "session.updated", "session": make_session()}
+    )
+
+    user = make_user_audio_item("item_u1", transcript="weather in Paris?")
+    fc = make_function_call_item(
+        "item_fc1",
+        name="get_weather",
+        arguments='{"location": "Paris"}',
+        call_id="call_123",
+    )
+    resp = make_response("resp_1", [fc], conversation_id="conv_t")
+    drive_response(exp, resp, input_items=[user])
+
+    time.sleep(0.12)
+    exp.on_exit()
+    spans = otel_spans.get_finished_spans()
+
+    chat = by_op(spans, "chat")[0]
+    tools = by_op(spans, "execute_tool")
+    assert len(tools) == 1
+    tool = tools[0]
+    tool_attrs = get_attrs(tool)
+    assert tool.name == "execute_tool get_weather"
+    assert tool_attrs["gen_ai.tool.name"] == "get_weather"
+    assert tool_attrs["gen_ai.tool.call.id"] == "call_123"
+    assert json.loads(tool_attrs["gen_ai.tool.call.arguments"]) == {"location": "Paris"}
+    # execute_tool nests under its chat span.
+    assert tool.parent.span_id == chat.context.span_id
+
+    # The chat output records the tool call request.
+    assert "tool_call" in part_types(messages(chat, "gen_ai.output.messages"))
+
+
+def test_usage_mapped_onto_chat_span(
+    otel_spans: InMemorySpanExporter, fake_publish: list[Any]
+) -> None:
+    exp = OTelStateExporter()
+    exp.handle_session_updated(
+        {"type": "session.updated", "session": make_session()}
+    )
+
+    out = make_assistant_audio_item("item_a1", transcript="hi")
+    usage = {
+        "input_tokens": 120,
+        "output_tokens": 80,
+        "input_token_details": {"audio_tokens": 100, "cached_tokens": 30},
+        "output_token_details": {"audio_tokens": 70},
+    }
+    resp = make_response("resp_1", [out], conversation_id="conv_u", usage=usage)
+    drive_response(exp, resp, response_audio={"item_a1": b"\x01\x02"})
+
+    time.sleep(0.12)
+    exp.on_exit()
+    chat = by_op(otel_spans.get_finished_spans(), "chat")[0]
+    attrs = get_attrs(chat)
+    assert attrs["gen_ai.usage.input_tokens"] == 120
+    assert attrs["gen_ai.usage.output_tokens"] == 80
+    assert attrs["gen_ai.usage.cache_read.input_tokens"] == 30
+
+
+def test_multiple_responses_share_session_root(
+    otel_spans: InMemorySpanExporter, fake_publish: list[Any]
+) -> None:
+    exp = OTelStateExporter()
+    exp.handle_session_updated(
+        {"type": "session.updated", "session": make_session()}
+    )
+
+    # Each response carries a DIFFERENT realtime conversation_id, yet they all
+    # belong to one session — so they must nest under a single root.
+    for i in range(3):
+        out = make_assistant_audio_item(f"item_a{i}", transcript=f"reply {i}")
+        resp = make_response(f"resp_{i}", [out], conversation_id=f"conv_{i}")
+        drive_response(exp, resp, response_audio={f"item_a{i}": b"\x00"})
+        time.sleep(0.08)
+
+    exp.on_exit()
+    spans = otel_spans.get_finished_spans()
+
+    agents = by_op(spans, "invoke_agent")
+    chats = by_op(spans, "chat")
+    assert len(agents) == 1
+    assert len(chats) == 3
+    # All chats nest under the single session root, sharing one trace — the
+    # session is the grouping unit even though each response carries its own
+    # realtime conversation_id (preserved on gen_ai.conversation.id).
+    root = agents[0]
+    assert {c.parent.span_id for c in chats} == {root.context.span_id}
+    assert {c.context.trace_id for c in chats} == {root.context.trace_id}
+    assert {get_attrs(c)["gen_ai.conversation.id"] for c in chats} == {
+        "conv_0",
+        "conv_1",
+        "conv_2",
+    }
+    # The root takes the conversation_id of the session's first response.
+    assert get_attrs(root)["gen_ai.conversation.id"] == "conv_0"
+
+
+def test_failed_response_sets_error_status(
+    otel_spans: InMemorySpanExporter, fake_publish: list[Any]
+) -> None:
+    from opentelemetry.trace import StatusCode
+
+    exp = OTelStateExporter()
+    exp.handle_session_updated(
+        {"type": "session.updated", "session": make_session()}
+    )
+    resp = make_response("resp_1", [], conversation_id="conv_e", status="failed")
+    resp["status_details"] = {"error": {"message": "boom"}}
+    drive_response(exp, resp)
+
+    time.sleep(0.12)
+    exp.on_exit()
+    chat = by_op(otel_spans.get_finished_spans(), "chat")[0]
+    assert chat.status.status_code == StatusCode.ERROR
+
+
+# --- schema population (real ingest path) -----------------------------------
+
+
+def _readable_to_ts_spans(readable_spans: list[Any]) -> list[Any]:
+    """Round-trip in-memory spans through OTLP protobuf into trace_server Spans.
+
+    This is the exact transformation the ingest endpoint performs, so the
+    resulting Spans feed ``extract_genai_span`` precisely as production does.
+    """
+    from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
+
+    from weave.trace_server.opentelemetry.python_spans import Resource, Span
+
+    req = encode_spans(readable_spans)
+    out: list[Any] = []
+    for rs in req.resource_spans:
+        resource = Resource.from_proto(rs.resource) if rs.HasField("resource") else None
+        for ss in rs.scope_spans:
+            for sp in ss.spans:
+                out.append(Span.from_proto(sp, resource))
+    return out
+
+
+def test_spans_populate_clickhouse_schema_via_extraction(
+    otel_spans: InMemorySpanExporter, fake_publish: list[Any]
+) -> None:
+    from weave.trace_server.opentelemetry.genai_extraction import extract_genai_span
+
+    exp = OTelStateExporter()
+    exp.handle_session_updated(
+        {"type": "session.updated", "session": make_session()}
+    )
+
+    # Turn 1: a spoken response to spoken input — exercises audio publishing on
+    # both sides, usage, and the message columns.
+    user1 = make_user_audio_item("item_u1", transcript="weather in Paris?")
+    exp.handle_speech_started({"item_id": "item_u1", "audio_start_ms": 0})
+    exp.handle_input_audio_append({"audio": base64.b64encode(b"\x01" * 960).decode()})
+    exp.handle_speech_stopped({"item_id": "item_u1", "audio_end_ms": 20})
+    out1 = make_assistant_audio_item("item_a1", transcript="It is sunny in Paris.")
+    usage = {
+        "input_tokens": 200,
+        "output_tokens": 50,
+        "input_token_details": {"cached_tokens": 40},
+    }
+    resp1 = make_response("resp_1", [out1], conversation_id="conv_a", usage=usage)
+    drive_response(
+        exp, resp1, input_items=[user1], response_audio={"item_a1": b"\xaa\xbb"}
+    )
+    time.sleep(0.1)
+
+    # Turn 2: a tool call — exercises the execute_tool columns.
+    user2 = make_user_audio_item("item_u2", transcript="book it")
+    fc = make_function_call_item(
+        "item_fc1",
+        name="get_weather",
+        arguments='{"location": "Paris"}',
+        call_id="call_xyz",
+    )
+    resp2 = make_response("resp_2", [fc], conversation_id="conv_b")
+    drive_response(exp, resp2, input_items=[user2])
+    time.sleep(0.1)
+
+    exp.on_exit()
+
+    ts_spans = _readable_to_ts_spans(otel_spans.get_finished_spans())
+    rows = [extract_genai_span(s, project_id="entity/proj") for s in ts_spans]
+    chat_rows = [r for r in rows if r.operation_name == "chat"]
+    tool_rows = [r for r in rows if r.operation_name == "execute_tool"]
+    agent_rows = [r for r in rows if r.operation_name == "invoke_agent"]
+    assert len(agent_rows) == 1
+    assert len(chat_rows) == 2
+    assert len(tool_rows) == 1
+
+    # Each turn keeps its own realtime conversation_id in the column; the two
+    # turns are one session (one invoke_agent root, asserted below).
+    assert {r.conversation_id for r in chat_rows} == {"conv_a", "conv_b"}
+    speech_chat = next(r for r in chat_rows if r.output_type == "speech")
+    assert speech_chat.provider_name == "openai"
+    assert speech_chat.request_model == _MODEL
+    assert speech_chat.response_model == _MODEL
+    assert speech_chat.conversation_id == "conv_a"
+    assert speech_chat.input_tokens == 200
+    assert speech_chat.output_tokens == 50
+    assert speech_chat.cache_read_input_tokens == 40
+    # Input + output speech each published a ref into the content_refs column.
+    assert len(speech_chat.content_refs) == 2
+    assert all(ref.startswith("weave:///") for ref in speech_chat.content_refs)
+    # Messages normalize into the Tuple(role, content, finish_reason) column shape.
+    assert speech_chat.input_messages[0].role == "user"
+    assert speech_chat.output_messages[0].role == "assistant"
+    assert "It is sunny in Paris." in speech_chat.output_messages[0].content
+
+    tool_row = tool_rows[0]
+    assert tool_row.tool_name == "get_weather"
+    assert tool_row.tool_call_id == "call_xyz"
+    assert json.loads(tool_row.tool_call_arguments) == {"location": "Paris"}
+
+    agent_row = agent_rows[0]
+    assert agent_row.agent_name == "openai_realtime"
+    assert agent_row.provider_name == "openai"
+    assert agent_row.conversation_id == "conv_a"

--- a/tests/integrations/openai_realtime/test_otel_state_exporter.py
+++ b/tests/integrations/openai_realtime/test_otel_state_exporter.py
@@ -32,6 +32,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from weave.integrations.openai_realtime.conversation_manager import ConversationManager
 from weave.integrations.openai_realtime.otel_state_exporter import OTelStateExporter
 from weave.integrations.openai_realtime.state_exporter import StateExporter
+from weave.session.agent_context import agent_name_override
 
 _MODEL = "gpt-4o-realtime-preview"
 _SESSION_ID = "sess_1"
@@ -264,6 +265,36 @@ def test_basic_response_emits_invoke_agent_chat_tree(
     # chat nests under the invoke_agent root, same trace.
     assert chat.parent.span_id == root.context.span_id
     assert chat.context.trace_id == root.context.trace_id
+
+
+def test_agent_name_override_captured_at_construction(
+    otel_spans: InMemorySpanExporter, fake_publish: list[Any]
+) -> None:
+    """A user's agent_name_override in scope at construction names the root span.
+
+    The override contextvar is invisible on the worker/FIFO threads that emit
+    spans, so the exporter must capture it when constructed on the user thread.
+    """
+    with agent_name_override("custom_agent"):
+        exp = OTelStateExporter()
+    exp.handle_session_updated({"type": "session.updated", "session": make_session()})
+
+    user = make_user_audio_item("item_u1", transcript="What's the weather?")
+    out = make_assistant_audio_item("item_a1", transcript="It's sunny.")
+    resp = make_response("resp_1", [out], conversation_id="conv_abc")
+    drive_response(
+        exp, resp, input_items=[user], response_audio={"item_a1": b"\x10\x20\x30\x40"}
+    )
+
+    time.sleep(0.12)
+    exp.on_exit()
+    spans = otel_spans.get_finished_spans()
+
+    agents = by_op(spans, "invoke_agent")
+    assert len(agents) == 1
+    root = agents[0]
+    assert root.name == "invoke_agent custom_agent"
+    assert get_attrs(root)["gen_ai.agent.name"] == "custom_agent"
 
 
 def test_input_audio_published_as_uri(

--- a/tests/integrations/openai_realtime/test_otel_state_exporter.py
+++ b/tests/integrations/openai_realtime/test_otel_state_exporter.py
@@ -115,7 +115,9 @@ def make_assistant_audio_item(item_id: str, transcript: str) -> dict:
     }
 
 
-def make_function_call_item(item_id: str, name: str, arguments: str, call_id: str) -> dict:
+def make_function_call_item(
+    item_id: str, name: str, arguments: str, call_id: str
+) -> dict:
     return {
         "id": item_id,
         "type": "function_call",
@@ -162,9 +164,7 @@ def drive_response(
     for item_id, audio in (response_audio or {}).items():
         exp.response_audio[item_id] = audio
 
-    exp.handle_response_created(
-        {"type": "response.created", "response": response}
-    )
+    exp.handle_response_created({"type": "response.created", "response": response})
     exp.handle_response_done({"type": "response.done", "response": response})
 
 
@@ -203,9 +203,7 @@ def test_basic_response_emits_invoke_agent_chat_tree(
     otel_spans: InMemorySpanExporter, fake_publish: list[Any]
 ) -> None:
     exp = OTelStateExporter()
-    exp.handle_session_updated(
-        {"type": "session.updated", "session": make_session()}
-    )
+    exp.handle_session_updated({"type": "session.updated", "session": make_session()})
 
     user = make_user_audio_item("item_u1", transcript="What's the weather?")
     out = make_assistant_audio_item("item_a1", transcript="It's sunny.")
@@ -246,9 +244,7 @@ def test_basic_response_emits_invoke_agent_chat_tree(
     # Output message carries the transcript (text) + audio (uri) parts.
     out_msgs = messages(chat, "gen_ai.output.messages")
     assert part_types(out_msgs) == {"text", "uri"}
-    uri_part = next(
-        p for m in out_msgs for p in m["parts"] if p["type"] == "uri"
-    )
+    uri_part = next(p for m in out_msgs for p in m["parts"] if p["type"] == "uri")
     assert uri_part["modality"] == "audio"
     assert uri_part["mime_type"] == "audio/wav"
     assert uri_part["uri"] == "weave:///entity/proj/object/content:1"
@@ -271,9 +267,7 @@ def test_input_audio_published_as_uri(
 ) -> None:
     """User speech is sliced from the input buffer and published as a uri."""
     exp = OTelStateExporter()
-    exp.handle_session_updated(
-        {"type": "session.updated", "session": make_session()}
-    )
+    exp.handle_session_updated({"type": "session.updated", "session": make_session()})
 
     user = make_user_audio_item("item_u1")
     # 20ms @ 24kHz/16-bit mono = 960 bytes.
@@ -304,9 +298,7 @@ def test_function_call_emits_execute_tool_span(
     otel_spans: InMemorySpanExporter, fake_publish: list[Any]
 ) -> None:
     exp = OTelStateExporter()
-    exp.handle_session_updated(
-        {"type": "session.updated", "session": make_session()}
-    )
+    exp.handle_session_updated({"type": "session.updated", "session": make_session()})
 
     user = make_user_audio_item("item_u1", transcript="weather in Paris?")
     fc = make_function_call_item(
@@ -342,9 +334,7 @@ def test_usage_mapped_onto_chat_span(
     otel_spans: InMemorySpanExporter, fake_publish: list[Any]
 ) -> None:
     exp = OTelStateExporter()
-    exp.handle_session_updated(
-        {"type": "session.updated", "session": make_session()}
-    )
+    exp.handle_session_updated({"type": "session.updated", "session": make_session()})
 
     out = make_assistant_audio_item("item_a1", transcript="hi")
     usage = {
@@ -369,9 +359,7 @@ def test_multiple_responses_share_session_root(
     otel_spans: InMemorySpanExporter, fake_publish: list[Any]
 ) -> None:
     exp = OTelStateExporter()
-    exp.handle_session_updated(
-        {"type": "session.updated", "session": make_session()}
-    )
+    exp.handle_session_updated({"type": "session.updated", "session": make_session()})
 
     # Each response carries a DIFFERENT realtime conversation_id, yet they all
     # belong to one session — so they must nest under a single root.
@@ -409,9 +397,7 @@ def test_failed_response_sets_error_status(
     from opentelemetry.trace import StatusCode
 
     exp = OTelStateExporter()
-    exp.handle_session_updated(
-        {"type": "session.updated", "session": make_session()}
-    )
+    exp.handle_session_updated({"type": "session.updated", "session": make_session()})
     resp = make_response("resp_1", [], conversation_id="conv_e", status="failed")
     resp["status_details"] = {"error": {"message": "boom"}}
     drive_response(exp, resp)
@@ -451,9 +437,7 @@ def test_spans_populate_clickhouse_schema_via_extraction(
     from weave.trace_server.opentelemetry.genai_extraction import extract_genai_span
 
     exp = OTelStateExporter()
-    exp.handle_session_updated(
-        {"type": "session.updated", "session": make_session()}
-    )
+    exp.handle_session_updated({"type": "session.updated", "session": make_session()})
 
     # Turn 1: a spoken response to spoken input — exercises audio publishing on
     # both sides, usage, and the message columns.

--- a/tests/integrations/openai_realtime/test_otel_state_exporter.py
+++ b/tests/integrations/openai_realtime/test_otel_state_exporter.py
@@ -192,7 +192,9 @@ def part_types(msgs: list[dict[str, Any]]) -> set[str]:
 
 def test_conversation_manager_selects_exporter_by_flag() -> None:
     """The dispatcher flag picks the destination; legacy path is untouched."""
-    assert isinstance(ConversationManager(use_otel=True).state_exporter, OTelStateExporter)
+    assert isinstance(
+        ConversationManager(use_otel=True).state_exporter, OTelStateExporter
+    )
     legacy = ConversationManager(use_otel=False).state_exporter
     assert isinstance(legacy, StateExporter)
     assert not isinstance(legacy, OTelStateExporter)

--- a/tests/integrations/test_autopatch.py
+++ b/tests/integrations/test_autopatch.py
@@ -89,6 +89,62 @@ def test_implicit_patch_multiple_libraries(setup_env, monkeypatch):
         mock_patch_mistral.assert_called_once()
 
 
+# The real modules realtime wraps. Tests below isolate the one under test by
+# clearing all three from sys.modules first, then injecting only the target.
+# Otherwise, since aiohttp/websockets are genuinely installed here, an un-mocked
+# sibling key still in sys.modules would let the real patch_openai_realtime fire
+# and pre-populate _PATCHED_INTEGRATIONS.
+_REALTIME_TRIGGER_MODULES = ["websocket", "websockets", "aiohttp"]
+
+
+def test_implicit_patch_realtime_websocket_already_imported(setup_env, monkeypatch):
+    """Realtime auto-patches when its real trigger module (websocket) is imported.
+
+    Mirrors ``test_implicit_patch_already_imported`` but keys on ``websocket``,
+    one of the real modules the realtime patcher wraps (the old synthetic
+    ``openai_realtime`` key never matched ``sys.modules`` so it never fired).
+    """
+    for module in _REALTIME_TRIGGER_MODULES:
+        _reset_import(monkeypatch, module)
+    _inject_fake_module(monkeypatch, "websocket")
+
+    mock_patch_func = MagicMock()
+
+    with patch.dict(
+        "weave.integrations.patch.INTEGRATION_MODULE_MAPPING",
+        {"websocket": mock_patch_func},
+    ):
+        implicit_patch()
+        mock_patch_func.assert_called_once()
+
+
+@pytest.mark.parametrize("module_name", _REALTIME_TRIGGER_MODULES)
+def test_implicit_patch_realtime_trigger_modules(setup_env, monkeypatch, module_name):
+    """Each of the three real modules realtime wraps triggers its patch func."""
+    for module in _REALTIME_TRIGGER_MODULES:
+        _reset_import(monkeypatch, module)
+    _inject_fake_module(monkeypatch, module_name)
+
+    mock_patch_func = MagicMock()
+
+    with patch.dict(
+        "weave.integrations.patch.INTEGRATION_MODULE_MAPPING",
+        {module_name: mock_patch_func},
+    ):
+        implicit_patch()
+        mock_patch_func.assert_called_once()
+
+
+def test_realtime_registered_under_real_trigger_modules(setup_env):
+    """The real mapping wires realtime to the modules it instruments, not a
+    synthetic ``openai_realtime`` key that never matched ``sys.modules``.
+    """
+    mapping = patch_module.INTEGRATION_MODULE_MAPPING
+    for module_name in ("websocket", "websockets", "aiohttp"):
+        assert mapping[module_name] is patch_module.patch_openai_realtime
+    assert "openai_realtime" not in mapping
+
+
 def test_implicit_patch_disabled(setup_env, monkeypatch):
     """Test that implicit patching can be disabled via environment variable."""
     monkeypatch.setenv("WEAVE_IMPLICITLY_PATCH_INTEGRATIONS", "false")

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -451,15 +451,17 @@ def test_build_trace_chat_handles_null_started_at() -> None:
             input_messages=[{"role": "user", "content": "hello from now"}],
         ),
     ]
-    # Must not raise. _find_user_prompt prefers invoke_agent spans, so the
-    # null-start invoke_agent's prompt wins over the chat span's prompt.
-    # The important thing is that the sort doesn't crash on the mixed key.
+    # Must not raise. The chat (LLM) span's own user input drives the turn, so
+    # its prompt is what renders; the null-start invoke_agent prompt is only a
+    # fallback for when no LLM span carries user input. The important thing is
+    # that the sort doesn't crash on the mixed (None / datetime) key.
     res = build_trace_chat(spans, "trace-with-null")
     assert res.trace_id == "trace-with-null"
     user_msgs = [m for m in res.messages if m.type == "user_message"]
     assert len(user_msgs) == 1
-    assert _user_payload(user_msgs[0]).text == "hello from the void"
-    assert user_msgs[0].started_at is None
+    assert _user_payload(user_msgs[0]).text == "hello from now"
+    # Sourced from the chat span (which has a real start), not the null one.
+    assert user_msgs[0].started_at is not None
 
 
 def test_build_trace_chat_uses_latest_ended_span_when_root_missing() -> None:
@@ -983,6 +985,169 @@ def test_content_ref_without_inline_part_is_not_attached() -> None:
     assistant = next(m for m in messages if m.type == "assistant_message")
     assert _user_payload(user).content_refs == []
     assert _assistant_payload(assistant).content_refs == []
+
+
+def test_realtime_multi_turn_in_one_trace_renders_each_user_turn() -> None:
+    """Regression (OpenAI Realtime): a whole voice session is ONE trace with
+    one chat span per turn. Each turn's user message must render with its OWN
+    audio — not collapse to a single leading bubble holding every turn's audio.
+
+    Each chat span's input replays the prior thread and ends with that turn's
+    new user message; output is that turn's assistant reply. Media is matched
+    per message from the inline part digest to the span's internal content_refs.
+    """
+
+    def at(sec: int) -> datetime.datetime:
+        return datetime.datetime(2026, 1, 1, 0, 0, sec, tzinfo=datetime.timezone.utc)
+
+    def ext(d: str) -> str:
+        return f"weave:///e/p/object/Content:{d}"
+
+    def intl(d: str) -> str:
+        return f"weave-trace-internal:///PID/object/Content:{d}"
+
+    def u(text: str, d: str) -> dict:
+        return {"role": "user", "content": _parts(_text_part(text), _uri_part(ext(d)))}
+
+    def a(text: str, d: str) -> dict:
+        return {
+            "role": "assistant",
+            "content": _parts(_text_part(text), _uri_part(ext(d))),
+        }
+
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="openai_realtime",
+            started_at=at(0),
+        ),
+        _span(
+            span_id="c1",
+            parent_span_id="agent",
+            operation_name="chat",
+            started_at=at(1),
+            input_messages=[u("Hello", "U1")],
+            output_messages=[a("Hi there!", "A1")],
+            content_refs=[intl("U1"), intl("A1")],
+        ),
+        _span(
+            span_id="c2",
+            parent_span_id="agent",
+            operation_name="chat",
+            started_at=at(3),
+            input_messages=[
+                u("Hello", "U1"),
+                a("Hi there!", "A1"),
+                u("Tell me a fact.", "U2"),
+            ],
+            output_messages=[a("Oceans cover 70%.", "A2")],
+            content_refs=[intl("U1"), intl("A1"), intl("U2"), intl("A2")],
+        ),
+        _span(
+            span_id="c3",
+            parent_span_id="agent",
+            operation_name="chat",
+            started_at=at(5),
+            input_messages=[
+                u("Hello", "U1"),
+                a("Hi there!", "A1"),
+                u("Tell me a fact.", "U2"),
+                a("Oceans cover 70%.", "A2"),
+                u("Thanks!", "U3"),
+            ],
+            output_messages=[a("Anytime!", "A3")],
+            content_refs=[
+                intl("U1"),
+                intl("A1"),
+                intl("U2"),
+                intl("A2"),
+                intl("U3"),
+                intl("A3"),
+            ],
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+    users = [m for m in messages if m.type == "user_message"]
+    assistants = [m for m in messages if m.type == "assistant_message"]
+
+    # All three user turns render, each with only its own audio.
+    assert [_user_payload(m).text for m in users] == [
+        "Hello",
+        "Tell me a fact.",
+        "Thanks!",
+    ]
+    assert [_user_payload(m).content_refs for m in users] == [
+        [intl("U1")],
+        [intl("U2")],
+        [intl("U3")],
+    ]
+    # Assistants keep their own audio (already per-span correct).
+    assert [_assistant_payload(m).content_refs for m in assistants] == [
+        [intl("A1")],
+        [intl("A2")],
+        [intl("A3")],
+    ]
+    # User/assistant alternate in order across the single trace.
+    chat_types = {"user_message", "assistant_message"}
+    assert [m.type for m in messages if m.type in chat_types] == [
+        "user_message",
+        "assistant_message",
+        "user_message",
+        "assistant_message",
+        "user_message",
+        "assistant_message",
+    ]
+
+
+def test_consecutive_user_messages_each_render_with_own_media() -> None:
+    """A turn can be several user messages in a row (no alternation). The
+    trailing run is all of them, and each renders as its own bubble keeping its
+    own media — not a single collapsed bubble that re-groups the audio.
+    """
+
+    def ext(d: str) -> str:
+        return f"weave:///e/p/object/Content:{d}"
+
+    def intl(d: str) -> str:
+        return f"weave-trace-internal:///PID/object/Content:{d}"
+
+    spans = [
+        _span(
+            span_id="chat",
+            operation_name="chat",
+            input_messages=[
+                {
+                    "role": "user",
+                    "content": _parts(_text_part("first"), _uri_part(ext("M1"))),
+                },
+                {"role": "assistant", "content": _parts(_text_part("ok"))},
+                # Two user messages in a row before the response.
+                {
+                    "role": "user",
+                    "content": _parts(_text_part("second"), _uri_part(ext("M2"))),
+                },
+                {
+                    "role": "user",
+                    "content": _parts(_text_part("third"), _uri_part(ext("M3"))),
+                },
+            ],
+            output_messages=[
+                {"role": "assistant", "content": _parts(_text_part("reply"))}
+            ],
+            content_refs=[intl("M1"), intl("M2"), intl("M3")],
+        ),
+    ]
+
+    users = [m for m in build_chat_messages(spans) if m.type == "user_message"]
+    # Only the trailing run ("second", "third") is this span's new turn; the
+    # earlier "first" (before the assistant) is history and is not re-emitted.
+    assert [_user_payload(m).text for m in users] == ["second", "third"]
+    assert [_user_payload(m).content_refs for m in users] == [
+        [intl("M2")],
+        [intl("M3")],
+    ]
 
 
 def test_build_span_tree_sort_is_stable_on_equal_timestamps() -> None:

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -901,6 +901,66 @@ def test_output_media_attaches_to_assistant_message() -> None:
     assert _assistant_payload(assistant).content_refs == [image_internal]
 
 
+def test_prior_assistant_media_in_input_history_not_attached_to_user() -> None:
+    """Regression: a multi-turn turn replays the prior assistant turn — audio
+    and all — into its ``input_messages`` as an assistant-role message. That
+    echoed model-generated media must NOT surface as the user's attachment.
+
+    Direction is the message *role*, not its input/output position: both the
+    echoed assistant audio and the user's own audio live in this span's
+    ``input_messages``, but only the user-role one belongs to the user. This is
+    the OpenAI Realtime conversations bug — turn 2's user bubble showed turn 1's
+    assistant audio clip.
+    """
+    user_audio_internal = "weave-trace-internal:///PID/object/Content:USERAUDIO"
+    user_audio_external = "weave:///e/p/object/Content:USERAUDIO"
+    asst_audio_internal = "weave-trace-internal:///PID/object/Content:ASSTAUDIO"
+    asst_audio_external = "weave:///e/p/object/Content:ASSTAUDIO"
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="voice-agent",
+            input_messages=[
+                {"role": "user", "content": _parts(_text_part("And after that?"))}
+            ],
+        ),
+        _span(
+            span_id="chat",
+            parent_span_id="agent",
+            operation_name="chat",
+            # The prior assistant turn is replayed as history (assistant role),
+            # followed by the current user turn (user role) with its own audio.
+            input_messages=[
+                {
+                    "role": "assistant",
+                    "content": _parts(
+                        _text_part("It's foggy."), _uri_part(asst_audio_external)
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": _parts(
+                        _text_part("And after that?"),
+                        _uri_part(user_audio_external),
+                    ),
+                },
+            ],
+            output_messages=[
+                {"role": "assistant", "content": _parts(_text_part("Clearing up."))}
+            ],
+            content_refs=[asst_audio_internal, user_audio_internal],
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+    user = next(m for m in messages if m.type == "user_message")
+
+    # Only the user's own audio attaches; the echoed assistant audio does not.
+    assert _user_payload(user).content_refs == [user_audio_internal]
+    assert asst_audio_internal not in _user_payload(user).content_refs
+
+
 def test_content_ref_without_inline_part_is_not_attached() -> None:
     """A `content_refs` entry with no matching inline message part has no
     direction signal, so it attaches to neither bubble — only refs anchored to

--- a/weave/integrations/openai_realtime/connection.py
+++ b/weave/integrations/openai_realtime/connection.py
@@ -191,7 +191,7 @@ class WeaveMediaConnection:
 
             def _target() -> None:
                 try:
-                    self.conversation_manager.state.on_exit()
+                    self.conversation_manager.state_exporter.on_exit()
                 except Exception:
                     logger.exception("Error in realtime on_exit handler")
 
@@ -284,7 +284,7 @@ class WeaveAsyncWebsocketConnection:
 
             def _target() -> None:
                 try:
-                    self.conversation_manager.state.on_exit()
+                    self.conversation_manager.state_exporter.on_exit()
                 except Exception:
                     logger.exception("Error in realtime on_exit handler")
 
@@ -383,7 +383,7 @@ class WeaveAiohttpWebsocketConnection:
 
             def _target() -> None:
                 try:
-                    self.conversation_manager.state.on_exit()
+                    self.conversation_manager.state_exporter.on_exit()
                 except Exception:
                     logger.exception("Error in realtime on_exit handler")
 

--- a/weave/integrations/openai_realtime/conversation_manager.py
+++ b/weave/integrations/openai_realtime/conversation_manager.py
@@ -6,7 +6,9 @@ from collections.abc import Callable
 from queue import Empty, Queue
 from threading import Lock
 
+from weave.integrations.openai_realtime.otel_state_exporter import OTelStateExporter
 from weave.integrations.openai_realtime.state_exporter import StateExporter
+from weave.trace.settings import should_use_otel_v2
 
 logger = logging.getLogger(__name__)
 
@@ -44,17 +46,10 @@ class ConversationManager:
         # it emits OTel GenAI spans, otherwise legacy Weave calls. ``use_otel``
         # lets callers (and tests) pin the destination explicitly.
         if use_otel is None:
-            from weave.trace.settings import should_use_otel_v2
-
             use_otel = should_use_otel_v2()
-        if use_otel:
-            from weave.integrations.openai_realtime.otel_state_exporter import (
-                OTelStateExporter,
-            )
-
-            self.state: StateExporter = OTelStateExporter()
-        else:
-            self.state = StateExporter()
+        self.state_exporter: StateExporter = (
+            OTelStateExporter() if use_otel else StateExporter()
+        )
         self._registry = EventHandlerRegistry()
         # Worker-thread based event queue + lifecycle
         self._queue: Queue[dict] = Queue()
@@ -64,34 +59,34 @@ class ConversationManager:
 
         handlers: dict[str, Handler] = {
             # Session lifecycle
-            "session.created": self.state.handle_session_created,
-            "session.update": self.state.handle_session_update,
-            "session.updated": self.state.handle_session_updated,
+            "session.created": self.state_exporter.handle_session_created,
+            "session.update": self.state_exporter.handle_session_update,
+            "session.updated": self.state_exporter.handle_session_updated,
             # Input audio buffer lifecycle
-            "input_audio_buffer.append": self.state.handle_input_audio_append,
-            "input_audio_buffer.cleared": self.state.handle_input_audio_cleared,
-            "input_audio_buffer.committed": self.state.handle_input_audio_committed,
-            "input_audio_buffer.speech_started": self.state.handle_speech_started,
-            "input_audio_buffer.speech_stopped": self.state.handle_speech_stopped,
+            "input_audio_buffer.append": self.state_exporter.handle_input_audio_append,
+            "input_audio_buffer.cleared": self.state_exporter.handle_input_audio_cleared,
+            "input_audio_buffer.committed": self.state_exporter.handle_input_audio_committed,
+            "input_audio_buffer.speech_started": self.state_exporter.handle_speech_started,
+            "input_audio_buffer.speech_stopped": self.state_exporter.handle_speech_stopped,
             # Conversation item changes (GA: .added/.done, Beta: .created)
-            "conversation.item.created": self.state.handle_item_created,
-            "conversation.item.added": self.state.handle_item_created,
-            "conversation.item.done": self.state.handle_item_done,
-            "conversation.item.deleted": self.state.handle_item_deleted,
-            "conversation.item.input_audio_transcription.completed": self.state.handle_item_input_audio_transcription_completed,
+            "conversation.item.created": self.state_exporter.handle_item_created,
+            "conversation.item.added": self.state_exporter.handle_item_created,
+            "conversation.item.done": self.state_exporter.handle_item_done,
+            "conversation.item.deleted": self.state_exporter.handle_item_deleted,
+            "conversation.item.input_audio_transcription.completed": self.state_exporter.handle_item_input_audio_transcription_completed,
             # Response lifecycle and parts
-            "response.created": self.state.handle_response_created,
-            "response.done": self.state.handle_response_done,
+            "response.created": self.state_exporter.handle_response_created,
+            "response.done": self.state_exporter.handle_response_done,
             # GA event names (output_audio, output_text)
-            "response.output_audio.delta": self.state.handle_response_audio_delta,
-            "response.output_audio.done": self.state.handle_response_audio_done,
-            "response.output_text.delta": self.state.handle_response_text_delta,
+            "response.output_audio.delta": self.state_exporter.handle_response_audio_delta,
+            "response.output_audio.done": self.state_exporter.handle_response_audio_done,
+            "response.output_text.delta": self.state_exporter.handle_response_text_delta,
             # Beta compatibility (audio)
-            "response.audio.delta": self.state.handle_response_audio_delta,
-            "response.audio.done": self.state.handle_response_audio_done,
-            "response.text.delta": self.state.handle_response_text_delta,
+            "response.audio.delta": self.state_exporter.handle_response_audio_delta,
+            "response.audio.done": self.state_exporter.handle_response_audio_done,
+            "response.text.delta": self.state_exporter.handle_response_text_delta,
             # Function call streaming
-            "response.function_call_arguments.delta": self.state.handle_function_call_arguments_delta,
+            "response.function_call_arguments.delta": self.state_exporter.handle_function_call_arguments_delta,
         }
 
         self._registry.update(handlers)

--- a/weave/integrations/openai_realtime/conversation_manager.py
+++ b/weave/integrations/openai_realtime/conversation_manager.py
@@ -39,11 +39,10 @@ class ConversationManager:
     def __init__(self, use_otel: bool | None = None) -> None:
         # Optional base URL for downstream export context
         self.client_base_url: str | None = None
-        # The exporter (StateExporter subclass) accumulates the same delta
-        # state regardless of destination; only the final ``_emit_response``
-        # differs. Under WEAVE_USE_OTEL_V2 we export OTel GenAI spans to the
-        # Agents tab; otherwise legacy Weave calls. ``use_otel`` lets callers
-        # (and tests) pin the destination explicitly.
+        # The exporter accumulates the same delta state regardless of
+        # destination; only ``_emit_response`` differs. Under WEAVE_USE_OTEL_V2
+        # it emits OTel GenAI spans, otherwise legacy Weave calls. ``use_otel``
+        # lets callers (and tests) pin the destination explicitly.
         if use_otel is None:
             from weave.trace.settings import should_use_otel_v2
 

--- a/weave/integrations/openai_realtime/conversation_manager.py
+++ b/weave/integrations/openai_realtime/conversation_manager.py
@@ -36,10 +36,26 @@ class ConversationManager:
     Provides async queue submission and direct processing.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, use_otel: bool | None = None) -> None:
         # Optional base URL for downstream export context
         self.client_base_url: str | None = None
-        self.state: StateExporter = StateExporter()
+        # The exporter (StateExporter subclass) accumulates the same delta
+        # state regardless of destination; only the final ``_emit_response``
+        # differs. Under WEAVE_USE_OTEL_V2 we export OTel GenAI spans to the
+        # Agents tab; otherwise legacy Weave calls. ``use_otel`` lets callers
+        # (and tests) pin the destination explicitly.
+        if use_otel is None:
+            from weave.trace.settings import should_use_otel_v2
+
+            use_otel = should_use_otel_v2()
+        if use_otel:
+            from weave.integrations.openai_realtime.otel_state_exporter import (
+                OTelStateExporter,
+            )
+
+            self.state: StateExporter = OTelStateExporter()
+        else:
+            self.state = StateExporter()
         self._registry = EventHandlerRegistry()
         # Worker-thread based event queue + lifecycle
         self._queue: Queue[dict] = Queue()

--- a/weave/integrations/openai_realtime/otel_state_exporter.py
+++ b/weave/integrations/openai_realtime/otel_state_exporter.py
@@ -1,0 +1,531 @@
+"""OTel GenAI export for the OpenAI Realtime integration.
+
+This is the OTel-native sibling of ``state_exporter.StateExporter``. It reuses
+*all* of the parent's delta-accumulation machinery — audio buffering, item
+threading, per-item timing, transcript gating, and FIFO response ordering —
+and overrides only the single export seam (``_emit_response``) so the same
+compiled ``inputs`` / ``output_dict`` / ``summary`` are emitted as
+OpenTelemetry GenAI spans to Weave's Agents tab instead of legacy Weave calls.
+
+The dispatcher selects this variant when ``WEAVE_USE_OTEL_V2`` is set (the
+default), mirroring ``claude_agent_sdk`` and ``openai_agents``. Spans are
+created via ``otel_trace.get_tracer(...)`` and ride the global OTel
+``TracerProvider`` configured by ``weave.init()`` (``_setup_session_tracing``),
+which exports to ``/agents/otel/v1/traces``.
+
+Span tree — one per realtime session:
+
+    invoke_agent {agent_name}     # session root; ended on connection close
+    ├── chat {model}              # one per response.done
+    │   └── execute_tool {name}   # one per function_call output item
+    ├── chat {model}
+    └── chat {model}
+
+The realtime API is speech-to-speech: each ``response.done`` is one model
+generation, so it maps to one ``chat`` span. Two distinct concerns:
+
+- **Tree grouping** is by the realtime **session** (the websocket connection,
+  ``session.id``) — the stable identifier for a whole voice call — so all of a
+  session's chat spans nest under one ``invoke_agent`` root in one trace.
+- **``gen_ai.conversation.id``** carries the realtime **conversation_id** when
+  the API supplies one (the semantically correct conversation identifier),
+  falling back to the session id only when it is absent (e.g. Beta).
+
+This path has no notion of legacy Weave "threads" / ``thread_id``.
+
+Audio (user speech in, model speech out) is published as a Weave ``Content``
+object and referenced from the message by a ``weave://`` URI ``UriPart``
+(plus ``weave.content_refs``), exactly as the Session SDK handles media.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import threading
+from typing import Any
+
+from opentelemetry import trace as otel_trace
+from opentelemetry.trace import StatusCode
+from pydantic import PrivateAttr
+
+from weave.integrations.integration_metadata import library_integration
+from weave.integrations.openai_realtime.encoding import pcm_to_wav
+from weave.integrations.openai_realtime.state_exporter import (
+    INPUT_AUDIO_TYPE,
+    OUTPUT_AUDIO_TYPES,
+    SessionSpan,
+    StateExporter,
+)
+from weave.session.agent_context import resolve_agent_name
+from weave.session.session_otel import (
+    execute_tool_attributes,
+    invoke_agent_attributes,
+    llm_attributes,
+)
+from weave.session.types import (
+    Message,
+    TextPart,
+    ToolCallPart,
+    ToolCallResponsePart,
+    UriPart,
+    Usage,
+)
+
+logger = logging.getLogger(__name__)
+
+_TRACER_NAME = "weave.openai_realtime"
+_DEFAULT_AGENT_NAME = "openai_realtime"
+_PROVIDER_NAME = "openai"
+_AUDIO_MIME_TYPE = "audio/wav"
+_AUDIO_MODALITY = "audio"
+
+# Content part types that carry plain text across Beta and GA event shapes.
+_TEXT_CONTENT_TYPES = ("text", "input_text", "output_text")
+
+# Integration provenance, flattened once for OTel span attributes (scalars only).
+_INTEGRATION_OTEL_ATTRS = library_integration(
+    "openai_realtime", distribution_name="openai"
+).as_otel_attributes()
+
+
+def _ns(dt: datetime.datetime | None) -> int | None:
+    """Convert a UTC datetime to epoch nanoseconds for OTel span timing.
+
+    Returns None when no timestamp was recorded, letting the OTel SDK fall
+    back to the current time at span start/end.
+    """
+    if dt is None:
+        return None
+    return int(dt.timestamp() * 1_000_000_000)
+
+
+def _safe_int(val: Any) -> int | None:
+    try:
+        return int(val) if val is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_float(val: Any) -> float | None:
+    try:
+        return float(val) if val is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_arg_string(val: Any) -> str:
+    """Coerce tool-call arguments to a string (semconv wants a JSON string)."""
+    if isinstance(val, str):
+        return val
+    if val is None:
+        return ""
+    try:
+        return json.dumps(val, default=str)
+    except (TypeError, ValueError):
+        return str(val)
+
+
+class OTelStateExporter(StateExporter):
+    """``StateExporter`` that exports compiled responses as OTel GenAI spans.
+
+    Only the export-time methods are overridden; every event handler that
+    accumulates state is inherited unchanged. The two audio-resolution hooks
+    (``_resolve_audio`` / ``_extract_audio_content``) are neutralized so the
+    compiled payloads keep raw item dicts — this exporter reconstructs audio
+    from the parent's buffers and publishes it to ``weave://`` refs itself.
+    """
+
+    # group key (session id, else conversation_id, else response_id) -> root span.
+    _session_root_spans: dict[str, Any] = PrivateAttr(default_factory=dict)
+    # group key -> last activity datetime, used as the root span end time.
+    _session_last_activity: dict[str, datetime.datetime] = PrivateAttr(
+        default_factory=dict
+    )
+    # Guards the two maps above; on_exit runs on a different thread than the
+    # FIFO completion thread that emits responses.
+    _otel_lock: Any = PrivateAttr(default_factory=threading.Lock)
+
+    # ------------------------------------------------------------------
+    # Session handlers — store config without creating any Weave calls.
+    # ------------------------------------------------------------------
+    def _store_session(self, msg: dict) -> None:
+        if self.session_span is None:
+            # Bare SessionSpan() creates no Weave call (unlike from_session()).
+            self.session_span = SessionSpan()
+        session = msg.get("session")
+        self.session_span.session = session if isinstance(session, dict) else {}
+
+    def handle_session_created(self, msg: dict) -> None:
+        self._store_session(msg)
+
+    def handle_session_update(self, msg: dict) -> None:
+        self._store_session(msg)
+
+    def handle_session_updated(self, msg: dict) -> None:
+        self._store_session(msg)
+
+    def handle_response_created(self, msg: dict) -> None:
+        # Record creation timing (used as the chat span start) but do NOT
+        # create a conversation call — the OTel root span is created lazily
+        # in _emit_response so it can carry semconv attributes.
+        self.pending_response = msg.get("response")
+        response = self.pending_response or {}
+        response_id = response.get("id")
+        if response_id:
+            self.response_created_at[response_id] = datetime.datetime.now(
+                tz=datetime.timezone.utc
+            )
+
+    # ------------------------------------------------------------------
+    # Audio hooks — neutralized so the compiled payloads stay raw. This
+    # exporter pulls audio bytes from the parent buffers and publishes them.
+    # ------------------------------------------------------------------
+    def _resolve_audio(self, msg: dict) -> Any:
+        return msg
+
+    def _extract_audio_content(self, output_list: list[dict], output_dict: dict) -> None:
+        return None
+
+    # ------------------------------------------------------------------
+    # Audio publishing + message construction
+    # ------------------------------------------------------------------
+    def _publish_audio(self, pcm_bytes: bytes | None) -> str | None:
+        """Publish PCM audio as a WAV ``Content`` and return its ``weave://`` ref.
+
+        Returns None (and logs) on any failure so a publish error degrades to a
+        span without the audio ref rather than dropping the whole span.
+        """
+        if not pcm_bytes:
+            return None
+        try:
+            from weave.trace.api import publish
+            from weave.type_wrappers.Content.content import Content
+
+            content = Content.from_bytes(
+                pcm_to_wav(bytes(pcm_bytes)), mimetype=_AUDIO_MIME_TYPE
+            )
+            ref = publish(content)
+            # ``ref.uri`` may be a str subclass that OTel attr validation rejects.
+            return str(getattr(ref, "uri", ref))
+        except Exception:
+            logger.exception("openai_realtime OTel: failed to publish audio content")
+            return None
+
+    def _content_parts(self, item: dict, refs: list[str]) -> list[Any]:
+        """Build message parts for a realtime message item.
+
+        Transcripts become ``TextPart``s; audio is published and referenced via
+        ``UriPart``. Any published ref is appended to ``refs`` so the caller can
+        populate ``weave.content_refs``.
+        """
+        item_id = item.get("id")
+        parts: list[Any] = []
+        for content in item.get("content", []) or []:
+            ctype = content.get("type")
+            if ctype in _TEXT_CONTENT_TYPES:
+                text = content.get("text")
+                if text:
+                    parts.append(TextPart(content=text))
+            elif ctype == INPUT_AUDIO_TYPE:
+                transcript = content.get("transcript")
+                if transcript:
+                    parts.append(TextPart(content=transcript))
+                ref = self._publish_audio(
+                    self._get_item_audio(item_id) if item_id else None
+                )
+                if ref:
+                    parts.append(
+                        UriPart(
+                            modality=_AUDIO_MODALITY, mime_type=_AUDIO_MIME_TYPE, uri=ref
+                        )
+                    )
+                    refs.append(ref)
+            elif ctype in OUTPUT_AUDIO_TYPES:
+                transcript = content.get("transcript")
+                if transcript:
+                    parts.append(TextPart(content=transcript))
+                ref = self._publish_audio(
+                    self.response_audio.get(item_id) if item_id else None
+                )
+                if ref:
+                    parts.append(
+                        UriPart(
+                            modality=_AUDIO_MODALITY, mime_type=_AUDIO_MIME_TYPE, uri=ref
+                        )
+                    )
+                    refs.append(ref)
+        return parts
+
+    def _item_to_message(self, item: dict, refs: list[str]) -> Message | None:
+        """Convert one realtime conversation item into a session ``Message``."""
+        itype = item.get("type")
+        if itype == "function_call":
+            call_id = item.get("call_id") or item.get("id") or ""
+            return Message(
+                role="assistant",
+                parts=[
+                    ToolCallPart(
+                        id=call_id,
+                        name=item.get("name", ""),
+                        arguments=_as_arg_string(item.get("arguments")),
+                    )
+                ],
+            )
+        if itype == "function_call_output":
+            call_id = item.get("call_id") or item.get("id") or ""
+            return Message(
+                role="tool",
+                parts=[ToolCallResponsePart(id=call_id, response=item.get("output", ""))],
+            )
+        if itype == "message":
+            role = item.get("role") or "user"
+            parts = self._content_parts(item, refs)
+            if parts:
+                return Message(role=role, parts=parts)
+            return Message(role=role, content="")
+        return None
+
+    def _build_usage(self, output_dict: dict) -> Usage | None:
+        """Map the realtime response usage block onto a session ``Usage``."""
+        usage = output_dict.get("usage")
+        if not isinstance(usage, dict):
+            return None
+        input_details = usage.get("input_token_details")
+        cached = 0
+        if isinstance(input_details, dict):
+            cached = _safe_int(input_details.get("cached_tokens")) or 0
+        return Usage(
+            input_tokens=_safe_int(usage.get("input_tokens")) or 0,
+            output_tokens=_safe_int(usage.get("output_tokens")) or 0,
+            cache_read_input_tokens=cached,
+        )
+
+    # ------------------------------------------------------------------
+    # Span lifecycle
+    # ------------------------------------------------------------------
+    def _ensure_session_root(
+        self,
+        tracer: Any,
+        group_key: str,
+        conversation_id: str,
+        model: str,
+        created_at: datetime.datetime | None,
+    ) -> Any:
+        """Return the open ``invoke_agent`` root span for a realtime session.
+
+        Created lazily on the first response and held open until the connection
+        closes (``on_exit``), so every ``chat`` of the session nests under one
+        root (``group_key`` is the session-scoped grouping key). The root's
+        ``gen_ai.conversation.id`` is the realtime conversation_id when
+        available, established from the first response of the session.
+        """
+        with self._otel_lock:
+            existing = self._session_root_spans.get(group_key)
+            if existing is not None:
+                return existing
+            agent_name = resolve_agent_name(_DEFAULT_AGENT_NAME)
+            attrs = invoke_agent_attributes(
+                agent_name=agent_name,
+                conversation_id=conversation_id,
+                provider_name=_PROVIDER_NAME,
+                model=model,
+            )
+            attrs.update(_INTEGRATION_OTEL_ATTRS)
+            root = tracer.start_span(
+                f"invoke_agent {agent_name}".rstrip(), start_time=_ns(created_at)
+            )
+            for key, value in attrs.items():
+                root.set_attribute(key, value)
+            self._session_root_spans[group_key] = root
+            if created_at:
+                self._session_last_activity[group_key] = created_at
+            return root
+
+    def _emit_response(
+        self,
+        *,
+        response: dict,
+        conv_id: str | None,
+        response_id: str | None,
+        inputs: dict[str, Any],
+        output_dict: dict[str, Any],
+        summary: dict[str, Any],
+        created_at: datetime.datetime | None,
+        done_at: datetime.datetime | None,
+        first_content_at: datetime.datetime | None,
+    ) -> None:
+        # Never let span bookkeeping break the FIFO completion thread.
+        try:
+            self._emit_otel(
+                response=response,
+                conv_id=conv_id,
+                response_id=response_id,
+                inputs=inputs,
+                output_dict=output_dict,
+                created_at=created_at,
+                done_at=done_at,
+                first_content_at=first_content_at,
+            )
+        except Exception:
+            logger.exception(
+                "openai_realtime OTel export failed for response %s", response_id
+            )
+
+    def _emit_otel(
+        self,
+        *,
+        response: dict,
+        conv_id: str | None,
+        response_id: str | None,
+        inputs: dict[str, Any],
+        output_dict: dict[str, Any],
+        created_at: datetime.datetime | None,
+        done_at: datetime.datetime | None,
+        first_content_at: datetime.datetime | None,
+    ) -> None:
+        tracer = otel_trace.get_tracer(_TRACER_NAME)
+        session = self.session_span.get_session() if self.session_span else None
+        model = (session or {}).get("model") or "unknown"
+
+        # gen_ai.conversation.id priority (semantic-convention first):
+        #   1. realtime conversation_id  — the spec-correct conversation id, and
+        #      what lands in the `conversation_id` column the agents tab groups on
+        #   2. realtime session id       — fallback only. The `spans` table has
+        #      `conversation_id` + `conversation_name` but NO dedicated session
+        #      column (verified against the schema), so the session id has no
+        #      other home; it backstops conversation_id when the API omits one
+        #      (e.g. Beta).
+        # Tree grouping is independent: the span tree is always rooted per
+        # SESSION (the websocket call) so the whole voice call is one trace,
+        # regardless of which value ends up in conversation.id.
+        session_id = (session or {}).get("id") or ""
+        group_key = session_id or conv_id or response_id or "default"
+        conversation_id = conv_id or session_id or ""
+
+        root = self._ensure_session_root(
+            tracer, group_key, conversation_id, model, created_at
+        )
+
+        refs: list[str] = []
+
+        # Input messages: the prior conversation thread feeding this response.
+        input_messages: list[Message] = []
+        for item in inputs.get("messages", []) or []:
+            msg = self._item_to_message(item, refs)
+            if msg is not None:
+                input_messages.append(msg)
+
+        # Output: assemble one assistant message (text + audio + tool-call parts)
+        # and collect function_call items for execute_tool child spans.
+        out_parts: list[Any] = []
+        tool_call_items: list[dict] = []
+        has_audio = False
+        for out_item in output_dict.get("output", []) or []:
+            otype = out_item.get("type")
+            if otype == "message":
+                before = len(refs)
+                out_parts.extend(self._content_parts(out_item, refs))
+                if len(refs) > before:
+                    has_audio = True
+            elif otype == "function_call":
+                call_id = out_item.get("call_id") or out_item.get("id") or ""
+                out_parts.append(
+                    ToolCallPart(
+                        id=call_id,
+                        name=out_item.get("name", ""),
+                        arguments=_as_arg_string(out_item.get("arguments")),
+                    )
+                )
+                tool_call_items.append(out_item)
+        output_messages = [Message(role="assistant", parts=out_parts)] if out_parts else []
+
+        attrs = llm_attributes(
+            model=model,
+            provider_name=_PROVIDER_NAME,
+            conversation_id=conversation_id,
+            input_messages=input_messages or None,
+            output_messages=output_messages or None,
+            usage=self._build_usage(output_dict),
+            response_id=response_id or "",
+            response_model=model,
+            output_type="speech" if has_audio else "text",
+            request_temperature=_safe_float((session or {}).get("temperature")),
+            request_max_tokens=_safe_int(
+                (session or {}).get("max_response_output_tokens")
+            ),
+        )
+        attrs.update(_INTEGRATION_OTEL_ATTRS)
+        if refs:
+            attrs["weave.content_refs"] = [str(r) for r in refs]
+
+        chat_ctx = otel_trace.set_span_in_context(root)
+        chat = tracer.start_span(
+            f"chat {model}".rstrip(), context=chat_ctx, start_time=_ns(created_at)
+        )
+        for key, value in attrs.items():
+            chat.set_attribute(key, value)
+        if response.get("status") == "failed":
+            details = response.get("status_details")
+            err = details.get("error") if isinstance(details, dict) else None
+            message = (
+                err.get("message") if isinstance(err, dict) else None
+            ) or "response failed"
+            chat.set_status(StatusCode.ERROR, str(message))
+
+        # execute_tool children, parented under the chat span.
+        tool_parent_ctx = otel_trace.set_span_in_context(chat)
+        for fc in tool_call_items:
+            self._emit_tool_span(
+                tracer, tool_parent_ctx, fc, conversation_id, created_at, done_at
+            )
+
+        chat.end(end_time=_ns(done_at) or _ns(first_content_at))
+
+        if done_at:
+            with self._otel_lock:
+                self._session_last_activity[group_key] = done_at
+
+    def _emit_tool_span(
+        self,
+        tracer: Any,
+        parent_ctx: Any,
+        fc: dict,
+        conversation_id: str,
+        created_at: datetime.datetime | None,
+        done_at: datetime.datetime | None,
+    ) -> None:
+        item_id = fc.get("id")
+        ts = self.item_timestamps.get(item_id, {}) if item_id else {}
+        start = ts.get("started") or created_at
+        end = ts.get("completed") or done_at
+        name = fc.get("name", "")
+        attrs = execute_tool_attributes(
+            tool_name=name,
+            conversation_id=conversation_id,
+            tool_call_id=fc.get("call_id") or fc.get("id") or "",
+            tool_call_arguments=_as_arg_string(fc.get("arguments")),
+        )
+        attrs.update(_INTEGRATION_OTEL_ATTRS)
+        tool_span = tracer.start_span(
+            f"execute_tool {name}".rstrip(), context=parent_ctx, start_time=_ns(start)
+        )
+        for key, value in attrs.items():
+            tool_span.set_attribute(key, value)
+        tool_span.end(end_time=_ns(end))
+
+    def on_exit(self) -> None:
+        """End all open session root spans on connection close."""
+        with self._otel_lock:
+            spans = list(self._session_root_spans.items())
+            last = dict(self._session_last_activity)
+            self._session_root_spans.clear()
+            self._session_last_activity.clear()
+        for group_key, root in spans:
+            try:
+                root.end(end_time=_ns(last.get(group_key)))
+            except Exception:
+                logger.exception(
+                    "openai_realtime OTel: failed to end session root span"
+                )

--- a/weave/integrations/openai_realtime/otel_state_exporter.py
+++ b/weave/integrations/openai_realtime/otel_state_exporter.py
@@ -135,6 +135,14 @@ class OTelStateExporter(StateExporter):
     # Guards the two maps above; on_exit runs on a different thread than the
     # FIFO completion thread that emits responses.
     _otel_lock: Any = PrivateAttr(default_factory=threading.Lock)
+    # Agent name resolved once at construction. Spans are emitted on worker/FIFO
+    # threads where the user's agent_name_override contextvar is not visible, so
+    # we capture it here on the constructing (user) thread, not at emit time.
+    _agent_name: str = PrivateAttr(default=_DEFAULT_AGENT_NAME)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._agent_name = resolve_agent_name(_DEFAULT_AGENT_NAME)
 
     # ------------------------------------------------------------------
     # Session handlers — store config without creating any Weave calls.
@@ -316,7 +324,7 @@ class OTelStateExporter(StateExporter):
             existing = self._session_root_spans.get(group_key)
             if existing is not None:
                 return existing
-            agent_name = resolve_agent_name(_DEFAULT_AGENT_NAME)
+            agent_name = self._agent_name
             attrs = invoke_agent_attributes(
                 agent_name=agent_name,
                 conversation_id=conversation_id,

--- a/weave/integrations/openai_realtime/otel_state_exporter.py
+++ b/weave/integrations/openai_realtime/otel_state_exporter.py
@@ -1,19 +1,14 @@
 """OTel GenAI export for the OpenAI Realtime integration.
 
-This is the OTel-native sibling of ``state_exporter.StateExporter``. It reuses
-*all* of the parent's delta-accumulation machinery — audio buffering, item
-threading, per-item timing, transcript gating, and FIFO response ordering —
-and overrides only the single export seam (``_emit_response``) so the same
-compiled ``inputs`` / ``output_dict`` / ``summary`` are emitted as
-OpenTelemetry GenAI spans to Weave's Agents tab instead of legacy Weave calls.
+The OTel-native sibling of ``StateExporter``: it inherits the parent's
+delta-accumulation machinery (audio buffering, item threading, transcript
+gating, FIFO response ordering) and overrides only ``_emit_response`` to emit
+the compiled response as OpenTelemetry GenAI spans rather than legacy Weave
+calls. Selected when ``WEAVE_USE_OTEL_V2`` is set (the default), like
+``claude_agent_sdk`` and ``openai_agents``.
 
-The dispatcher selects this variant when ``WEAVE_USE_OTEL_V2`` is set (the
-default), mirroring ``claude_agent_sdk`` and ``openai_agents``. Spans are
-created via ``otel_trace.get_tracer(...)`` and ride the global OTel
-``TracerProvider`` configured by ``weave.init()`` (``_setup_session_tracing``),
-which exports to ``/agents/otel/v1/traces``.
-
-Span tree — one per realtime session:
+The realtime API is speech-to-speech, so each ``response.done`` is one model
+generation and maps to one ``chat`` span:
 
     invoke_agent {agent_name}     # session root; ended on connection close
     ├── chat {model}              # one per response.done
@@ -21,21 +16,12 @@ Span tree — one per realtime session:
     ├── chat {model}
     └── chat {model}
 
-The realtime API is speech-to-speech: each ``response.done`` is one model
-generation, so it maps to one ``chat`` span. Two distinct concerns:
+Spans are grouped into one trace per realtime session (the websocket
+connection); ``gen_ai.conversation.id`` carries the API's conversation_id,
+falling back to the session id when absent (e.g. Beta).
 
-- **Tree grouping** is by the realtime **session** (the websocket connection,
-  ``session.id``) — the stable identifier for a whole voice call — so all of a
-  session's chat spans nest under one ``invoke_agent`` root in one trace.
-- **``gen_ai.conversation.id``** carries the realtime **conversation_id** when
-  the API supplies one (the semantically correct conversation identifier),
-  falling back to the session id only when it is absent (e.g. Beta).
-
-This path has no notion of legacy Weave "threads" / ``thread_id``.
-
-Audio (user speech in, model speech out) is published as a Weave ``Content``
-object and referenced from the message by a ``weave://`` URI ``UriPart``
-(plus ``weave.content_refs``), exactly as the Session SDK handles media.
+Audio is published as a Weave ``Content`` object and referenced from the
+message by a ``weave://`` ``UriPart``, as the Session SDK handles media.
 """
 
 from __future__ import annotations
@@ -72,6 +58,8 @@ from weave.session.types import (
     UriPart,
     Usage,
 )
+from weave.trace import urls
+from weave.trace.context.weave_client_context import get_weave_client
 
 logger = logging.getLogger(__name__)
 
@@ -130,9 +118,8 @@ def _as_arg_string(val: Any) -> str:
 class OTelStateExporter(StateExporter):
     """``StateExporter`` that exports compiled responses as OTel GenAI spans.
 
-    Only the export-time methods are overridden; every event handler that
-    accumulates state is inherited unchanged. The two audio-resolution hooks
-    (``_resolve_audio`` / ``_extract_audio_content``) are neutralized so the
+    Only the export seam is overridden; the state-accumulating event handlers
+    are inherited unchanged. The audio-resolution hooks are neutralized so the
     compiled payloads keep raw item dicts — this exporter reconstructs audio
     from the parent's buffers and publishes it to ``weave://`` refs itself.
     """
@@ -167,9 +154,9 @@ class OTelStateExporter(StateExporter):
         self._store_session(msg)
 
     def handle_response_created(self, msg: dict) -> None:
-        # Record creation timing (used as the chat span start) but do NOT
-        # create a conversation call — the OTel root span is created lazily
-        # in _emit_response so it can carry semconv attributes.
+        # Record creation timing for the chat span start. Unlike the parent we
+        # create no call here; the root span is built lazily in _emit_response
+        # so it can carry semconv attributes.
         self.pending_response = msg.get("response")
         response = self.pending_response or {}
         response_id = response.get("id")
@@ -179,8 +166,7 @@ class OTelStateExporter(StateExporter):
             )
 
     # ------------------------------------------------------------------
-    # Audio hooks — neutralized so the compiled payloads stay raw. This
-    # exporter pulls audio bytes from the parent buffers and publishes them.
+    # Audio hooks — neutralized; this exporter publishes audio itself.
     # ------------------------------------------------------------------
     def _resolve_audio(self, msg: dict) -> Any:
         return msg
@@ -321,13 +307,11 @@ class OTelStateExporter(StateExporter):
         model: str,
         created_at: datetime.datetime | None,
     ) -> Any:
-        """Return the open ``invoke_agent`` root span for a realtime session.
+        """Return the ``invoke_agent`` root span for the session, creating it on
+        first use.
 
-        Created lazily on the first response and held open until the connection
-        closes (``on_exit``), so every ``chat`` of the session nests under one
-        root (``group_key`` is the session-scoped grouping key). The root's
-        ``gen_ai.conversation.id`` is the realtime conversation_id when
-        available, established from the first response of the session.
+        Held open until the connection closes (``on_exit``) so every ``chat``
+        of the session nests under one root.
         """
         with self._otel_lock:
             existing = self._session_root_spans.get(group_key)
@@ -349,7 +333,19 @@ class OTelStateExporter(StateExporter):
             self._session_root_spans[group_key] = root
             if created_at:
                 self._session_last_activity[group_key] = created_at
-            return root
+        # Log outside the lock; this runs once, when the root is first created.
+        self._log_conversation_link(conversation_id)
+        return root
+
+    def _log_conversation_link(self, conversation_id: str) -> None:
+        """Log a link to this conversation's page in the Weave UI, once."""
+        client = get_weave_client()
+        if not conversation_id or client is None:
+            return
+        url = urls.agent_conversation_path(
+            client.entity, client.project, conversation_id
+        )
+        logger.info("View realtime conversation at %s", url)
 
     def _emit_response(
         self,
@@ -397,17 +393,11 @@ class OTelStateExporter(StateExporter):
         session = self.session_span.get_session() if self.session_span else None
         model = (session or {}).get("model") or "unknown"
 
-        # gen_ai.conversation.id priority (semantic-convention first):
-        #   1. realtime conversation_id  — the spec-correct conversation id, and
-        #      what lands in the `conversation_id` column the agents tab groups on
-        #   2. realtime session id       — fallback only. The `spans` table has
-        #      `conversation_id` + `conversation_name` but NO dedicated session
-        #      column (verified against the schema), so the session id has no
-        #      other home; it backstops conversation_id when the API omits one
-        #      (e.g. Beta).
-        # Tree grouping is independent: the span tree is always rooted per
-        # SESSION (the websocket call) so the whole voice call is one trace,
-        # regardless of which value ends up in conversation.id.
+        # gen_ai.conversation.id prefers the realtime conversation_id (the
+        # spec-correct id, and what the agents tab groups on), falling back to
+        # the session id when the API omits one (e.g. Beta) — the spans table
+        # has no dedicated session column. Tree grouping is independent: it is
+        # always rooted per session, so the whole voice call is one trace.
         session_id = (session or {}).get("id") or ""
         group_key = session_id or conv_id or response_id or "default"
         conversation_id = conv_id or session_id or ""

--- a/weave/integrations/openai_realtime/otel_state_exporter.py
+++ b/weave/integrations/openai_realtime/otel_state_exporter.py
@@ -205,7 +205,7 @@ class OTelStateExporter(StateExporter):
             from weave.trace.api import publish
             from weave.type_wrappers.Content.content import Content
 
-            content = Content.from_bytes(
+            content: Content = Content.from_bytes(
                 pcm_to_wav(bytes(pcm_bytes)), mimetype=_AUDIO_MIME_TYPE
             )
             ref = publish(content)

--- a/weave/integrations/openai_realtime/otel_state_exporter.py
+++ b/weave/integrations/openai_realtime/otel_state_exporter.py
@@ -59,7 +59,9 @@ from weave.session.types import (
     Usage,
 )
 from weave.trace import urls
+from weave.trace.api import publish
 from weave.trace.context.weave_client_context import get_weave_client
+from weave.type_wrappers.Content.content import Content
 
 logger = logging.getLogger(__name__)
 
@@ -185,12 +187,9 @@ class OTelStateExporter(StateExporter):
         Returns None (and logs) on any failure so a publish error degrades to a
         span without the audio ref rather than dropping the whole span.
         """
-        if not pcm_bytes:
+        if pcm_bytes is None or len(pcm_bytes) == 0:
             return None
         try:
-            from weave.trace.api import publish
-            from weave.type_wrappers.Content.content import Content
-
             content: Content = Content.from_bytes(
                 pcm_to_wav(bytes(pcm_bytes)), mimetype=_AUDIO_MIME_TYPE
             )

--- a/weave/integrations/openai_realtime/otel_state_exporter.py
+++ b/weave/integrations/openai_realtime/otel_state_exporter.py
@@ -185,7 +185,9 @@ class OTelStateExporter(StateExporter):
     def _resolve_audio(self, msg: dict) -> Any:
         return msg
 
-    def _extract_audio_content(self, output_list: list[dict], output_dict: dict) -> None:
+    def _extract_audio_content(
+        self, output_list: list[dict], output_dict: dict
+    ) -> None:
         return None
 
     # ------------------------------------------------------------------
@@ -238,7 +240,9 @@ class OTelStateExporter(StateExporter):
                 if ref:
                     parts.append(
                         UriPart(
-                            modality=_AUDIO_MODALITY, mime_type=_AUDIO_MIME_TYPE, uri=ref
+                            modality=_AUDIO_MODALITY,
+                            mime_type=_AUDIO_MIME_TYPE,
+                            uri=ref,
                         )
                     )
                     refs.append(ref)
@@ -252,7 +256,9 @@ class OTelStateExporter(StateExporter):
                 if ref:
                     parts.append(
                         UriPart(
-                            modality=_AUDIO_MODALITY, mime_type=_AUDIO_MIME_TYPE, uri=ref
+                            modality=_AUDIO_MODALITY,
+                            mime_type=_AUDIO_MIME_TYPE,
+                            uri=ref,
                         )
                     )
                     refs.append(ref)
@@ -277,7 +283,9 @@ class OTelStateExporter(StateExporter):
             call_id = item.get("call_id") or item.get("id") or ""
             return Message(
                 role="tool",
-                parts=[ToolCallResponsePart(id=call_id, response=item.get("output", ""))],
+                parts=[
+                    ToolCallResponsePart(id=call_id, response=item.get("output", ""))
+                ],
             )
         if itype == "message":
             role = item.get("role") or "user"
@@ -439,7 +447,9 @@ class OTelStateExporter(StateExporter):
                     )
                 )
                 tool_call_items.append(out_item)
-        output_messages = [Message(role="assistant", parts=out_parts)] if out_parts else []
+        output_messages = (
+            [Message(role="assistant", parts=out_parts)] if out_parts else []
+        )
 
         attrs = llm_attributes(
             model=model,

--- a/weave/integrations/openai_realtime/state_exporter.py
+++ b/weave/integrations/openai_realtime/state_exporter.py
@@ -635,45 +635,9 @@ class StateExporter(BaseModel):
         if session:
             inputs.update(session)
 
-        from weave.trace.context.weave_client_context import require_weave_client
-
-        client = require_weave_client()
-
-        session_call: Call | None = None
-        if self.session_span:
-            session_call = self.session_span.get_root_call()
-
         response = msg.get("response", {})
         conv_id = response.get("conversation_id")
         response_id = response.get("id")
-
-        if conv_id and self.conversation_responses.get(conv_id) is not None:
-            if response_id:
-                self.conversation_responses[conv_id].append(response_id)
-
-        elif conv_id and response_id:
-            self.conversation_responses[conv_id] = [response_id]
-
-        if conv_id and (conv_call := self.conversation_calls.get(conv_id)):
-            response_parent = conv_call
-
-        elif conv_id:
-            conv_call = client.create_call(
-                op="realtime.conversation",
-                inputs={"id": conv_id},
-                parent=session_call,
-                attributes=OPENAI_REALTIME_INTEGRATION.as_attributes(),
-            )
-            self.conversation_calls[conv_id] = conv_call
-            response_parent = conv_call
-
-        elif session_call:
-            response_parent = session_call
-
-        else:
-            logger.warning("Could not find session for response - %s", response_id)
-            # Will not happen in GA but potentially possible in Beta
-            response_parent = None
 
         # Pop all pre-recorded timestamps for this response
         created_at = (
@@ -702,31 +666,6 @@ class StateExporter(BaseModel):
                 if not isinstance(inputs.get("metadata"), dict):
                     inputs["metadata"] = {}
                 inputs["metadata"]["metrics"] = input_metrics_array
-
-        # Latency = TTFT: started_at=response.created, ended_at=first content
-        # Use user-set thread_id if present, otherwise fall back to conv_id
-        user_thread_id = get_thread_id()
-        if user_thread_id is not None and user_thread_id != "":
-            thread_id = user_thread_id
-        else:
-            thread_id = conv_id
-        if thread_id is not None and conv_id != "":
-            with set_thread_id(thread_id):
-                call = client.create_call(
-                    "realtime.response",
-                    inputs=inputs,
-                    parent=response_parent,
-                    started_at=created_at,
-                    attributes=OPENAI_REALTIME_INTEGRATION.as_attributes(),
-                )
-        else:
-            call = client.create_call(
-                "realtime.response",
-                inputs=inputs,
-                parent=response_parent,
-                started_at=created_at,
-                attributes=OPENAI_REALTIME_INTEGRATION.as_attributes(),
-            )
 
         output_dict = dict(response)
         output_list = response.get("output", [])
@@ -784,6 +723,103 @@ class StateExporter(BaseModel):
 
         if summary_usage:
             summary["usage"] = summary_usage
+
+        self._emit_response(
+            response=response,
+            conv_id=conv_id,
+            response_id=response_id,
+            inputs=inputs,
+            output_dict=output_dict,
+            summary=summary,
+            created_at=created_at,
+            done_at=done_at,
+            first_content_at=first_content_at,
+        )
+
+    def _emit_response(
+        self,
+        *,
+        response: dict,
+        conv_id: str | None,
+        response_id: str | None,
+        inputs: dict[str, Any],
+        output_dict: dict[str, Any],
+        summary: dict[str, Any],
+        created_at: datetime.datetime | None,
+        done_at: datetime.datetime | None,
+        first_content_at: datetime.datetime | None,
+    ) -> None:
+        """Export the compiled response state for one finished response.
+
+        This is the single seam between the delta-accumulation machinery
+        (audio buffers, transcript gating, FIFO ordering — all above and in
+        the event handlers) and the destination it is exported to. The
+        default implementation creates the legacy ``realtime.response`` Weave
+        call, parented under its ``realtime.conversation`` / ``realtime.session``
+        call. Subclasses override this to export the *same* compiled
+        ``inputs`` / ``output_dict`` / ``summary`` elsewhere (e.g. as OTel
+        GenAI spans) without re-deriving any state.
+        """
+        from weave.trace.context.weave_client_context import require_weave_client
+
+        client = require_weave_client()
+
+        session_call: Call | None = None
+        if self.session_span:
+            session_call = self.session_span.get_root_call()
+
+        if conv_id and self.conversation_responses.get(conv_id) is not None:
+            if response_id:
+                self.conversation_responses[conv_id].append(response_id)
+
+        elif conv_id and response_id:
+            self.conversation_responses[conv_id] = [response_id]
+
+        if conv_id and (conv_call := self.conversation_calls.get(conv_id)):
+            response_parent = conv_call
+
+        elif conv_id:
+            conv_call = client.create_call(
+                op="realtime.conversation",
+                inputs={"id": conv_id},
+                parent=session_call,
+                attributes=OPENAI_REALTIME_INTEGRATION.as_attributes(),
+            )
+            self.conversation_calls[conv_id] = conv_call
+            response_parent = conv_call
+
+        elif session_call:
+            response_parent = session_call
+
+        else:
+            logger.warning("Could not find session for response - %s", response_id)
+            # Will not happen in GA but potentially possible in Beta
+            response_parent = None
+
+        # Latency = TTFT: started_at=response.created, ended_at=first content
+        # Use user-set thread_id if present, otherwise fall back to conv_id
+        user_thread_id = get_thread_id()
+        if user_thread_id is not None and user_thread_id != "":
+            thread_id = user_thread_id
+        else:
+            thread_id = conv_id
+        if thread_id is not None and conv_id != "":
+            with set_thread_id(thread_id):
+                call = client.create_call(
+                    "realtime.response",
+                    inputs=inputs,
+                    parent=response_parent,
+                    started_at=created_at,
+                    attributes=OPENAI_REALTIME_INTEGRATION.as_attributes(),
+                )
+        else:
+            call = client.create_call(
+                "realtime.response",
+                inputs=inputs,
+                parent=response_parent,
+                started_at=created_at,
+                attributes=OPENAI_REALTIME_INTEGRATION.as_attributes(),
+            )
 
         if summary:
             call.summary = summary

--- a/weave/integrations/openai_realtime/state_exporter.py
+++ b/weave/integrations/openai_realtime/state_exporter.py
@@ -749,16 +749,13 @@ class StateExporter(BaseModel):
         done_at: datetime.datetime | None,
         first_content_at: datetime.datetime | None,
     ) -> None:
-        """Export the compiled response state for one finished response.
+        """Export the compiled state for one finished response.
 
-        This is the single seam between the delta-accumulation machinery
-        (audio buffers, transcript gating, FIFO ordering — all above and in
-        the event handlers) and the destination it is exported to. The
-        default implementation creates the legacy ``realtime.response`` Weave
-        call, parented under its ``realtime.conversation`` / ``realtime.session``
-        call. Subclasses override this to export the *same* compiled
-        ``inputs`` / ``output_dict`` / ``summary`` elsewhere (e.g. as OTel
-        GenAI spans) without re-deriving any state.
+        The single seam between the delta-accumulation machinery and the export
+        destination. The default creates the legacy ``realtime.response`` Weave
+        call under its conversation/session call; subclasses override it to
+        export the same ``inputs`` / ``output_dict`` / ``summary`` elsewhere
+        (e.g. as OTel GenAI spans) without re-deriving state.
         """
         from weave.trace.context.weave_client_context import require_weave_client
 
@@ -902,11 +899,7 @@ class StateExporter(BaseModel):
                     pass
 
             def _cb() -> None:
-                try:
-                    self._advance_fifo()
-                finally:
-                    # If more remain and head not ready, a new timer will be scheduled
-                    pass
+                self._advance_fifo()
 
             self.fifo_timer = threading.Timer(FIFO_TIMER_INTERVAL_SECONDS, _cb)
             self.fifo_timer.start()

--- a/weave/integrations/openai_realtime/state_exporter.py
+++ b/weave/integrations/openai_realtime/state_exporter.py
@@ -799,6 +799,7 @@ class StateExporter(BaseModel):
         # Latency = TTFT: started_at=response.created, ended_at=first content
         # Use user-set thread_id if present, otherwise fall back to conv_id
         user_thread_id = get_thread_id()
+        thread_id: str | None
         if user_thread_id is not None and user_thread_id != "":
             thread_id = user_thread_id
         else:

--- a/weave/integrations/patch.py
+++ b/weave/integrations/patch.py
@@ -464,11 +464,19 @@ def patch_llamaindex() -> None:
 
 
 def patch_openai_realtime(settings: IntegrationSettings | None = None) -> None:
-    """Enable Weave tracing for OpenAI Realtime."""
+    """Enable Weave tracing for OpenAI Realtime.
+
+    Triggers on the real modules the websocket patcher instruments
+    (``websocket``, ``websockets``, ``aiohttp``) rather than a synthetic
+    ``openai_realtime`` symbol that no user imports — that synthetic key never
+    matched ``sys.modules`` or the import hook, so realtime never auto-patched.
+    The wrappers guard by URL, so non-realtime websocket/aiohttp traffic passes
+    through untouched.
+    """
     _patch_integration(
         module_path="weave.integrations.openai_realtime",
         patcher_func_getter_name="get_openai_realtime_websocket_patcher",
-        triggering_symbols=["openai_realtime"],
+        triggering_symbols=["websocket", "websockets", "aiohttp"],
         settings=settings,
     )
 
@@ -509,7 +517,11 @@ INTEGRATION_MODULE_MAPPING: dict[str, Callable[[], None]] = {
     "langchain": patch_langchain,
     "langchain_core": patch_langchain,
     "llama_index": patch_llamaindex,
-    "openai_realtime": patch_openai_realtime,
+    # Realtime wraps these three real modules; its wrappers guard by URL, so
+    # non-realtime websocket/aiohttp traffic passes through untouched.
+    "websocket": patch_openai_realtime,
+    "websockets": patch_openai_realtime,
+    "aiohttp": patch_openai_realtime,
 }
 
 

--- a/weave/trace/urls.py
+++ b/weave/trace/urls.py
@@ -58,4 +58,6 @@ def redirect_call(entity_name: str, project_name: str, call_id: str) -> str:
 def agent_conversation_path(
     entity_name: str, project_name: str, conversation_id: str
 ) -> str:
-    return f"{project_weave_root_url(entity_name, project_name)}/agents/conversations/{quote(conversation_id)}"
+    project_root_url = project_weave_root_url(entity_name, project_name)
+    quoted_conversation_id = quote(conversation_id)
+    return f"{project_root_url}/agents/conversations/{quoted_conversation_id}"

--- a/weave/trace/urls.py
+++ b/weave/trace/urls.py
@@ -53,3 +53,9 @@ def leaderboard_path(entity_name: str, project_name: str, object_name: str) -> s
 
 def redirect_call(entity_name: str, project_name: str, call_id: str) -> str:
     return f"{remote_project_root_url(entity_name, project_name)}/r/call/{call_id}"
+
+
+def agent_conversation_path(
+    entity_name: str, project_name: str, conversation_id: str
+) -> str:
+    return f"{project_weave_root_url(entity_name, project_name)}/agents/conversations/{quote(conversation_id)}"

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -207,20 +207,39 @@ def build_trace_chat(
 def build_chat_messages(spans: list[AgentSpanSchema]) -> list[AgentChatMessage]:
     """Convert a list of agent spans into a linear chat trajectory.
 
-    Build the parent-child tree, prepend a single user prompt if one can be
-    found, then let `ChatTraversal` apply the explicit tree-walk policy.
+    Walk the parent-child tree, emitting one user message per turn — each LLM
+    span's *new* user input (see `ChatTraversal._emit_user_turn`) — interleaved
+    with its assistant/tool events. A single realtime trace can hold many turns
+    (one chat span each), so the conversation is reconstructed from the spans'
+    own messages rather than assuming one user prompt per trace.
+
+    Only when the walk surfaces no user message at all — e.g. an SDK that
+    records the prompt on the enclosing `invoke_agent` span rather than the LLM
+    span — do we fall back to a single synthesized leading prompt.
     """
     if not spans:
         return []
 
     tree = build_span_tree(spans)
     traversal = ChatTraversal()
-
-    if user_message := _find_user_message(spans):
-        traversal.messages.append(user_message)
-
     traversal.walk_roots(tree)
-    return traversal.messages
+
+    messages = traversal.messages
+    if not traversal.emitted_user and (user_message := _find_user_message(spans)):
+        messages.insert(0, user_message)
+
+    # The walk emits an invoke_agent's `agent_start` before descending to the
+    # chat span that carries that turn's user message, but the user speaks
+    # first and the agent is invoked in response. Restore that order so the
+    # opening prompt leads (matches the single-prompt-per-trace SDK shape).
+    if (
+        len(messages) >= 2
+        and messages[0].type == "agent_start"
+        and messages[1].type == "user_message"
+    ):
+        messages[0], messages[1] = messages[1], messages[0]
+
+    return messages
 
 
 @dataclass
@@ -235,6 +254,12 @@ class ChatTraversal:
     """
 
     messages: list[AgentChatMessage] = field(default_factory=list)
+    # True once any per-turn user message has been emitted during the walk;
+    # gates the invoke_agent leading-prompt fallback in build_chat_messages.
+    emitted_user: bool = False
+    # (text, media-digests) of the most recently emitted user message, so the
+    # same message replayed by a following LLM span is not emitted twice.
+    _last_user_sig: tuple[str, tuple[str, ...]] | None = None
 
     def walk_roots(self, roots: list[SpanNode]) -> None:
         for root in roots:
@@ -359,6 +384,7 @@ class ChatTraversal:
         """
         span = node.span
         agent_name = _agent_label(span, nearest_agent)
+        self._emit_user_turn(span)
         subtree_emitted_assistant = self._walk_children(
             node, nearest_agent=agent_name, depth=depth
         )
@@ -370,6 +396,46 @@ class ChatTraversal:
         assistant = msg.assistant_message
         emitted_text = bool(assistant and assistant.text)
         return emitted_text or subtree_emitted_assistant
+
+    def _emit_user_turn(self, span: AgentSpanSchema) -> None:
+        """Emit the user message(s) for the new turn this LLM span answers.
+
+        The new user input is the trailing run of consecutive user-role
+        messages in ``input_messages`` — the messages appended since the
+        previous assistant/system message (or the start). Earlier turns are
+        replayed as history and are skipped; they were emitted by the span that
+        first answered them. The sequence is NOT assumed to alternate: a turn
+        can be several user messages in a row, and runs of assistant messages
+        are handled by the run boundary.
+
+        Each user message becomes its own bubble so its own media stays with
+        it (collapsing the run would re-group every turn's audio onto one
+        message — the bug this fixes). Media comes from the message's inline
+        ``uri`` parts, resolved to the internal ref form via the span's
+        ``content_refs`` because the read path requires internal refs (the int
+        -> ext converter rejects a bare external ref). Reading ``content_refs``
+        here is only that ref-form lookup, keyed by the inline part's digest;
+        the conversation itself drives everything else (removal of the
+        ``content_refs`` column is a planned follow-up).
+        """
+        for message in _trailing_user_messages(span.input_messages):
+            text = _display_text(message.content)
+            media = _directional_content_refs(span, _media_part_digests([message]))
+            if not text and not media:
+                continue
+            sig = (text, tuple(media))
+            if sig == self._last_user_sig:
+                continue
+            self._last_user_sig = sig
+            self.emitted_user = True
+            self.messages.append(
+                AgentChatMessage(
+                    type="user_message",
+                    agent_name="User",
+                    started_at=span.started_at,
+                    user_message=AgentChatUserMessage(text=text, content_refs=media),
+                )
+            )
 
     def _walk_children(
         self, node: SpanNode, nearest_agent: str | None, depth: int
@@ -636,6 +702,27 @@ def _user_messages(messages: list[NormalizedMessage]) -> list[NormalizedMessage]
     (so explicit ``user`` plus provider-variant empty/unknown roles).
     """
     return [m for m in messages if m.role not in _NON_USER_PROMPT_ROLES]
+
+
+def _trailing_user_messages(
+    messages: list[NormalizedMessage],
+) -> list[NormalizedMessage]:
+    """The contiguous run of user-role messages at the end of ``messages``.
+
+    This is the new user input an LLM span is responding to: the run of N user
+    messages appended since the previous assistant/system message (or the
+    start). The count N is whatever the run holds — a turn can be several user
+    messages in a row. Messages earlier in the history are excluded; they were
+    answered (and emitted) by earlier spans. Role decides the boundary (see
+    ``_user_messages``), so the sequence need not alternate user/assistant.
+    """
+    turn: list[NormalizedMessage] = []
+    for message in reversed(messages):
+        if message.role in _NON_USER_PROMPT_ROLES:
+            break
+        turn.append(message)
+    turn.reverse()
+    return turn
 
 
 def _input_content_refs(spans: list[AgentSpanSchema]) -> list[str]:

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -401,22 +401,17 @@ class ChatTraversal:
         """Emit the user message(s) for the new turn this LLM span answers.
 
         The new user input is the trailing run of consecutive user-role
-        messages in ``input_messages`` — the messages appended since the
-        previous assistant/system message (or the start). Earlier turns are
-        replayed as history and are skipped; they were emitted by the span that
-        first answered them. The sequence is NOT assumed to alternate: a turn
-        can be several user messages in a row, and runs of assistant messages
-        are handled by the run boundary.
+        messages in ``input_messages`` — those appended since the previous
+        assistant/system message (or the start). Earlier turns are replayed as
+        history and skipped; they were emitted by the span that first answered
+        them. The run need not alternate: a turn can be several user messages.
 
-        Each user message becomes its own bubble so its own media stays with
-        it (collapsing the run would re-group every turn's audio onto one
-        message — the bug this fixes). Media comes from the message's inline
-        ``uri`` parts, resolved to the internal ref form via the span's
-        ``content_refs`` because the read path requires internal refs (the int
-        -> ext converter rejects a bare external ref). Reading ``content_refs``
-        here is only that ref-form lookup, keyed by the inline part's digest;
-        the conversation itself drives everything else (removal of the
-        ``content_refs`` column is a planned follow-up).
+        Each message becomes its own bubble so its own media stays with it;
+        collapsing the run would re-group every turn's audio onto one message.
+        Media comes from the message's inline ``uri`` parts, resolved to the
+        internal ref form via the span's ``content_refs`` because the read path
+        requires internal refs (the int->ext converter rejects a bare external
+        ref).
         """
         for message in _trailing_user_messages(span.input_messages):
             text = _display_text(message.content)
@@ -657,10 +652,9 @@ def _media_part_digests(messages: list[NormalizedMessage]) -> set[str]:
     """Object digests of media (uri/blob/file) parts inlined in ``messages``.
 
     Pure extraction — it carries no notion of direction. Callers decide whose
-    media this is by choosing *which* messages to pass: media belongs to the
-    role that owns the message it sits on, not to whichever input/output list
-    the message happens to appear in (see ``_user_messages``). Position would
-    mislabel a prior assistant turn that a later turn replays into its inputs.
+    media this is by choosing which messages to pass: media belongs to the role
+    that owns the message it sits on, not to whichever input/output list it
+    appears in (see ``_user_messages``).
     """
     digests: set[str] = set()
     for message in messages:
@@ -677,13 +671,12 @@ def _directional_content_refs(
 ) -> list[str]:
     """Resolve ``part_digests`` against the span's ``content_refs``.
 
-    ``content_refs`` is a direction-agnostic digest->ref lookup: it holds each
-    ref in the internal, int<->ext-convertible form the response pipeline
-    requires (the int->ext adapter raises on a bare external ``weave:///`` ref,
-    which is the form inline message parts carry). This returns the internal
-    refs whose digest matches a supplied part digest. Direction is decided by
-    the caller via the messages it digests (role-based — see ``_user_messages``
-    and ``_emit_assistant_message``), never by this lookup.
+    ``content_refs`` is a direction-agnostic digest->ref lookup holding each ref
+    in the internal, int<->ext-convertible form the response pipeline requires
+    (the int->ext adapter raises on a bare external ``weave:///`` ref, the form
+    inline message parts carry). Returns the internal refs whose digest matches
+    a supplied part digest; direction is the caller's choice of messages, never
+    this lookup.
     """
     if not part_digests:
         return []
@@ -693,13 +686,13 @@ def _directional_content_refs(
 def _user_messages(messages: list[NormalizedMessage]) -> list[NormalizedMessage]:
     """The user's side of a message list, selected by role.
 
-    Direction is the message role, not its input/output position. A multi-turn
+    Direction is the message role, not its input/output position: a multi-turn
     conversation replays the prior assistant turn — model-generated media and
-    all — back into the next turn's ``input_messages``; selecting by position
-    would mislabel that assistant audio/image as user-supplied (the multi-turn
-    misattribution this guards against). Uses the same role resolution as
-    ``_extract_user_text``: everything that isn't assistant/system/tool context
-    (so explicit ``user`` plus provider-variant empty/unknown roles).
+    all — into the next turn's ``input_messages``, so selecting by position
+    would mislabel that assistant audio/image as user-supplied. Uses the same
+    role resolution as ``_extract_user_text``: everything that isn't
+    assistant/system/tool context (explicit ``user`` plus provider-variant
+    empty/unknown roles).
     """
     return [m for m in messages if m.role not in _NON_USER_PROMPT_ROLES]
 
@@ -709,12 +702,10 @@ def _trailing_user_messages(
 ) -> list[NormalizedMessage]:
     """The contiguous run of user-role messages at the end of ``messages``.
 
-    This is the new user input an LLM span is responding to: the run of N user
-    messages appended since the previous assistant/system message (or the
-    start). The count N is whatever the run holds — a turn can be several user
-    messages in a row. Messages earlier in the history are excluded; they were
-    answered (and emitted) by earlier spans. Role decides the boundary (see
-    ``_user_messages``), so the sequence need not alternate user/assistant.
+    This is the new user input an LLM span responds to: the messages appended
+    since the previous assistant/system message (or the start). Earlier history
+    is excluded; it was answered by earlier spans. Role decides the boundary
+    (see ``_user_messages``), so the sequence need not alternate.
     """
     turn: list[NormalizedMessage] = []
     for message in reversed(messages):
@@ -729,11 +720,10 @@ def _input_content_refs(spans: list[AgentSpanSchema]) -> list[str]:
     """User-supplied media refs across a trace, de-duplicated, in internal form.
 
     ``attach_media`` records media on the LLM/chat span, but the rendered user
-    prompt is synthesized from the enclosing invoke_agent span, so the media
-    lives on a different span than the user text. Gather user-side input media
-    across all spans so it lands on the user message regardless of which span
-    carries it. Only user-role messages contribute (see ``_user_messages``);
-    assistant turns echoed into a later turn's inputs stay on the assistant.
+    prompt is synthesized from the enclosing invoke_agent span, so media and
+    user text live on different spans. Gather user-side input media across all
+    spans so it lands on the user message regardless of which span carries it;
+    only user-role messages contribute (see ``_user_messages``).
     """
     refs: list[str] = []
     seen: set[str] = set()

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -588,10 +588,13 @@ def _ref_digest(ref: str) -> str:
 
 
 def _media_part_digests(messages: list[NormalizedMessage]) -> set[str]:
-    """Object digests of media (uri/blob/file) parts inlined in these messages.
+    """Object digests of media (uri/blob/file) parts inlined in ``messages``.
 
-    Direction lives in the parts: a user-supplied audio/image is a ``uri`` part
-    on an input message; model-generated media is a part on an output message.
+    Pure extraction — it carries no notion of direction. Callers decide whose
+    media this is by choosing *which* messages to pass: media belongs to the
+    role that owns the message it sits on, not to whichever input/output list
+    the message happens to appear in (see ``_user_messages``). Position would
+    mislabel a prior assistant turn that a later turn replays into its inputs.
     """
     digests: set[str] = set()
     for message in messages:
@@ -606,31 +609,49 @@ def _media_part_digests(messages: list[NormalizedMessage]) -> set[str]:
 def _directional_content_refs(
     span: AgentSpanSchema, part_digests: set[str]
 ) -> list[str]:
-    """Span ``content_refs`` whose object digest matches an inline part.
+    """Resolve ``part_digests`` against the span's ``content_refs``.
 
-    The value comes from ``content_refs`` because it holds the ref in the
-    internal, int<->ext-convertible form the response pipeline requires — the
-    int->ext adapter raises on a bare external ref. The direction comes from
-    the message parts (external form). Match the two by digest so each ref is
-    surfaced on the correct side (input -> user, output -> assistant).
+    ``content_refs`` is a direction-agnostic digest->ref lookup: it holds each
+    ref in the internal, int<->ext-convertible form the response pipeline
+    requires (the int->ext adapter raises on a bare external ``weave:///`` ref,
+    which is the form inline message parts carry). This returns the internal
+    refs whose digest matches a supplied part digest. Direction is decided by
+    the caller via the messages it digests (role-based — see ``_user_messages``
+    and ``_emit_assistant_message``), never by this lookup.
     """
     if not part_digests:
         return []
     return [r for r in _content_refs(span) if _ref_digest(r) in part_digests]
 
 
+def _user_messages(messages: list[NormalizedMessage]) -> list[NormalizedMessage]:
+    """The user's side of a message list, selected by role.
+
+    Direction is the message role, not its input/output position. A multi-turn
+    conversation replays the prior assistant turn — model-generated media and
+    all — back into the next turn's ``input_messages``; selecting by position
+    would mislabel that assistant audio/image as user-supplied (the multi-turn
+    misattribution this guards against). Uses the same role resolution as
+    ``_extract_user_text``: everything that isn't assistant/system/tool context
+    (so explicit ``user`` plus provider-variant empty/unknown roles).
+    """
+    return [m for m in messages if m.role not in _NON_USER_PROMPT_ROLES]
+
+
 def _input_content_refs(spans: list[AgentSpanSchema]) -> list[str]:
-    """Input-side media refs across a trace, de-duplicated, in internal form.
+    """User-supplied media refs across a trace, de-duplicated, in internal form.
 
     ``attach_media`` records media on the LLM/chat span, but the rendered user
     prompt is synthesized from the enclosing invoke_agent span, so the media
-    lives on a different span than the user text. Gather input media across all
-    spans so it lands on the user message regardless of which span carries it.
+    lives on a different span than the user text. Gather user-side input media
+    across all spans so it lands on the user message regardless of which span
+    carries it. Only user-role messages contribute (see ``_user_messages``);
+    assistant turns echoed into a later turn's inputs stay on the assistant.
     """
     refs: list[str] = []
     seen: set[str] = set()
     for span in spans:
-        in_digests = _media_part_digests(span.input_messages)
+        in_digests = _media_part_digests(_user_messages(span.input_messages))
         for ref in _directional_content_refs(span, in_digests):
             if ref not in seen:
                 seen.add(ref)


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-36032
https://coreweave.atlassian.net/browse/WB-36035

  
## Summary
 - Adds an OTel-native exporter for the OpenAI Realtime integration
 - Fixes media handling in chat view builder by using role for direction instead of input and output.
 - Adds handling for edge cases like multiple user messages or assistant messages in a row
 - Selected by default via `should_use_otel_v2()` or (`WEAVE_USE_OTEL_V2`) like mirroring `openai_agents`

