### PR TITLE
fix(weave): make realtime autopatch consistent with other integrations

### DIFF
--- a/tests/integrations/openai_realtime/test_otel_state_exporter.py
+++ b/tests/integrations/openai_realtime/test_otel_state_exporter.py
@@ -32,6 +32,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from weave.integrations.openai_realtime.conversation_manager import ConversationManager
 from weave.integrations.openai_realtime.otel_state_exporter import OTelStateExporter
 from weave.integrations.openai_realtime.state_exporter import StateExporter
+from weave.session.agent_context import agent_name_override
 
 _MODEL = "gpt-4o-realtime-preview"
 _SESSION_ID = "sess_1"
@@ -264,6 +265,36 @@ def test_basic_response_emits_invoke_agent_chat_tree(
     # chat nests under the invoke_agent root, same trace.
     assert chat.parent.span_id == root.context.span_id
     assert chat.context.trace_id == root.context.trace_id
+
+
+def test_agent_name_override_captured_at_construction(
+    otel_spans: InMemorySpanExporter, fake_publish: list[Any]
+) -> None:
+    """A user's agent_name_override in scope at construction names the root span.
+
+    The override contextvar is invisible on the worker/FIFO threads that emit
+    spans, so the exporter must capture it when constructed on the user thread.
+    """
+    with agent_name_override("custom_agent"):
+        exp = OTelStateExporter()
+    exp.handle_session_updated({"type": "session.updated", "session": make_session()})
+
+    user = make_user_audio_item("item_u1", transcript="What's the weather?")
+    out = make_assistant_audio_item("item_a1", transcript="It's sunny.")
+    resp = make_response("resp_1", [out], conversation_id="conv_abc")
+    drive_response(
+        exp, resp, input_items=[user], response_audio={"item_a1": b"\x10\x20\x30\x40"}
+    )
+
+    time.sleep(0.12)
+    exp.on_exit()
+    spans = otel_spans.get_finished_spans()
+
+    agents = by_op(spans, "invoke_agent")
+    assert len(agents) == 1
+    root = agents[0]
+    assert root.name == "invoke_agent custom_agent"
+    assert get_attrs(root)["gen_ai.agent.name"] == "custom_agent"
 
 
 def test_input_audio_published_as_uri(

--- a/tests/integrations/test_autopatch.py
+++ b/tests/integrations/test_autopatch.py
@@ -89,6 +89,62 @@ def test_implicit_patch_multiple_libraries(setup_env, monkeypatch):
         mock_patch_mistral.assert_called_once()
 
 
+# The real modules realtime wraps. Tests below isolate the one under test by
+# clearing all three from sys.modules first, then injecting only the target.
+# Otherwise, since aiohttp/websockets are genuinely installed here, an un-mocked
+# sibling key still in sys.modules would let the real patch_openai_realtime fire
+# and pre-populate _PATCHED_INTEGRATIONS.
+_REALTIME_TRIGGER_MODULES = ["websocket", "websockets", "aiohttp"]
+
+
+def test_implicit_patch_realtime_websocket_already_imported(setup_env, monkeypatch):
+    """Realtime auto-patches when its real trigger module (websocket) is imported.
+
+    Mirrors ``test_implicit_patch_already_imported`` but keys on ``websocket``,
+    one of the real modules the realtime patcher wraps (the old synthetic
+    ``openai_realtime`` key never matched ``sys.modules`` so it never fired).
+    """
+    for module in _REALTIME_TRIGGER_MODULES:
+        _reset_import(monkeypatch, module)
+    _inject_fake_module(monkeypatch, "websocket")
+
+    mock_patch_func = MagicMock()
+
+    with patch.dict(
+        "weave.integrations.patch.INTEGRATION_MODULE_MAPPING",
+        {"websocket": mock_patch_func},
+    ):
+        implicit_patch()
+        mock_patch_func.assert_called_once()
+
+
+@pytest.mark.parametrize("module_name", _REALTIME_TRIGGER_MODULES)
+def test_implicit_patch_realtime_trigger_modules(setup_env, monkeypatch, module_name):
+    """Each of the three real modules realtime wraps triggers its patch func."""
+    for module in _REALTIME_TRIGGER_MODULES:
+        _reset_import(monkeypatch, module)
+    _inject_fake_module(monkeypatch, module_name)
+
+    mock_patch_func = MagicMock()
+
+    with patch.dict(
+        "weave.integrations.patch.INTEGRATION_MODULE_MAPPING",
+        {module_name: mock_patch_func},
+    ):
+        implicit_patch()
+        mock_patch_func.assert_called_once()
+
+
+def test_realtime_registered_under_real_trigger_modules(setup_env):
+    """The real mapping wires realtime to the modules it instruments, not a
+    synthetic ``openai_realtime`` key that never matched ``sys.modules``.
+    """
+    mapping = patch_module.INTEGRATION_MODULE_MAPPING
+    for module_name in ("websocket", "websockets", "aiohttp"):
+        assert mapping[module_name] is patch_module.patch_openai_realtime
+    assert "openai_realtime" not in mapping
+
+
 def test_implicit_patch_disabled(setup_env, monkeypatch):
     """Test that implicit patching can be disabled via environment variable."""
     monkeypatch.setenv("WEAVE_IMPLICITLY_PATCH_INTEGRATIONS", "false")

--- a/weave/integrations/openai_realtime/otel_state_exporter.py
+++ b/weave/integrations/openai_realtime/otel_state_exporter.py
@@ -135,6 +135,14 @@ class OTelStateExporter(StateExporter):
     # Guards the two maps above; on_exit runs on a different thread than the
     # FIFO completion thread that emits responses.
     _otel_lock: Any = PrivateAttr(default_factory=threading.Lock)
+    # Agent name resolved once at construction. Spans are emitted on worker/FIFO
+    # threads where the user's agent_name_override contextvar is not visible, so
+    # we capture it here on the constructing (user) thread, not at emit time.
+    _agent_name: str = PrivateAttr(default=_DEFAULT_AGENT_NAME)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._agent_name = resolve_agent_name(_DEFAULT_AGENT_NAME)
 
     # ------------------------------------------------------------------
     # Session handlers — store config without creating any Weave calls.
@@ -316,7 +324,7 @@ class OTelStateExporter(StateExporter):
             existing = self._session_root_spans.get(group_key)
             if existing is not None:
                 return existing
-            agent_name = resolve_agent_name(_DEFAULT_AGENT_NAME)
+            agent_name = self._agent_name
             attrs = invoke_agent_attributes(
                 agent_name=agent_name,
                 conversation_id=conversation_id,

--- a/weave/integrations/patch.py
+++ b/weave/integrations/patch.py
@@ -464,11 +464,19 @@ def patch_llamaindex() -> None:
 
 
 def patch_openai_realtime(settings: IntegrationSettings | None = None) -> None:
-    """Enable Weave tracing for OpenAI Realtime."""
+    """Enable Weave tracing for OpenAI Realtime.
+
+    Triggers on the real modules the websocket patcher instruments
+    (``websocket``, ``websockets``, ``aiohttp``) rather than a synthetic
+    ``openai_realtime`` symbol that no user imports — that synthetic key never
+    matched ``sys.modules`` or the import hook, so realtime never auto-patched.
+    The wrappers guard by URL, so non-realtime websocket/aiohttp traffic passes
+    through untouched.
+    """
     _patch_integration(
         module_path="weave.integrations.openai_realtime",
         patcher_func_getter_name="get_openai_realtime_websocket_patcher",
-        triggering_symbols=["openai_realtime"],
+        triggering_symbols=["websocket", "websockets", "aiohttp"],
         settings=settings,
     )
 
@@ -509,7 +517,11 @@ INTEGRATION_MODULE_MAPPING: dict[str, Callable[[], None]] = {
     "langchain": patch_langchain,
     "langchain_core": patch_langchain,
     "llama_index": patch_llamaindex,
-    "openai_realtime": patch_openai_realtime,
+    # Realtime wraps these three real modules; its wrappers guard by URL, so
+    # non-realtime websocket/aiohttp traffic passes through untouched.
+    "websocket": patch_openai_realtime,
+    "websockets": patch_openai_realtime,
+    "aiohttp": patch_openai_realtime,
 }
 
 


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-36036

  
## Summary
 - Auto-patches realtime on import of the modules it wraps (`websocket`, `websockets`, `aiohttp`) instead of a synthetic `openai_realtime` key that never matched `sys.modules`, so it patches on import like every other integration
 - Wrappers already guard by URL, so non-realtime websocket/aiohttp traffic passes through untouched
