### PR TITLE
chore(weave): read calls_complete distributed table in call_end_v2

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1143,16 +1143,19 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         Raises:
             NotFoundError: If no start row exists for (project_id, id).
         """
-        table_name = self._get_calls_complete_table_name()
+        update_table_name = self._get_calls_complete_table_name()
+        # Reads hit the distributed `calls_complete` so the existence check sees
+        # rows on every shard; the local-table UPDATE fans out via ON CLUSTER.
+        read_table_name = "calls_complete"
 
         # Confirm the row exists before the UPDATE (full PK fast path, then a
         # (project_id, id) fallback) so a wrong started_at can't silently no-op.
         started_at = end_call.started_at
         if started_at is None or not self._calls_complete_call_exists(
-            table_name, end_call.project_id, end_call.id, started_at
+            read_table_name, end_call.project_id, end_call.id, started_at
         ):
             started_at = self._read_calls_complete_started_at(
-                table_name, end_call.project_id, end_call.id
+                read_table_name, end_call.project_id, end_call.id
             )
             if started_at is None:
                 raise NotFoundError(
@@ -1188,7 +1191,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         started_at_param = pb.add_param(started_at_us)
 
         query = build_calls_complete_update_end_query(
-            table_name=table_name,
+            table_name=update_table_name,
             project_id_param=project_id_param,
             id_param=id_param,
             ended_at_param=ended_at_param,


### PR DESCRIPTION
## Summary
- `call_end_v2`'s existence check read the local mutation table (`calls_complete_local`), so on a distributed cluster it only saw the connected node's shard and raised `NotFoundError` for calls whose row hashed to the other shard. Read the distributed `calls_complete` for the existence check; the `ON CLUSTER` UPDATE stays on the local table.
- Sole remaining blocker for the 2s2r nightly leg ([failing run](https://github.com/wandb/weave/actions/runs/28067603887)).

## Testing
reproduced red->green on a local 2s2r cluster: 4 failed (`NotFoundError: no start found`) -> 42 passed.