### PR TITLE
chore(weave): drop flaky libmagic install step

### DIFF
--- a/.github/workflows/nightly-replicated-leg.yaml
+++ b/.github/workflows/nightly-replicated-leg.yaml
@@ -109,9 +109,6 @@ jobs:
       - name: Enable debug logging
         if: steps.filter_shards.outputs.skip != 'true'
         run: echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
-      - name: Install Libmagic dependency package
-        if: steps.filter_shards.outputs.skip != 'true'
-        run: sudo apt update && sudo apt install -y libmagic1
       - name: Start ${{ inputs.topology }} ClickHouse cluster
         if: steps.filter_shards.outputs.skip != 'true'
         working-directory: tests/trace_server/conftest_lib/topologies

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -111,8 +111,6 @@ jobs:
       - name: Enable debug logging
         if: steps.filter_shards.outputs.skip != 'true'
         run: echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
-      - name: Install Libmagic dependency package
-        run: sudo apt update && sudo apt install -y libmagic1
       - name: Set up Python ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
         if: steps.filter_shards.outputs.skip != 'true'
         uses: actions/setup-python@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,8 +80,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Install Libmagic dependency package
-        run: sudo apt update && sudo apt install -y libmagic1
       - name: Set up Python ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
         uses: actions/setup-python@v5
         with:
@@ -195,8 +193,6 @@ jobs:
           exit 1
       - name: Enable debug logging
         run: echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
-      - name: Install Libmagic dependency package
-        run: sudo apt update && sudo apt install -y libmagic1
       - name: Set up Python ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
         uses: actions/setup-python@v5
         with:
@@ -250,8 +246,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Install Libmagic dependency package
-        run: sudo apt update && sudo apt install -y libmagic1
       - name: Set up Python ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/weave-trace-tests.yaml
+++ b/.github/workflows/weave-trace-tests.yaml
@@ -76,11 +76,6 @@ jobs:
         working-directory: ${{ env.CORE_DIR }}
         run: docker compose up --detach
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libmagic1
-
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
## Summary
- `libmagic.so.1` already ships on `ubuntu-latest` (via `file` / `libmagic1t64`), so the `apt update && apt install -y libmagic1` step adds nothing but a flaky network call.
- That step fails intermittently with exit 100 when an apt mirror times out, e.g. [this run](https://github.com/wandb/weave/actions/runs/28120608563/job/83271295718).
- Drops it from test.yaml (x3), nightly-tests.yaml, nightly-replicated-leg.yaml, weave-trace-tests.yaml.

## Testing
verified on a live ubuntu-latest runner: `ldconfig` already resolves `libmagic.so.1` and `python-magic` imports + classifies a buffer with the step removed.