### PR TITLE
fix(weave): stop integrations churning object versions via repr() memory addresses

### DIFF
--- a/tests/integrations/gepa/gepa_test.py
+++ b/tests/integrations/gepa/gepa_test.py
@@ -9,8 +9,12 @@ from gepa.core.adapter import EvaluationBatch
 
 import weave
 from weave.integrations.gepa import gepa_sdk
-from weave.integrations.gepa.gepa_callback import WeaveGEPACallback
-from weave.integrations.gepa.gepa_sdk import get_gepa_patcher
+from weave.integrations.gepa.gepa_callback import WeaveGEPACallback, _safe
+from weave.integrations.gepa.gepa_sdk import (
+    _optimize_postprocess_inputs,
+    _optimize_postprocess_output,
+    get_gepa_patcher,
+)
 from weave.integrations.integration_utilities import (
     flatten_calls,
     flattened_calls_to_names,
@@ -34,6 +38,31 @@ def patch_gepa() -> Generator[None, None, None]:
     finally:
         patcher.undo_patch()
         gepa_sdk._gepa_patcher = None
+
+
+def test_gepa_logging_helpers_strip_memory_addresses() -> None:
+    # GEPA logs candidate/optimize metadata as versioned objects, so repr() fallbacks
+    # for unserializable values must not embed `at 0x...` addresses (object churn).
+    obj = object()
+    assert " at 0x" in repr(obj)
+
+    assert _safe({"adapter": obj, "nested": [obj]}) == {
+        "adapter": "<object object>",
+        "nested": ["<object object>"],
+    }
+    assert _optimize_postprocess_inputs(
+        {"adapter": obj, "callbacks": [obj], "seed": 7}
+    ) == {"adapter": "<object object>", "callbacks": ["<object object>"], "seed": 7}
+
+    class _Result:
+        best_idx = 2
+        best_candidate = obj
+
+    assert _optimize_postprocess_output(_Result()) == {
+        "__class__": "_Result",
+        "best_candidate": "<object object>",
+        "best_idx": 2,
+    }
 
 
 class _StubAdapter:

--- a/tests/trace/test_op_versioning.py
+++ b/tests/trace/test_op_versioning.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Callable
 from typing import TypedDict
 
@@ -519,7 +518,7 @@ def test_op_no_repeats(client):
 
 EXPECTED_INSTANCE_CODE = """import weave
 
-instance = "<test_op_versioning.test_op_instance.<locals>.MyClass object at 0x000000000>"
+instance = "<test_op_versioning.test_op_instance.<locals>.MyClass object>"
 
 @weave.op
 def t(text: str):
@@ -554,10 +553,8 @@ def test_op_instance(client):
     print("SAVED CODE")
     print(saved_code)
 
-    # Instance address expected to change each run
-    clean_saved_code = re.sub(r"0x[0-9a-fA-F]+", "0x000000000", saved_code)
-
-    assert clean_saved_code == EXPECTED_INSTANCE_CODE
+    # stable_repr strips the instance's volatile memory address, so the code is deterministic.
+    assert saved_code == EXPECTED_INSTANCE_CODE
 
 
 EXPECTED_IMPORT_AS_CODE = """import json as js

--- a/tests/trace/test_serialize.py
+++ b/tests/trace/test_serialize.py
@@ -4,7 +4,6 @@ from pydantic import BaseModel
 
 import weave
 from weave.trace.object_record import pydantic_object_record
-from weave.trace.serialization.op_type import _replace_memory_address
 from weave.trace.serialization.serialize import (
     dictify,
     is_pydantic_model_class,
@@ -12,6 +11,7 @@ from weave.trace.serialization.serialize import (
     stringify,
     to_json,
 )
+from weave.utils.sanitize import strip_memory_addresses
 
 
 def test_dictify_simple() -> None:
@@ -364,21 +364,14 @@ def test_to_json_function_with_memory_address_in_op(weave_active) -> None:
     assert len(log_me.calls()) == 4
 
 
-def test__replace_memory_address() -> None:
-    # Test with memory addresses of different lengths
+def test_strip_memory_addresses() -> None:
+    # Every ` at 0x...` is removed (not zero-filled), including multiple in one string.
     assert (
-        _replace_memory_address("<Function object at 0x1234>")
-        == "<Function object at 0x0000>"
+        strip_memory_addresses("<Object at 0x1234> and <Object at 0xdeadbeef>")
+        == "<Object> and <Object>"
     )
-    assert _replace_memory_address("<Class at 0xdeadbeef>") == "<Class at 0x00000000>"
-
-    # Test with multiple memory addresses
-    assert (
-        _replace_memory_address("<Object at 0x1234> and <Object at 0xabcd>")
-        == "<Object at 0x0000> and <Object at 0x0000>"
-    )
-    # Test with no memory addresses
-    assert _replace_memory_address("No memory address here") == "No memory address here"
+    # Strings without a memory address pass through unchanged.
+    assert strip_memory_addresses("No memory address here") == "No memory address here"
 
 
 def test_stable_repr_strips_memory_addresses() -> None:

--- a/tests/trace/test_serialize.py
+++ b/tests/trace/test_serialize.py
@@ -8,6 +8,7 @@ from weave.trace.serialization.op_type import _replace_memory_address
 from weave.trace.serialization.serialize import (
     dictify,
     is_pydantic_model_class,
+    stable_repr,
     stringify,
     to_json,
 )
@@ -378,3 +379,18 @@ def test__replace_memory_address() -> None:
     )
     # Test with no memory addresses
     assert _replace_memory_address("No memory address here") == "No memory address here"
+
+
+def test_stable_repr_strips_memory_addresses() -> None:
+    # Two distinct instances differ only by their `at 0x...` address in repr() (the
+    # source of object-version churn when such a repr is stored in published content).
+    a, b = object(), object()
+    assert repr(a) != repr(b)
+    assert " at 0x" in repr(a)
+    assert stable_repr(a) == stable_repr(b) == "<object object>"
+
+    # Functions (e.g. a dspy metric) collapse to a stable, address-free repr.
+    assert stable_repr(stringify) == "<function stringify>"
+
+    # Reprs without a memory address pass through unchanged.
+    assert stable_repr("no address here") == "'no address here'"

--- a/weave/integrations/dspy/dspy_sdk.py
+++ b/weave/integrations/dspy/dspy_sdk.py
@@ -17,6 +17,7 @@ from weave.integrations.integration_metadata import (
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, Patcher
 from weave.trace.autopatch import IntegrationSettings
 from weave.trace.context import call_context
+from weave.trace.serialization.serialize import stable_repr
 
 logger = logging.getLogger(__name__)
 
@@ -111,9 +112,11 @@ class DSPyPatcher(MultiPatcher):
                     "name": model_name,
                     "dump_state": raw_dump_state,
                     "_compiled": getattr(program, "_compiled", None),
-                    "callbacks": [repr(cb) for cb in getattr(program, "callbacks", [])],
-                    "program_repr": repr(program),
-                    "metric_repr": repr(metric),
+                    "callbacks": [
+                        stable_repr(cb) for cb in getattr(program, "callbacks", [])
+                    ],
+                    "program_repr": stable_repr(program),
+                    "metric_repr": stable_repr(metric),
                     "num_threads": num_threads,
                     "display_progress": display_progress,
                     "failure_score": failure_score,

--- a/weave/integrations/gepa/gepa_callback.py
+++ b/weave/integrations/gepa/gepa_callback.py
@@ -8,6 +8,7 @@ from weave.evaluation.eval_imperative import EvaluationLogger
 from weave.integrations.integration_metadata import library_integration
 from weave.trace.call import Call
 from weave.trace.context import weave_client_context
+from weave.trace.serialization.serialize import stable_repr
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ def _safe(value: Any) -> Any:
         return [_safe(v) for v in value]
     if isinstance(value, dict):
         return {str(k): _safe(v) for k, v in value.items()}
-    return repr(value)
+    return stable_repr(value)
 
 
 def _kind_attrs(kind: str) -> dict[str, Any]:

--- a/weave/integrations/gepa/gepa_sdk.py
+++ b/weave/integrations/gepa/gepa_sdk.py
@@ -14,6 +14,7 @@ from weave.integrations.integration_metadata import (
 )
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
+from weave.trace.serialization.serialize import stable_repr
 
 _gepa_patcher: MultiPatcher | None = None
 GEPA_INTEGRATION = library_integration("gepa")
@@ -55,9 +56,9 @@ def _optimize_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
         if key in safe and not isinstance(
             safe[key], (str, int, float, bool, type(None))
         ):
-            safe[key] = repr(safe[key])
+            safe[key] = stable_repr(safe[key])
     if "callbacks" in safe:
-        safe["callbacks"] = [repr(cb) for cb in (safe["callbacks"] or [])]
+        safe["callbacks"] = [stable_repr(cb) for cb in (safe["callbacks"] or [])]
     return safe
 
 
@@ -81,10 +82,10 @@ def _optimize_postprocess_output(output: Any) -> Any:
                     if isinstance(
                         value, (dict, list, str, int, float, bool, type(None))
                     )
-                    else repr(value)
+                    else stable_repr(value)
                 )
             except Exception:
-                summary[attr] = repr(value)
+                summary[attr] = stable_repr(value)
     return summary
 
 

--- a/weave/integrations/langchain/langchain.py
+++ b/weave/integrations/langchain/langchain.py
@@ -53,6 +53,7 @@ from weave.integrations.patcher import Patcher
 from weave.trace.call import Call
 from weave.trace.context import call_context, weave_client_context
 from weave.trace.op_protocol import OpKind
+from weave.trace.serialization.serialize import stable_repr
 
 import_failed = False
 
@@ -97,7 +98,7 @@ if not import_failed:
             return list(obj)
 
         try:
-            return repr(obj)
+            return stable_repr(obj)
         except Exception:
             return f"<{type(obj).__name__}>"
 

--- a/weave/trace/serialization/op_type.py
+++ b/weave/trace/serialization/op_type.py
@@ -29,15 +29,16 @@ from weave.utils.ipython import (
     get_class_source,
     is_running_interactively,
 )
-from weave.utils.sanitize import REDACTED_VALUE, should_redact
+from weave.utils.sanitize import (
+    REDACTED_VALUE,
+    should_redact,
+    strip_memory_addresses,
+)
 
 logger = logging.getLogger(__name__)
 
 WEAVE_OP_PATTERN = re.compile(r"@weave\.op(\(\))?")
 WEAVE_OP_NO_PAREN_PATTERN = re.compile(r"@weave\.op(?!\()")
-
-# Memory address with at least 4 characters (decrease false positives)
-MEMORY_ADDRESS_PATTERN = re.compile(r"0x[0-9a-fA-F]{4,}>", re.ASCII)
 
 CODE_DEP_ERROR_SENTINEL = "<error>"
 
@@ -318,7 +319,7 @@ def get_code_deps_safe(
         fn: The Python function to analyze.
 
     Returns:
-        tupe: A tuple containing
+        A tuple containing
             import_code: str, the code that should be included in the generated code to ensure all
                 dependencies are available for the function body.
             code: str, the function body code.
@@ -456,8 +457,7 @@ def _get_code_deps(
                         json_val = REDACTED_VALUE
                     else:
                         json_val = to_json(var_value, client.project_id, client)
-                        if _has_memory_address(json_val):
-                            json_val = _replace_memory_address(json_val)
+                        json_val = strip_memory_addresses(json_val)
                 except Exception as e:
                     warnings.append(
                         f"Serialization error for value of {var_name} needed by {fn}. Encountered:\n    {e}"
@@ -476,22 +476,6 @@ def _get_code_deps(
                     )
                     code.append(code_paragraph)
     return {"import_code": import_code, "code": code, "warnings": warnings}
-
-
-def _has_memory_address(obj: Any) -> bool:
-    return isinstance(obj, str) and MEMORY_ADDRESS_PATTERN.search(obj) is not None
-
-
-def _replace_memory_address(json_val: str) -> str:
-    """Turn <Function object at 0x10c349010> into <Function object at 0x000000000>."""
-
-    def _replacement_with_same_length(match: re.Match[str]) -> str:
-        # Get matched text and replace with 0s of the same length
-        address = match.group(0)
-        # Keep the 0x prefix and > suffix, replace the rest with 0s
-        return "0x" + "0" * (len(address) - 3) + ">"
-
-    return MEMORY_ADDRESS_PATTERN.sub(_replacement_with_same_length, json_val)
 
 
 def find_last_weave_op_function(

--- a/weave/trace/serialization/op_type.py
+++ b/weave/trace/serialization/op_type.py
@@ -457,7 +457,8 @@ def _get_code_deps(
                         json_val = REDACTED_VALUE
                     else:
                         json_val = to_json(var_value, client.project_id, client)
-                        json_val = strip_memory_addresses(json_val)
+                        if isinstance(json_val, str):
+                            json_val = strip_memory_addresses(json_val)
                 except Exception as e:
                     warnings.append(
                         f"Serialization error for value of {var_name} needed by {fn}. Encountered:\n    {e}"

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from collections.abc import Mapping, Sequence
 from types import CoroutineType
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, TypedDict
@@ -17,7 +16,11 @@ from weave.trace_server.trace_server_interface import (
     FileCreateReq,
     TraceServerInterface,
 )
-from weave.utils.sanitize import REDACTED_VALUE, should_redact
+from weave.utils.sanitize import (
+    REDACTED_VALUE,
+    should_redact,
+    strip_memory_addresses,
+)
 
 if TYPE_CHECKING:
     from weave.trace.weave_client import WeaveClient
@@ -295,12 +298,9 @@ def stringify(obj: Any, limit: int = MAX_STR_LEN) -> str:
     return rep
 
 
-_MEMORY_ADDRESS_RE = re.compile(r" at 0x[0-9a-fA-F]+")
-
-
 def stable_repr(obj: Any) -> str:
-    """`repr(obj)` with volatile ` at 0x...` memory addresses removed so object digests stay stable across processes."""
-    return _MEMORY_ADDRESS_RE.sub("", repr(obj))
+    """`repr(obj)` with volatile memory addresses removed (see `strip_memory_addresses`)."""
+    return strip_memory_addresses(repr(obj))
 
 
 def is_primitive(obj: Any) -> bool:

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Mapping, Sequence
 from types import CoroutineType
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, TypedDict
@@ -292,6 +293,14 @@ def stringify(obj: Any, limit: int = MAX_STR_LEN) -> str:
     if isinstance(rep, str) and len(rep) > limit:
         rep = rep[: limit - 3] + "..."
     return rep
+
+
+_MEMORY_ADDRESS_RE = re.compile(r" at 0x[0-9a-fA-F]+")
+
+
+def stable_repr(obj: Any) -> str:
+    """`repr(obj)` with volatile ` at 0x...` memory addresses removed so object digests stay stable across processes."""
+    return _MEMORY_ADDRESS_RE.sub("", repr(obj))
 
 
 def is_primitive(obj: Any) -> bool:

--- a/weave/utils/sanitize.py
+++ b/weave/utils/sanitize.py
@@ -1,5 +1,6 @@
 # always use lowercase keys for the redact keys
 import dataclasses
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -113,3 +114,11 @@ def redact_dataclass_fields(obj: Any, recursive_fn: Callable[[Any], Any]) -> Any
 
 
 # Note: No backward-compatibility alias is exposed; use add/remove/get helpers.
+
+
+_MEMORY_ADDRESS_RE = re.compile(r" at 0x[0-9a-fA-F]+")
+
+
+def strip_memory_addresses(s: str) -> str:
+    """Remove volatile ` at 0x...` memory addresses so serialized object digests stay stable across processes."""
+    return _MEMORY_ADDRESS_RE.sub("", s)


### PR DESCRIPTION
## Summary
- `dspy`, `gepa`, and `langchain` logged raw `repr()` of functions/objects (e.g. a dspy metric) into published content. `repr()` embeds `at 0x...` memory addresses that change every process, so content-addressed objects churned a new version every run (one prod project logged 20k+ `LLMJudge` versions in 24h, defeating dedup).
- Add `stable_repr()` in the central serializer (strips ` at 0x...`) and route every integration `repr()` site through it.
- Jira: [WB-36408](https://coreweave.atlassian.net/browse/WB-36408)

## Testing
unit test for `stable_repr` + gepa logging-helper coverage; dspy/langchain covered via the shared helper.


[WB-36408]: https://coreweave.atlassian.net/browse/WB-36408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ