### PR TITLE
chore(weave): expand docstrings for Weave Agents Python surface (v3)

### DIFF
--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -356,6 +356,31 @@ class CallRef(RefWithExtra):
 
 @dataclass(frozen=True)
 class AgentTurnRef(Ref):
+    """Stable URI pointing at one turn in the Agents view.
+
+    A turn is a single trace's chat trajectory: one user prompt, the
+    assistant's complete response, and every tool call or sub-agent
+    invocation in between. Use this ref when you have a `trace_id`
+    and want a URI that the Weave UI (or the `agent_traces_chat` API)
+    can resolve back to a turn.
+
+    URI grammar: `weave:///{entity}/{project}/agent_turn/{trace_id}`.
+
+    Args:
+        entity: W&B entity (team or username) that owns the project.
+        project: Project name within the entity.
+        trace_id: OTel trace ID that identifies the turn.
+
+    Examples:
+        >>> ref = AgentTurnRef(
+        ...     entity="your-team", project="your-project", trace_id="t1"
+        ... )
+        >>> ref.uri
+        'weave:///your-team/your-project/agent_turn/t1'
+        >>> AgentTurnRef.parse_uri(ref.uri) == ref
+        True
+    """
+
     entity: str
     project: str
     trace_id: str
@@ -366,6 +391,26 @@ class AgentTurnRef(Ref):
 
     @staticmethod
     def parse_uri(uri: str) -> AgentTurnRef:
+        """Parse a Weave URI into an `AgentTurnRef`.
+
+        Args:
+            uri: A `weave:///` URI produced by `AgentTurnRef.uri`.
+
+        Returns:
+            AgentTurnRef: The parsed ref.
+
+        Raises:
+            TypeError: When `uri` is valid Weave syntax but points at
+                a non-turn ref kind (e.g. a call or object ref).
+            ValueError: When `uri` doesn't match the Weave URI
+                grammar.
+
+        Examples:
+            >>> AgentTurnRef.parse_uri(
+            ...     "weave:///your-team/your-project/agent_turn/t1"
+            ... ).trace_id
+            't1'
+        """
         if not isinstance(parsed := Ref.parse_uri(uri), AgentTurnRef):
             raise TypeError(f"URI is not for an AgentTurn: {uri}")
         return parsed
@@ -373,6 +418,37 @@ class AgentTurnRef(Ref):
 
 @dataclass(frozen=True)
 class AgentConversationRef(Ref):
+    """Stable URI pointing at one conversation in the Agents view.
+
+    A conversation is the ordered set of turns sharing one
+    `gen_ai.conversation.id`. Use this ref to link to the multi-turn
+    chat view served by `agent_conversation_chat`.
+
+    URI grammar:
+    `weave:///{entity}/{project}/agent_conversation/{encoded_conversation_id}`.
+
+    Note: `conversation_id` is URL-quoted in the URI so IDs
+    containing `/` or other reserved characters round-trip safely.
+    The ref itself stores the decoded value.
+
+    Args:
+        entity: W&B entity (team or username) that owns the project.
+        project: Project name within the entity.
+        conversation_id: Conversation identifier extracted from
+            `gen_ai.conversation.id` on the producing spans.
+
+    Examples:
+        >>> ref = AgentConversationRef(
+        ...     entity="your-team",
+        ...     project="your-project",
+        ...     conversation_id="sess/42",
+        ... )
+        >>> ref.uri
+        'weave:///your-team/your-project/agent_conversation/sess%2F42'
+        >>> AgentConversationRef.parse_uri(ref.uri).conversation_id
+        'sess/42'
+    """
+
     entity: str
     project: str
     conversation_id: str
@@ -384,6 +460,31 @@ class AgentConversationRef(Ref):
 
     @staticmethod
     def parse_uri(uri: str) -> AgentConversationRef:
+        """Parse a Weave URI into an `AgentConversationRef`.
+
+        The encoded `conversation_id` segment is URL-decoded during
+        parsing, so the resulting `conversation_id` matches the value
+        emitted by the producing instrumentation.
+
+        Args:
+            uri: A `weave:///` URI produced by
+                `AgentConversationRef.uri`.
+
+        Returns:
+            AgentConversationRef: The parsed ref.
+
+        Raises:
+            TypeError: When `uri` is valid Weave syntax but points at
+                a non-conversation ref kind.
+            ValueError: When `uri` doesn't match the Weave URI
+                grammar.
+
+        Examples:
+            >>> AgentConversationRef.parse_uri(
+            ...     "weave:///your-team/your-project/agent_conversation/sess%2F42"
+            ... ).conversation_id
+            'sess/42'
+        """
         if not isinstance(parsed := Ref.parse_uri(uri), AgentConversationRef):
             raise TypeError(f"URI is not for an AgentConversation: {uri}")
         return parsed
@@ -391,6 +492,28 @@ class AgentConversationRef(Ref):
 
 @dataclass(frozen=True)
 class AgentSpanRef(Ref):
+    """Stable URI pointing at one span in the Agents view.
+
+    A span is a single OTel GenAI span: an agent invocation, an LLM
+    call, a tool execution, or another GenAI event. Use this ref
+    when you want a URI that resolves back to a specific span row
+    inside an agent trace.
+
+    URI grammar: `weave:///{entity}/{project}/agent_span/{span_id}`.
+
+    Args:
+        entity: W&B entity (team or username) that owns the project.
+        project: Project name within the entity.
+        span_id: OTel span ID.
+
+    Examples:
+        >>> ref = AgentSpanRef(
+        ...     entity="your-team", project="your-project", span_id="s9"
+        ... )
+        >>> ref.uri
+        'weave:///your-team/your-project/agent_span/s9'
+    """
+
     entity: str
     project: str
     span_id: str
@@ -401,6 +524,26 @@ class AgentSpanRef(Ref):
 
     @staticmethod
     def parse_uri(uri: str) -> AgentSpanRef:
+        """Parse a Weave URI into an `AgentSpanRef`.
+
+        Args:
+            uri: A `weave:///` URI produced by `AgentSpanRef.uri`.
+
+        Returns:
+            AgentSpanRef: The parsed ref.
+
+        Raises:
+            TypeError: When `uri` is valid Weave syntax but points at
+                a non-span ref kind.
+            ValueError: When `uri` doesn't match the Weave URI
+                grammar.
+
+        Examples:
+            >>> AgentSpanRef.parse_uri(
+            ...     "weave:///your-team/your-project/agent_span/s9"
+            ... ).span_id
+            's9'
+        """
         if not isinstance(parsed := Ref.parse_uri(uri), AgentSpanRef):
             raise TypeError(f"URI is not for an AgentSpan: {uri}")
         return parsed

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -1,8 +1,47 @@
-"""Request/response types for the Weave Agents observability API.
+"""Pydantic request and response types for the Weave Agents API.
 
-All types are Pydantic BaseModel subclasses used by both the FastAPI
-endpoints (services/weave-trace) and the ClickHouse query handlers
-(weave/trace_server/clickhouse_trace_server_batched.py).
+Every shape that crosses the wire for agent observability lives here. The
+FastAPI handlers in `services/weave-trace`, the ClickHouse handler in
+`weave/trace_server/clickhouse_trace_server_batched.py`, the in-memory
+fake, and the SDK bindings all import from this module so the contract
+is one set of definitions, not three.
+
+The domain has five concepts. Read them in order; later concepts
+compose earlier ones.
+
+1. **Agent.** Identified by `agent_name`. The container at the top of
+   the Agents view.
+2. **Agent version.** Identified by `(agent_name, agent_version)`.
+   Lets a caller diff behavior across releases of the same agent.
+3. **Span.** One OTel GenAI span: an agent invocation, an LLM call, a
+   tool execution, a context compaction, or a handoff. The atomic
+   unit of recorded activity.
+4. **Turn.** One trace's span tree rendered as a linear chat
+   timeline. Roughly "one user message and the agent's complete
+   response."
+5. **Conversation.** Turns that share a `conversation_id`, presented
+   as ordered multi-turn chat.
+
+Endpoints come in `*Req` / `*Res` pairs:
+
+* `agent_agents_query` — `AgentsQueryReq` -> `AgentsQueryRes`
+* `agent_versions_query` — `AgentVersionsQueryReq` ->
+  `AgentVersionsQueryRes`
+* `agent_spans_query` — `AgentSpansQueryReq` ->
+  `AgentSpansQueryRes` (list mode and group mode share the same
+  endpoint, picked by whether `group_by` is set)
+* `agent_spans_stats` — `AgentSpanStatsReq` -> `AgentSpanStatsRes`
+* `agent_traces_chat` — `AgentTraceChatReq` -> `AgentTraceChatRes`
+* `agent_conversation_chat` — `AgentConversationChatReq` ->
+  `AgentConversationChatRes`
+* `agent_search` — `AgentSearchReq` -> `AgentSearchRes`
+* `agent_custom_attrs_schema` — `AgentCustomAttrsSchemaReq` ->
+  `AgentCustomAttrsSchemaRes`
+* `genai_otel_export` — `GenAIOTelExportReq` ->
+  `GenAIOTelExportRes`
+
+For the user-facing concepts and instrumentation patterns behind these
+shapes, see https://docs.wandb.ai/weave/guides/tracking/trace-agents.
 """
 
 from __future__ import annotations
@@ -141,7 +180,40 @@ def _as_utc(dt: datetime.datetime) -> datetime.datetime:
 
 
 class AgentSpanValueRef(BaseModel):
-    """Reference to a span field or typed custom attribute map value."""
+    """Pointer to one value on a span row.
+
+    The primitive that every higher-level spec composes:
+    `AgentSpanMeasureSpec`, `AgentSpanStatsMetricSpec`,
+    `AgentSpanGroupDistributionSpec`, and
+    `AgentSpanStatsNumericBucketSpec` all hold one of these to name
+    "the thing to read." The `source` chooses where the value lives:
+
+    1. `field` — a semconv field like `agent.name` or a direct column
+       like `agent_name`; resolved through the server's allowlist.
+    2. `derived` — a query-time metric from
+       `AGENT_SPAN_STATS_DERIVED_VALUE_TYPES` (e.g. `duration_ms`,
+       `total_tokens`, `total_cost_usd`).
+    3. `custom_attrs_string` / `custom_attrs_int` /
+       `custom_attrs_float` / `custom_attrs_bool` — a user-defined key
+       inside the matching typed Map column on the span row.
+
+    Args:
+        source: Where the value lives. Defaults to `field`.
+        key: Field name, derived-metric name, or custom-attribute key,
+            interpreted according to `source`.
+
+    Raises:
+        ValueError: When `source="derived"` but `key` is not a
+            recognized derived metric.
+
+    Examples:
+        >>> # Group spans by the request_model field.
+        >>> AgentSpanValueRef(source="field", key="request_model")
+        >>> # Sum the derived total_cost_usd metric.
+        >>> AgentSpanValueRef(source="derived", key="total_cost_usd")
+        >>> # Read a user-defined integer attribute named "retries".
+        >>> AgentSpanValueRef(source="custom_attrs_int", key="retries")
+    """
 
     source: AgentSpanValueSource = "field"
     key: str
@@ -157,7 +229,47 @@ class AgentSpanValueRef(BaseModel):
 
 
 class AgentSpanMeasureSpec(BaseModel):
-    """One aggregate measure computed over spans in a group or bucket."""
+    """Aggregated roll-up of one span value into a single number per group.
+
+    Pairs an `AgentSpanValueRef` with an aggregation function. Used on
+    `AgentSpansQueryReq.measures` (per-group measures land in
+    `AgentSpanGroupRow.metrics`) and on `AgentSpanGroupFilter.measure`
+    (range-filter groups by an aggregated value).
+
+    The aggregation must be legal for `value_type`; see
+    `_ALLOWED_AGGS_BY_TYPE`. `count` is the only aggregation that may
+    omit `value`.
+
+    Args:
+        alias: Output key in `AgentSpanGroupRow.metrics`. Must be a
+            valid Python identifier and must not collide with the
+            reserved aggregate fields on `AgentSpanGroupRow`.
+        aggregation: Roll-up function to apply.
+        value: Span value to aggregate. Required for every aggregation
+            except `count`.
+        value_type: Declared type of `value`. Drives aggregation
+            validation. Optional when the aggregation is `count` or
+            when `value.source="derived"` (the derived metric pins the
+            type).
+        filter: Optional Mongo-style `Query` further restricting which
+            spans contribute. Applied on top of the request-level
+            filter.
+
+    Raises:
+        ValueError: When `value` is missing for a non-`count`
+            aggregation, when `value_type` disagrees with a derived
+            metric's known type, or when the aggregation is not legal
+            for `value_type`.
+
+    Examples:
+        >>> # Average duration in milliseconds across spans in each group.
+        >>> AgentSpanMeasureSpec(
+        ...     alias="avg_duration_ms",
+        ...     aggregation="avg",
+        ...     value=AgentSpanValueRef(source="derived", key="duration_ms"),
+        ...     value_type="number",
+        ... )
+    """
 
     alias: str = Field(pattern=_IDENT_RE)
     aggregation: AgentSpanStatsAggregation
@@ -193,7 +305,44 @@ class AgentSpanMeasureSpec(BaseModel):
 
 
 class AgentSpanStatsMetricSpec(BaseModel):
-    """Metric to extract from each matching span and aggregate into chart rows."""
+    """Chart series for the `agent_spans_stats` endpoint.
+
+    Use on `AgentSpanStatsReq.metrics`. Each spec fans out into one
+    response column per aggregation or percentile, named
+    `{alias}__{aggregation}` or `{alias}__p{percentile}`.
+
+    Note: when both `aggregations` and `percentiles` are empty, the
+    validator picks a default (`sum` for numbers, `count` otherwise).
+    Don't rely on that in new code. Pass at least one aggregation
+    explicitly.
+
+    Args:
+        alias: Prefix shared by every column this metric produces.
+            Must be a valid Python identifier.
+        value_type: Type of the underlying span value. Drives which
+            aggregations are legal.
+        aggregations: Aggregations to compute. Must be unique and must
+            match `value_type` (see `_ALLOWED_AGGS_BY_TYPE`).
+        percentiles: Quantile cutoffs in the closed interval
+            `[0, 100]`. Only valid when `value_type="number"`. Must be
+            unique.
+        value: Span value the aggregations apply to.
+
+    Raises:
+        ValueError: When aggregations are non-unique or illegal for
+            `value_type`, when percentiles are out of range or
+            duplicated, or when percentiles are requested on a
+            non-numeric metric.
+
+    Examples:
+        >>> # p50 and p99 of duration_ms.
+        >>> AgentSpanStatsMetricSpec(
+        ...     alias="duration_ms",
+        ...     value_type="number",
+        ...     percentiles=[50.0, 99.0],
+        ...     value=AgentSpanValueRef(source="derived", key="duration_ms"),
+        ... )
+    """
 
     alias: str = Field(pattern=_IDENT_RE)
     value_type: AgentSpanStatsValueType
@@ -240,7 +389,33 @@ class AgentSpanStatsMetricSpec(BaseModel):
 
 
 class AgentSpanStatsColumn(BaseModel):
-    """Metadata describing one column in an agent span stats result row."""
+    """Schema entry for one cell in an `AgentSpanStatsRes` row.
+
+    `AgentSpanStatsRes.rows` is a list of untyped dicts so the wire
+    format stays compact. This column list, returned alongside, pins
+    down the type and meaning of each key in those dicts.
+
+    Args:
+        name: Key used inside each row dict.
+        role: Provenance of the column. `time` for the time bucket
+            boundary, `bucket` for a numeric bucket boundary, `group`
+            for a group-by ref, `metric` for one aggregation or
+            percentile of a metric.
+        value_type: Cell type.
+        metric: Originating metric `alias` for `metric` columns.
+            `None` for the other roles.
+        aggregation: Aggregation name or `pNN` percentile label for
+            `metric` columns. `None` for the other roles.
+
+    Examples:
+        >>> AgentSpanStatsColumn(
+        ...     name="duration_ms__p99",
+        ...     role="metric",
+        ...     value_type="number",
+        ...     metric="duration_ms",
+        ...     aggregation="p99",
+        ... )
+    """
 
     name: str
     role: Literal["time", "bucket", "group", "metric"]
@@ -250,7 +425,39 @@ class AgentSpanStatsColumn(BaseModel):
 
 
 class AgentSpanGroupFilter(BaseModel):
-    """Range filter over one grouped span measure."""
+    """Keep only groups whose aggregated measure falls in a range.
+
+    Use on `AgentSpansQueryReq.group_filters` (post-grouping filter)
+    and `AgentSpanStatsReq.group_filters` (post-bucket filter).
+    Examples: "agents whose error count is between 5 and 100" or
+    "conversations whose first span happened after yesterday."
+
+    At least one of `min` or `max` must be set. When both are set,
+    they must share a type and `max` must be greater than or equal to
+    `min`.
+
+    Args:
+        group_by: Optional override for the grouping used by this
+            filter. Empty reuses the surrounding request's grouping.
+        measure: Aggregated measure the range applies to.
+        min: Lower bound, inclusive. `None` for no lower bound.
+        max: Upper bound, inclusive. `None` for no upper bound.
+
+    Raises:
+        ValueError: When both bounds are `None`, when `min` and `max`
+            have mismatched types, or when `max < min`.
+
+    Examples:
+        >>> # Keep groups whose error count is at least 5.
+        >>> AgentSpanGroupFilter(
+        ...     measure=AgentSpanMeasureSpec(
+        ...         alias="error_count",
+        ...         aggregation="count",
+        ...         filter=None,
+        ...     ),
+        ...     min=5,
+        ... )
+    """
 
     group_by: list[AgentGroupByRef] = Field(default_factory=list)
     measure: AgentSpanMeasureSpec
@@ -278,13 +485,61 @@ class AgentSpanGroupFilter(BaseModel):
 
 
 class AgentSpanStatsTimeBucketSpec(BaseModel):
-    """Bucket stats rows by started_at time intervals."""
+    """Time-series bucketing for `agent_spans_stats`.
+
+    Default branch of the `AgentSpanStatsBucketSpec` discriminated
+    union. Bucket width comes from `AgentSpanStatsReq.granularity`
+    (seconds); when granularity is `None`, the server picks a width
+    based on the date range. Use `AgentSpanStatsNumericBucketSpec` for
+    histogram-style charts instead.
+
+    Examples:
+        >>> AgentSpanStatsTimeBucketSpec()
+    """
 
     type: Literal["time"] = "time"
 
 
 class AgentSpanStatsNumericBucketSpec(BaseModel):
-    """Bucket stats rows by ranges of one numeric span or grouped value."""
+    """Histogram bucketing for `agent_spans_stats`.
+
+    Numeric branch of `AgentSpanStatsBucketSpec`. Two mutually
+    exclusive modes:
+
+    1. **Per-span histogram** — set `value`, leave
+       `group_by`/`measure` empty. Each span's `value` lands in one
+       bucket.
+    2. **Grouped-measure histogram** — set `group_by` and `measure`,
+       leave `value` empty. Each group's aggregated measure lands in
+       one bucket.
+
+    `bins` divides `[min, max]` into equal-width buckets; `min` and
+    `max` default to the data range.
+
+    Args:
+        alias: Output column name for the bucket boundary.
+        bins: Bucket count, 1 to 200. Defaults to 24.
+        min: Lower bound. `None` uses the data minimum.
+        max: Upper bound. `None` uses the data maximum.
+        value: Per-span numeric value to bucket. Mutually exclusive
+            with `group_by`/`measure`.
+        group_by: Group-by refs whose aggregated measure should be
+            bucketed. Requires `measure`.
+        measure: Aggregated measure to bucket. Requires `group_by`.
+
+    Raises:
+        ValueError: When the two modes overlap or both are empty,
+            when only one of `group_by`/`measure` is set, when a
+            non-numeric value or measure is referenced, or when
+            `max < min`.
+
+    Examples:
+        >>> # Per-span histogram of duration_ms across 20 buckets.
+        >>> AgentSpanStatsNumericBucketSpec(
+        ...     bins=20,
+        ...     value=AgentSpanValueRef(source="derived", key="duration_ms"),
+        ... )
+    """
 
     type: Literal["number"] = "number"
     alias: str = Field(default="value", pattern=_IDENT_RE)
@@ -341,7 +596,64 @@ AgentSpanStatsBucketSpec = Annotated[
 
 
 class AgentSpanStatsReq(BaseModel):
-    """Request chart-ready aggregations over GenAI agent spans."""
+    """Chart-ready aggregation request for `agent_spans_stats`.
+
+    Five-stage pipeline: filter spans (`query` + `started_at` window),
+    bucket (`bucket_by`, default time at `granularity` seconds), group
+    within bucket (`group_by`), compute metrics, drop groups failing
+    `group_filters`.
+
+    Pair with `AgentSpanStatsRes`.
+
+    Note: grouped requests cap the window at
+    `MAX_AGENT_STATS_RANGE_DAYS`. Unfiltered, ungrouped requests are
+    exempt because they back cheap top-line counts.
+
+    Args:
+        project_id: Target project in `entity/project` form.
+        query: Optional Mongo-style filter. Field names resolve via
+            GenAI semconv, direct span columns, or typed custom
+            attribute keys.
+        start: Window start, inclusive. Naive datetimes are read as
+            UTC.
+        end: Window end, exclusive. Defaults to "now (UTC)" when
+            omitted.
+        granularity: Time bucket width in seconds. Server picks a
+            default when `None`. Ignored for numeric buckets.
+        timezone: IANA timezone for time-of-day grouping in the
+            response. Defaults to `UTC`.
+        group_by: Group within each bucket by these refs. Mutually
+            exclusive with `bucket_by` set to a numeric bucket spec.
+        metrics: Metrics to compute per bucket and group. Required
+            unless a numeric bucket spec already produces counts.
+        group_limit: Maximum groups per bucket, 1 to
+            `MAX_AGENT_STATS_GROUP_LIMIT`.
+        bucket_by: Bucketing strategy. `None` is equivalent to
+            `AgentSpanStatsTimeBucketSpec()`.
+        group_filters: Range filters over aggregated measures. Valid
+            for time buckets and grouped numeric buckets only.
+
+    Raises:
+        ValueError: When `metrics` are missing without a numeric
+            bucket spec, when metric aliases collide, when
+            `end < start`, when a grouped request exceeds
+            `MAX_AGENT_STATS_RANGE_DAYS`, or when `group_by`,
+            `metrics`, and `bucket_by` combine illegally.
+
+    Examples:
+        >>> AgentSpanStatsReq(
+        ...     project_id="your-team/your-project",
+        ...     start=datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc),
+        ...     metrics=[
+        ...         AgentSpanStatsMetricSpec(
+        ...             alias="duration_ms",
+        ...             value_type="number",
+        ...             percentiles=[50.0, 99.0],
+        ...             value=AgentSpanValueRef(source="derived", key="duration_ms"),
+        ...         ),
+        ...     ],
+        ... )
+    """
 
     project_id: str
     query: Query | None = None
@@ -415,7 +727,34 @@ class AgentSpanStatsReq(BaseModel):
 
 
 class AgentSpanStatsRes(BaseModel):
-    """Response containing chart-ready agent span stats rows."""
+    """Chart-ready response from `agent_spans_stats`.
+
+    Read `columns` first to get the schema, then index each entry in
+    `rows` by `AgentSpanStatsColumn.name`. The `start`, `end`,
+    `granularity`, and `timezone` fields echo what the server actually
+    applied, so clients render axes without re-deriving them. Empty
+    buckets are omitted from `rows`.
+
+    Args:
+        start: Window start the server used. UTC.
+        end: Window end the server used. UTC.
+        granularity: Time bucket width the server applied. `None` for
+            numeric buckets.
+        timezone: IANA timezone echoed from the request.
+        bucket_type: Which discriminant of `AgentSpanStatsBucketSpec`
+            was applied.
+        columns: Schema for cells in each `rows` dict.
+        rows: One dict per non-empty bucket-and-group combination.
+
+    Examples:
+        >>> res = AgentSpanStatsRes(
+        ...     start=datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc),
+        ...     end=datetime.datetime(2026, 6, 2, tzinfo=datetime.timezone.utc),
+        ...     timezone="UTC",
+        ... )
+        >>> [col.name for col in res.columns]
+        []
+    """
 
     start: datetime.datetime
     end: datetime.datetime
@@ -427,7 +766,132 @@ class AgentSpanStatsRes(BaseModel):
 
 
 class AgentSpanSchema(BaseModel):
-    """A normalized agent span returned by query APIs."""
+    """Normalized agent span row, the unit of `agent_spans_query`.
+
+    One OTel GenAI span flattened into Weave's column layout. Same
+    shape regardless of how the span was produced:
+    `weave.start_session()` / `weave.start_turn()` /
+    `weave.start_llm()` / `weave.start_tool()`, a raw OTel exporter,
+    or one of the autopatched integrations.
+
+    Most fields are nullable because the producing span may not have
+    emitted the corresponding GenAI attribute. List fields default to
+    empty.
+
+    Note: the `*_cost_usd` fields and `raw_span_dump` are opt-in. The
+    server populates them only when the request sets
+    `include_costs=True` or `include_details=True` respectively. Cost
+    fields use `None` (not `0`) to mean "no priced model matched," so
+    the UI can distinguish "unpriced" from "free."
+
+    Args:
+        project_id: Owning project in `entity/project` form.
+        trace_id: OTel trace ID. All spans in one turn share this.
+        span_id: OTel span ID. Unique within the trace.
+        parent_span_id: Parent span ID, or `None` for root spans.
+        span_name: OTel span name (`chat gpt-4o`,
+            `execute_tool search`, etc.).
+        span_kind: OTel span kind (`Server`, `Client`, `Internal`).
+        started_at: Span start time. UTC.
+        ended_at: Span end time. UTC.
+        status_code: OTel status: `Ok`, `Error`, or `Unset`.
+        status_message: Human-readable status detail; typically the
+            error message when `status_code == "Error"`.
+        operation_name: GenAI `gen_ai.operation.name`
+            (`invoke_agent`, `chat`, `execute_tool`).
+        provider_name: GenAI `gen_ai.provider.name` (`openai`,
+            `anthropic`, etc.).
+        agent_name: Identifier of the agent that owns the span.
+        agent_id: Stable agent ID emitted by the SDK, if any.
+        agent_description: Free-form agent description.
+        agent_version: Agent version string for cross-release
+            grouping.
+        request_model: Model requested.
+        response_model: Model the provider reports actually served the
+            response.
+        response_id: Provider's response identifier.
+        input_tokens: Prompt tokens reported by the provider.
+        output_tokens: Completion tokens reported by the provider.
+        reasoning_tokens: Reasoning tokens for reasoning-capable
+            models.
+        cache_creation_input_tokens: Tokens written to a provider
+            prompt cache.
+        cache_read_input_tokens: Tokens read from a provider prompt
+            cache.
+        input_cost_usd: Query-time input-token cost in USD. Opt-in
+            via `include_costs`. See the note above on `None`
+            semantics.
+        output_cost_usd: Query-time output-token cost in USD. Opt-in.
+        cache_read_cost_usd: Query-time cost of cached prompt reads
+            in USD. Opt-in.
+        cache_creation_cost_usd: Query-time cost of cache writes in
+            USD. Opt-in.
+        total_cost_usd: Sum of the per-direction cost fields above.
+            Opt-in.
+        reasoning_content: Reasoning text captured from a reasoning
+            model's response.
+        conversation_id: GenAI `gen_ai.conversation.id`. Spans
+            sharing this value belong to one conversation.
+        conversation_name: Human-readable conversation label.
+        tool_name: Tool name for `execute_tool` spans.
+        tool_type: Optional tool classification.
+        tool_call_id: ID of the originating tool-use call; links an
+            LLM's tool call to its `execute_tool` span.
+        tool_description: Tool description captured at call time.
+        tool_definitions: Serialized tool catalog given to the model.
+        finish_reasons: Provider finish reasons, one per output
+            choice.
+        error_type: Exception type or provider error code for failed
+            spans.
+        request_temperature: Sampling temperature for the LLM call.
+        request_max_tokens: Max completion tokens requested.
+        request_top_p: Top-p sampling parameter.
+        request_frequency_penalty: Frequency penalty.
+        request_presence_penalty: Presence penalty.
+        request_seed: Provider seed for deterministic sampling.
+        request_stop_sequences: Stop sequences.
+        request_choice_count: Number of completions requested.
+        output_type: Provider-specific output format (`text`,
+            `json_object`, etc.).
+        input_messages: Normalized input messages sent to the model.
+        output_messages: Normalized output messages returned by the
+            model.
+        system_instructions: System prompts attached to the call.
+        tool_call_arguments: JSON-encoded tool call arguments for
+            `execute_tool` spans.
+        tool_call_result: Serialized tool result.
+        compaction_summary: Summary emitted by a context-window
+            compaction event.
+        compaction_items_before: Items in context before compaction.
+        compaction_items_after: Items in context after compaction.
+        content_refs: Refs to large message content stored outside
+            the row.
+        artifact_refs: Refs to W&B artifacts attached to the span.
+        object_refs: Refs to Weave objects attached to the span.
+        custom_attrs_string: User-defined string attributes.
+        custom_attrs_int: User-defined integer attributes.
+        custom_attrs_float: User-defined float attributes.
+        custom_attrs_bool: User-defined boolean attributes.
+        server_address: Provider host recorded on the span.
+        server_port: Provider port recorded on the span.
+        wb_user_id: W&B user who recorded the span.
+        wb_run_id: Associated W&B run ID.
+        wb_run_step: W&B run step at span start.
+        wb_run_step_end: W&B run step at span end.
+        raw_span_dump: Full OTel JSON payload for the span. Opt-in
+            via `include_details`.
+
+    Examples:
+        >>> span = AgentSpanSchema(
+        ...     project_id="your-team/your-project",
+        ...     trace_id="t1",
+        ...     span_id="s1",
+        ...     agent_name="research-bot",
+        ...     operation_name="invoke_agent",
+        ... )
+        >>> span.agent_version is None
+        True
+    """
 
     project_id: str
     trace_id: str
@@ -510,20 +974,60 @@ class AgentSpanSchema(BaseModel):
 
 
 class AgentSortBy(BaseModel):
-    """Sort specification for agent query endpoints."""
+    """One step of the sort order for list endpoints.
+
+    Pass as an ordered list to `AgentsQueryReq.sort_by`,
+    `AgentVersionsQueryReq.sort_by`, and `AgentSpansQueryReq.sort_by`.
+    Steps apply left to right; the allowed `field` values are
+    validated per endpoint server-side.
+
+    Args:
+        field: Sortable field name.
+        direction: `desc` (default) sorts newest or largest first;
+            `asc` sorts oldest or smallest first.
+
+    Examples:
+        >>> # Newest spans first.
+        >>> AgentSortBy(field="started_at", direction="desc")
+    """
 
     field: str
     direction: Literal["asc", "desc"] = "desc"
 
 
 class AgentGroupByRef(BaseModel):
-    """Reference to a field or map-key that spans should be grouped by.
+    """Group-by axis for `agent_spans_query` and `agent_spans_stats`.
 
-    `source="field"` targets a semantic span field (`agent.name`) or direct
-    span column (`agent_name`), allowlisted server-side. `source="column"` is
-    accepted for existing callers.
-    The other sources target keys inside the typed custom attribute Map columns,
-    which accept arbitrary user-defined keys.
+    Used on `AgentSpansQueryReq.group_by`,
+    `AgentSpanStatsReq.group_by`,
+    `AgentSpanStatsNumericBucketSpec.group_by`, and
+    `AgentSpanGroupFilter.group_by`. The resolved alias appears in
+    `AgentSpanGroupRow.group_keys`; compute it with
+    `group_by_ref_alias` rather than recomputing the resolution rules.
+
+    Sources split into two families:
+
+    1. **Field / column** (`field`, `column`) — an allowlisted
+       semconv field (`agent.name`) or direct span column
+       (`agent_name`). `column` is the legacy alias and behaves the
+       same as `field`.
+    2. **Custom attribute** (`custom_attrs_string`,
+       `custom_attrs_int`, `custom_attrs_float`, `custom_attrs_bool`)
+       — a user-defined key inside the matching typed Map column on
+       the span row.
+
+    Args:
+        source: Which family `key` resolves through.
+        key: Field name (family 1) or attribute key (family 2).
+        alias: Override for the output key in
+            `AgentSpanGroupRow.group_keys`. When `None`, the server
+            falls back to the resolved column or the raw `key`.
+
+    Examples:
+        >>> # Group by agent_name.
+        >>> AgentGroupByRef(source="field", key="agent_name")
+        >>> # Group by a user-defined string attribute "tenant".
+        >>> AgentGroupByRef(source="custom_attrs_string", key="tenant")
     """
 
     source: Literal[
@@ -539,10 +1043,26 @@ class AgentGroupByRef(BaseModel):
 
 
 def group_by_ref_alias(ref: AgentGroupByRef) -> str:
-    """Return the SQL-safe output alias for a group-by ref.
+    """Resolve the output alias the server uses for a group-by ref.
 
-    Used for both request validation here and SQL projection in the query
-    builder, so both call sites agree on what shows up in `group_keys`.
+    The single source of truth for the alias resolution rules. Both
+    request validation and SQL projection call this so both sides
+    agree on what key ends up in `AgentSpanGroupRow.group_keys`.
+
+    Args:
+        ref: A group-by ref from `AgentSpansQueryReq.group_by` or
+            `AgentSpanStatsReq.group_by`.
+
+    Returns:
+        Explicit `ref.alias` when set; the semconv-resolved column
+        name for `field`/`column` sources; the raw `ref.key`
+        otherwise.
+
+    Examples:
+        >>> group_by_ref_alias(
+        ...     AgentGroupByRef(source="field", key="agent.name")
+        ... )
+        'agent_name'
     """
     if ref.alias is not None:
         return ref.alias
@@ -552,7 +1072,47 @@ def group_by_ref_alias(ref: AgentGroupByRef) -> str:
 
 
 class AgentSpanGroupDistributionSpec(BaseModel):
-    """One custom attribute distribution to compute per returned span group."""
+    """Custom attribute distribution attached to each returned span group.
+
+    Pass on `AgentSpansQueryReq.group_distributions`. For each group
+    in the response, the server adds an
+    `AgentSpanGroupDistributionItem` under
+    `AgentSpanGroupRow.distributions[alias]` summarizing the
+    distribution of one custom attribute across that group's spans.
+
+    Numeric attributes (`custom_attrs_int`, `custom_attrs_float`)
+    produce a `bins`-wide histogram. Categorical attributes
+    (`custom_attrs_string`, `custom_attrs_bool`) produce a `top_n`
+    list.
+
+    Note: currently limited to a single `group_by` ref on the parent
+    request. See `AgentSpansQueryReq.validate_spans_query_request`.
+
+    Args:
+        alias: Output key in `AgentSpanGroupRow.distributions`.
+        value: Custom attribute to summarize. `value.source` must be
+            one of the `custom_attrs_*` sources.
+        bins: Histogram bin count for numeric attributes, 1 to
+            `MAX_AGENT_CUSTOM_ATTR_DISTRIBUTION_BINS`. Ignored for
+            categorical attributes.
+        top_n: Maximum categorical values returned, 1 to
+            `MAX_AGENT_CUSTOM_ATTR_DISTRIBUTION_TOP_N`. Ignored for
+            numeric attributes.
+
+    Raises:
+        ValueError: When `value.source` is not a custom attribute
+            source.
+
+    Examples:
+        >>> # Top 10 values of a string attribute named "tenant".
+        >>> AgentSpanGroupDistributionSpec(
+        ...     alias="tenants",
+        ...     value=AgentSpanValueRef(
+        ...         source="custom_attrs_string", key="tenant"
+        ...     ),
+        ...     top_n=10,
+        ... )
+    """
 
     alias: str = Field(pattern=_IDENT_RE)
     value: AgentSpanValueRef
@@ -584,10 +1144,20 @@ class AgentSpanGroupDistributionSpec(BaseModel):
 
 
 class AgentSpanGroupDistributionBin(BaseModel):
-    """One numeric histogram bin for a custom attribute in a span group."""
+    """One bucket of a numeric custom attribute histogram in a span group.
 
-    # 0-based bucket position within the histogram; clients render bins in
-    # `index` order so this can double as a stable sort key.
+    Args:
+        index: 0-based bucket position within the histogram. Clients
+            render bins in `index` order, so this doubles as a stable
+            sort key.
+        min: Lower bound, inclusive.
+        max: Upper bound, exclusive (inclusive on the final bucket).
+        count: Spans whose attribute value fell in this bucket.
+
+    Examples:
+        >>> AgentSpanGroupDistributionBin(index=0, min=0.0, max=10.0, count=42)
+    """
+
     index: int
     min: float
     max: float
@@ -595,14 +1165,54 @@ class AgentSpanGroupDistributionBin(BaseModel):
 
 
 class AgentSpanGroupDistributionValue(BaseModel):
-    """One categorical custom attribute value count in a span group."""
+    """One observed value in a categorical distribution.
+
+    Args:
+        value: The attribute value, stringified for transport.
+        count: Spans in the group that carried this value.
+
+    Examples:
+        >>> AgentSpanGroupDistributionValue(value="prod", count=17)
+    """
 
     value: str
     count: int
 
 
 class AgentSpanGroupDistributionItem(BaseModel):
-    """Distribution data for one span-group/custom-attribute pair."""
+    """Distribution result inside an `AgentSpanGroupRow`.
+
+    Returned in `AgentSpanGroupRow.distributions` keyed by the
+    requesting `AgentSpanGroupDistributionSpec.alias`. Numeric
+    attribute requests populate `bins`; categorical requests populate
+    `values`. The four `*_count` fields always sum to `total_count`.
+
+    Args:
+        alias: Echoes the requesting spec's `alias`.
+        source: Custom attribute source that produced the
+            distribution.
+        key: Attribute key inside the source map.
+        value_type: Inferred attribute type.
+        total_count: Spans evaluated for the distribution.
+        present_count: Spans where the attribute was set.
+        missing_count: Spans where the attribute was absent.
+        other_count: Spans whose values fell outside `bins` or below
+            the `top_n` cutoff.
+        bins: Histogram bins. Populated for numeric distributions
+            only.
+        values: Top values. Populated for categorical distributions
+            only.
+
+    Examples:
+        >>> item = AgentSpanGroupDistributionItem(
+        ...     alias="tenants",
+        ...     source="custom_attrs_string",
+        ...     key="tenant",
+        ...     value_type="string",
+        ... )
+        >>> item.total_count
+        0
+    """
 
     alias: str
     source: AgentCustomAttrSource
@@ -617,11 +1227,24 @@ class AgentSpanGroupDistributionItem(BaseModel):
 
 
 class AgentConversationMessagePreview(BaseModel):
-    """A truncated first/last message snippet for a grouped conversation row.
+    """Length-capped message snippet on a conversation group row.
 
-    `role` is the chat-timeline message type (e.g. "user_message",
-    "assistant_message") so clients can style it consistently with the full
-    chat view; `text` is the trimmed, length-capped preview content.
+    Populated on `AgentSpanGroupRow.first_message` and
+    `AgentSpanGroupRow.last_message` when grouping by
+    `conversation_id`. Lets the conversations table render teaser text
+    without a per-row hydration query.
+
+    Args:
+        role: Chat-timeline message type (`user_message`,
+            `assistant_message`, etc.). Matches `AgentChatMessage.type`
+            so previews style identically to the full chat view.
+        text: Trimmed preview content. Empty when no renderable text
+            was available on the source span.
+
+    Examples:
+        >>> AgentConversationMessagePreview(
+        ...     role="user_message", text="Hello, can you help me?"
+        ... )
     """
 
     role: str = ""
@@ -629,10 +1252,64 @@ class AgentConversationMessagePreview(BaseModel):
 
 
 class AgentSpanGroupRow(BaseModel):
-    """A single row in a grouped spans query response.
+    """One aggregated row in `AgentSpansQueryRes.groups`.
 
-    `group_keys` maps each group_by ref's alias to its value for this row.
-    The remaining fields are a fixed aggregate bundle computed per group.
+    Returned by `agent_spans_query` in group mode. The fixed aggregate
+    bundle (`span_count`, the `total_*_tokens` family, `first_seen`,
+    `last_seen`, etc.) is always present; `metrics` and
+    `distributions` are populated when the request supplied the
+    corresponding spec.
+
+    Note: `first_message` and `last_message` are populated only when
+    grouping by `conversation_id`. Cost fields use `None` (not `0`)
+    to mean "no priced model matched in this group."
+
+    Args:
+        group_keys: Group-by values for the row, keyed by the
+            resolved alias (see `group_by_ref_alias`).
+        span_count: Total spans in the group.
+        invocation_count: Spans where
+            `operation_name == "invoke_agent"`.
+        conversation_count: Distinct `conversation_id` values in the
+            group.
+        total_input_tokens: Sum of `input_tokens`.
+        total_cache_creation_input_tokens: Sum of
+            `cache_creation_input_tokens`.
+        total_cache_read_input_tokens: Sum of
+            `cache_read_input_tokens`.
+        total_output_tokens: Sum of `output_tokens`.
+        total_reasoning_tokens: Sum of `reasoning_tokens`.
+        total_duration_ms: Sum of span wall-clock durations.
+        error_count: Spans with `status_code == "Error"`.
+        total_cost_usd: Sum of `total_cost_usd` across the group's
+            spans. Opt-in via `include_costs`.
+        total_input_cost_usd: Sum of `input_cost_usd`. Opt-in.
+        total_output_cost_usd: Sum of `output_cost_usd`. Opt-in.
+        agent_names: Distinct `agent_name` values in the group.
+        agent_versions: Distinct `agent_version` values.
+        provider_names: Distinct `provider_name` values.
+        request_models: Distinct `request_model` values.
+        conversation_names: Distinct `conversation_name` values.
+        first_seen: Earliest `started_at` in the group. UTC.
+        last_seen: Latest `started_at` in the group. UTC.
+        first_message: Preview of the earliest renderable message in
+            the group. Conversation grouping only.
+        last_message: Preview of the latest renderable message in
+            the group. Conversation grouping only.
+        metrics: Per-measure aggregates keyed by
+            `AgentSpanMeasureSpec.alias`.
+        distributions: Per-distribution data keyed by
+            `AgentSpanGroupDistributionSpec.alias`.
+
+    Examples:
+        >>> row = AgentSpanGroupRow(
+        ...     group_keys={"agent_name": "research-bot"},
+        ...     span_count=128,
+        ...     invocation_count=64,
+        ...     error_count=2,
+        ... )
+        >>> row.metrics
+        {}
     """
 
     group_keys: dict[str, str | int | float | bool | None] = Field(default_factory=dict)
@@ -671,11 +1348,67 @@ class AgentSpanGroupRow(BaseModel):
 
 
 class AgentSpansQueryReq(BaseModel):
-    """Request to query agent spans for a project.
+    """Two-mode span query for the `agent_spans_query` endpoint.
 
-    When `group_by` is empty (or omitted), returns raw span rows in the
-    response's `spans` field. When `group_by` is non-empty, returns
-    aggregate group rows in the response's `groups` field.
+    One endpoint, two output shapes, picked by `group_by`:
+
+    1. **List mode** — `group_by` empty or omitted. Returns one
+       `AgentSpanSchema` per matched span in
+       `AgentSpansQueryRes.spans`. Backs the spans table and
+       single-trace drill-downs.
+    2. **Group mode** — `group_by` set. Returns one
+       `AgentSpanGroupRow` per group in `AgentSpansQueryRes.groups`,
+       with optional `measures` and `distributions`. Backs the
+       agents, versions, and conversations lists (group by
+       `conversation_id`).
+
+    Note: `group_by` is the discriminator. Setting any group-only
+    field (`measures`, `group_filters`, `group_distributions`)
+    without `group_by` is a validation error. `include_details` and
+    `custom_attr_columns` are list-mode only.
+
+    Args:
+        project_id: Target project in `entity/project` form.
+        query: Optional Mongo-style filter. Field names resolve via
+            GenAI semconv, direct span columns, or typed custom
+            attribute keys.
+        group_by: Refs to group by. Triggers group mode when
+            non-empty.
+        measures: Aggregated measures per group.
+        group_filters: Range filters applied to aggregated measures.
+        group_distributions: Per-group custom attribute
+            distributions. Limited to one `group_by` ref.
+        custom_attr_columns: Extra custom attribute values to project
+            on each span row. List mode only.
+        include_details: Include large fields (messages, tool
+            payloads, `raw_span_dump`) on each span row. List mode
+            only; intended for single-trace fetches, not list views.
+        include_costs: Compute query-time USD costs by joining each
+            span's model against `llm_token_prices`.
+        sort_by: Sort steps. Allowed fields validated server-side.
+        limit: Max rows, 0 to `MAX_AGENT_QUERY_LIMIT`.
+        offset: Rows to skip.
+        started_after: Filter `started_at >= start`.
+        started_before: Filter `started_at < end`.
+
+    Raises:
+        ValueError: When group-only fields are set without
+            `group_by`, when `custom_attr_columns` or
+            `include_details` is combined with `group_by`, when
+            `group_distributions` has more than one `group_by` ref,
+            when `custom_attr_columns` aren't custom-attr sources,
+            or when measure/distribution aliases collide or
+            duplicate.
+
+    Examples:
+        >>> # List the conversations for one agent, grouped by id.
+        >>> AgentSpansQueryReq(
+        ...     project_id="your-team/your-project",
+        ...     group_by=[
+        ...         AgentGroupByRef(source="field", key="conversation_id"),
+        ...     ],
+        ...     include_costs=True,
+        ... )
     """
 
     project_id: str
@@ -769,10 +1502,21 @@ class AgentSpansQueryReq(BaseModel):
 
 
 class AgentSpansQueryRes(BaseModel):
-    """Response from a spans query.
+    """Response from `agent_spans_query`.
 
-    Exactly one of `spans` or `groups` will be populated, based on
-    whether the request specified `group_by`.
+    Exactly one of `spans` or `groups` is populated, mirroring the
+    request's list/group mode discriminator.
+
+    Args:
+        spans: Raw span rows. Populated in list mode.
+        groups: Aggregated group rows. Populated in group mode.
+        total_count: Total rows that matched the filter before
+            `limit`/`offset`.
+
+    Examples:
+        >>> res = AgentSpansQueryRes(total_count=1)
+        >>> res.spans, res.groups
+        ([], [])
     """
 
     spans: list[AgentSpanSchema] = Field(default_factory=list)
@@ -781,7 +1525,26 @@ class AgentSpansQueryRes(BaseModel):
 
 
 class AgentCustomAttrsSchemaReq(BaseModel):
-    """Request to discover typed custom attribute keys for matching spans."""
+    """Discovery request for custom attribute keys.
+
+    Run before constructing filters, group-bys, or distributions that
+    target user-defined attributes. The response tells the client
+    which `(source, key, value_type)` triples actually exist in the
+    data.
+
+    Args:
+        project_id: Target project in `entity/project` form.
+        query: Optional Mongo-style filter narrowing the discovery
+            scan.
+        started_after: Filter `started_at >= start`.
+        started_before: Filter `started_at < end`.
+        limit: Maximum keys returned, 1 to
+            `MAX_AGENT_CUSTOM_ATTR_SCHEMA_LIMIT`.
+        offset: Keys to skip for pagination.
+
+    Examples:
+        >>> AgentCustomAttrsSchemaReq(project_id="your-team/your-project")
+    """
 
     project_id: str
     query: Query | None = None
@@ -796,7 +1559,24 @@ class AgentCustomAttrsSchemaReq(BaseModel):
 
 
 class AgentCustomAttrSchemaItem(BaseModel):
-    """One custom attribute key/type observed in the matching spans."""
+    """One discovered custom attribute key.
+
+    Args:
+        source: Which typed Map column the key lives in
+            (`custom_attrs_string`/`int`/`float`/`bool`).
+        key: Attribute key as recorded by the producing span.
+        value_type: Inferred value type.
+        span_count: Spans in the discovery scope that carried the
+            key.
+
+    Examples:
+        >>> AgentCustomAttrSchemaItem(
+        ...     source="custom_attrs_string",
+        ...     key="tenant",
+        ...     value_type="string",
+        ...     span_count=42,
+        ... )
+    """
 
     source: AgentCustomAttrSource
     key: str
@@ -805,7 +1585,23 @@ class AgentCustomAttrSchemaItem(BaseModel):
 
 
 class AgentCustomAttrsSchemaRes(BaseModel):
-    """Typed custom attribute keys available for spans query/group/stats APIs."""
+    """Response from `agent_custom_attrs_schema`.
+
+    Feed each entry's `(source, key)` back into `AgentSpansQueryReq`
+    and `AgentSpanStatsReq` through the matching `custom_attrs_*`
+    source on `AgentSpanValueRef`/`AgentGroupByRef`.
+
+    Args:
+        attributes: One entry per discovered key.
+        limit: Echoes the request limit.
+        offset: Echoes the request offset.
+        has_more: `True` when at least one more page is available.
+
+    Examples:
+        >>> res = AgentCustomAttrsSchemaRes(has_more=False)
+        >>> res.attributes
+        []
+    """
 
     attributes: list[AgentCustomAttrSchemaItem] = Field(default_factory=list)
     limit: int = DEFAULT_AGENT_CUSTOM_ATTR_SCHEMA_LIMIT
@@ -819,13 +1615,53 @@ class AgentCustomAttrsSchemaRes(BaseModel):
 
 
 class AgentSearchReq(BaseModel):
-    """Query the `messages` table by content and/or span-level filters.
+    """Two-mode message search for the `agent_search` endpoint.
 
-    Scans the `messages` table (one row per message occurrence, populated by an
-    MV from spans) and returns matching span-level hits. Full-text search sets
-    `query`; structured retrieval (e.g. all messages in a trace) leaves `query`
-    empty and uses the filters below. The caller groups by conversation for the
-    response shape.
+    Backed by the `messages` materialized view (one row per message
+    occurrence, fed from spans). Two ways to use it:
+
+    1. **Full-text search** — set `query` to a substring. The
+       structured filters narrow the scope (e.g. "assistant messages
+       from agent X in the last week").
+    2. **Structured retrieval** — leave `query` empty and use only
+       the structured filters (e.g. set `trace_id` to fetch every
+       message in a trace). Pair with `truncate_content=False` to
+       receive full bodies.
+
+    Note: results are grouped by conversation in the response shape,
+    not by trace. One conversation can contain matches from multiple
+    traces.
+
+    Args:
+        project_id: Target project in `entity/project` form.
+        query: Content substring. Empty disables the content filter.
+        trace_id: Restrict to messages in this trace.
+        roles: Restrict to these message roles.
+        conversation_id: Restrict to messages in this conversation.
+        agent_name: Restrict to messages from this agent.
+        provider_name: Restrict to messages from this provider.
+        request_model: Restrict to messages from this model.
+        truncate_content: `True` (default) returns previews; `False`
+            returns full message bodies. Flip to `False` for
+            structured retrieval, not for ad-hoc search UIs because
+            payloads get large.
+        started_after: Filter `started_at >= start`.
+        started_before: Filter `started_at < end`.
+        limit: Max messages, 0 to `MAX_SEARCH_LIMIT`.
+        offset: Messages to skip for pagination.
+
+    Examples:
+        >>> # Full-text search across all messages in a project.
+        >>> AgentSearchReq(
+        ...     project_id="your-team/your-project",
+        ...     query="rate limit",
+        ... )
+        >>> # Structured retrieval: every message in one trace.
+        >>> AgentSearchReq(
+        ...     project_id="your-team/your-project",
+        ...     trace_id="t1",
+        ...     truncate_content=False,
+        ... )
     """
 
     project_id: str
@@ -850,7 +1686,30 @@ class AgentSearchReq(BaseModel):
 
 
 class AgentSearchMatchedMessage(BaseModel):
-    """A single message that matched the search query."""
+    """One message hit in an `AgentSearchRes`.
+
+    Args:
+        span_id: Span that produced the message.
+        trace_id: Trace containing the span.
+        role: Message role (`user`, `assistant`, `tool`, etc.).
+        content_preview: Trimmed preview, or full body when the
+            request set `truncate_content=False`.
+        content_digest: Stable digest of the full content. Useful for
+            deduplicating identical messages across re-runs.
+        started_at: Time the producing span started. UTC.
+
+    Examples:
+        >>> AgentSearchMatchedMessage(
+        ...     span_id="s1",
+        ...     trace_id="t1",
+        ...     role="assistant",
+        ...     content_preview="Sure, I can help with that.",
+        ...     content_digest="abc123",
+        ...     started_at=datetime.datetime(
+        ...         2026, 6, 1, tzinfo=datetime.timezone.utc
+        ...     ),
+        ... )
+    """
 
     span_id: str
     trace_id: str
@@ -861,7 +1720,27 @@ class AgentSearchMatchedMessage(BaseModel):
 
 
 class AgentSearchConversationResult(BaseModel):
-    """A conversation containing messages that matched the search query."""
+    """One conversation's matching messages, the row shape of `AgentSearchRes`.
+
+    Args:
+        conversation_id: Conversation identifier shared by every
+            entry in `matched_messages`.
+        conversation_name: Human-readable conversation label.
+        agent_name: Agent that owns the conversation.
+        matched_messages: Matching messages, in chronological order.
+        last_activity: Time of the most recent matching message. UTC.
+
+    Examples:
+        >>> AgentSearchConversationResult(
+        ...     conversation_id="c1",
+        ...     conversation_name="Customer support session",
+        ...     agent_name="support-bot",
+        ...     matched_messages=[],
+        ...     last_activity=datetime.datetime(
+        ...         2026, 6, 1, tzinfo=datetime.timezone.utc
+        ...     ),
+        ... )
+    """
 
     conversation_id: str
     conversation_name: str
@@ -871,7 +1750,16 @@ class AgentSearchConversationResult(BaseModel):
 
 
 class AgentSearchRes(BaseModel):
-    """Response from a full-text search across agent messages."""
+    """Response from `agent_search`.
+
+    Args:
+        results: One entry per conversation containing a match.
+        total_conversations: Conversations matched before
+            `limit`/`offset`.
+
+    Examples:
+        >>> AgentSearchRes(results=[], total_conversations=0)
+    """
 
     results: list[AgentSearchConversationResult]
     total_conversations: int = 0
@@ -888,14 +1776,55 @@ AgentChatMessageType = Literal[
 
 
 class AgentChatUserMessage(BaseModel):
-    """Payload for a user prompt in the chat timeline."""
+    """Payload for the `user_message` branch of `AgentChatMessage`.
+
+    Args:
+        text: Rendered user prompt text.
+        content_refs: Refs to detached content blobs (e.g. uploaded
+            images).
+
+    Examples:
+        >>> AgentChatUserMessage(text="What's the weather in Paris?")
+    """
 
     text: str
     content_refs: list[str] = Field(default_factory=list)
 
 
 class AgentChatAssistantMessage(BaseModel):
-    """Payload for assistant text emitted by an agent or LLM span."""
+    """Payload for the `assistant_message` branch of `AgentChatMessage`.
+
+    Carries one assistant response, plus the LLM-call metadata the
+    chat-view assembler folded in from the underlying span (model,
+    token counts, costs, status).
+
+    Note: the `*_cost_usd` fields use `None` (not `0`) to mean "no
+    priced model matched." For aggregated agent turns, cost fields
+    are summed across the agent's whole subtree.
+
+    Args:
+        text: Rendered assistant response text.
+        model: Model that produced the response.
+        reasoning_content: Reasoning text from a reasoning-capable
+            model.
+        reasoning_tokens: Reasoning tokens consumed.
+        input_tokens: Prompt tokens for this message's span.
+        output_tokens: Completion tokens for this message's span.
+        input_cost_usd: Input-token cost in USD.
+        output_cost_usd: Output-token cost in USD.
+        total_cost_usd: Sum of input and output costs.
+        duration_ms: Wall-clock duration of the producing span.
+        status: OTel status code from the producing span.
+        content_refs: Refs to detached content blobs.
+
+    Examples:
+        >>> AgentChatAssistantMessage(
+        ...     text="It's sunny and 24°C in Paris.",
+        ...     model="gpt-4o",
+        ...     input_tokens=120,
+        ...     output_tokens=18,
+        ... )
+    """
 
     text: str
     model: str | None = None
@@ -914,7 +1843,27 @@ class AgentChatAssistantMessage(BaseModel):
 
 
 class AgentChatToolCall(BaseModel):
-    """Payload for a tool call timeline event."""
+    """Payload for the `tool_call` branch of `AgentChatMessage`.
+
+    Folds the LLM's tool-call request and the matching `execute_tool`
+    span result into one timeline event.
+
+    Args:
+        tool_name: Tool name as registered with the agent.
+        tool_arguments: JSON-encoded arguments passed to the tool.
+        tool_result: Serialized tool result.
+        duration_ms: Wall-clock duration of the `execute_tool` span.
+        status: OTel status code from the `execute_tool` span.
+        content_refs: Refs to detached content blobs attached to the
+            call or its result.
+
+    Examples:
+        >>> AgentChatToolCall(
+        ...     tool_name="search_web",
+        ...     tool_arguments='{"query": "weather in Paris"}',
+        ...     tool_result='{"temperature_c": 24, "condition": "sunny"}',
+        ... )
+    """
 
     tool_name: str | None = None
     tool_arguments: str | None = None
@@ -925,7 +1874,25 @@ class AgentChatToolCall(BaseModel):
 
 
 class AgentChatAgentStart(BaseModel):
-    """Payload for an agent lifecycle boundary."""
+    """Payload for the `agent_start` branch of `AgentChatMessage`.
+
+    Marks an `invoke_agent` boundary and carries the system
+    instructions and tool catalog the model was given for the
+    invocation.
+
+    Args:
+        model: Model bound to the agent for this invocation.
+        system_instructions: System prompt set on the agent.
+        tool_definitions: Serialized tool catalog provided to the
+            agent.
+        status: OTel status code from the `invoke_agent` span.
+
+    Examples:
+        >>> AgentChatAgentStart(
+        ...     model="gpt-4o",
+        ...     system_instructions="You are a helpful weather assistant.",
+        ... )
+    """
 
     model: str | None = None
     system_instructions: str | None = None
@@ -934,11 +1901,35 @@ class AgentChatAgentStart(BaseModel):
 
 
 class AgentChatAgentHandoff(BaseModel):
-    """Payload for a future agent-to-agent handoff event."""
+    """Payload for the `agent_handoff` branch of `AgentChatMessage`.
+
+    Reserved for handoff semantics in multi-agent frameworks. No
+    fields yet, but present so the timeline model is
+    forward-compatible with handoff-aware UIs.
+
+    Examples:
+        >>> AgentChatAgentHandoff()
+    """
 
 
 class AgentChatContextCompacted(BaseModel):
-    """Payload for a context-window compaction event."""
+    """Payload for the `context_compacted` branch of `AgentChatMessage`.
+
+    Emitted when an agent rewrites its context window to fit within
+    the model's token budget.
+
+    Args:
+        compaction_summary: Summary of what was compacted.
+        compaction_items_before: Message items before compaction.
+        compaction_items_after: Message items after compaction.
+
+    Examples:
+        >>> AgentChatContextCompacted(
+        ...     compaction_summary="Earlier conversation about Paris weather.",
+        ...     compaction_items_before=40,
+        ...     compaction_items_after=8,
+        ... )
+    """
 
     compaction_summary: str | None = None
     compaction_items_before: int | None = None
@@ -946,12 +1937,49 @@ class AgentChatContextCompacted(BaseModel):
 
 
 class AgentChatMessage(BaseModel):
-    """A single element in the structured agent trajectory / chat view.
+    """One event in the agent trajectory / chat timeline.
 
-    Common event fields live at the top level. Type-specific fields are
-    grouped under the payload matching `type`, and exactly one payload must be
-    set. This keeps subtype nullability explicit while preserving a single
-    ordered timeline model for callers.
+    The chat view flattens a trace's span tree into a linear list of
+    these. Each event is one of six discriminated kinds (see
+    `AgentChatMessageType`); the payload field whose name matches
+    `type` is populated, and all other payload fields must be `None`.
+
+    Common header fields (`span_id`, `agent_name`, `started_at`, etc.)
+    live at the top so callers render headers and filters without
+    unwrapping the payload.
+
+    Note: exactly one payload must be set, and it must match `type`.
+    The validator rejects mismatched or missing payloads, which
+    prevents drift between the discriminator and the data.
+
+    Args:
+        type: Event kind. Picks which payload field is populated.
+        span_id: Producing span ID, when one exists.
+        agent_name: Agent that produced the event.
+        agent_version: Agent version that produced the event.
+        status_code: OTel status code from the producing span.
+        started_at: Event start time. UTC.
+        user_message: Payload when `type="user_message"`.
+        assistant_message: Payload when `type="assistant_message"`.
+        tool_call: Payload when `type="tool_call"`.
+        agent_start: Payload when `type="agent_start"`.
+        agent_handoff: Payload when `type="agent_handoff"`.
+        context_compacted: Payload when `type="context_compacted"`.
+        feedback: Feedback rows attached to this event. Populated
+            only when the parent request set `include_feedback=True`.
+
+    Raises:
+        ValueError: When the payload field matching `type` is
+            missing, or when any other payload field is also set.
+
+    Examples:
+        >>> AgentChatMessage(
+        ...     type="user_message",
+        ...     span_id="s1",
+        ...     user_message=AgentChatUserMessage(
+        ...         text="What's the weather in Paris?"
+        ...     ),
+        ... )
     """
 
     type: AgentChatMessageType
@@ -997,7 +2025,26 @@ class AgentChatMessage(BaseModel):
 
 
 class AgentTraceChatReq(BaseModel):
-    """Request to get the structured chat / trajectory view for a trace."""
+    """Single-turn chat-view request for `agent_traces_chat`.
+
+    Folds the trace's span tree into a linear `AgentChatMessage`
+    timeline ready to render top-to-bottom. Pair with
+    `AgentTraceChatRes`.
+
+    Args:
+        project_id: Target project in `entity/project` form.
+        trace_id: OTel trace ID for the turn to render.
+        include_feedback: Attach feedback rows on the response and on
+            each message that has any. `False` by default to keep
+            payloads small.
+
+    Examples:
+        >>> AgentTraceChatReq(
+        ...     project_id="your-team/your-project",
+        ...     trace_id="t1",
+        ...     include_feedback=True,
+        ... )
+    """
 
     project_id: str
     trace_id: str
@@ -1005,8 +2052,38 @@ class AgentTraceChatReq(BaseModel):
 
 
 class AgentTraceChatRes(BaseModel):
-    """Structured chat view: a linear sequence of messages representing
-    the agent trajectory for a single trace.
+    """Single-turn chat view, the response of `agent_traces_chat`.
+
+    Header fields summarize the trace (agent identity, status,
+    duration, cost); `messages` is the ordered chat timeline. The
+    same shape is reused inside `AgentConversationChatRes.turns`, so
+    one client renderer covers both single-turn and per-turn views.
+
+    Note: `total_duration_ms` is the root span's wall-clock duration,
+    not a sum across child spans. `total_cost_usd` is a sum across
+    every span in the trace.
+
+    Args:
+        trace_id: OTel trace ID echoed from the request.
+        root_span_name: Name of the trace's root span.
+        agent_name: Agent that owns the trace.
+        agent_version: Agent version that produced the trace.
+        status_code: OTel status of the root span.
+        provider: Provider name reported by the root span.
+        total_duration_ms: Wall-clock duration of the root span.
+        total_cost_usd: Sum of `total_cost_usd` across every span in
+            the trace. `None` signals no priced model matched.
+        messages: Chat timeline in chronological order.
+        feedback: Trace-level feedback rows. Populated only when the
+            request set `include_feedback=True`.
+
+    Examples:
+        >>> AgentTraceChatRes(
+        ...     trace_id="t1",
+        ...     agent_name="research-bot",
+        ...     status_code="Ok",
+        ...     total_duration_ms=420,
+        ... )
     """
 
     trace_id: str
@@ -1030,7 +2107,29 @@ class AgentTraceChatRes(BaseModel):
 
 
 class AgentConversationChatReq(BaseModel):
-    """Request to get the multi-turn chat view for a conversation."""
+    """Multi-turn chat-view request for `agent_conversation_chat`.
+
+    Returns an ordered page of turns that share one
+    `conversation_id`. The id is `gen_ai.conversation.id` on the
+    producing spans.
+
+    Args:
+        project_id: Target project in `entity/project` form.
+        conversation_id: Conversation identifier.
+        limit: Max turns returned per page, 0 to
+            `MAX_CONVERSATION_CHAT_TURNS`.
+        offset: Most-recent turns to skip. Within the selected page,
+            turns are returned in chronological order.
+        include_feedback: Attach feedback rows to each turn and
+            message that has any.
+
+    Examples:
+        >>> AgentConversationChatReq(
+        ...     project_id="your-team/your-project",
+        ...     conversation_id="c1",
+        ...     limit=10,
+        ... )
+    """
 
     project_id: str
     conversation_id: str
@@ -1052,13 +2151,31 @@ class AgentConversationChatReq(BaseModel):
 
 
 class AgentConversationChatRes(BaseModel):
-    """Multi-turn chat view: an ordered list of per-turn chat responses.
+    """Multi-turn chat view, the response of `agent_conversation_chat`.
 
-    Each entry in `turns` corresponds to one trace_id, which Weave treats as
-    one conversation turn. This is not necessarily one `invoke_agent` span:
-    a turn can contain zero, one, or many agent invocations. The frontend can
-    render turn-number dividers between entries and still reuse
-    `AgentTraceChatRes` rendering for each individual turn.
+    `turns` is an ordered list of per-turn `AgentTraceChatRes` rows,
+    so the client reuses single-turn rendering for each one.
+    Conversation-level totals (cost, feedback) sit on the parent
+    response.
+
+    Note: one turn corresponds to one trace, not one `invoke_agent`
+    span. A turn can contain zero, one, or many agent invocations.
+
+    Args:
+        conversation_id: Echoes the request.
+        turns: Per-turn chat views in chronological order.
+        total_turns: Turns in the conversation before
+            `limit`/`offset`.
+        has_more: `True` when another page is available.
+        limit: Echoes the request limit.
+        offset: Echoes the request offset.
+        total_cost_usd: Sum of `total_cost_usd` across the returned
+            turns. `None` signals no priced model matched.
+        feedback: Conversation-level feedback rows. Populated only
+            when the request set `include_feedback=True`.
+
+    Examples:
+        >>> AgentConversationChatRes(conversation_id="c1", total_turns=3)
     """
 
     conversation_id: str
@@ -1074,7 +2191,46 @@ class AgentConversationChatRes(BaseModel):
 
 
 class AgentSchema(BaseModel):
-    """Aggregated per-agent stats from the agents table."""
+    """One aggregated row from the agents materialized view.
+
+    Returned in `AgentsQueryRes.agents`. One row per `agent_name`,
+    summarizing every span attributed to that agent across all
+    versions and conversations. Backs the entry point of the Agents
+    view.
+
+    Note: `total_cost_usd` is filled by a supplementary grouped spans
+    query because the agents MV has no cost column. It uses `None`
+    (not `0`) to mean "costs weren't requested or no priced model
+    matched."
+
+    Args:
+        project_id: Owning project in `entity/project` form.
+        agent_name: Agent identifier.
+        invocation_count: `invoke_agent` spans attributed to the
+            agent.
+        span_count: Total spans attributed to the agent.
+        total_input_tokens: Sum of `input_tokens`.
+        total_output_tokens: Sum of `output_tokens`.
+        total_duration_ms: Sum of span wall-clock durations.
+        error_count: Spans with `status_code == "Error"`.
+        first_seen: Earliest `started_at` for the agent. UTC.
+        last_seen: Latest `started_at` for the agent. UTC.
+        total_cost_usd: Opt-in summed cost in USD.
+
+    Examples:
+        >>> AgentSchema(
+        ...     project_id="your-team/your-project",
+        ...     agent_name="research-bot",
+        ...     invocation_count=42,
+        ...     span_count=210,
+        ...     total_input_tokens=12345,
+        ...     total_output_tokens=6789,
+        ...     total_duration_ms=58000,
+        ...     error_count=1,
+        ...     first_seen=None,
+        ...     last_seen=None,
+        ... )
+    """
 
     project_id: str
     agent_name: str
@@ -1094,13 +2250,40 @@ class AgentSchema(BaseModel):
 
 
 class AgentsQueryFilters(BaseModel):
-    """Optional filters for querying agents."""
+    """Optional filters block for `AgentsQueryReq`.
+
+    Args:
+        agent_name: Exact-match filter on agent name. `None` matches
+            every agent in the project.
+
+    Examples:
+        >>> AgentsQueryFilters(agent_name="research-bot")
+    """
 
     agent_name: str | None = None
 
 
 class AgentsQueryReq(BaseModel):
-    """Request to list agents with aggregated stats for a project."""
+    """Agent listing request for `agent_agents_query`.
+
+    Entry point for the Agents view. Drill into a specific agent's
+    versions with `AgentVersionsQueryReq`; drill into its
+    conversations with `AgentSpansQueryReq` in group mode.
+
+    Args:
+        project_id: Target project in `entity/project` form.
+        filters: Optional narrowing of which agents are returned.
+        sort_by: Sort steps. Allowed fields validated server-side.
+        limit: Max rows, 0 to `MAX_AGENT_QUERY_LIMIT`.
+        offset: Rows to skip.
+        include_costs: Opt into supplementary cost computation for
+            `AgentSchema.total_cost_usd`.
+
+    Examples:
+        >>> AgentsQueryReq(
+        ...     project_id="your-team/your-project", include_costs=True
+        ... )
+    """
 
     project_id: str
     filters: AgentsQueryFilters | None = None
@@ -1115,7 +2298,15 @@ class AgentsQueryReq(BaseModel):
 
 
 class AgentsQueryRes(BaseModel):
-    """Response containing aggregated agent stats."""
+    """Response from `agent_agents_query`.
+
+    Args:
+        agents: One `AgentSchema` per matched agent.
+        total_count: Agents matched before `limit`/`offset`.
+
+    Examples:
+        >>> AgentsQueryRes(agents=[], total_count=0)
+    """
 
     agents: list[AgentSchema]
     total_count: int = 0
@@ -1127,13 +2318,54 @@ class AgentsQueryRes(BaseModel):
 
 
 class AgentVersionSchema(AgentSchema):
-    """Aggregated per-version stats from the agent_versions AMT."""
+    """`AgentSchema` row keyed by `(agent_name, agent_version)`.
+
+    Returned by `agent_versions_query`. Extends `AgentSchema` with
+    `agent_version`; every other field has the same meaning.
+
+    Args:
+        agent_version: Version label on the producing spans.
+
+    Examples:
+        >>> AgentVersionSchema(
+        ...     project_id="your-team/your-project",
+        ...     agent_name="research-bot",
+        ...     agent_version="2026-06-01",
+        ...     invocation_count=10,
+        ...     span_count=42,
+        ...     total_input_tokens=1000,
+        ...     total_output_tokens=500,
+        ...     total_duration_ms=12000,
+        ...     error_count=0,
+        ...     first_seen=None,
+        ...     last_seen=None,
+        ... )
+    """
 
     agent_version: str
 
 
 class AgentVersionsQueryReq(BaseModel):
-    """Request to list versions for an agent."""
+    """Version-listing request for `agent_versions_query`.
+
+    Run after `agent_agents_query` to diff behavior across releases
+    of one agent.
+
+    Args:
+        project_id: Target project in `entity/project` form.
+        agent_name: Agent to enumerate versions for.
+        sort_by: Sort steps. Allowed fields validated server-side.
+        limit: Max rows, 0 to `MAX_AGENT_QUERY_LIMIT`.
+        offset: Rows to skip.
+        include_costs: Opt into supplementary cost computation for
+            `AgentVersionSchema.total_cost_usd`.
+
+    Examples:
+        >>> AgentVersionsQueryReq(
+        ...     project_id="your-team/your-project",
+        ...     agent_name="research-bot",
+        ... )
+    """
 
     project_id: str
     agent_name: str
@@ -1148,7 +2380,16 @@ class AgentVersionsQueryReq(BaseModel):
 
 
 class AgentVersionsQueryRes(BaseModel):
-    """Response containing agent version stats."""
+    """Response from `agent_versions_query`.
+
+    Args:
+        versions: One `AgentVersionSchema` per matched `(agent_name,
+            agent_version)` pair.
+        total_count: Versions matched before `limit`/`offset`.
+
+    Examples:
+        >>> AgentVersionsQueryRes(versions=[], total_count=0)
+    """
 
     versions: list[AgentVersionSchema]
     total_count: int = 0
@@ -1160,10 +2401,30 @@ class AgentVersionsQueryRes(BaseModel):
 
 
 class GenAIOTelExportReq(BaseModel):
-    """Request for the GenAI OTel ingest endpoint.
+    """Ingest request for `genai_otel_export`.
 
-    Carries the same ProcessedResourceSpans as the standard OTel endpoint
-    but routes through GenAI extraction and into spans.
+    The single write-side entry point in this module. Sits at the
+    start of the workflow: spans flow in here from the SDK or a raw
+    OTel exporter, land in the agent spans table, and refresh the
+    downstream materialized views (agents, agent_versions, messages)
+    that the read-side endpoints query.
+
+    Note: carries `ProcessedResourceSpans` (post-deserialization), not
+    the raw protobuf payload. The model sets
+    `arbitrary_types_allowed=True` because Pydantic doesn't have a
+    schema for the OTel proto type.
+
+    Args:
+        processed_spans: Deserialized OTel resource spans to ingest.
+        project_id: Target project in `entity/project` form.
+        wb_user_id: Optional W&B user ID to record on each span.
+
+    Examples:
+        >>> # Construct an empty ingest call against your project.
+        >>> GenAIOTelExportReq(
+        ...     processed_spans=[],
+        ...     project_id="your-team/your-project",
+        ... )
     """
 
     model_config = {"arbitrary_types_allowed": True}
@@ -1176,7 +2437,21 @@ class GenAIOTelExportReq(BaseModel):
 
 
 class GenAIOTelExportRes(BaseModel):
-    """Response for the GenAI OTel ingest endpoint."""
+    """Response from `genai_otel_export`.
+
+    Note: rejected spans don't block the rest of the batch. Inspect
+    `error_message` for a summary of why some were dropped.
+
+    Args:
+        accepted_spans: Spans that passed extraction and were
+            enqueued for insertion.
+        rejected_spans: Spans the server skipped.
+        error_message: Short summary of the rejection cause when
+            `rejected_spans > 0`. Empty when everything succeeded.
+
+    Examples:
+        >>> GenAIOTelExportRes(accepted_spans=100)
+    """
 
     accepted_spans: int = 0
     rejected_spans: int = 0

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3245,33 +3245,296 @@ class TraceServerInterface(Protocol):
     def otel_export(self, req: OTelExportReq) -> OTelExportRes: ...
 
     # GenAI / Agent Observability API
+    #
+    # Contract every backend (ClickHouse, in-memory fake, remote HTTP)
+    # implements for the Agents view. Workflow:
+    #
+    # 1. Ingest spans via `genai_otel_export`.
+    # 2. List agents with `agent_agents_query`, drill into one agent's
+    #    versions with `agent_versions_query`, and into its conversations
+    #    by calling `agent_spans_query` in group mode with
+    #    `group_by=[conversation_id]`.
+    # 3. Open a conversation with `agent_conversation_chat`; open a single
+    #    turn with `agent_traces_chat`.
+    # 4. Side queries: `agent_spans_stats` for charts,
+    #    `agent_custom_attrs_schema` for filter builders, `agent_search`
+    #    for content or structured retrieval over messages.
+    #
+    # User-facing concepts: https://docs.wandb.ai/weave/guides/tracking/trace-agents
     def genai_otel_export(
         self, req: agent_types.GenAIOTelExportReq
-    ) -> agent_types.GenAIOTelExportRes: ...
+    ) -> agent_types.GenAIOTelExportRes:
+        """Ingest GenAI OTel spans into the agent observability store.
+
+        The single write-side entry point. Spans land in the agent
+        spans table and refresh the downstream materialized views
+        (agents, agent_versions, messages) that the read-side
+        endpoints query.
+
+        Note: rejected spans don't block the rest of the batch.
+        Inspect `res.error_message` for the rejection cause.
+
+        Args:
+            req: Spans plus destination project.
+
+        Returns:
+            agent_types.GenAIOTelExportRes: Counts of accepted and
+            rejected spans.
+
+        Examples:
+            >>> # Empty ingest call.
+            >>> req = agent_types.GenAIOTelExportReq(
+            ...     processed_spans=[],
+            ...     project_id="your-team/your-project",
+            ... )
+            >>> # server.genai_otel_export(req)
+        """
+        ...
     def agent_spans_query(
         self, req: agent_types.AgentSpansQueryReq
-    ) -> agent_types.AgentSpansQueryRes: ...
+    ) -> agent_types.AgentSpansQueryRes:
+        """List or aggregate agent spans.
+
+        Two-mode endpoint, picked by `req.group_by`:
+
+        1. **List mode** (`group_by` empty) — `res.spans` contains
+           one `AgentSpanSchema` per matched span. Backs the spans
+           table and single-trace detail views.
+        2. **Group mode** (`group_by` set) — `res.groups` contains
+           one `AgentSpanGroupRow` per group. Backs the conversations
+           list (group by `conversation_id`), per-agent rollups, and
+           any other grouped view.
+
+        Opt-ins:
+
+        * `req.include_costs=True` attaches query-time USD costs.
+        * `req.include_details=True` (list mode only) includes large
+          fields like messages and `raw_span_dump`.
+        * `req.custom_attr_columns` projects extra typed custom
+          attributes alongside the standard columns.
+
+        Args:
+            req: Filter, grouping, sort, and pagination parameters.
+
+        Returns:
+            agent_types.AgentSpansQueryRes: Either `spans` or
+            `groups` populated based on `req.group_by`.
+
+        Examples:
+            >>> # Conversations list: group spans by conversation_id.
+            >>> req = agent_types.AgentSpansQueryReq(
+            ...     project_id="your-team/your-project",
+            ...     group_by=[
+            ...         agent_types.AgentGroupByRef(
+            ...             source="field", key="conversation_id"
+            ...         ),
+            ...     ],
+            ... )
+            >>> # res = server.agent_spans_query(req); res.groups
+        """
+        ...
     def agent_spans_stats(
         self, req: agent_types.AgentSpanStatsReq
-    ) -> agent_types.AgentSpanStatsRes: ...
+    ) -> agent_types.AgentSpanStatsRes:
+        """Chart-ready aggregation over agent spans.
+
+        Pipeline: filter spans, bucket (time or numeric, per
+        `req.bucket_by`), group within bucket (per `req.group_by`),
+        compute metrics, drop groups failing `req.group_filters`. The
+        response carries a column schema so clients render axes and
+        legends without re-deriving them.
+
+        Args:
+            req: Time window, grouping, bucketing, and metric specs.
+
+        Returns:
+            agent_types.AgentSpanStatsRes: Column schema plus one
+            row per non-empty bucket and group combination.
+
+        Examples:
+            >>> req = agent_types.AgentSpanStatsReq(
+            ...     project_id="your-team/your-project",
+            ...     start=datetime.datetime(
+            ...         2026, 6, 1, tzinfo=datetime.timezone.utc
+            ...     ),
+            ...     metrics=[
+            ...         agent_types.AgentSpanStatsMetricSpec(
+            ...             alias="duration_ms",
+            ...             value_type="number",
+            ...             percentiles=[50.0, 99.0],
+            ...             value=agent_types.AgentSpanValueRef(
+            ...                 source="derived", key="duration_ms"
+            ...             ),
+            ...         ),
+            ...     ],
+            ... )
+            >>> # server.agent_spans_stats(req)
+        """
+        ...
     def agent_custom_attrs_schema(
         self, req: agent_types.AgentCustomAttrsSchemaReq
-    ) -> agent_types.AgentCustomAttrsSchemaRes: ...
+    ) -> agent_types.AgentCustomAttrsSchemaRes:
+        """Discover custom attribute keys present on agent spans.
+
+        Call before constructing filters, group-bys, or distributions
+        that target user-defined attributes. The response tells the
+        client which `(source, key, value_type)` triples actually
+        exist in the data. Feed them back into `AgentSpansQueryReq`
+        and `AgentSpanStatsReq` through the matching `custom_attrs_*`
+        source.
+
+        Args:
+            req: Discovery scope (project, optional filter and time
+                window, pagination).
+
+        Returns:
+            agent_types.AgentCustomAttrsSchemaRes: One entry per
+            discovered key.
+
+        Examples:
+            >>> req = agent_types.AgentCustomAttrsSchemaReq(
+            ...     project_id="your-team/your-project",
+            ... )
+            >>> # server.agent_custom_attrs_schema(req)
+        """
+        ...
     def agent_agents_query(
         self, req: agent_types.AgentsQueryReq
-    ) -> agent_types.AgentsQueryRes: ...
+    ) -> agent_types.AgentsQueryRes:
+        """List agents in a project with aggregated stats.
+
+        Entry point for the Agents view. Returns one `AgentSchema`
+        per `agent_name`, summarizing every span attributed to that
+        agent. Drill into a specific agent with
+        `agent_versions_query` or `agent_spans_query` in group mode.
+
+        Args:
+            req: Project, optional filters, sort, pagination, and
+                `include_costs` opt-in.
+
+        Returns:
+            agent_types.AgentsQueryRes: Aggregated stats plus the
+            total count before `limit`/`offset`.
+
+        Examples:
+            >>> req = agent_types.AgentsQueryReq(
+            ...     project_id="your-team/your-project",
+            ...     include_costs=True,
+            ... )
+            >>> # server.agent_agents_query(req)
+        """
+        ...
     def agent_versions_query(
         self, req: agent_types.AgentVersionsQueryReq
-    ) -> agent_types.AgentVersionsQueryRes: ...
+    ) -> agent_types.AgentVersionsQueryRes:
+        """List the versions seen for an agent.
+
+        Run after `agent_agents_query` to diff behavior across
+        releases of one agent. Returns one `AgentVersionSchema` per
+        `(agent_name, agent_version)` pair.
+
+        Args:
+            req: Project, target `agent_name`, sort, pagination, and
+                `include_costs` opt-in.
+
+        Returns:
+            agent_types.AgentVersionsQueryRes: Per-version stats plus
+            the total count before `limit`/`offset`.
+
+        Examples:
+            >>> req = agent_types.AgentVersionsQueryReq(
+            ...     project_id="your-team/your-project",
+            ...     agent_name="research-bot",
+            ... )
+            >>> # server.agent_versions_query(req)
+        """
+        ...
     def agent_search(
         self, req: agent_types.AgentSearchReq
-    ) -> agent_types.AgentSearchRes: ...
+    ) -> agent_types.AgentSearchRes:
+        """Search agent messages by content or structured filters.
+
+        Backed by the messages MV. Two modes:
+
+        1. **Full-text search** — set `req.query` to a substring.
+        2. **Structured retrieval** — leave `req.query` empty and
+           use the structured filters (e.g. `req.trace_id` to fetch
+           every message in a trace).
+
+        Args:
+            req: Content query, structured filters,
+                content-truncation opt-out, and pagination.
+
+        Returns:
+            agent_types.AgentSearchRes: One entry per conversation
+            containing a match, with the matching messages listed
+            inside.
+
+        Examples:
+            >>> req = agent_types.AgentSearchReq(
+            ...     project_id="your-team/your-project",
+            ...     query="rate limit",
+            ... )
+            >>> # server.agent_search(req)
+        """
+        ...
     def agent_traces_chat(
         self, req: agent_types.AgentTraceChatReq
-    ) -> agent_types.AgentTraceChatRes: ...
+    ) -> agent_types.AgentTraceChatRes:
+        """Render the chat / trajectory view for a single trace.
+
+        Folds the trace's span tree into a linear timeline of
+        `AgentChatMessage` events ready to render top-to-bottom. The
+        response header carries the trace's agent identity, status,
+        duration, and total cost.
+
+        Args:
+            req: Project, `trace_id`, and `include_feedback` opt-in.
+
+        Returns:
+            agent_types.AgentTraceChatRes: Chat timeline plus
+            trace-level metadata. Reused inside
+            `agent_conversation_chat` for each turn.
+
+        Examples:
+            >>> req = agent_types.AgentTraceChatReq(
+            ...     project_id="your-team/your-project",
+            ...     trace_id="t1",
+            ... )
+            >>> # server.agent_traces_chat(req)
+        """
+        ...
     def agent_conversation_chat(
         self, req: agent_types.AgentConversationChatReq
-    ) -> agent_types.AgentConversationChatRes: ...
+    ) -> agent_types.AgentConversationChatRes:
+        """Render the multi-turn chat view for a conversation.
+
+        Returns an ordered page of turns sharing one
+        `conversation_id`, each turn rendered as a full
+        `AgentTraceChatRes` so clients reuse single-turn rendering.
+
+        Note: a turn corresponds to one trace, not one
+        `invoke_agent` span. A turn can contain zero, one, or many
+        agent invocations.
+
+        Args:
+            req: Project, `conversation_id`, pagination, and
+                `include_feedback` opt-in.
+
+        Returns:
+            agent_types.AgentConversationChatRes: Per-turn chat
+            views in chronological order plus conversation-level
+            totals.
+
+        Examples:
+            >>> req = agent_types.AgentConversationChatReq(
+            ...     project_id="your-team/your-project",
+            ...     conversation_id="c1",
+            ...     limit=10,
+            ... )
+            >>> # server.agent_conversation_chat(req)
+        """
+        ...
 
     # Call API
     def call_start(self, req: CallStartReq) -> CallStartRes: ...


### PR DESCRIPTION
## Description

Third pass over the same surface as [#7362](https://github.com/wandb/weave/pull/7362) and [#7363](https://github.com/wandb/weave/pull/7363), produced by an updated **/sdk-docs** skill that now:

1. Reads a colocated `talk-to-tim/SKILL.md` for voice and reasoning style (concrete, contract-anchored, numbered constraints, no "This class…" preambles).
2. Mandates an example on every public symbol ("Always include an example of how to use the symbol" in the section table).

Opened as **draft** for comparison only. Merge at most one of #7362, #7363, or this PR.

### Same scope as the other two PRs

- `weave/trace_server/agents/types.py` — module docstring + ~30 public Pydantic request/response/payload types.
- `weave/trace/refs.py` — `AgentTurnRef`, `AgentConversationRef`, `AgentSpanRef` and their `parse_uri` methods.
- `weave/trace_server/trace_server_interface.py` — the nine `agent_*` / `genai_otel_export` Protocol methods.

### How v3 reads differently

|   | #7362 (sdk-docs v1) | #7363 (docstring-writer) | This PR (sdk-docs v3) |
|---|---|---|---|
| Net lines | +1192 | +1221 | +1681 |
| Examples on Pydantic types | none | none | runnable `>>>` block on every type |
| Examples on refs | none | doctest round-trips | doctest round-trips |
| Examples on `TraceServerInterface` agent methods | none | none | canonical request construction |
| `Note:` blocks for caveats | no | yes | yes |
| Numbered multi-mode contracts | bullets | numbered | numbered |
| Workflow-positioned openers | shape-led | role-led | role-led |
| Interface section preamble | brief | 4-step workflow | 4-step workflow |

The dominant new effect vs the other two PRs is the **examples mandate** — ~30 new doctest blocks on Pydantic types that #7362 and #7363 both skipped. The Tim style reference also tightened openers ("Pointer to one value on a span row." vs #7362's "Reference to a span field or typed custom attribute map value.").

### Caveat on the skill version

The skill change that produced this PR lives in `~/.claude/plugins/cache/cw-claude-code-plugins/sdk-docs/1.0.0/skills/sdk-docs/SKILL.md` (local cache only). The upstream `coreweave/agent-plugins` marketplace clone hasn't been updated yet. If reviewers want to reproduce, the same edit needs to land upstream.

## Testing

- `uvx ruff check` — clean.
- `uv run --group test python -m pytest tests/trace_server/test_genai_agent_queries.py tests/trace_server/test_genai_chat_view.py --trace-server=fake` — 24 passed, 27 skipped.
- Smoke import: every newly documented symbol has a populated `__doc__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)