### PR TITLE
chore(weave): assert complete values in trace/ tests

### DIFF
--- a/tests/trace/concurrent/test_futures.py
+++ b/tests/trace/concurrent/test_futures.py
@@ -39,7 +39,7 @@ def test_defer_with_exception(log_collector) -> None:
 
     logs = log_collector.get_error_logs()
     assert len(logs) == 1
-    assert "ValueError: Test exception" in logs[0].getMessage()
+    assert logs[0].getMessage() == "Task failed: ValueError: Test exception"
 
 
 def test_then_single_future() -> None:
@@ -139,7 +139,7 @@ def test_then_with_exception_in_future(log_collector) -> None:
 
     logs = log_collector.get_error_logs()
     assert len(logs) == 1
-    assert "ValueError: Future exception" in logs[0].getMessage()
+    assert logs[0].getMessage() == "Task failed: ValueError: Future exception"
 
 
 @pytest.mark.disable_logging_error_check
@@ -160,7 +160,7 @@ def test_then_with_exception_in_callback(log_collector) -> None:
 
     logs = log_collector.get_error_logs()
     assert len(logs) == 1
-    assert "ValueError: Callback exception" in logs[0].getMessage()
+    assert logs[0].getMessage() == "Task failed: ValueError: Callback exception"
 
 
 def test_concurrent_execution() -> None:

--- a/tests/trace/test_base_object_classes.py
+++ b/tests/trace/test_base_object_classes.py
@@ -1133,7 +1133,6 @@ def test_obj_create_rejects_name_type_collision(client: WeaveClient):
     assert excinfo.value.kind == "object"
     assert excinfo.value.new_base_object_class == "TestOnlyExample"
     assert excinfo.value.existing_base_object_classes == ["TestOnlyNestedBaseObject"]
-    assert "TestOnlyNestedBaseObject" in str(excinfo.value)
 
     # And the original type must still be the only one present for that name.
     objs_res = client.server.objs_query(

--- a/tests/trace/test_ref_json_encoder.py
+++ b/tests/trace/test_ref_json_encoder.py
@@ -40,9 +40,8 @@ class TestRefJSONEncoderDefault:
     def test_object_ref_returns_wrapped_ref_string(self, object_ref: ObjectRef) -> None:
         result = json.dumps(object_ref, cls=RefJSONEncoder)
 
-        assert RefJSONEncoder.SPECIAL_REF_TOKEN in result
-        assert "weave.ref(" in result
-        assert ".get()" in result
+        token = RefJSONEncoder.SPECIAL_REF_TOKEN
+        assert result == f"\"{token}weave.ref('{object_ref!s}').get(){token}\""
 
     def test_object_ref_contains_correct_uri(self, object_ref: ObjectRef) -> None:
         result = json.dumps(object_ref, cls=RefJSONEncoder)
@@ -67,19 +66,19 @@ class TestRefJSONEncoderIntegration:
             json.dumps({"key": object_ref}, cls=RefJSONEncoder, indent=4)
         )
 
-        assert f"weave.ref('{object_ref!s}').get()" in result
-        # The ref call should NOT be inside quotes
-        assert '"weave.ref(' not in result
+        assert result == (f"{{\n    \"key\": weave.ref('{object_ref!s}').get()\n}}")
 
     def test_mixed_ref_and_plain_values(self, object_ref: ObjectRef) -> None:
         data = {"plain": "hello", "number": 42, "ref_val": object_ref}
         result = strip_ref_tokens(json.dumps(data, cls=RefJSONEncoder, indent=4))
 
-        # Plain values should be unaffected
-        assert '"hello"' in result
-        assert "42" in result
-        # Ref should be a bare call
-        assert f"weave.ref('{object_ref!s}').get()" in result
+        assert result == (
+            "{\n"
+            '    "plain": "hello",\n'
+            '    "number": 42,\n'
+            f"    \"ref_val\": weave.ref('{object_ref!s}').get()\n"
+            "}"
+        )
 
     def test_multiple_refs(self) -> None:
         ref1 = ObjectRef(

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -335,12 +335,12 @@ def test_retry_max_attempts_settings(client_creator, caplog) -> None:
     assert len(retry_attempt_logs) == 1
     attempt_log = retry_attempt_logs[0]
     assert attempt_log.attempt_number == 1
-    assert "Test error" in attempt_log.exception
+    assert attempt_log.exception == "Test error"
 
     assert len(retry_failed_logs) == 1
     failed_log = retry_failed_logs[0]
     assert failed_log.attempt_number == 2
-    assert "Test error" in failed_log.exception
+    assert failed_log.exception == "Test error"
 
 
 def test_retry_max_attempts_env(caplog) -> None:
@@ -360,12 +360,12 @@ def test_retry_max_attempts_env(caplog) -> None:
     assert len(retry_attempt_logs) == 1
     attempt_log = retry_attempt_logs[0]
     assert attempt_log.attempt_number == 1
-    assert "Test error" in attempt_log.exception
+    assert attempt_log.exception == "Test error"
 
     assert len(retry_failed_logs) == 1
     failed_log = retry_failed_logs[0]
     assert failed_log.attempt_number == 2
-    assert "Test error" in failed_log.exception
+    assert failed_log.exception == "Test error"
 
     del os.environ["WEAVE_RETRY_MAX_ATTEMPTS"]
 


### PR DESCRIPTION
## Summary
- continues the complete-payload test-rule rollout (#7355) into `tests/trace/`.
- most of `trace/`'s substring/membership hits are NOT cleanly convertible: op_name/ref URIs carry a per-run content digest, `test_display.py` asserts nondeterministic ANSI console output, and many are exception-message fragments. Forcing `==` there is brittle or infeasible, so they are intentionally left.
- converts the genuine wins: `FutureExecutor` error messages, `RefJSONEncoder` output strings, retry-log `.exception` fields; drops one redundant `str(exc)` substring already covered by adjacent structured-field assertions.

## Testing
touched tests pass, including the 2 ClickHouse-backed ones run against a local CH.