### PR TITLE
test(weave): convert trace_calls_complete_only shard to cover calls_merged

### DIFF
--- a/.github/workflows/nightly-replicated-leg.yaml
+++ b/.github/workflows/nightly-replicated-leg.yaml
@@ -37,7 +37,7 @@ jobs:
     # mirror test.yaml's pattern and bump just that shard to 8-core. Other
     # shards stay on free 2-core. 8-core is billed at $0.022/min, so a
     # typical 30 min trace leg ~= $0.66.
-    runs-on: ${{ (matrix.shard == 'trace' || matrix.shard == 'trace_calls_complete_only') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.shard == 'trace' || matrix.shard == 'trace_calls_merged_only') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     env:
       # MAX_ATTEMPTS=1 (no retry). Retries on replicated topologies amplify
       # failures: each attempt re-runs against the same docker-compose CH

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -107,8 +107,8 @@ jobs:
       contents: read
       packages: write
     # TODO: refactor to use matrix.include for runner selection
-    # Use 8-core runners for trace and trace_calls_complete_only shards (resource-intensive)
-    runs-on: ${{ (matrix.nox-shard == 'trace' || matrix.nox-shard == 'trace_calls_complete_only') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
+    # Use 8-core runners for trace and trace_calls_merged_only shards (resource-intensive)
+    runs-on: ${{ (matrix.nox-shard == 'trace' || matrix.nox-shard == 'trace_calls_merged_only') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     strategy:
       matrix:
         python-version-major: ["3"]
@@ -120,7 +120,7 @@ jobs:
           ]
         nox-shard: [
             "trace",
-            "trace_calls_complete_only",
+            "trace_calls_merged_only",
             "flow",
             "trace_server",
             "trace_server_bindings",

--- a/noxfile.py
+++ b/noxfile.py
@@ -53,7 +53,7 @@ SHARDS_WITHOUT_EXTRAS = {
     "custom",
     "flow",
     "trace",
-    "trace_calls_complete_only",
+    "trace_calls_merged_only",
     "trace_no_server",
     "trace_server",
     "trace_server_bindings",
@@ -116,7 +116,7 @@ SHARDS_WITHOUT_EXTRAS = {
         "verifiers_test",
         "autogen_tests",
         "trace",
-        "trace_calls_complete_only",
+        "trace_calls_merged_only",
         "trace_no_server",
         "stainless",
     ],
@@ -209,7 +209,7 @@ def tests(session: nox.Session, shard: str):
             "tests/wandb_interface/",
             "tests/session/",
         ],
-        "trace_calls_complete_only": [
+        "trace_calls_merged_only": [
             "tests/trace/",
             "tests/compat/",
             "tests/utils/",
@@ -234,7 +234,7 @@ def tests(session: nox.Session, shard: str):
 
     # Each worker gets its own isolated database namespace
     # Only use parallel workers for the trace shard if we have more than 1 CPU core
-    if shard in {"trace", "trace_calls_complete_only"}:
+    if shard in {"trace", "trace_calls_merged_only"}:
         cpu_count = os.cpu_count()
         if cpu_count is not None and cpu_count > 1:
             session.posargs.insert(0, f"-n{cpu_count}")
@@ -252,14 +252,14 @@ def tests(session: nox.Session, shard: str):
         "--cov-branch",
     ]
 
-    if shard in {"trace", "trace_calls_complete_only"}:
+    if shard in {"trace", "trace_calls_merged_only"}:
         pytest_args.extend(["-m", "trace_server"])
 
     if shard == "trace_no_server":
         pytest_args.extend(["-m", "not trace_server"])
 
-    if shard == "trace_calls_complete_only":
-        env["WEAVE_USE_CALLS_COMPLETE"] = "true"
+    if shard == "trace_calls_merged_only":
+        env["WEAVE_USE_CALLS_COMPLETE"] = "false"
 
     # Set trace-server flag for stainless shard
     if shard == "stainless":


### PR DESCRIPTION
## Summary
- #6840 flipped the SDK default `use_calls_complete` to `True`, so the plain `trace` shard already exercises calls_complete end-to-end. The `trace_calls_complete_only` shard (sets `WEAVE_USE_CALLS_COMPLETE=true`) became a duplicate of it.
- Repurpose it to `trace_calls_merged_only` with `WEAVE_USE_CALLS_COMPLETE=false`, restoring end-to-end CI coverage of the legacy calls_merged write/read path (currently untested end-to-end).

## Testing
ci shard rename + env flip; no production code touched.