### PR TITLE
fix(weave): cap GCS upload socket stalls

### DIFF
--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -7,6 +7,7 @@ specific setup requirements.
 
 import base64
 import os
+import socket
 from unittest import mock
 
 import boto3
@@ -290,6 +291,23 @@ def test_keepalive_gcs_client_scopes_credentials_for_session():
     prescoped = _ScopedFakeCredentials(scopes=["existing-scope"])
     passthrough = file_storage._build_keepalive_gcs_client(prescoped)
     assert passthrough._http.credentials.scopes == ["existing-scope"]
+
+
+def test_keepalive_adapter_sets_tcp_user_timeout():
+    """In-flight stalls need TCP_USER_TIMEOUT; keep-alive only covers idle sockets."""
+    adapter = file_storage._KeepAliveHTTPAdapter(
+        pool_maxsize=file_storage.GCS_POOL_MAXSIZE
+    )
+    socket_options = adapter.poolmanager.connection_pool_kw["socket_options"]
+
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in socket_options
+    # Linux-only knob (skipped on macOS/BSD where the constant is absent).
+    if hasattr(socket, "TCP_USER_TIMEOUT"):
+        assert (
+            socket.IPPROTO_TCP,
+            socket.TCP_USER_TIMEOUT,
+            file_storage.GCS_TCP_USER_TIMEOUT_MS,
+        ) in socket_options
 
 
 class TestAzureStorage:

--- a/weave/trace_server/file_storage.py
+++ b/weave/trace_server/file_storage.py
@@ -106,6 +106,11 @@ GCS_TCP_KEEPALIVE_COUNT = 5
 # uploads reuse warm keep-alive connections instead of churning new ones.
 GCS_POOL_MAXSIZE = 40
 
+# Keep-alive only probes IDLE sockets; an in-flight request whose peer goes silent
+# rides TCP retransmit backoff (~23s, under the read timeout). TCP_USER_TIMEOUT caps
+# unacked data so the socket errors fast and the retry decorator hits a fresh conn.
+GCS_TCP_USER_TIMEOUT_MS = 8000
+
 P = ParamSpec("P")
 R = TypeVar("R")
 
@@ -425,11 +430,13 @@ class _KeepAliveHTTPAdapter(HTTPAdapter):
         ]
         # TCP_KEEPIDLE (Linux) and TCP_KEEPALIVE (macOS/BSD) are the same idle knob;
         # only the platform's own constant exists, so getattr-guard each.
+        # TCP_USER_TIMEOUT (Linux, milliseconds) bounds in-flight unacked data.
         for opt_name, value in (
             ("TCP_KEEPIDLE", GCS_TCP_KEEPALIVE_IDLE),
             ("TCP_KEEPALIVE", GCS_TCP_KEEPALIVE_IDLE),
             ("TCP_KEEPINTVL", GCS_TCP_KEEPALIVE_INTERVAL),
             ("TCP_KEEPCNT", GCS_TCP_KEEPALIVE_COUNT),
+            ("TCP_USER_TIMEOUT", GCS_TCP_USER_TIMEOUT_MS),
         ):
             opt: int | None = getattr(socket, opt_name, None)
             if opt is not None:


### PR DESCRIPTION
## Summary
- The GCS upload tail behind `/v2/.../calls/complete` p99~15s is an in-flight socket whose peer goes silent and rides TCP retransmit backoff to ~23s (under the 30s read timeout). Confirmed in prod: two concurrent uploads of the same tiny payload, one 82ms, the other 23.65s, both 412.
- TCP keep-alive only probes idle sockets, so it can't catch this. Set `TCP_USER_TIMEOUT=8s` (Linux) on the GCS pool so a dead socket errors fast and the existing 3-attempt retry decorator reconnects on a fresh socket (~9s worst case vs ~23s).

## Testing
unit test asserts the keep-alive adapter wires TCP_USER_TIMEOUT into the pool socket options.
