### PR TITLE
test(weave_ts): fix flaky genai test by dropping real login() from beforeEach

### DIFF
--- a/sdks/node/src/__tests__/genai/genai.test.ts
+++ b/sdks/node/src/__tests__/genai/genai.test.ts
@@ -7,9 +7,8 @@ import type {
   ChatCompletionMessageFunctionToolCall,
 } from 'openai/resources/chat/completions';
 import * as weave from '../../../src';
-import {login, type Turn, type Message, type MessagePart} from '../../../src';
+import {type Turn, type Message, type MessagePart} from '../../../src';
 import {clearWeaveTracerProvider} from '../../../src/genai/provider';
-import {getWandbConfigs} from '../../wandb/settings';
 import {spanSnapshot, type SpanSnapshotOpts} from './common';
 import {InMemoryTraceServer} from '../helpers/inMemoryTraceServer';
 import {initWithCustomTraceServer} from '../clientMock';
@@ -302,9 +301,10 @@ async function run(agent: Agent, prompts: string[]): Promise<string[]> {
 describe('GenAI', () => {
   let exporter: InMemorySpanExporter;
 
-  beforeEach(async () => {
-    const {apiKey} = getWandbConfigs();
-    await login(apiKey ?? '');
+  beforeEach(() => {
+    // Stub the key the OTel exporter reads; tracing runs through the
+    // in-memory server below, so no real backend connection is needed.
+    process.env.WANDB_API_KEY = 'test-api-key';
 
     exporter = new InMemorySpanExporter();
 


### PR DESCRIPTION
## Summary
- `genai.test.ts` `beforeEach` called real `login()` whose only purpose here is setting `process.env.WANDB_API_KEY`. `login()` first does an unretried `GET /health` against the live backend, so a transient blip fails the whole suite.
- The test traces through an `InMemoryTraceServer`, so no backend is needed. Set the env key directly, matching the sibling genai tests (`common.ts` `setupGenAITestEnvironment`).

Original failure ([CI job](https://github.com/wandb/weave/actions/runs/28198557928/job/83531755452?pr=7401)):
```
Unable to verify connection to the weave trace server with given API Key  (clientApi.ts:48)
```

## Testing
test only change. genai.test.ts passes with `WANDB_API_KEY` unset (no network).