### PR TITLE
fix(weave): map request-input validation failures to 400 not 500

### DIFF
--- a/tests/trace/test_obj_tags_aliases.py
+++ b/tests/trace/test_obj_tags_aliases.py
@@ -1,13 +1,16 @@
 import time
 
 import pytest
-from pydantic import ValidationError
 
 import weave
 from weave.trace.refs import ObjectRef
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
-from weave.trace_server.errors import NotFoundError, ObjectDeletedError
+from weave.trace_server.errors import (
+    InvalidRequest,
+    NotFoundError,
+    ObjectDeletedError,
+)
 from weave.trace_server.trace_server_common import digest_is_content_hash
 
 
@@ -47,42 +50,42 @@ def _create_obj_in_project(server, project_id: str, name: str, val: dict | None 
 def test_tag_validation():
     """All tag format rules: regex, length, whitespace, deduplication, version-like names."""
     # Empty tag rejected
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         tsi.ObjAddTagsReq(
             project_id="test/proj", object_id="obj", digest="abc123", tags=[""]
         )
 
     # Too long (>256 chars) rejected
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         tsi.ObjAddTagsReq(
             project_id="test/proj", object_id="obj", digest="abc123", tags=["a" * 257]
         )
 
     # Whitespace-only rejected
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         tsi.ObjAddTagsReq(
             project_id="test/proj", object_id="obj", digest="abc123", tags=["   "]
         )
 
     # Special characters rejected
     for bad_tag in ["special!chars", "my.tag", "hello@world", "a+b"]:
-        with pytest.raises(ValidationError):
+        with pytest.raises(InvalidRequest):
             tsi.ObjAddTagsReq(
                 project_id="test/proj", object_id="obj", digest="abc123", tags=[bad_tag]
             )
 
     # Leading/trailing spaces rejected
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         tsi.ObjAddTagsReq(
             project_id="test/proj", object_id="obj", digest="abc123", tags=[" leading"]
         )
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         tsi.ObjAddTagsReq(
             project_id="test/proj", object_id="obj", digest="abc123", tags=["trailing "]
         )
 
     # Consecutive spaces rejected
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         tsi.ObjAddTagsReq(
             project_id="test/proj",
             object_id="obj",
@@ -125,7 +128,7 @@ def test_alias_validation():
     """All alias format rules: reserved names, invalid chars, length, whitespace."""
     # Reserved names rejected: 'latest', version-like
     for reserved in ["latest", "v0", "v123"]:
-        with pytest.raises(ValidationError):
+        with pytest.raises(InvalidRequest):
             tsi.ObjSetAliasesReq(
                 project_id="test/proj",
                 object_id="obj",
@@ -135,7 +138,7 @@ def test_alias_validation():
 
     # Invalid characters: '/' and ':' rejected
     for bad in ["path/slash", "has:colon"]:
-        with pytest.raises(ValidationError):
+        with pytest.raises(InvalidRequest):
             tsi.ObjSetAliasesReq(
                 project_id="test/proj",
                 object_id="obj",
@@ -145,7 +148,7 @@ def test_alias_validation():
 
     # Whitespace-only rejected (spaces, tabs)
     for ws in ["   ", "\t"]:
-        with pytest.raises(ValidationError):
+        with pytest.raises(InvalidRequest):
             tsi.ObjSetAliasesReq(
                 project_id="test/proj",
                 object_id="obj",
@@ -154,13 +157,13 @@ def test_alias_validation():
             )
 
     # Empty string rejected
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         tsi.ObjSetAliasesReq(
             project_id="test/proj", object_id="obj", digest="abc123", aliases=[""]
         )
 
     # Too long (>128 chars) rejected
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         tsi.ObjSetAliasesReq(
             project_id="test/proj",
             object_id="obj",

--- a/tests/trace_server/test_errors.py
+++ b/tests/trace_server/test_errors.py
@@ -1,6 +1,9 @@
+from collections.abc import Callable
+
 import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError as CHDatabaseError
 from gql.transport.exceptions import TransportServerError
+from pydantic import ValidationError
 
 from weave.trace_server.errors import (
     BadQueryParameterError,
@@ -9,6 +12,15 @@ from weave.trace_server.errors import (
     ObjectNameTypeCollision,
     handle_clickhouse_query_error,
     handle_server_exception,
+)
+from weave.trace_server.interface.builtin_object_classes.provider import (
+    INVALID_BASE_URL_MSG,
+    Provider,
+)
+from weave.trace_server.trace_server_interface import (
+    ObjAddTagsReq,
+    ObjRemoveAliasesReq,
+    ObjSetAliasesReq,
 )
 
 
@@ -70,6 +82,88 @@ def test_invalid_field_error_maps_to_422() -> None:
     """
     result = handle_server_exception(InvalidFieldError("Field 'foo' is not allowed"))
     assert result.status_code == 422
+
+
+# A *Req validator that rejects user input raises InvalidRequest, which propagates
+# unwrapped (pydantic only wraps ValueError/AssertionError) and hits the exact-type
+# registry -> 400. A bare pydantic ValidationError (a structural failure, e.g. the
+# server deserializing stored data) is not a client error and stays 500. WB-36386.
+@pytest.mark.parametrize(
+    ("build", "reason"),
+    [
+        (
+            lambda: ObjSetAliasesReq(
+                project_id="1", object_id="o", digest="d", aliases=["bad:alias"]
+            ),
+            "alias name cannot contain character ':'",
+        ),
+        (
+            lambda: ObjRemoveAliasesReq(
+                project_id="1", object_id="o", aliases=["bad/alias"]
+            ),
+            "alias name cannot contain character '/'",
+        ),
+        (
+            lambda: ObjAddTagsReq(
+                project_id="1", object_id="o", digest="d", tags=["bad:tag"]
+            ),
+            "tag name 'bad:tag' is invalid: only alphanumeric characters, "
+            "hyphens, underscores, and single spaces between words are allowed",
+        ),
+    ],
+)
+def test_request_validators_map_to_400(
+    build: Callable[[], object], reason: str
+) -> None:
+    with pytest.raises(InvalidRequest) as excinfo:
+        build()
+    result = handle_server_exception(excinfo.value)
+    assert result.status_code == 400
+    assert result.message == {"reason": reason}
+
+
+@pytest.mark.parametrize(
+    ("build", "reason"),
+    [
+        (
+            lambda: Provider(
+                base_url="http://metadata.google.internal", api_key_name="k"
+            ),
+            INVALID_BASE_URL_MSG,
+        ),
+        (
+            lambda: Provider(
+                base_url="https://api.openai.com",
+                api_key_name="k",
+                extra_headers={"Metadata-Flavor": "Google"},
+            ),
+            "extra_headers contains a disallowed header",
+        ),
+    ],
+)
+def test_provider_ssrf_validators_map_to_400(
+    build: Callable[[], object], reason: str
+) -> None:
+    """Provider base_url / extra_headers SSRF defenses (VULNMGMT-770) reject
+    client input -> 400, not 500.
+    """
+    with pytest.raises(InvalidRequest) as excinfo:
+        build()
+    result = handle_server_exception(excinfo.value)
+    assert result.status_code == 400
+    assert result.message == {"reason": reason}
+
+
+def test_structural_validation_error_stays_500() -> None:
+    """A bare pydantic ValidationError (a field structurally mistyped, as when the
+    server deserializes stored data) is not the client's fault -> 500. Guards
+    against blanket-registering ValidationError -> 400.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        ObjAddTagsReq(project_id="1", object_id="o", digest="d", tags=123)
+    result = handle_server_exception(excinfo.value)
+    assert result.status_code == 500
+    assert result.message == {"reason": "Internal server error"}
 
 
 def test_object_name_type_collision_maps_to_400() -> None:

--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -3,7 +3,6 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pydantic import ValidationError
 
 from weave.trace_server import clickhouse_trace_server_batched as chts
 from weave.trace_server import llm_completion as llm_mod
@@ -1601,17 +1600,17 @@ def test_provider_base_url_validation():
     assert p.base_url == "http://my-ollama-server.example.com:11434"
 
     # Non-http schemes rejected
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         _make_provider("ftp://bad.example.com")
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         _make_provider("file:///etc/passwd")
 
     # Query strings, bare '?', and fragments rejected
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         _make_provider("https://api.example.com/v1?foo=bar")
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         _make_provider("https://api.example.com/v1#section")
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         _make_provider("http://10.0.0.1/path?")
 
     # Blocked hostnames rejected
@@ -1621,28 +1620,28 @@ def test_provider_base_url_validation():
         "foo.metadata.google.internal",
         "169.254.169.254",
     ):
-        with pytest.raises(ValidationError):
+        with pytest.raises(InvalidRequest):
             _make_provider(f"http://{hostname}/v1")
 
     # Non-globally-routable IPs rejected
     for addr in ("10.0.0.1", "172.16.0.1", "192.168.1.1", "127.0.0.1"):
-        with pytest.raises(ValidationError):
+        with pytest.raises(InvalidRequest):
             _make_provider(f"http://{addr}/v1")
 
     # Alternative IP encodings rejected
     for alt_ip in ("0xa9fea9fe", "2852039166", "0x7f000001", "0"):
-        with pytest.raises(ValidationError):
+        with pytest.raises(InvalidRequest):
             _make_provider(f"http://{alt_ip}/v1")
 
     # IPv6 non-global addresses rejected
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         _make_provider("http://[::1]/v1")
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         _make_provider("http://[::ffff:169.254.169.254]/v1")
 
     # Blocked extra_headers rejected
     for blocked in ("Metadata-Flavor", "METADATA-FLAVOR", "X-aws-ec2-metadata-token"):
-        with pytest.raises(ValidationError):
+        with pytest.raises(InvalidRequest):
             _make_provider("https://api.example.com", extra_headers={blocked: "val"})
 
     # Allowed headers accepted
@@ -1654,9 +1653,9 @@ def test_provider_base_url_validation():
 
     # Validation also runs on assignment, not just init
     p = _make_provider("https://api.example.com")
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         p.base_url = "http://169.254.169.254/v1"
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidRequest):
         p.extra_headers = {"Metadata-Flavor": "Google"}
 
 

--- a/weave/trace_server/interface/builtin_object_classes/provider.py
+++ b/weave/trace_server/interface/builtin_object_classes/provider.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 
 from pydantic import ConfigDict, Field, field_validator
 
+from weave.trace_server.errors import InvalidRequest
 from weave.trace_server.helpers.url_safety import is_publicly_routable_url
 from weave.trace_server.interface.builtin_object_classes import base_object_def
 
@@ -27,15 +28,15 @@ def _validate_provider_base_url(url: str) -> str:
     """
     # urlparse silently strips a bare trailing '?', so check the raw string too.
     if "?" in url:
-        raise ValueError(INVALID_BASE_URL_MSG)
+        raise InvalidRequest(INVALID_BASE_URL_MSG)
     try:
         parsed = urlparse(url)
     except ValueError as exc:
-        raise ValueError(INVALID_BASE_URL_MSG) from exc
+        raise InvalidRequest(INVALID_BASE_URL_MSG) from exc
     if parsed.fragment:
-        raise ValueError(INVALID_BASE_URL_MSG)
+        raise InvalidRequest(INVALID_BASE_URL_MSG)
     if not is_publicly_routable_url(url):
-        raise ValueError(INVALID_BASE_URL_MSG)
+        raise InvalidRequest(INVALID_BASE_URL_MSG)
     return url
 
 
@@ -61,7 +62,7 @@ class Provider(base_object_def.BaseObject):
     def validate_extra_headers(cls, v: dict[str, str]) -> dict[str, str]:
         for key in v:
             if BLOCKED_HEADER_RE.match(key):
-                raise ValueError("extra_headers contains a disallowed header")
+                raise InvalidRequest("extra_headers contains a disallowed header")
         return v
 
 

--- a/weave/trace_server/validation.py
+++ b/weave/trace_server/validation.py
@@ -172,11 +172,11 @@ def validate_tag_name(name: str) -> None:
     Max length: 256 characters.
     """
     if not name:
-        raise ValueError("tag name must not be empty")
+        raise InvalidRequest("tag name must not be empty")
     if len(name) > MAX_TAG_LENGTH:
-        raise ValueError(f"tag name must be at most {MAX_TAG_LENGTH} characters")
+        raise InvalidRequest(f"tag name must be at most {MAX_TAG_LENGTH} characters")
     if not TAG_REGEX.match(name):
-        raise ValueError(
+        raise InvalidRequest(
             f"tag name {name!r} is invalid: only alphanumeric characters, "
             "hyphens, underscores, and single spaces between words are allowed"
         )
@@ -185,17 +185,19 @@ def validate_tag_name(name: str) -> None:
 def validate_alias_name(name: str) -> None:
     """Validate an alias name. Disallows '/' and ':', reserves 'latest' and version indices."""
     if not name:
-        raise ValueError("alias name must not be empty")
+        raise InvalidRequest("alias name must not be empty")
     if not name.strip():
-        raise ValueError("alias name must not be whitespace-only")
+        raise InvalidRequest("alias name must not be whitespace-only")
     if len(name) > MAX_ALIAS_LENGTH:
-        raise ValueError(f"alias name must be at most {MAX_ALIAS_LENGTH} characters")
+        raise InvalidRequest(
+            f"alias name must be at most {MAX_ALIAS_LENGTH} characters"
+        )
     for ch in name:
         if ch in _INVALID_ALIAS_CHARACTERS:
-            raise ValueError(f"alias name cannot contain character '{ch}'")
+            raise InvalidRequest(f"alias name cannot contain character '{ch}'")
     if _VERSION_LIKE_PATTERN.match(name):
-        raise ValueError(
+        raise InvalidRequest(
             f"alias name '{name}' is reserved (matches version pattern v<number>)"
         )
     if name in _RESERVED_ALIAS_NAMES:
-        raise ValueError(f"alias name '{name}' is reserved")
+        raise InvalidRequest(f"alias name '{name}' is reserved")


### PR DESCRIPTION
## Summary
- Tag/alias/Provider validators raised `ValueError`, which pydantic wraps as `ValidationError`; the exact-type error registry missed it and fell through to a generic 500. Raise `InvalidRequest` from these client-input validators so it propagates unwrapped to the existing `InvalidRequest -> 400` mapping.
- Scoped deliberately over a blanket `ValidationError -> 400`: a structural/server-side `ValidationError` (e.g. deserializing stored data on read paths like `eval_results/query`) stays 500, so real server bugs aren't mislabeled as client errors and dropped from the 5xx budget.
- Prod (30d) hot paths covered: tags (186), aliases set/remove (116), Provider SSRF/base_url on `obj/create` (4); the 1 read-path server error stays 500.
- Jira: [WB-36386](https://coreweave.atlassian.net/browse/WB-36386)

## Testing
unit tests: tag/alias/Provider validators map to 400; a structural ValidationError stays 500


[WB-36386]: https://coreweave.atlassian.net/browse/WB-36386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ