### PR TITLE
fix(weave): bind agent span-stats time bounds as whole-second ints

### DIFF
--- a/tests/trace_server/query_builder/test_agent_stats_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_stats_query_builder.py
@@ -92,6 +92,23 @@ def _req(**kwargs) -> AgentSpanStatsReq:
     return AgentSpanStatsReq(**defaults)
 
 
+def test_time_bucket_epoch_bounds_are_whole_second_ints() -> None:
+    """Epoch bounds bind as whole-second ints; a `.0` float trips ClickHouse Int64 param parsing (400 on `/agents/spans/stats`)."""
+    start = datetime.datetime(
+        2026, 1, 1, 0, 0, 30, 500000, tzinfo=datetime.timezone.utc
+    )
+    end = datetime.datetime(2026, 1, 1, 1, 0, 0, 750000, tzinfo=datetime.timezone.utc)
+    params = build_agent_span_stats_query(
+        _req(start=start, end=end), ParamBuilder("genai")
+    ).parameters
+    start_epoch = int(start.timestamp())
+    end_epoch = int(end.timestamp())
+    assert start_epoch in params.values()
+    assert end_epoch in params.values()
+    epochs = [v for v in params.values() if v in {start_epoch, end_epoch}]
+    assert [type(v) for v in epochs] == [int, int]
+
+
 def test_ungrouped_stats_query_full_sql_shape() -> None:
     pb = ParamBuilder("genai")
     req = _req(

--- a/weave/trace_server/query_builder/agent_stats_query_builder.py
+++ b/weave/trace_server/query_builder/agent_stats_query_builder.py
@@ -319,8 +319,9 @@ def build_agent_span_stats_query(
         )
 
     granularity_seconds = _resolve_granularity(req, start, end)
-    start_epoch = start.replace(tzinfo=datetime.timezone.utc).timestamp()
-    end_epoch = end.replace(tzinfo=datetime.timezone.utc).timestamp()
+    # Whole unix seconds: a fractional float trips ClickHouse Int64 param parsing.
+    start_epoch = int(start.replace(tzinfo=datetime.timezone.utc).timestamp())
+    end_epoch = int(end.replace(tzinfo=datetime.timezone.utc).timestamp())
     start_param = pb.add_param(start_epoch)
     end_param = pb.add_param(end_epoch)
     tz_param = pb.add_param(tz)


### PR DESCRIPTION
## Summary
- `/agents/spans/stats` returns 400 `BadQueryParameterError` when the time-bucket query binds a fractional epoch: `start.timestamp()` -> `1782314343.0`, and ClickHouse rejects the trailing `.0` parsing the time param as Int64 (`Code: 457 BAD_QUERY_PARAMETER`). ~285/day in prod from the Agents UI time-window histogram, spread across many users.
- Floor the start/end bounds to whole unix seconds so the value parses cleanly regardless of param type.
- Jira: [WB-36062](https://coreweave.atlassian.net/browse/WB-36062)

## Testing
unit regression test (fails on a fractional epoch, passes floored); existing ClickHouse-backed stats test still green.


[WB-36062]: https://coreweave.atlassian.net/browse/WB-36062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ