### PR TITLE
feat(weave_ts): send is_eval on call-end ingest messages

### DIFF
--- a/sdks/node/src/__tests__/evaluation.test.ts
+++ b/sdks/node/src/__tests__/evaluation.test.ts
@@ -266,4 +266,36 @@ describe('Evaluation - declarative eval metadata', () => {
       });
     }
   });
+
+  // is_eval rides each eval call-end (root matched by op_name, children by
+  // attrs) for a server-side sampler. Write-only, so inspect the outgoing batch.
+  test('stamps is_eval on every eval call-end', async () => {
+    const batchSpy = jest.spyOn(
+      traceServer.call,
+      'callStartBatchCallUpsertBatchPost'
+    );
+    const evaluation = createMockEvaluation(false);
+    const model = createMockModel(false);
+
+    await evaluation.evaluate({model, nTrials: 2, maxConcurrency: 2});
+    await traceServer.waitForPendingOperations();
+
+    const items = batchSpy.mock.calls.flatMap(([batchReq]) => batchReq.batch);
+    const starts = items.filter(i => i.mode === 'start');
+    const ends = items.filter(i => i.mode === 'end');
+
+    // Root: matched by op_name (it carries no _weave_eval_meta) -> true.
+    const rootStart = starts.find(i =>
+      i.req.start.op_name.includes(EVALUATION_RUN_OP_NAME)
+    );
+    expect(rootStart).toBeDefined();
+    const rootEnd = ends.find(e => e.req.end.id === rootStart!.req.start.id);
+    expect(rootEnd!.req.end.is_eval).toBe(true);
+
+    // Every eval call-end is marked (children via attributes).
+    expect(ends.length).toBeGreaterThan(1);
+    for (const e of ends) {
+      expect(e.req.end.is_eval).toBe(true);
+    }
+  });
 });

--- a/sdks/node/src/__tests__/opFlow.test.ts
+++ b/sdks/node/src/__tests__/opFlow.test.ts
@@ -361,4 +361,22 @@ describe('Op Flow', () => {
     expect(startTraceId).toBeTruthy();
     expect(endItem!.req.end.trace_id).toBe(startTraceId);
   });
+
+  test('call-end carries is_eval=false for a non-eval op', async () => {
+    const batchSpy = jest.spyOn(
+      traceServer.call,
+      'callStartBatchCallUpsertBatchPost'
+    );
+
+    const myOp = op((x: number) => x * 2, {name: 'myOp'});
+    await myOp(21);
+
+    await traceServer.waitForPendingOperations();
+
+    const items = batchSpy.mock.calls.flatMap(([batchReq]) => batchReq.batch);
+    const endItem = items.find(item => item.mode === 'end');
+
+    expect(endItem).toBeDefined();
+    expect(endItem!.req.end.is_eval).toBe(false);
+  });
 });

--- a/sdks/node/src/generated/traceServerApi.ts
+++ b/sdks/node/src/generated/traceServerApi.ts
@@ -2546,6 +2546,8 @@ export interface EndedCallSchemaForInsert {
   id: string;
   /** Trace Id */
   trace_id?: string | null;
+  /** Is Eval */
+  is_eval?: boolean | null;
   /**
    * Ended At
    * @format date-time

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -2,7 +2,11 @@ import {AsyncLocalStorage} from 'async_hooks';
 import * as fs from 'fs';
 import {uuidv7} from 'uuidv7';
 
-import {MAX_OBJECT_NAME_LENGTH} from './constants';
+import {
+  EVAL_META_KEY,
+  EVALUATION_RUN_OP_NAME,
+  MAX_OBJECT_NAME_LENGTH,
+} from './constants';
 import {computeDigest} from './digest';
 import {
   type AgentChatMessage as AgentChatMessageSchema,
@@ -1354,6 +1358,16 @@ export class WeaveClient {
     return this.saveCallStart(startReq);
   }
 
+  // The eval root is matched by op-name substring (op_name is a ref URI); eval
+  // children carry the marker in their attributes.
+  private isEvalCall(call: InternalCall): boolean {
+    const {attributes, op_name} = call.callSchema;
+    return (
+      (attributes != null && EVAL_META_KEY in attributes) ||
+      (op_name?.includes(EVALUATION_RUN_OP_NAME) ?? false)
+    );
+  }
+
   public async finishCall(
     call: InternalCall,
     result: any,
@@ -1384,6 +1398,7 @@ export class WeaveClient {
       project_id: this.projectId,
       id: currentCall.callId,
       trace_id: currentCall.traceId,
+      is_eval: this.isEvalCall(call),
       ...callSchemaExchangeData,
       // User might change the display name of the call after the call has started.
       // take this into account when logging the end call.
@@ -1421,6 +1436,7 @@ export class WeaveClient {
       project_id: this.projectId,
       id: currentCall.callId,
       trace_id: currentCall.traceId,
+      is_eval: this.isEvalCall(call),
       ...callSchemaExchangeData,
       // User might change the display name of the call after the call has started.
       // take this into account when logging the end call.

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -310,6 +310,17 @@ type CallEndParams = EndedCallSchemaForInsert;
 
 // We count characters item by item, and try to limit batches to about this size.
 const MAX_BATCH_SIZE_CHARS = 10 * 1024 * 1024;
+
+// Whether the call is part of an evaluation: root by op-name substring (op_name
+// is a ref URI), children by the attribute marker.
+function isEvalCall(call: InternalCall): boolean {
+  const {attributes, op_name} = call.callSchema;
+  return (
+    attributes?.[EVAL_META_KEY] != null ||
+    (op_name?.includes(EVALUATION_RUN_OP_NAME) ?? false)
+  );
+}
+
 export class WeaveClient {
   private stackContext = new AsyncLocalStorage<CallStack>();
   private attributesContext = new AsyncLocalStorage<Record<string, any>>();
@@ -1358,16 +1369,6 @@ export class WeaveClient {
     return this.saveCallStart(startReq);
   }
 
-  // The eval root is matched by op-name substring (op_name is a ref URI); eval
-  // children carry the marker in their attributes.
-  private isEvalCall(call: InternalCall): boolean {
-    const {attributes, op_name} = call.callSchema;
-    return (
-      (attributes != null && EVAL_META_KEY in attributes) ||
-      (op_name?.includes(EVALUATION_RUN_OP_NAME) ?? false)
-    );
-  }
-
   public async finishCall(
     call: InternalCall,
     result: any,
@@ -1398,7 +1399,7 @@ export class WeaveClient {
       project_id: this.projectId,
       id: currentCall.callId,
       trace_id: currentCall.traceId,
-      is_eval: this.isEvalCall(call),
+      is_eval: isEvalCall(call),
       ...callSchemaExchangeData,
       // User might change the display name of the call after the call has started.
       // take this into account when logging the end call.
@@ -1436,7 +1437,7 @@ export class WeaveClient {
       project_id: this.projectId,
       id: currentCall.callId,
       trace_id: currentCall.traceId,
-      is_eval: this.isEvalCall(call),
+      is_eval: isEvalCall(call),
       ...callSchemaExchangeData,
       // User might change the display name of the call after the call has started.
       // take this into account when logging the end call.

--- a/sdks/node/weave.openapi.json
+++ b/sdks/node/weave.openapi.json
@@ -11249,6 +11249,17 @@
             ],
             "title": "Trace Id"
           },
+          "is_eval": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Eval"
+          },
           "ended_at": {
             "type": "string",
             "format": "date-time",


### PR DESCRIPTION
## Description

A future server-side ingest sampler will decide, per call, whether to keep or drop it. It can tell an evaluation call from a normal one by looking at the call's attributes and op name — except on the call-END, which arrives carrying only ids, with no attributes or op name to recompute from. In the Node SDK every end is sent separately from its start, so this gap applies to every eval call, not just the root.

This adds an optional `is_eval` boolean to the call-end. At finish time the SDK still has the call's attributes and op name, so it computes the same predicate the server would and stamps the answer on the end. The field is optional and the server does not read it yet, so this change is inert until the sampler ships — no behavior change today.

The predicate is `is_eval = (eval metadata present in attributes) or (op name is the evaluation root)`. Eval children carry the metadata in their attributes; the declarative root does not, so it is recognized by its op name. Because `op_name` is a ref URI, the op-name check is a substring match. It is computed in `finishCall` and `finishCallWithException` from the call's own stored schema (not the live AsyncLocalStorage context, which under concurrency could return a sibling's attributes).

This is the Node companion to the Python SDK change in #7391.

## Why this approach

The shape mirrors #7257 (which put `trace_id` on the call-end for the same sampler): an optional field on `EndedCallSchemaForInsert`, filled where the call object is in scope. As in #7257, the generated `traceServerApi.ts` and `weave.openapi.json` are hand-edited rather than regenerated, so unrelated generator drift stays out of the diff; the edit matches what regeneration produces. The shared predicate is a single private method, so the two finish paths cannot drift apart.

## Testing

A new test runs a real declarative evaluation and inspects the outgoing upsert batch (the same spy approach #7257 uses), asserting the root end is `is_eval = true` (matched by op name) and every eval end is marked; a separate op-flow test asserts a plain non-eval call comes out `false`. Verified locally: the two suites pass (14 tests), and typecheck, prettier, and eslint are clean.

## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-36097
