### PR TITLE
fix(weave): better error on permission-denied project

### DIFF
--- a/tests/wandb_interface/test_project_creator.py
+++ b/tests/wandb_interface/test_project_creator.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from gql.transport.exceptions import TransportQueryError
 
 from weave.compat.wandb import AuthenticationError, CommError
 from weave.wandb_interface.project_creator import (
@@ -136,6 +137,37 @@ def test_ensure_project_exists_authentication_error(mock_api_with_no_project):
     mock_api_with_no_project.upsert_project.assert_called_once_with(
         entity="test_entity", project="test_project"
     )
+
+
+@pytest.mark.disable_logging_error_check
+def test_ensure_project_exists_permission_denied(mock_api_with_no_project):
+    """Permission denial surfaces a clear error with no raw gql traceback or retries."""
+    permission_error = TransportQueryError(
+        "permission denied",
+        errors=[
+            {
+                "message": "permission denied",
+                "path": ["upsertModel"],
+                "extensions": {"code": "PERMISSION_ERROR"},
+            }
+        ],
+    )
+    mock_api_with_no_project.upsert_project.side_effect = permission_error
+
+    with pytest.raises(UnableToCreateProjectError) as exc_info:
+        ensure_project_exists("test_entity", "test_project")
+
+    assert str(exc_info.value) == (
+        "You do not have permission to access or create project "
+        "`test_entity/test_project`. Your API key may belong to a service "
+        "account or user that is not a member of the `test_entity` team, or "
+        "that lacks write access. Verify the key's team/entity scope."
+    )
+    assert not isinstance(exc_info.value, TransportQueryError)
+    assert exc_info.value.__cause__ is None
+    # Permission errors are non-retryable: one lookup, one create attempt, no retries.
+    assert mock_api_with_no_project.project.call_count == 1
+    assert mock_api_with_no_project.upsert_project.call_count == 1
 
 
 @pytest.mark.disable_logging_error_check

--- a/weave/wandb_interface/project_creator.py
+++ b/weave/wandb_interface/project_creator.py
@@ -31,6 +31,8 @@ class UnableToCreateProjectError(Exception): ...
 
 logger = logging.getLogger(__name__)
 
+PERMISSION_ERROR_CODE = "PERMISSION_ERROR"
+
 
 @contextmanager
 def wandb_logging_disabled() -> Iterator[None]:
@@ -83,6 +85,16 @@ def _is_retryable_project_exception(exception: BaseException) -> bool:
     )
 
 
+def _is_permission_denied(exception: Exception) -> bool:
+    """Return True if the exception is a GraphQL permission denial."""
+    if not isinstance(exception, TransportQueryError):
+        return False
+    for error in exception.errors or []:
+        if (error.get("extensions") or {}).get("code") == PERMISSION_ERROR_CODE:
+            return True
+    return False
+
+
 def _raise_project_access_error(
     entity_name: str, project_name: str, exception: Exception
 ) -> NoReturn:
@@ -90,10 +102,15 @@ def _raise_project_access_error(
     logger.error("Unable to access `%s/%s`.", entity_name, project_name)
     logger.error(str(exception))
 
-    if isinstance(exception, (wandb.AuthenticationError, wandb.CommError)):
-        # Suppress the stack trace for these exceptions to minimize noise for users
-        cls = exception.__class__
-        raise cls(str(exception)) from None
+    # Surface permission denials as a clear message, suppressing the raw gql
+    # traceback. gorilla returns PERMISSION_ERROR for forbidden and not-logged-in.
+    if _is_permission_denied(exception):
+        raise UnableToCreateProjectError(
+            f"You do not have permission to access or create project "
+            f"`{entity_name}/{project_name}`. Your API key may belong to a service "
+            f"account or user that is not a member of the `{entity_name}` team, or "
+            f"that lacks write access. Verify the key's team/entity scope."
+        ) from None
 
     raise exception
 


### PR DESCRIPTION
## Summary
- `weave.init` with a team-scoped key dumped a raw `gql` `TransportQueryError` traceback (referencing the internal `upsertModel` mutation) on a permission denial.
- Now re-raise `PERMISSION_ERROR` denials as a clear `UnableToCreateProjectError` via `from None`. gorilla returns `PERMISSION_ERROR` for both forbidden and not-logged-in, so this covers the GraphQL auth/permission surface.
- Drop the dead `(AuthenticationError, CommError)` branch in `_raise_project_access_error`. Dead since #5048, which rewired this path from the real `wandb` `InternalApi` to `wandb_thin`'s `Api` (raises gql `TransportQueryError`, never those types) while porting this branch over unchanged.
- Jira: [WB-36061](https://coreweave.atlassian.net/browse/WB-36061) | [slack thread](https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1782314956888779)

## Testing
unit test asserting the clear message, no chained traceback, and no retries.


[WB-36061]: https://coreweave.atlassian.net/browse/WB-36061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
