### PR TITLE
chore(weave): 0.82.x server release patch 1

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_settings.py
+++ b/tests/trace_server/test_clickhouse_trace_server_settings.py
@@ -6,6 +6,7 @@ from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 
 ENV_KEYS = [
     "WF_CLICKHOUSE_MAX_EXECUTION_TIME",
+    "WF_CLICKHOUSE_MAX_ESTIMATED_EXECUTION_TIME",
     "WF_CLICKHOUSE_DISABLE_QUERY_FAILURE_PREDICTION",
 ]
 
@@ -51,6 +52,13 @@ def test_query_settings_apply_prediction_guards(monkeypatch, reload_settings):
         settings["timeout_before_checking_execution_speed"]
         == settings_module.DEFAULT_TIMEOUT_BEFORE_CHECKING_EXECUTION_SPEED
     )
+
+    # A dedicated override decouples the projection guard from the hard cap.
+    monkeypatch.setenv("WF_CLICKHOUSE_MAX_ESTIMATED_EXECUTION_TIME", "5")
+    settings_module = reload_settings()
+    settings = settings_module.CLICKHOUSE_DEFAULT_QUERY_SETTINGS
+    assert settings["max_execution_time"] == 30
+    assert settings["max_estimated_execution_time"] == 5
 
     # Operators can disable the estimated-time guard entirely.
     monkeypatch.setenv("WF_CLICKHOUSE_DISABLE_QUERY_FAILURE_PREDICTION", "true")

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -60,6 +60,12 @@ RETURN_TYPE_ALLOW_COMPLEX = "1"
 _env_max_execution_time = wf_env.wf_clickhouse_max_execution_time()
 # Treat 0 as unset; a zero-second timeout is not a useful service default.
 _max_execution_time = _env_max_execution_time or DEFAULT_MAX_EXECUTION_TIME
+# The projection guard is tuned independently of the hard runtime cap: a flaky
+# estimate can fire early, so operators may want a looser projection ceiling
+# while keeping a tight real-runtime cap. Falls back to the hard cap when unset.
+_max_estimated_execution_time = (
+    wf_env.wf_clickhouse_max_estimated_execution_time() or _max_execution_time
+)
 _disable_query_failure_prediction = (
     wf_env.wf_clickhouse_disable_query_failure_prediction()
 )
@@ -78,7 +84,7 @@ CLICKHOUSE_QUERY_FAILURE_PREDICTION_SETTINGS: dict[str, int | str] = {}
 if not _disable_query_failure_prediction:
     CLICKHOUSE_QUERY_FAILURE_PREDICTION_SETTINGS.update(
         {
-            "max_estimated_execution_time": _max_execution_time,
+            "max_estimated_execution_time": _max_estimated_execution_time,
             "timeout_before_checking_execution_speed": DEFAULT_TIMEOUT_BEFORE_CHECKING_EXECUTION_SPEED,
             "timeout_overflow_mode": "throw",
         }

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -320,6 +320,20 @@ def wf_clickhouse_max_execution_time() -> int | None:
         return None
 
 
+def wf_clickhouse_max_estimated_execution_time() -> int | None:
+    """The estimated-time (TOO_SLOW) projection guard for the clickhouse server."""
+    time = os.environ.get("WF_CLICKHOUSE_MAX_ESTIMATED_EXECUTION_TIME")
+    if time is None:
+        return None
+    try:
+        return int(time)
+    except ValueError:
+        logger.exception(
+            "WF_CLICKHOUSE_MAX_ESTIMATED_EXECUTION_TIME value '%s' is not valid", time
+        )
+        return None
+
+
 def wf_clickhouse_disable_query_failure_prediction() -> bool:
     """Whether to disable ClickHouse estimated-time query failure prediction."""
     return (


### PR DESCRIPTION
## Summary
Cherry-picks for image build `wandb/weave-trace:0.82.x-patch-1`. Not intended to merge.

Cherry-picked from:
- #7336 decouple clickhouse estimated-time guard from execution-time cap

Branched off `griffin/0.82.x-weave-patch-base`.

## Testing
non-functional change.