### PR TITLE
fix(weave): reject feedback on a deleted annotation spec with not-found

### DIFF
--- a/tests/trace/test_annotation_feedback.py
+++ b/tests/trace/test_annotation_feedback.py
@@ -4,7 +4,11 @@ from pydantic import BaseModel, Field
 import weave
 from weave import AnnotationSpec
 from weave.trace_server.clickhouse_trace_server_batched import InvalidRequest
-from weave.trace_server.trace_server_interface import FeedbackCreateReq, ObjQueryReq
+from weave.trace_server.trace_server_interface import (
+    FeedbackCreateReq,
+    ObjDeleteReq,
+    ObjQueryReq,
+)
 
 
 def test_human_feedback_basic(client):
@@ -84,6 +88,39 @@ def test_human_feedback_basic(client):
                     "feedback_type": "wandb.annotation." + ref1.name,
                     "annotation_ref": ref1.uri,
                     "payload": {"value": 42},
+                }
+            )
+        )
+
+
+def test_feedback_create_on_deleted_annotation_spec(client):
+    """A feedback ref pointing at a deleted annotation spec resolves to None;
+    the request is rejected as not-found, not a 500 (TypeError on model_validate(None)).
+    """
+    spec = AnnotationSpec(
+        name="Deleted Spec",
+        field_schema={"type": "number", "minimum": 0, "maximum": 1},
+    )
+    ref = weave.publish(spec, "deleted spec")
+    assert ref
+
+    client.server.obj_delete(
+        ObjDeleteReq(
+            project_id=client.project_id,
+            object_id=ref.name,
+            digests=[ref.digest],
+        )
+    )
+
+    with pytest.raises(InvalidRequest, match="not found"):
+        client.server.feedback_create(
+            FeedbackCreateReq.model_validate(
+                {
+                    "project_id": client.project_id,
+                    "weave_ref": "weave:///entity/project/call/name:digest",
+                    "feedback_type": "wandb.annotation." + ref.name,
+                    "annotation_ref": ref.uri,
+                    "payload": {"value": 0},
                 }
             )
         )

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -215,12 +215,13 @@ def validate_feedback_create_req(
         data = trace_server.refs_read_batch(
             tsi.RefsReadBatchReq(refs=[req.annotation_ref])
         )
-        if len(data.vals) == 0:
+        # A deleted annotation spec resolves to a None val, not an empty list.
+        spec = data.vals[0] if data.vals else None
+        if spec is None:
             raise InvalidRequest(f"Annotation ref {req.annotation_ref} not found")
 
         # 3. Validate the payload against the annotation spec
         value = req.payload["value"]
-        spec = data.vals[0]
         try:
             annotation_spec = AnnotationSpec.model_validate(spec)
         except ValidationError as e:


### PR DESCRIPTION
## Summary
- A deleted annotation spec resolves to a `[None]` val, so the `len == 0` guard missed it and `AnnotationSpec.model_validate(None)` ran. Guard `spec is None` and raise the existing `InvalidRequest` ("not found").
- The hard 500 (`TypeError: 'NoneType' is not iterable`, ~33/7d on `POST /feedback/create`) is already resolved on master and pending deploy; this hardens the path (explicit not-found vs relying on pydantic incidentally raising `ValidationError` for `None`) and adds the missing regression test.
- Jira: [WB-36387](https://coreweave.atlassian.net/browse/WB-36387)

## Testing
functional test: feedback_create on a deleted annotation spec returns not-found


[WB-36387]: https://coreweave.atlassian.net/browse/WB-36387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ