### PR TITLE
feat(weave): add env-gated row/byte read-scan caps to fail expensive queries fast

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_settings.py
+++ b/tests/trace_server/test_clickhouse_trace_server_settings.py
@@ -8,6 +8,8 @@ ENV_KEYS = [
     "WF_CLICKHOUSE_MAX_EXECUTION_TIME",
     "WF_CLICKHOUSE_MAX_ESTIMATED_EXECUTION_TIME",
     "WF_CLICKHOUSE_DISABLE_QUERY_FAILURE_PREDICTION",
+    "WF_CLICKHOUSE_MAX_ROWS_TO_READ",
+    "WF_CLICKHOUSE_MAX_BYTES_TO_READ",
 ]
 
 
@@ -83,3 +85,27 @@ def test_command_settings_skip_prediction_guards(monkeypatch, reload_settings):
     assert "max_estimated_execution_time" not in command_settings
     assert "timeout_before_checking_execution_speed" not in command_settings
     assert "timeout_overflow_mode" not in command_settings
+
+
+def test_read_scan_caps_apply_to_reads_not_commands(monkeypatch, reload_settings):
+    # Unset by default: no read-scan caps.
+    settings_module = reload_settings()
+    settings = settings_module.CLICKHOUSE_DEFAULT_QUERY_SETTINGS
+    assert "max_rows_to_read" not in settings
+    assert "max_bytes_to_read" not in settings
+    assert "read_overflow_mode" not in settings
+
+    # Configured caps apply to read queries and throw (not truncate) on overflow.
+    monkeypatch.setenv("WF_CLICKHOUSE_MAX_ROWS_TO_READ", "1000000")
+    monkeypatch.setenv("WF_CLICKHOUSE_MAX_BYTES_TO_READ", "2000000")
+    settings_module = reload_settings()
+    settings = settings_module.CLICKHOUSE_DEFAULT_QUERY_SETTINGS
+    assert settings["max_rows_to_read"] == 1000000
+    assert settings["max_bytes_to_read"] == 2000000
+    assert settings["read_overflow_mode"] == "throw"
+
+    # The caps are for read-query scans, not mutations.
+    command_settings = settings_module.CLICKHOUSE_DEFAULT_COMMAND_SETTINGS
+    assert "max_rows_to_read" not in command_settings
+    assert "max_bytes_to_read" not in command_settings
+    assert "read_overflow_mode" not in command_settings

--- a/tests/trace_server/test_errors.py
+++ b/tests/trace_server/test_errors.py
@@ -91,6 +91,28 @@ def test_clickhouse_too_slow_returns_400_with_error_code() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    "error_msg",
+    [
+        # Real ClickHouse messages captured from read-cap overflows (CH 25.12):
+        "Code: 158. DB::Exception: Limit for rows (controlled by 'max_rows_to_read' "
+        "setting) exceeded, max rows: 5.00, current rows: 100.00. (TOO_MANY_ROWS)",
+        "Code: 307. DB::Exception: Limit for rows or bytes to read exceeded, max "
+        "bytes: 16.00 B, current bytes: 511.01 KiB: While executing NumbersRange. "
+        "(TOO_MANY_BYTES)",
+    ],
+)
+def test_clickhouse_read_scan_cap_returns_400(error_msg: str) -> None:
+    """The read-scan caps (max_rows_to_read / max_bytes_to_read) abort with
+    TOO_MANY_ROWS (158) / TOO_MANY_BYTES (307); like TOO_SLOW it's a too-broad query
+    -> 400, classified as the same QueryTooExpensiveError.
+    """
+    exc = CHDatabaseError(error_msg)
+
+    with pytest.raises(QueryTooExpensiveError, match="limit the scope"):
+        handle_clickhouse_query_error(exc)
+
+
 def test_invalid_field_error_maps_to_422() -> None:
     """Unsupported/unselectable fields are well-formed but unprocessable input -> 422,
     not 403 (Forbidden, which implies an authz failure) or 500.

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -72,6 +72,11 @@ _max_estimated_execution_time = (
 _disable_query_failure_prediction = (
     wf_env.wf_clickhouse_disable_query_failure_prediction()
 )
+# Optional hard caps on how much data a single read query may scan. Unset by
+# default; operators opt in per deployment to fail very large scans fast, at
+# planning time -- before (and independent of) the estimated-time guard.
+_max_rows_to_read = wf_env.wf_clickhouse_max_rows_to_read()
+_max_bytes_to_read = wf_env.wf_clickhouse_max_bytes_to_read()
 
 CLICKHOUSE_BASE_QUERY_SETTINGS: dict[str, int | str] = {
     "max_memory_usage": wf_env.wf_clickhouse_max_memory_usage()
@@ -94,11 +99,23 @@ if not _disable_query_failure_prediction:
         }
     )
 
-# Read paths get query failure prediction. Command paths use the base settings
-# because the prediction guard is intended for read-query scans, not mutations.
+# Read-scan caps abort a read that would exceed them with TOO_MANY_ROWS (code 158)
+# or TOO_MANY_BYTES (code 307). 'throw' (the ClickHouse default) aborts rather than
+# silently truncating results.
+CLICKHOUSE_READ_SCAN_CAP_SETTINGS: dict[str, int | str] = {}
+if _max_rows_to_read is not None:
+    CLICKHOUSE_READ_SCAN_CAP_SETTINGS["max_rows_to_read"] = _max_rows_to_read
+if _max_bytes_to_read is not None:
+    CLICKHOUSE_READ_SCAN_CAP_SETTINGS["max_bytes_to_read"] = _max_bytes_to_read
+if CLICKHOUSE_READ_SCAN_CAP_SETTINGS:
+    CLICKHOUSE_READ_SCAN_CAP_SETTINGS["read_overflow_mode"] = "throw"
+
+# Read paths get the prediction guard and read-scan caps. Command paths use the
+# base settings -- these guards are for read-query scans, not mutations.
 CLICKHOUSE_DEFAULT_QUERY_SETTINGS: dict[str, int | str] = {
     **CLICKHOUSE_BASE_QUERY_SETTINGS,
     **CLICKHOUSE_QUERY_FAILURE_PREDICTION_SETTINGS,
+    **CLICKHOUSE_READ_SCAN_CAP_SETTINGS,
 }
 CLICKHOUSE_DEFAULT_COMMAND_SETTINGS = CLICKHOUSE_BASE_QUERY_SETTINGS
 

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -365,6 +365,38 @@ def wf_clickhouse_max_estimated_execution_time() -> int | None:
         return None
 
 
+def wf_clickhouse_max_rows_to_read() -> int | None:
+    """Hard cap on rows a single read query may scan (ClickHouse max_rows_to_read).
+
+    Unset by default. When set, ClickHouse aborts a read that would exceed it
+    with TOO_MANY_ROWS (code 158), failing very large scans at planning time --
+    before (and independent of) the estimated-time projection guard.
+    """
+    rows = os.environ.get("WF_CLICKHOUSE_MAX_ROWS_TO_READ")
+    if rows is None:
+        return None
+    try:
+        return int(rows)
+    except ValueError:
+        logger.exception("WF_CLICKHOUSE_MAX_ROWS_TO_READ value '%s' is not valid", rows)
+        return None
+
+
+def wf_clickhouse_max_bytes_to_read() -> int | None:
+    """Hard cap on bytes a single read query may scan (ClickHouse max_bytes_to_read).
+
+    Unset by default; see wf_clickhouse_max_rows_to_read.
+    """
+    val = os.environ.get("WF_CLICKHOUSE_MAX_BYTES_TO_READ")
+    if val is None:
+        return None
+    try:
+        return int(val)
+    except ValueError:
+        logger.exception("WF_CLICKHOUSE_MAX_BYTES_TO_READ value '%s' is not valid", val)
+        return None
+
+
 def wf_clickhouse_disable_query_failure_prediction() -> bool:
     """Whether to disable ClickHouse estimated-time query failure prediction."""
     return (

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -137,7 +137,8 @@ class QueryTooExpensiveError(Error):
 
     Covers ClickHouse's pre-emptive scan guards: the estimated-time projection
     guard (code 160, TOO_SLOW) and, when configured, the row/byte read caps
-    (TOO_MANY_ROWS_OR_BYTES). The query is well-formed but would scan too much
+    (code 158 TOO_MANY_ROWS / code 307 TOO_MANY_BYTES). The query is well-formed
+    but would scan too much
     data; the outcome is deterministic for a given query + dataset, so it is a
     4xx the client must fix by narrowing scope -- never a 5xx the SDK retries.
 
@@ -472,6 +473,14 @@ def handle_clickhouse_query_error(e: Exception) -> None:
         # won't retry), not a generic DatabaseError 502 it would retry in vain.
         raise QueryTooExpensiveError(
             "Query is too expensive to run on this dataset. " + limit_scope_message
+        ) from e
+    if "TOO_MANY_ROWS" in error_str or "TOO_MANY_BYTES" in error_str:
+        # ClickHouse's read-scan caps (max_rows_to_read / max_bytes_to_read) abort
+        # a query that would scan past the configured limit -- code 158 (TOO_MANY_ROWS)
+        # or 307 (TOO_MANY_BYTES). Same story as TOO_SLOW: deterministic for a given
+        # query + dataset, so a 4xx to fix by narrowing, not a retried 502.
+        raise QueryTooExpensiveError(
+            "Query would scan too much data to run. " + limit_scope_message
         ) from e
     if "NO_COMMON_TYPE" in error_str:
         raise QueryNoCommonTypeError(


### PR DESCRIPTION
- Adds `WF_CLICKHOUSE_MAX_ROWS_TO_READ` / `WF_CLICKHOUSE_MAX_BYTES_TO_READ` (unset by default).
- When set, read queries abort an over-large scan at planning time (`read_overflow_mode=throw`) — faster and cheaper than the estimated-time guard.
- Classifies the resulting `TOO_MANY_ROWS_OR_BYTES` as `QueryTooExpensiveError` (400), reusing the #7412 path.