### PR TITLE
feat(weave): add agent read APIs to Python RemoteHTTPTraceServer

### DIFF
--- a/tests/trace_server_bindings/test_agent_routes.py
+++ b/tests/trace_server_bindings/test_agent_routes.py
@@ -78,6 +78,25 @@ def _mock_response(json_data: dict | None = None) -> MagicMock:
             {"conversation_id": "conv-123"},
             id="agent_conversation_chat",
         ),
+        pytest.param(
+            "agent_agents_query",
+            agent_types.AgentsQueryReq(project_id="entity/project"),
+            "/agents/query",
+            agent_types.AgentsQueryRes,
+            {"agents": [], "total_count": 0},
+            id="agent_agents_query",
+        ),
+        pytest.param(
+            "agent_versions_query",
+            agent_types.AgentVersionsQueryReq(
+                project_id="entity/project",
+                agent_name="my-agent",
+            ),
+            "/agents/agent-versions/query",
+            agent_types.AgentVersionsQueryRes,
+            {"versions": [], "total_count": 0},
+            id="agent_versions_query",
+        ),
     ],
 )
 def test_agent_read_route_posts_request_and_parses_response(

--- a/tests/trace_server_bindings/test_agent_routes.py
+++ b/tests/trace_server_bindings/test_agent_routes.py
@@ -1,0 +1,125 @@
+"""Tests for agent observability read routes in RemoteHTTPTraceServer.
+
+These tests verify that the agent read methods send the correct HTTP method,
+URL path, and request body through the RemoteHTTPTraceServer client, and that
+the response is parsed back into the correct typed model.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from weave.trace_server.agents import types as agent_types
+from weave.trace_server.interface.query import Query
+from weave.trace_server_bindings.remote_http_trace_server import (
+    RemoteHTTPTraceServer,
+)
+
+BASE_URL = "http://example.com"
+
+
+@pytest.fixture
+def server():
+    """Create a RemoteHTTPTraceServer with mocked HTTP methods."""
+    srv = RemoteHTTPTraceServer(BASE_URL, should_batch=False)
+    yield srv
+    if srv.call_processor:
+        srv.call_processor.stop_accepting_new_work_and_flush_queue()
+    if srv.feedback_processor:
+        srv.feedback_processor.stop_accepting_new_work_and_flush_queue()
+
+
+def _mock_response(json_data: dict | None = None) -> MagicMock:
+    """Create a mock httpx.Response with the given JSON data."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = json_data or {}
+    return resp
+
+
+@pytest.mark.parametrize(
+    ("method_name", "req", "expected_url", "res_type", "res_json"),
+    [
+        pytest.param(
+            "agent_spans_query",
+            agent_types.AgentSpansQueryReq(project_id="entity/project"),
+            "/agents/spans/query",
+            agent_types.AgentSpansQueryRes,
+            {"spans": [], "groups": [], "total_count": 0},
+            id="agent_spans_query",
+        ),
+        pytest.param(
+            "agent_traces_chat",
+            agent_types.AgentTraceChatReq(
+                project_id="entity/project",
+                trace_id="trace-123",
+                include_feedback=True,
+            ),
+            "/agents/traces/chat",
+            agent_types.AgentTraceChatRes,
+            {"trace_id": "trace-123"},
+            id="agent_traces_chat",
+        ),
+        pytest.param(
+            "agent_conversation_chat",
+            agent_types.AgentConversationChatReq(
+                project_id="entity/project",
+                conversation_id="conv-123",
+                limit=10,
+                offset=2,
+            ),
+            "/agents/conversations/chat",
+            agent_types.AgentConversationChatRes,
+            {"conversation_id": "conv-123"},
+            id="agent_conversation_chat",
+        ),
+    ],
+)
+def test_agent_read_route_posts_request_and_parses_response(
+    server,
+    method_name: str,
+    req: BaseModel,
+    expected_url: str,
+    res_type: type[BaseModel],
+    res_json: dict,
+):
+    mock_resp = _mock_response(res_json)
+    with patch.object(server, "post", return_value=mock_resp) as mock_post:
+        result = getattr(server, method_name)(req)
+
+    # Posts to the documented endpoint.
+    mock_post.assert_called_once()
+    assert mock_post.call_args[0][0] == expected_url
+
+    # Sends the complete serialized request body (no fields dropped or renamed).
+    sent_data = mock_post.call_args[1]["data"]
+    assert json.loads(sent_data) == json.loads(req.model_dump_json(by_alias=True))
+
+    # Parses the response into the correct typed model.
+    assert isinstance(result, res_type)
+
+
+def test_agent_spans_query_serializes_mongo_query_with_aliases(server):
+    """The embedded Mongo-style `query` must keep its `$`-aliased operators on
+    the wire — the one behavior that differs from a trivial passthrough.
+    """
+    req = agent_types.AgentSpansQueryReq(
+        project_id="entity/project",
+        query=Query.model_validate(
+            {"$expr": {"$gt": [{"$getField": "retries"}, {"$literal": 3}]}}
+        ),
+    )
+    mock_resp = _mock_response({"spans": [], "groups": [], "total_count": 0})
+    with patch.object(server, "post", return_value=mock_resp) as mock_post:
+        server.agent_spans_query(req)
+
+    mock_post.assert_called_once()
+    body = json.loads(mock_post.call_args[1]["data"])
+    assert body["query"] == {
+        "$expr": {"$gt": [{"$getField": "retries"}, {"$literal": 3}]}
+    }

--- a/tests/trace_server_bindings/test_agent_routes.py
+++ b/tests/trace_server_bindings/test_agent_routes.py
@@ -7,6 +7,7 @@ the response is parsed back into the correct typed model.
 
 from __future__ import annotations
 
+import datetime
 import json
 from unittest.mock import MagicMock, patch
 
@@ -96,6 +97,48 @@ def _mock_response(json_data: dict | None = None) -> MagicMock:
             agent_types.AgentVersionsQueryRes,
             {"versions": [], "total_count": 0},
             id="agent_versions_query",
+        ),
+        pytest.param(
+            "agent_spans_stats",
+            agent_types.AgentSpanStatsReq(
+                project_id="entity/project",
+                start=datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+                end=datetime.datetime(2024, 1, 1, 1, tzinfo=datetime.timezone.utc),
+                metrics=[
+                    agent_types.AgentSpanStatsMetricSpec(
+                        alias="input_tokens",
+                        value_type="number",
+                        value=agent_types.AgentSpanValueRef(
+                            source="field", key="usage.input_tokens"
+                        ),
+                        aggregations=["sum"],
+                    )
+                ],
+            ),
+            "/agents/spans/stats",
+            agent_types.AgentSpanStatsRes,
+            {
+                "start": "2024-01-01T00:00:00+00:00",
+                "end": "2024-01-01T01:00:00+00:00",
+                "timezone": "UTC",
+            },
+            id="agent_spans_stats",
+        ),
+        pytest.param(
+            "agent_custom_attrs_schema",
+            agent_types.AgentCustomAttrsSchemaReq(project_id="entity/project"),
+            "/agents/spans/custom-attrs/schema",
+            agent_types.AgentCustomAttrsSchemaRes,
+            {"attributes": []},
+            id="agent_custom_attrs_schema",
+        ),
+        pytest.param(
+            "agent_search",
+            agent_types.AgentSearchReq(project_id="entity/project", query="error"),
+            "/agents/search",
+            agent_types.AgentSearchRes,
+            {"results": [], "total_conversations": 0},
+            id="agent_search",
         ),
     ],
 )

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -662,6 +662,28 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             agent_types.AgentConversationChatRes,
         )
 
+    @validate_call
+    def agent_agents_query(
+        self, req: agent_types.AgentsQueryReq
+    ) -> agent_types.AgentsQueryRes:
+        return self._generic_request(
+            "/agents/query",
+            req,
+            agent_types.AgentsQueryReq,
+            agent_types.AgentsQueryRes,
+        )
+
+    @validate_call
+    def agent_versions_query(
+        self, req: agent_types.AgentVersionsQueryReq
+    ) -> agent_types.AgentVersionsQueryRes:
+        return self._generic_request(
+            "/agents/agent-versions/query",
+            req,
+            agent_types.AgentVersionsQueryReq,
+            agent_types.AgentVersionsQueryRes,
+        )
+
     # Call API
     @validate_call
     def call_start(self, req: tsi.CallStartReq) -> tsi.CallStartRes:

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -18,9 +18,9 @@ from weave.trace.settings import (
 )
 from weave.trace_server import http_service_interface as his
 from weave.trace_server import trace_server_interface as tsi
-from weave.trace_server.agents import types as agent_types
 from weave.trace_server.ids import generate_id
 from weave.trace_server.service_interface import ServerInfoRes
+from weave.trace_server.trace_server_interface import agent_types
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
 from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
 from weave.trace_server_bindings.client_interface import TraceServerClientInterface

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -684,6 +684,39 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             agent_types.AgentVersionsQueryRes,
         )
 
+    @validate_call
+    def agent_spans_stats(
+        self, req: agent_types.AgentSpanStatsReq
+    ) -> agent_types.AgentSpanStatsRes:
+        return self._generic_request(
+            "/agents/spans/stats",
+            req,
+            agent_types.AgentSpanStatsReq,
+            agent_types.AgentSpanStatsRes,
+        )
+
+    @validate_call
+    def agent_custom_attrs_schema(
+        self, req: agent_types.AgentCustomAttrsSchemaReq
+    ) -> agent_types.AgentCustomAttrsSchemaRes:
+        return self._generic_request(
+            "/agents/spans/custom-attrs/schema",
+            req,
+            agent_types.AgentCustomAttrsSchemaReq,
+            agent_types.AgentCustomAttrsSchemaRes,
+        )
+
+    @validate_call
+    def agent_search(
+        self, req: agent_types.AgentSearchReq
+    ) -> agent_types.AgentSearchRes:
+        return self._generic_request(
+            "/agents/search",
+            req,
+            agent_types.AgentSearchReq,
+            agent_types.AgentSearchRes,
+        )
+
     # Call API
     @validate_call
     def call_start(self, req: tsi.CallStartReq) -> tsi.CallStartRes:

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -18,6 +18,7 @@ from weave.trace.settings import (
 )
 from weave.trace_server import http_service_interface as his
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.agents import types as agent_types
 from weave.trace_server.ids import generate_id
 from weave.trace_server.service_interface import ServerInfoRes
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
@@ -625,6 +626,41 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
     def otel_export(self, req: tsi.OTelExportReq) -> tsi.OTelExportRes:
         # TODO: Add docs link (DOCS-1390)
         raise NotImplementedError("Sending otel traces directly is not yet supported.")
+
+    # === GenAI / Agent Observability API (read) ===
+
+    @validate_call
+    def agent_spans_query(
+        self, req: agent_types.AgentSpansQueryReq
+    ) -> agent_types.AgentSpansQueryRes:
+        return self._generic_request(
+            "/agents/spans/query",
+            req,
+            agent_types.AgentSpansQueryReq,
+            agent_types.AgentSpansQueryRes,
+        )
+
+    @validate_call
+    def agent_traces_chat(
+        self, req: agent_types.AgentTraceChatReq
+    ) -> agent_types.AgentTraceChatRes:
+        return self._generic_request(
+            "/agents/traces/chat",
+            req,
+            agent_types.AgentTraceChatReq,
+            agent_types.AgentTraceChatRes,
+        )
+
+    @validate_call
+    def agent_conversation_chat(
+        self, req: agent_types.AgentConversationChatReq
+    ) -> agent_types.AgentConversationChatRes:
+        return self._generic_request(
+            "/agents/conversations/chat",
+            req,
+            agent_types.AgentConversationChatReq,
+            agent_types.AgentConversationChatRes,
+        )
 
     # Call API
     @validate_call


### PR DESCRIPTION
## Summary

Adds **eight of the nine** agent observability **read** endpoints to the Python `RemoteHTTPTraceServer` so the Python SDK can read back agent data the same way the trace server already exposes it. These endpoints are already live server-side and declared on `TraceServerInterface`; this PR fills in the missing client bindings. It is the Python counterpart of WB-35775 (which covers the TS SDK via codegen).

## Endpoints

| Method | Endpoint | Models |
|---|---|---|
| `agent_spans_query` | `POST /agents/spans/query` | `AgentSpansQueryReq` / `AgentSpansQueryRes` |
| `agent_spans_stats` | `POST /agents/spans/stats` | `AgentSpanStatsReq` / `AgentSpanStatsRes` |
| `agent_custom_attrs_schema` | `POST /agents/spans/custom-attrs/schema` | `AgentCustomAttrsSchemaReq` / `AgentCustomAttrsSchemaRes` |
| `agent_agents_query` | `POST /agents/query` | `AgentsQueryReq` / `AgentsQueryRes` |
| `agent_versions_query` | `POST /agents/agent-versions/query` | `AgentVersionsQueryReq` / `AgentVersionsQueryRes` |
| `agent_search` | `POST /agents/search` | `AgentSearchReq` / `AgentSearchRes` |
| `agent_traces_chat` | `POST /agents/traces/chat` | `AgentTraceChatReq` / `AgentTraceChatRes` |
| `agent_conversation_chat` | `POST /agents/conversations/chat` | `AgentConversationChatReq` / `AgentConversationChatRes` |

Each is a thin `_generic_request` POST wrapper, matching the existing `calls_query_stats` / `feedback_query` read methods. `_generic_request` already serializes the body with `by_alias=True`, which the embedded Mongo-style `query` field on `AgentSpansQueryReq`, `AgentSpanStatsReq`, and `AgentCustomAttrsSchemaReq` needs.

## Scope

Eight of the nine `agent_*` read endpoints declared on `TraceServerInterface`. Excluded:

- `agent_conversation_spans` — landed on the interface after this branch opened (per-conversation span sequences for the spans minimap, #7223); bindings to follow.
- `genai_otel_export` — the OTel write/ingest path, not a read (`otel_export` already raises `NotImplementedError` here).

`agent_spans_stats` / `agent_custom_attrs_schema` / `agent_search` are binding-only, matching the TS `WeaveClient` surface. The ergonomic `WeaveClient` methods (`get_agents`, `get_agent_versions`, `get_agent_spans`, `get_agent_turn`, `get_agent_turns`) that wrap the five navigation-style bindings land in stacked follow-up #7384.

## Testing

`tests/trace_server_bindings/test_agent_routes.py`, mirroring `test_tags_aliases_routes.py`: a parametrized test asserts each of the eight methods POSTs to the correct URL, sends the complete serialized request body, and parses the response into the correct typed model; a focused case verifies the Mongo-style `query` keeps its `$`-aliased operators on the wire. `ruff`, `pyright`, and `mypy` are clean on the changed files.

## Notes for reviewers

`@validate_call` follows the existing query/stats read cluster (`calls_query_stats`, `feedback_query`, `cost_query`); happy to drop it to match the newer annotation-queue methods if preferred.
