### PR TITLE
perf(weave): dedup repeat bucket writes with a per-pod stored-key cache

### DIFF
--- a/tests/trace/conftest.py
+++ b/tests/trace/conftest.py
@@ -14,10 +14,19 @@ from google.auth.credentials import AnonymousCredentials
 
 from tests.trace.test_utils import FailingSaveType, failing_load, failing_save
 from weave.trace.serialization import serializer
+from weave.trace_server.file_storage import reset_stored_key_cache
 
 # Pinned to the project id of the standard `client` fixture (shawn/test-project).
 TEST_BUCKET = "test-bucket"
 _TEST_PROJECT_ID_B64 = base64.b64encode(b"shawn/test-project").decode()
+
+
+@pytest.fixture(autouse=True)
+def reset_bucket_dedup_cache():
+    """Clear the process-global stored-key cache so one test's write never skips the next's."""
+    reset_stored_key_cache()
+    yield
+    reset_stored_key_cache()
 
 
 @pytest.fixture

--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -310,6 +310,43 @@ def test_keepalive_adapter_sets_tcp_user_timeout():
         ) in socket_options
 
 
+class _CountingStorageClient(file_storage.FileStorageClient):
+    """Records store() calls so a test can assert the dedup cache skips repeats."""
+
+    def __init__(self, base_uri):
+        super().__init__(base_uri)
+        self.store_calls = 0
+
+    def store(self, uri, data) -> None:
+        self.store_calls += 1
+
+    def read(self, uri) -> bytes:
+        raise NotImplementedError
+
+
+def test_store_in_bucket_dedups_repeat_keys():
+    """A repeat content-addressed write is served from the per-pod cache, not the backend."""
+    file_storage.reset_stored_key_cache()
+    base = file_storage.FileStorageURI.parse_uri_str("gs://dedup-test-bucket")
+    client = _CountingStorageClient(base)
+
+    path = file_storage.key_for_project_digest("proj", "digestA")
+    uri1 = file_storage.store_in_bucket(client, path, b"data")
+    uri2 = file_storage.store_in_bucket(client, path, b"data")
+    assert uri1.to_uri_str() == uri2.to_uri_str()
+    assert client.store_calls == 1  # second call served from cache
+
+    file_storage.store_in_bucket(
+        client, file_storage.key_for_project_digest("proj", "digestB"), b"x"
+    )
+    assert client.store_calls == 2  # a distinct key still reaches the backend
+
+    # reset re-arms the backend write for an already-seen key.
+    file_storage.reset_stored_key_cache()
+    file_storage.store_in_bucket(client, path, b"data")
+    assert client.store_calls == 3
+
+
 class TestAzureStorage:
     """Tests for Azure Blob Storage implementation using mocks."""
 

--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -313,14 +313,14 @@ def test_keepalive_adapter_sets_tcp_user_timeout():
 class _CountingStorageClient(file_storage.FileStorageClient):
     """Records store() calls so a test can assert the dedup cache skips repeats."""
 
-    def __init__(self, base_uri):
+    def __init__(self, base_uri: file_storage.FileStorageURI):
         super().__init__(base_uri)
         self.store_calls = 0
 
-    def store(self, uri, data) -> None:
+    def store(self, uri: file_storage.FileStorageURI, data: bytes) -> None:
         self.store_calls += 1
 
-    def read(self, uri) -> bytes:
+    def read(self, uri: file_storage.FileStorageURI) -> bytes:
         raise NotImplementedError
 
 

--- a/weave/trace_server/file_storage.py
+++ b/weave/trace_server/file_storage.py
@@ -42,6 +42,7 @@ There are two ways to authenticate with Azure Blob Storage:
 
 import logging
 import socket
+import threading
 from abc import abstractmethod
 from collections.abc import Callable
 from typing import TypeVar, cast
@@ -51,6 +52,7 @@ from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.storage.blob import BlobServiceClient
 from botocore.config import Config
 from botocore.exceptions import ClientError
+from cachetools import LRUCache
 from google.api_core import exceptions as gcp_exceptions
 from google.auth import default as google_auth_default
 from google.auth.credentials import with_scopes_if_required
@@ -111,6 +113,12 @@ GCS_POOL_MAXSIZE = 40
 # unacked data so the socket errors fast and the retry decorator hits a fresh conn.
 GCS_TCP_USER_TIMEOUT_MS = 8000
 
+# Per-pod memo of content-addressed bucket keys already confirmed stored, so a
+# repeat write skips the redundant create that the provider rejects (GCS 412).
+STORED_KEY_CACHE_SIZE = 100_000
+_stored_key_cache: LRUCache[str, bool] = LRUCache(maxsize=STORED_KEY_CACHE_SIZE)
+_stored_key_cache_lock = threading.Lock()
+
 P = ParamSpec("P")
 R = TypeVar("R")
 
@@ -155,13 +163,20 @@ class FileStorageClient:
 def store_in_bucket(
     client: FileStorageClient, path: str, data: bytes
 ) -> FileStorageURI:
-    """Store a file in a storage bucket."""
+    """Store a file in a storage bucket, deduping repeat content-addressed writes."""
+    target_file_storage_uri = client.base_uri.with_path(path)
+    uri_str = target_file_storage_uri.to_uri_str()
+    with _stored_key_cache_lock:
+        already_stored = uri_str in _stored_key_cache
+    if already_stored:
+        return target_file_storage_uri
     try:
-        target_file_storage_uri = client.base_uri.with_path(path)
         client.store(target_file_storage_uri, data)
     except Exception as e:
         logger.exception("Failed to store file at %s", target_file_storage_uri)
         raise FileStorageWriteError(f"Failed to store file at {path}: {e!s}") from e
+    with _stored_key_cache_lock:
+        _stored_key_cache[uri_str] = True
     return target_file_storage_uri
 
 
@@ -179,6 +194,12 @@ def read_from_bucket(
 
 
 ### Everything below here is internal
+
+
+def reset_stored_key_cache() -> None:
+    """Clear the per-pod stored-key cache (used by tests)."""
+    with _stored_key_cache_lock:
+        _stored_key_cache.clear()
 
 
 def key_for_project_digest(project_id: str, digest: str) -> str:

--- a/weave/trace_server/parallel_bucket_uploads.py
+++ b/weave/trace_server/parallel_bucket_uploads.py
@@ -32,10 +32,10 @@ Partial-failure semantics: if a worker raises something other than
 re-raises it and `flush()` logs a warning and re-raises. Peer workers
 still complete via the `ThreadPoolExecutor.__exit__` join, so their
 bucket objects may land without a corresponding `files` row. On retry,
-the same `(project_id, digest)` triggers
-`if_generation_match=0 -> PreconditionFailed`, which `store_in_bucket`
-wraps as `FileStorageWriteError`, which falls back to inline-CH chunks.
-End state is content-addressable and consistent.
+the repeat write is an idempotent no-op (served from the per-pod
+stored-key cache, or GCS `if_generation_match=0` swallows the duplicate)
+and the worker re-inserts the missing `files` row. End state is
+content-addressable and consistent.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- ~55% of GCS uploads (650k/day in prod) are dedup no-ops: weave content-addresses blobs and writes with `if_generation_match=0`, so a repeat of an already-stored digest pays a full multipart round-trip just to get a 412 (and each is exposed to the ~20s connection-stall tail).
- Add a per-pod bounded LRU of confirmed-stored keys, mirroring `project_version`'s residence cache (module-level `LRUCache` + `Lock` + `reset_*` fn). `store_in_bucket` skips the upload on a hit and still returns the URI, so the files-table row is inserted exactly as before. Content-addressed keys are immutable so a hit is always safe; best-effort per pod, never a correctness dependency.

## Testing
unit test: repeat key served from cache (no backend call), distinct key still writes, reset re-arms.
