### PR TITLE
feat(weave_ts): Add `attributes` option to `weave.startSession`.

### DIFF
--- a/sdks/node/src/__tests__/genai/api.test.ts
+++ b/sdks/node/src/__tests__/genai/api.test.ts
@@ -311,4 +311,42 @@ describe('genai api (top-level functions)', () => {
     const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
     expectSpanTimesToMatch(llmSpan, startedAt, endedAt);
   });
+
+  test('startSession stamps custom attributes on every emitted span', () => {
+    startSession({
+      attributes: {
+        'weave.integration.name': 'wb-agent',
+        'weave.custom.run_id': 42,
+      },
+    });
+    startTurn({});
+    startLLM({model: 'gpt-4o'});
+    const tool = startTool({name: 'get_weather'});
+    tool.end();
+    endLLM();
+    endSession();
+
+    const spans = getExporter().getFinishedSpans();
+    expect(spans.map(s => s.name).sort()).toEqual([
+      'chat',
+      'execute_tool',
+      'invoke_agent',
+    ]);
+    for (const s of spans) {
+      expect(s.attributes['weave.integration.name']).toBe('wb-agent');
+      expect(s.attributes['weave.custom.run_id']).toBe(42);
+    }
+  });
+
+  test('custom attributes do not override the emitter`s own semconv keys', () => {
+    startSession({
+      attributes: {'gen_ai.operation.name': 'custom-loses'},
+    });
+    startTurn({});
+    endTurn();
+    endSession();
+
+    const turnSpan = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
+    expect(turnSpan.attributes['gen_ai.operation.name']).toBe('invoke_agent');
+  });
 });

--- a/sdks/node/src/__tests__/genai/genai.test.ts
+++ b/sdks/node/src/__tests__/genai/genai.test.ts
@@ -274,7 +274,13 @@ async function runAgentLoop(
 }
 
 async function run(agent: Agent, prompts: string[]): Promise<string[]> {
-  const session = weave.startSession({agentName: agent.name});
+  const session = weave.startSession({
+    agentName: agent.name,
+    attributes: {
+      'myagent.region': 'ORD',
+      'myagent.version': '4.21',
+    },
+  });
   try {
     const messages: Message[] = [{role: 'system', content: agent.instructions}];
     const answers: string[] = [];
@@ -350,6 +356,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "some-model",
             "gen_ai.usage.input_tokens": 42,
             "gen_ai.usage.output_tokens": 10,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -362,6 +370,8 @@ describe('GenAI', () => {
             "gen_ai.tool.call.id": "call_t1",
             "gen_ai.tool.call.result": "{"temp":28,"condition":"Humid"}",
             "gen_ai.tool.name": "get_weather",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -376,6 +386,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "some-model",
             "gen_ai.usage.input_tokens": 70,
             "gen_ai.usage.output_tokens": 9,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -385,6 +397,8 @@ describe('GenAI', () => {
             "gen_ai.agent.name": "Reasearch Assistant",
             "gen_ai.conversation.id": "<uuid>",
             "gen_ai.operation.name": "invoke_agent",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -399,6 +413,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "some-model",
             "gen_ai.usage.input_tokens": 90,
             "gen_ai.usage.output_tokens": 16,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -411,6 +427,8 @@ describe('GenAI', () => {
             "gen_ai.tool.call.id": "call_t2_sf",
             "gen_ai.tool.call.result": "{"temp":18,"condition":"Foggy"}",
             "gen_ai.tool.name": "get_weather",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -423,6 +441,8 @@ describe('GenAI', () => {
             "gen_ai.tool.call.id": "call_t2_ldn",
             "gen_ai.tool.call.result": "{"temp":12,"condition":"Cloudy"}",
             "gen_ai.tool.name": "get_weather",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -437,6 +457,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "some-model",
             "gen_ai.usage.input_tokens": 140,
             "gen_ai.usage.output_tokens": 18,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -446,6 +468,8 @@ describe('GenAI', () => {
             "gen_ai.agent.name": "Reasearch Assistant",
             "gen_ai.conversation.id": "<uuid>",
             "gen_ai.operation.name": "invoke_agent",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -460,6 +484,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "some-model",
             "gen_ai.usage.input_tokens": 170,
             "gen_ai.usage.output_tokens": 12,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -472,6 +498,8 @@ describe('GenAI', () => {
             "gen_ai.tool.call.id": "call_t3",
             "gen_ai.tool.call.result": ""28 - 18 = 10"",
             "gen_ai.tool.name": "calculate",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -486,6 +514,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "some-model",
             "gen_ai.usage.input_tokens": 200,
             "gen_ai.usage.output_tokens": 12,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -495,6 +525,8 @@ describe('GenAI', () => {
             "gen_ai.agent.name": "Reasearch Assistant",
             "gen_ai.conversation.id": "<uuid>",
             "gen_ai.operation.name": "invoke_agent",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": "<timestamp>",
           "startTime": "<timestamp>",
@@ -537,6 +569,10 @@ describe('GenAI', () => {
     for (const recordedSession of AGENT_SESSIONS) {
       const session = weave.startSession({
         agentName: recordedSession.agentName,
+        attributes: {
+          'myagent.region': 'ORD',
+          'myagent.version': '4.21',
+        },
       });
 
       const messages: Message[] = [
@@ -633,6 +669,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 42,
             "gen_ai.usage.output_tokens": 10,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048800,
@@ -651,6 +689,8 @@ describe('GenAI', () => {
             "gen_ai.tool.call.id": "call_t1",
             "gen_ai.tool.call.result": "{"temp":28,"condition":"Humid"}",
             "gen_ai.tool.name": "get_weather",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048800,
@@ -671,6 +711,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 70,
             "gen_ai.usage.output_tokens": 9,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048800,
@@ -686,6 +728,8 @@ describe('GenAI', () => {
             "gen_ai.agent.name": "Reasearch Assistant",
             "gen_ai.conversation.id": "<uuid>",
             "gen_ai.operation.name": "invoke_agent",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048800,
@@ -706,6 +750,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 90,
             "gen_ai.usage.output_tokens": 16,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048805,
@@ -724,6 +770,8 @@ describe('GenAI', () => {
             "gen_ai.tool.call.id": "call_t2_sf",
             "gen_ai.tool.call.result": "{"temp":18,"condition":"Foggy"}",
             "gen_ai.tool.name": "get_weather",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048805,
@@ -742,6 +790,8 @@ describe('GenAI', () => {
             "gen_ai.tool.call.id": "call_t2_ldn",
             "gen_ai.tool.call.result": "{"temp":12,"condition":"Cloudy"}",
             "gen_ai.tool.name": "get_weather",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048805,
@@ -762,6 +812,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 140,
             "gen_ai.usage.output_tokens": 18,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048805,
@@ -777,6 +829,8 @@ describe('GenAI', () => {
             "gen_ai.agent.name": "Reasearch Assistant",
             "gen_ai.conversation.id": "<uuid>",
             "gen_ai.operation.name": "invoke_agent",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048805,
@@ -797,6 +851,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 170,
             "gen_ai.usage.output_tokens": 12,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048810,
@@ -815,6 +871,8 @@ describe('GenAI', () => {
             "gen_ai.tool.call.id": "call_t3",
             "gen_ai.tool.call.result": ""28 - 18 = 10"",
             "gen_ai.tool.name": "calculate",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048810,
@@ -835,6 +893,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 200,
             "gen_ai.usage.output_tokens": 12,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048810,
@@ -850,6 +910,8 @@ describe('GenAI', () => {
             "gen_ai.agent.name": "Reasearch Assistant",
             "gen_ai.conversation.id": "<uuid>",
             "gen_ai.operation.name": "invoke_agent",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048810,
@@ -874,6 +936,10 @@ describe('GenAI', () => {
     for (const recordedSession of AGENT_SESSIONS) {
       weave.startSession({
         agentName: recordedSession.agentName,
+        attributes: {
+          'myagent.region': 'ORD',
+          'myagent.version': '4.21',
+        },
       });
 
       const messages: Message[] = [
@@ -970,6 +1036,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 42,
             "gen_ai.usage.output_tokens": 10,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048800,
@@ -988,6 +1056,8 @@ describe('GenAI', () => {
             "gen_ai.tool.call.id": "call_t1",
             "gen_ai.tool.call.result": "{"temp":28,"condition":"Humid"}",
             "gen_ai.tool.name": "get_weather",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048800,
@@ -1008,6 +1078,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 70,
             "gen_ai.usage.output_tokens": 9,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048800,
@@ -1023,6 +1095,8 @@ describe('GenAI', () => {
             "gen_ai.agent.name": "Reasearch Assistant",
             "gen_ai.conversation.id": "<uuid>",
             "gen_ai.operation.name": "invoke_agent",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048800,
@@ -1043,6 +1117,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 90,
             "gen_ai.usage.output_tokens": 16,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048805,
@@ -1061,6 +1137,8 @@ describe('GenAI', () => {
             "gen_ai.tool.call.id": "call_t2_sf",
             "gen_ai.tool.call.result": "{"temp":18,"condition":"Foggy"}",
             "gen_ai.tool.name": "get_weather",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048805,
@@ -1079,6 +1157,8 @@ describe('GenAI', () => {
             "gen_ai.tool.call.id": "call_t2_ldn",
             "gen_ai.tool.call.result": "{"temp":12,"condition":"Cloudy"}",
             "gen_ai.tool.name": "get_weather",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048805,
@@ -1099,6 +1179,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 140,
             "gen_ai.usage.output_tokens": 18,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048805,
@@ -1114,6 +1196,8 @@ describe('GenAI', () => {
             "gen_ai.agent.name": "Reasearch Assistant",
             "gen_ai.conversation.id": "<uuid>",
             "gen_ai.operation.name": "invoke_agent",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048805,
@@ -1134,6 +1218,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 170,
             "gen_ai.usage.output_tokens": 12,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048810,
@@ -1152,6 +1238,8 @@ describe('GenAI', () => {
             "gen_ai.tool.call.id": "call_t3",
             "gen_ai.tool.call.result": ""28 - 18 = 10"",
             "gen_ai.tool.name": "calculate",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048810,
@@ -1172,6 +1260,8 @@ describe('GenAI', () => {
             "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 200,
             "gen_ai.usage.output_tokens": 12,
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048810,
@@ -1187,6 +1277,8 @@ describe('GenAI', () => {
             "gen_ai.agent.name": "Reasearch Assistant",
             "gen_ai.conversation.id": "<uuid>",
             "gen_ai.operation.name": "invoke_agent",
+            "myagent.region": "ORD",
+            "myagent.version": "4.21",
           },
           "endTime": [
             1780048810,

--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -10,6 +10,9 @@ import {Turn, type TurnInit} from './turn';
  * Start a new Session and install it as the current session.
  * Subsequent calls to `startTurn` will pick it up automatically.
  *
+ * Pass `attributes` to stamp custom (non-semconv) attributes on every
+ * span the session emits.
+ *
  * @example
  * weave.startSession({agentName: 'research-bot'});
  *
@@ -17,6 +20,7 @@ import {Turn, type TurnInit} from './turn';
  * weave.startSession({
  *   agentName: 'research-bot',
  *   sessionId: '019efa53-8a65-711c-b4c1-7c1cb72c0bb7',
+ *   attributes: {'myagent.version': '1.23'},
  * });
  */
 export function startSession(opts: SessionInit = {}): Session {

--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -1,4 +1,4 @@
-import {_getGenaiState} from './context';
+import {getGenaiState} from './context';
 import {type LLM, type LLMInit} from './llm';
 import {Session, type SessionInit} from './session';
 import type {SpanEndOptions} from './spanBase';
@@ -41,7 +41,7 @@ export function startSession(opts: SessionInit = {}): Session {
  * });
  */
 export function startTurn(opts: TurnInit = {}): Turn {
-  const session = _getGenaiState().session;
+  const session = getGenaiState().session;
   if (session) {
     return session.startTurn(opts);
   }
@@ -63,7 +63,7 @@ export function startTurn(opts: TurnInit = {}): Turn {
  * });
  */
 export function startLLM(opts: LLMInit): LLM {
-  const turn = _getGenaiState().turn;
+  const turn = getGenaiState().turn;
   if (!turn) {
     throw new Error(
       'weave.startLLM() called without an active Turn. Call weave.startTurn() first.'
@@ -96,7 +96,7 @@ export function startLLM(opts: LLMInit): LLM {
  * });
  */
 export function startTool(opts: ToolInit): Tool {
-  const state = _getGenaiState();
+  const state = getGenaiState();
   if (state.llm) {
     return state.llm.startTool(opts);
   }
@@ -122,7 +122,7 @@ export function startTool(opts: ToolInit): Tool {
  * });
  */
 export function startSubagent(opts: SubAgentInit): SubAgent {
-  const state = _getGenaiState();
+  const state = getGenaiState();
   if (state.llm) {
     return state.llm.startSubagent(opts);
   }
@@ -144,7 +144,7 @@ export function startSubagent(opts: SubAgentInit): SubAgent {
  * weave.endSession({endTime: new Date('2026-05-29T10:00:01.700Z')});
  */
 export function endSession(opts?: SpanEndOptions): void {
-  const session = _getGenaiState().session;
+  const session = getGenaiState().session;
   if (session) {
     session.end(opts);
   }
@@ -163,7 +163,7 @@ export function endSession(opts?: SpanEndOptions): void {
  * weave.endTurn({error: new Error('agent loop diverged')});
  */
 export function endTurn(opts?: SpanEndOptions): void {
-  const turn = _getGenaiState().turn;
+  const turn = getGenaiState().turn;
   if (turn) {
     turn.end(opts);
   }
@@ -182,7 +182,7 @@ export function endTurn(opts?: SpanEndOptions): void {
  * weave.endLLM({error: new Error('llm call failed')});
  */
 export function endLLM(opts?: SpanEndOptions): void {
-  const llm = _getGenaiState().llm;
+  const llm = getGenaiState().llm;
   if (llm) {
     llm.end(opts);
   }

--- a/sdks/node/src/genai/context.ts
+++ b/sdks/node/src/genai/context.ts
@@ -29,7 +29,7 @@ function freshState(): GenAIState {
  *
  * Internal helper, not part of the public API.
  */
-export function _getGenaiState(): GenAIState {
+export function getGenaiState(): GenAIState {
   return state.genAi.state.getStore() ?? state.genAi.defaultState;
 }
 
@@ -57,15 +57,15 @@ export function runIsolated<T>(fn: () => T): T {
 
 /** Returns the current Session, or undefined. */
 export function getCurrentSession(): Session | undefined {
-  return _getGenaiState().session ?? undefined;
+  return getGenaiState().session ?? undefined;
 }
 
 /** Returns the current Turn, or undefined. */
 export function getCurrentTurn(): Turn | undefined {
-  return _getGenaiState().turn ?? undefined;
+  return getGenaiState().turn ?? undefined;
 }
 
 /** Returns the current LLM, or undefined. */
 export function getCurrentLLM(): LLM | undefined {
-  return _getGenaiState().llm ?? undefined;
+  return getGenaiState().llm ?? undefined;
 }

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -7,7 +7,7 @@ import {
 } from '@opentelemetry/api';
 
 import type {ChildSpanContext} from './common';
-import {_getGenaiState} from './context';
+import {getGenaiState} from './context';
 import {getWeaveTracer} from './provider';
 import {SpanBase, type SpanEndOptions, type SpanInitBase} from './spanBase';
 import {
@@ -101,7 +101,7 @@ export class LLM extends SpanBase {
   }
 
   static create(opts: LLMInit & ChildSpanContext): LLM {
-    const state = _getGenaiState();
+    const state = getGenaiState();
     if (state.llm !== null) {
       throw new Error(
         'An LLM is already active in this async chain. End it before starting a new one.'
@@ -296,7 +296,7 @@ export class LLM extends SpanBase {
     }
 
     this._closeSpan(opts);
-    const state = _getGenaiState();
+    const state = getGenaiState();
     if (state.llm === this) {
       state.llm = null;
     }

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -1,4 +1,10 @@
-import {type Context, type Span, SpanKind, trace} from '@opentelemetry/api';
+import {
+  type Attributes,
+  type Context,
+  type Span,
+  SpanKind,
+  trace,
+} from '@opentelemetry/api';
 
 import type {ChildSpanContext} from './common';
 import {_getGenaiState} from './context';
@@ -102,7 +108,8 @@ export class LLM extends SpanBase {
       );
     }
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
-    const attributes: Record<string, string> = {
+    const attributes: Attributes = {
+      ...(state.session?.attributes ?? {}),
       [ATTR_GEN_AI_OPERATION_NAME]: 'chat',
       [ATTR_GEN_AI_REQUEST_MODEL]: opts.model,
     };

--- a/sdks/node/src/genai/session.ts
+++ b/sdks/node/src/genai/session.ts
@@ -1,3 +1,4 @@
+import type {Attributes} from '@opentelemetry/api';
 import {uuidv7} from 'uuidv7';
 
 import {_getGenaiState} from './context';
@@ -10,6 +11,13 @@ export interface SessionInit {
   /** Conversation ID propagated to every span under this session as
    *  `gen_ai.conversation.id`. Auto-generated if omitted. */
   sessionId?: string;
+  /**
+   * Custom attributes stamped on every span the session emits.
+   *
+   * A key here that collides with a span's own `gen_ai.*` / `weave.*`
+   * attribute is unsupported; the span's value wins.
+   */
+  attributes?: Attributes;
 }
 
 /**
@@ -22,7 +30,8 @@ export class Session {
   private constructor(
     public readonly agentName: string,
     public readonly model: string,
-    public readonly sessionId: string
+    public readonly sessionId: string,
+    public readonly attributes: Attributes
   ) {}
 
   static create(opts: SessionInit = {}): Session {
@@ -35,7 +44,8 @@ export class Session {
     const session = new Session(
       opts.agentName ?? '',
       opts.model ?? '',
-      opts.sessionId ?? uuidv7()
+      opts.sessionId ?? uuidv7(),
+      opts.attributes ?? {}
     );
     state.session = session;
     return session;

--- a/sdks/node/src/genai/session.ts
+++ b/sdks/node/src/genai/session.ts
@@ -1,7 +1,7 @@
 import type {Attributes} from '@opentelemetry/api';
 import {uuidv7} from 'uuidv7';
 
-import {_getGenaiState} from './context';
+import {getGenaiState} from './context';
 import {Turn, type TurnInit} from './turn';
 import type {SpanEndOptions} from './spanBase';
 
@@ -35,7 +35,7 @@ export class Session {
   ) {}
 
   static create(opts: SessionInit = {}): Session {
-    const state = _getGenaiState();
+    const state = getGenaiState();
     if (state.session !== null) {
       throw new Error(
         'A Session is already active in this async chain. End it before starting a new one.'
@@ -65,7 +65,7 @@ export class Session {
       return;
     }
     this._ended = true;
-    const state = _getGenaiState();
+    const state = getGenaiState();
     // Cascade: end any active descendants innermost-first so each child span
     // closes before its parent.
     if (state.llm) {

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -1,6 +1,7 @@
-import {type Span, SpanKind} from '@opentelemetry/api';
+import {type Attributes, type Span, SpanKind} from '@opentelemetry/api';
 
 import type {ChildSpanContext} from './common';
+import {_getGenaiState} from './context';
 import {getWeaveTracer} from './provider';
 import {SpanBase, type SpanEndOptions, type SpanInitBase} from './spanBase';
 import {
@@ -43,8 +44,10 @@ export class SubAgent extends SpanBase {
   }
 
   static create(opts: SubAgentInit & ChildSpanContext): SubAgent {
+    const state = _getGenaiState();
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
-    const attributes: Record<string, string> = {
+    const attributes: Attributes = {
+      ...(state.session?.attributes ?? {}),
       [ATTR_GEN_AI_OPERATION_NAME]: 'invoke_agent',
       [ATTR_GEN_AI_AGENT_NAME]: opts.name,
     };

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -1,7 +1,7 @@
 import {type Attributes, type Span, SpanKind} from '@opentelemetry/api';
 
 import type {ChildSpanContext} from './common';
-import {_getGenaiState} from './context';
+import {getGenaiState} from './context';
 import {getWeaveTracer} from './provider';
 import {SpanBase, type SpanEndOptions, type SpanInitBase} from './spanBase';
 import {
@@ -44,7 +44,7 @@ export class SubAgent extends SpanBase {
   }
 
   static create(opts: SubAgentInit & ChildSpanContext): SubAgent {
-    const state = _getGenaiState();
+    const state = getGenaiState();
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
     const attributes: Attributes = {
       ...(state.session?.attributes ?? {}),

--- a/sdks/node/src/genai/tool.ts
+++ b/sdks/node/src/genai/tool.ts
@@ -1,6 +1,7 @@
-import {type Span, SpanKind} from '@opentelemetry/api';
+import {type Attributes, type Span, SpanKind} from '@opentelemetry/api';
 
 import type {ChildSpanContext} from './common';
+import {_getGenaiState} from './context';
 import {getWeaveTracer} from './provider';
 import {SpanBase, type SpanEndOptions, type SpanInitBase} from './spanBase';
 import {
@@ -55,8 +56,10 @@ export class Tool extends SpanBase {
   }
 
   static create(opts: ToolInit & ChildSpanContext): Tool {
+    const state = _getGenaiState();
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
-    const attributes: Record<string, string> = {
+    const attributes: Attributes = {
+      ...(state.session?.attributes ?? {}),
       [ATTR_GEN_AI_OPERATION_NAME]: 'execute_tool',
       [ATTR_GEN_AI_TOOL_NAME]: opts.name,
     };

--- a/sdks/node/src/genai/tool.ts
+++ b/sdks/node/src/genai/tool.ts
@@ -1,7 +1,7 @@
 import {type Attributes, type Span, SpanKind} from '@opentelemetry/api';
 
 import type {ChildSpanContext} from './common';
-import {_getGenaiState} from './context';
+import {getGenaiState} from './context';
 import {getWeaveTracer} from './provider';
 import {SpanBase, type SpanEndOptions, type SpanInitBase} from './spanBase';
 import {
@@ -56,7 +56,7 @@ export class Tool extends SpanBase {
   }
 
   static create(opts: ToolInit & ChildSpanContext): Tool {
-    const state = _getGenaiState();
+    const state = getGenaiState();
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
     const attributes: Attributes = {
       ...(state.session?.attributes ?? {}),

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -8,7 +8,7 @@ import {
   trace,
 } from '@opentelemetry/api';
 
-import {_getGenaiState} from './context';
+import {getGenaiState} from './context';
 import {LLM, type LLMInit} from './llm';
 import {getWeaveTracer} from './provider';
 import {SpanBase, type SpanEndOptions, type SpanInitBase} from './spanBase';
@@ -61,7 +61,7 @@ export class Turn extends SpanBase {
   }
 
   static create(opts: TurnInit & {conversationId?: string} = {}): Turn {
-    const state = _getGenaiState();
+    const state = getGenaiState();
     if (state.turn !== null) {
       throw new Error(
         'A Turn is already active in this async chain. End it before starting a new one.'
@@ -147,7 +147,7 @@ export class Turn extends SpanBase {
     }
     this._ended = true;
     this._closeSpan(opts);
-    const state = _getGenaiState();
+    const state = getGenaiState();
     if (state.turn === this) {
       state.turn = null;
     }

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -1,5 +1,6 @@
 import {
   type AttributeValue,
+  type Attributes,
   type Context,
   ROOT_CONTEXT,
   type Span,
@@ -67,7 +68,8 @@ export class Turn extends SpanBase {
       );
     }
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
-    const attributes: Record<string, string> = {
+    const attributes: Attributes = {
+      ...(state.session?.attributes ?? {}),
       [ATTR_GEN_AI_OPERATION_NAME]: 'invoke_agent',
     };
     if (opts.agentName) {

--- a/sdks/node/src/state.ts
+++ b/sdks/node/src/state.ts
@@ -31,9 +31,9 @@ type State = {
      *
      * When the user calls `runIsolated(fn)`, this AsyncLocalStorage is `.run`-installed with
      * a fresh `GenAIState` container for that frame. Inside the frame,
-     * `_getGenaiState()` reads back that fresh container. When `runIsolated`
+     * `getGenaiState()` reads back that fresh container. When `runIsolated`
      * isn't on the call stack, `_genaiState.getStore()` returns `undefined`
-     * and `_getGenaiState()` falls back to `_defaultState`.
+     * and `getGenaiState()` falls back to `_defaultState`.
      *
      * The AsyncLocalStorage provides the isolation boundary for concurrent work — each
      * `runIsolated` frame has its own container object, so mutations inside


### PR DESCRIPTION
## Description

* Support `attributes` option to `weave.startSession`:

```ts
  const session = weave.startSession({
    agentName: agent.name,
    attributes: {
      'myagent.region': 'ORD',
      'myagent.version': '4.21',
    },
  });
```

* These attributes are stamped on every span emitted by the session.

* Equivalent PR for Python SDK (https://github.com/wandb/weave/pull/7308)


