### PR TITLE
feat(weave_ts): Accept `endTime` on `weave.endSession` and `Session.end`

### DIFF
--- a/sdks/node/src/__tests__/genai/api.test.ts
+++ b/sdks/node/src/__tests__/genai/api.test.ts
@@ -272,6 +272,23 @@ describe('genai api (top-level functions)', () => {
     expect(getExporter().getFinishedSpans()).toHaveLength(2);
   });
 
+  it('endSession passes options when implicitly ending LLM and Turn', () => {
+    const startedAt = new Date('2026-05-29T10:00:00.000Z');
+    const endedAt = new Date('2026-05-29T10:00:01.700Z');
+
+    startSession({});
+    startTurn({startTime: startedAt});
+    startLLM({model: 'gpt-4o', startTime: startedAt});
+
+    endSession({endTime: endedAt});
+
+    const spans = getExporter().getFinishedSpans();
+    const turnSpan = findSpan(spans, 'invoke_agent');
+    const llmSpan = findSpan(spans, 'chat');
+    expectSpanTimesToMatch(turnSpan, startedAt, endedAt);
+    expectSpanTimesToMatch(llmSpan, startedAt, endedAt);
+  });
+
   it('startTurn and endTurn respect given times', () => {
     const startedAt = new Date('2026-05-29T10:00:00.000Z');
     const endedAt = new Date('2026-05-29T10:00:01.700Z');

--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -135,11 +135,14 @@ export function startSubagent(opts: SubAgentInit): SubAgent {
  *
  * @example
  * weave.endSession();
+ *
+ * @example
+ * weave.endSession({endTime: new Date('2026-05-29T10:00:01.700Z')});
  */
-export function endSession(): void {
+export function endSession(opts?: SpanEndOptions): void {
   const session = _getGenaiState().session;
   if (session) {
-    session.end();
+    session.end(opts);
   }
 }
 

--- a/sdks/node/src/genai/session.ts
+++ b/sdks/node/src/genai/session.ts
@@ -2,6 +2,7 @@ import {uuidv7} from 'uuidv7';
 
 import {_getGenaiState} from './context';
 import {Turn, type TurnInit} from './turn';
+import type {SpanEndOptions} from './spanBase';
 
 export interface SessionInit {
   agentName?: string;
@@ -49,7 +50,7 @@ export class Session {
     });
   }
 
-  end(): void {
+  end(opts?: SpanEndOptions): void {
     if (this._ended) {
       return;
     }
@@ -58,10 +59,10 @@ export class Session {
     // Cascade: end any active descendants innermost-first so each child span
     // closes before its parent.
     if (state.llm) {
-      state.llm.end();
+      state.llm.end(opts);
     }
     if (state.turn) {
-      state.turn.end();
+      state.turn.end(opts);
     }
     if (state.session === this) {
       state.session = null;


### PR DESCRIPTION
## Description

* While our "session" abstraction is not an OTel span itself, it does automatically `end` child `llm`s and `turn`s, when not already explicitly `end`-ed.

* This change update `weave.endSession` and `Session.end` to accept options to pass down to those instances when ending them.

