### PR TITLE
fix(weave): client.inference_models.list() error

### DIFF
--- a/tests/trace/test_inference_models.py
+++ b/tests/trace/test_inference_models.py
@@ -62,9 +62,7 @@ def test_list_success_uses_get_and_sorts() -> None:
 
 
 def test_list_missing_api_key_raises() -> None:
-    with patch(
-        "weave.chat.inference_models.get_wandb_api_context", return_value=None
-    ):
+    with patch("weave.chat.inference_models.get_wandb_api_context", return_value=None):
         with pytest.raises(ValueError, match="No API key found"):
             _make_models().list()
 

--- a/tests/trace/test_inference_models.py
+++ b/tests/trace/test_inference_models.py
@@ -1,0 +1,112 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from weave.chat.inference_models import InferenceModels
+from weave.chat.types.models import ModelsResponseError, ModelsResponseSuccess
+from weave.trace_server.constants import INFERENCE_HOST
+
+
+def _make_models() -> InferenceModels:
+    client = SimpleNamespace(entity="my-entity", project="my-project")
+    return InferenceModels(client)
+
+
+def _patch_httpx(response: MagicMock) -> MagicMock:
+    """Patch httpx.Client so the context manager yields a mock whose GET/POST
+    return ``response``. Returns the mock client for call assertions.
+    """
+    mock_client = MagicMock()
+    mock_client.get.return_value = response
+    mock_client.post.return_value = response
+    ctx = MagicMock()
+    ctx.__enter__.return_value = mock_client
+    return mock_client, ctx
+
+
+def test_list_success_uses_get_and_sorts() -> None:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "object": "list",
+        "data": [
+            {"id": "b-model", "object": "model", "owned_by": "wandb"},
+            {"id": "a-model", "object": "model", "owned_by": "wandb"},
+        ],
+    }
+    mock_client, ctx = _patch_httpx(response)
+
+    with (
+        patch(
+            "weave.chat.inference_models.get_wandb_api_context",
+            return_value="fake-key",
+        ),
+        patch("weave.chat.inference_models.httpx.Client", return_value=ctx),
+    ):
+        result = _make_models().list()
+
+    # The fix under test: a GET request is issued (not POST).
+    expected_url = f"https://{INFERENCE_HOST}/v1/models"
+    expected_headers = {
+        "Authorization": "Bearer fake-key",
+        "OpenAI-Project": "my-entity/my-project",
+        "Content-Type": "application/json",
+    }
+    mock_client.get.assert_called_once_with(expected_url, headers=expected_headers)
+    mock_client.post.assert_not_called()
+
+    assert isinstance(result, ModelsResponseSuccess)
+    assert [m.id for m in result.data] == ["a-model", "b-model"]
+
+
+def test_list_missing_api_key_raises() -> None:
+    with patch(
+        "weave.chat.inference_models.get_wandb_api_context", return_value=None
+    ):
+        with pytest.raises(ValueError, match="No API key found"):
+            _make_models().list()
+
+
+def test_list_401_raises_http_status_error() -> None:
+    response = MagicMock()
+    response.status_code = 401
+    response.reason_phrase = "Unauthorized"
+    response.request = MagicMock()
+    _, ctx = _patch_httpx(response)
+
+    with (
+        patch(
+            "weave.chat.inference_models.get_wandb_api_context",
+            return_value="fake-key",
+        ),
+        patch("weave.chat.inference_models.httpx.Client", return_value=ctx),
+    ):
+        with pytest.raises(httpx.HTTPStatusError, match="my-entity"):
+            _make_models().list()
+
+
+def test_list_non_200_returns_error_model() -> None:
+    response = MagicMock()
+    response.status_code = 500
+    response.json.return_value = {
+        "error": {
+            "code": "internal_error",
+            "message": "boom",
+            "type": "server_error",
+        }
+    }
+    _, ctx = _patch_httpx(response)
+
+    with (
+        patch(
+            "weave.chat.inference_models.get_wandb_api_context",
+            return_value="fake-key",
+        ),
+        patch("weave.chat.inference_models.httpx.Client", return_value=ctx),
+    ):
+        result = _make_models().list()
+
+    assert isinstance(result, ModelsResponseError)
+    assert result.error.message == "boom"

--- a/weave/chat/inference_models.py
+++ b/weave/chat/inference_models.py
@@ -36,7 +36,7 @@ class InferenceModels:
         }
         url = f"https://{INFERENCE_HOST}/v1/models"
         with httpx.Client(timeout=http_timeout()) as client:
-            response = client.post(url, headers=headers)
+            response = client.get(url, headers=headers)
         if response.status_code == 401:
             raise httpx.HTTPStatusError(
                 f"{response.reason_phrase} - please make sure inference is enabled for entity {self._client.entity}",


### PR DESCRIPTION
## Description

The `/v1/models` [API](https://developers.openai.com/api/reference/resources/models/methods/list) is GET not POST.

Calling this method:
```
import weave
client = weave.init("2026-06-23_test")
client.inference_models.list()
```

was generating this error:
```
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[4], line 1
----> 1 client.inference_models.list()

File /Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/weave/chat/inference_models.py:49, in InferenceModels.list(self)
     47 d = response.json()
     48 if response.status_code != 200:
---> 49     return ModelsResponseError.model_validate(d)
     51 try:
     52     validated = ModelsResponseSuccess.model_validate(d)

File /Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pydantic/main.py:716, in BaseModel.model_validate(cls, obj, strict, extra, from_attributes, context, by_alias, by_name)
    710 if by_alias is False and by_name is not True:
    711     raise PydanticUserError(
    712         'At least one of `by_alias` or `by_name` must be set to True.',
    713         code='validate-by-alias-and-name-false',
    714     )
--> 716 return cls.__pydantic_validator__.validate_python(
    717     obj,
    718     strict=strict,
    719     extra=extra,
    720     from_attributes=from_attributes,
    721     context=context,
    722     by_alias=by_alias,
    723     by_name=by_name,
    724 )

ValidationError: 1 validation error for ModelsResponseError
error.code
  Field required [type=missing, input_value={'message': 'Invalid HTTP...'invalid_request_error'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
```
