### PR TITLE
feat(weave): surface QUERY_TOO_EXPENSIVE as a typed, non-retryable client error

### DIFF
--- a/tests/trace_server_bindings/test_http_utils.py
+++ b/tests/trace_server_bindings/test_http_utils.py
@@ -10,10 +10,12 @@ from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 from weave.trace_server_bindings import http_utils
 from weave.trace_server_bindings.http_utils import (
     CallsCompleteModeRequired,
+    QueryTooExpensive,
     handle_response_error,
     process_batch_with_retry,
     retry_on_not_found,
 )
+from weave.utils.retry import _is_retryable_exception
 
 
 def test_413_splits_batch_and_retries():
@@ -55,6 +57,34 @@ def test_calls_complete_mode_required_raises():
 
     with pytest.raises(CallsCompleteModeRequired, match="calls_complete mode required"):
         handle_response_error(response, "/call/upsert_batch")
+
+
+def test_query_too_expensive_raises():
+    """Map a QUERY_TOO_EXPENSIVE error_code to the dedicated QueryTooExpensive error,
+    carrying the server's scope-narrowing guidance.
+    """
+    response = httpx.Response(
+        400,
+        json={
+            "error_code": "QUERY_TOO_EXPENSIVE",
+            "reason": (
+                "Query is too expensive to run on this dataset. Please limit the "
+                "scope of the query by including a date range and/or additional "
+                "filter criteria. "
+            ),
+        },
+        request=httpx.Request("POST", "http://example.com"),
+    )
+
+    with pytest.raises(QueryTooExpensive, match="limit the scope"):
+        handle_response_error(response, "/traces/calls/stream_query")
+
+
+def test_query_too_expensive_is_not_retryable():
+    """A too-expensive query is deterministically doomed, so the SDK must not retry it
+    (it is not an HTTPStatusError, which would otherwise default to retryable).
+    """
+    assert _is_retryable_exception(QueryTooExpensive("too expensive")) is False
 
 
 def _make_404(body: dict) -> httpx.HTTPStatusError:

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -297,6 +297,14 @@ def handle_response_error(response: httpx.Response, url: str) -> None:
         message = extracted_message or default_message or "Calls complete mode required"
         raise CallsCompleteModeRequired(message)
 
+    # A query the backend predicts is too expensive will fail again on retry, so
+    # surface it as a dedicated, non-retryable error carrying the server's guidance.
+    if error_code == ERROR_CODE_QUERY_TOO_EXPENSIVE:
+        message = (
+            extracted_message or default_message or "Query is too expensive to run"
+        )
+        raise QueryTooExpensive(message)
+
     # Combine messages
     if default_message and extracted_message:
         message = f"{default_message}:\n{extracted_message}"
@@ -410,11 +418,28 @@ def retry_on_not_found(func: Callable[P, R]) -> Callable[P, R]:
 # This matches the ErrorCode.CALLS_COMPLETE_MODE_REQUIRED from weave.trace_server.errors
 ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED = "CALLS_COMPLETE_MODE_REQUIRED"
 
+# Error code from server when a read query is too expensive to run (ClickHouse
+# TOO_SLOW projection guard / read caps). Matches ErrorCode.QUERY_TOO_EXPENSIVE.
+ERROR_CODE_QUERY_TOO_EXPENSIVE = "QUERY_TOO_EXPENSIVE"
+
 
 class CallsCompleteModeRequired(Exception):
     """Raised when a project requires calls_complete mode but SDK is using legacy mode.
 
     This exception triggers automatic mode switching in the SDK.
+    """
+
+    pass
+
+
+class QueryTooExpensive(Exception):
+    """Raised when the server rejects a read query as too expensive to run.
+
+    The server (ClickHouse TOO_SLOW projection guard / read caps) returns a 4xx
+    with error_code QUERY_TOO_EXPENSIVE. The query is deterministically doomed
+    for this dataset, so it is surfaced as a dedicated, non-retryable error
+    (weave.utils.retry._is_retryable_exception) carrying the server's
+    scope-narrowing guidance, rather than a raw HTTPStatusError.
     """
 
     pass

--- a/weave/utils/retry.py
+++ b/weave/utils/retry.py
@@ -101,11 +101,16 @@ def _is_retryable_exception(e: BaseException) -> bool:
     if isinstance(e, ValidationError):
         return False
 
-    # Don't retry CallsCompleteModeRequired - should trigger immediate mode switch
+    # Don't retry deterministic domain errors: a calls_complete mode switch should
+    # trigger an immediate mode change, and a query the backend rejected as too
+    # expensive will fail again on retry.
     # Lazy import to avoid circular dependency (http_utils imports from this module)
-    from weave.trace_server_bindings.http_utils import CallsCompleteModeRequired
+    from weave.trace_server_bindings.http_utils import (
+        CallsCompleteModeRequired,
+        QueryTooExpensive,
+    )
 
-    if isinstance(e, CallsCompleteModeRequired):
+    if isinstance(e, (CallsCompleteModeRequired, QueryTooExpensive)):
         return False
 
     # Don't retry on HTTP 4xx (except 429)


### PR DESCRIPTION
- Maps the server's `QUERY_TOO_EXPENSIVE` error_code to a dedicated, catchable `QueryTooExpensive` client exception (mirrors `CallsCompleteModeRequired`).
- Marks it non-retryable — a custom exception would otherwise default to retryable in `_is_retryable_exception`.