### PR TITLE
perf(weave): use approximate uniq for agent span stats counts

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -370,7 +370,7 @@ class TestMakeSpansListQuery:
 #: readable without duplicating the bundle across every test.
 _GROUPED_AGG_TAIL = """count() AS span_count,
                countIf(s.operation_name = 'invoke_agent') AS invocation_count,
-               uniqExact(s.conversation_id) AS conversation_count,
+               uniq(s.conversation_id) AS conversation_count,
                sum(s.input_tokens) AS total_input_tokens,
                sum(s.cache_creation_input_tokens) AS total_cache_creation_input_tokens,
                sum(s.cache_read_input_tokens) AS total_cache_read_input_tokens,

--- a/tests/trace_server/query_builder/test_agent_stats_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_stats_query_builder.py
@@ -775,7 +775,7 @@ def test_time_stats_apply_group_filters() -> None:
            INNER JOIN qualified_groups_0 q ON s.conversation_id = q.conversation_id),
              aggregated_data AS
           (SELECT bucket,
-                  uniqExactIf(m_conversations, v_conversations) AS count_distinct_conversations
+                  uniqIf(m_conversations, v_conversations) AS count_distinct_conversations
            FROM
              (SELECT toStartOfInterval(s.started_at, INTERVAL 3600 SECOND, {genai_10:String}) AS bucket,
                      s.conversation_id AS m_conversations,

--- a/tests/trace_server/test_genai_agent_query_handler.py
+++ b/tests/trace_server/test_genai_agent_query_handler.py
@@ -229,7 +229,7 @@ def test_grouped_rows_hydrate_message_previews() -> None:
         "\n        SELECT s.conversation_id AS conversation_id,\n"
         "               count() AS span_count,\n"
         "               countIf(s.operation_name = 'invoke_agent') AS invocation_count,\n"
-        "               uniqExact(s.conversation_id) AS conversation_count,\n"
+        "               uniq(s.conversation_id) AS conversation_count,\n"
         "               sum(s.input_tokens) AS total_input_tokens,\n"
         "               sum(s.cache_creation_input_tokens) AS total_cache_creation_input_tokens,\n"
         "               sum(s.cache_read_input_tokens) AS total_cache_read_input_tokens,\n"

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -722,7 +722,8 @@ def span_measure_sql(
             aggregate_sql = f"maxOrNull(if({valid_sql}, {metric_sql}, NULL))"
             value_type = value_sql.value_type
         elif agg == _AGG_COUNT_DISTINCT:
-            aggregate_sql = f"uniqExactIf({metric_sql}, {valid_sql})"
+            # uniq (approx, memory-bounded); uniqExact OOMs on large projects.
+            aggregate_sql = f"uniqIf({metric_sql}, {valid_sql})"
             value_type = _VALUE_TYPE_NUMBER
         elif agg == _AGG_COUNT_TRUE:
             if value_sql.value_type != _VALUE_TYPE_BOOLEAN:
@@ -976,7 +977,7 @@ def _search_filter_sql(pb: ParamBuilder, req: AgentSearchReq) -> _FilterSQL:
 # same schema.
 _GROUPED_SPAN_AGGREGATES: str = """count() AS span_count,
                countIf(s.operation_name = 'invoke_agent') AS invocation_count,
-               uniqExact(s.conversation_id) AS conversation_count,
+               uniq(s.conversation_id) AS conversation_count,
                sum(s.input_tokens) AS total_input_tokens,
                sum(s.cache_creation_input_tokens) AS total_cache_creation_input_tokens,
                sum(s.cache_read_input_tokens) AS total_cache_read_input_tokens,

--- a/weave/trace_server/query_builder/agent_stats_query_builder.py
+++ b/weave/trace_server/query_builder/agent_stats_query_builder.py
@@ -669,7 +669,8 @@ def _aggregation_output(
         aggregate_sql = f"countIf({valid_col})"
         value_type = _VALUE_TYPE_NUMBER
     elif agg == _AGG_COUNT_DISTINCT:
-        aggregate_sql = f"uniqExactIf({metric_col}, {valid_col})"
+        # uniq (approx, memory-bounded); uniqExact OOMs on large projects.
+        aggregate_sql = f"uniqIf({metric_col}, {valid_col})"
         value_type = _VALUE_TYPE_NUMBER
     elif agg == _AGG_COUNT_TRUE:
         aggregate_sql = f"countIf({valid_col} AND {metric_col} = 1)"


### PR DESCRIPTION
## Summary
- Mirror #7380 (approx `uniq` for `calls_merged` stats counts) on the agent query builders: swap `uniqExact`/`uniqExactIf` -> `uniq`/`uniqIf` for the grouped-spans `conversation_count` and the `count_distinct` span measures.
- `uniqExact` builds an exact hash set that grows with distinct cardinality and OOMs on large agent projects; `uniq` keeps a fixed HLL and is bit-exact below ~64K distinct, so small/medium projects count identically.

## Performance
Counting memory goes from unbounded (grows with distinct values) to a fixed HLL (~KB) per group, the same swap that fixed the `calls_merged` count OOMs in #7380.

## Testing
unit tests (SQL snapshots). Exact-vs-approx validated on prod `spans.conversation_id`; synthetic `numbers()` is bit-exact through 65,536 then <0.5% off (70K +0.51%, 1M +0.19%, 10M -0.16%).

| project distinct convos | uniqExact | uniq | diff |
|---|---|---|---|
| ≤ 40,219 (all but top 3 projects) | exact | = exact | 0% |
| 187,357 | 187,357 | 187,220 | -0.07% |
| 274,316 | 274,316 | 273,130 | -0.43% |
| 458,692 (largest, 41M spans) | 458,692 | 456,993 | -0.37% |

every medium project (≤~64K distinct) counts bit-exact; even the largest prod project is <0.5% off.
