### PR TITLE
feat(weave_ts): Add `WeaveClient.getAgentSpanStats`

### DIFF
--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_bucketed_by_time_granularity.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_bucketed_by_time_granularity.yaml
@@ -1,0 +1,66 @@
+- request:
+    url: https://trace.wandb.ai/health
+    method: GET
+    headers:
+      authorization: masked
+      user-agent: W&B Weave JS Client unknown
+    body: ""
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "15"
+      content-type: application/json
+      date: Fri, 26 Jun 2026 15:04:11 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"status":"ok"}'
+- request:
+    url: https://api.wandb.ai/graphql
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: Weave JS Client 0.15.1
+    body: '{"query":"\nquery DefaultEntity {\n    viewer
+      {\n        username\n        defaultEntity
+      {\n            name\n        }\n    }\n}\n","variables":{}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-encoding: br
+      content-length: "69"
+      content-type: application/json; charset=utf-8
+      date: Fri, 26 Jun 2026 15:04:12 GMT
+      ratelimit-limit: "1000"
+      ratelimit-remaining: "1000"
+      vary: Origin
+      via: 1.1 google
+      x-content-type-options: nosniff
+      x-ratelimit-limit: "1000"
+      x-ratelimit-remaining: "1000"
+      x-wandb-trace-id: 23d9088f538720ee133349250535dd1f
+    body: '{"data":{"viewer":{"username":"drtangible","defaultEntity":{"name":"drtangible-mocha"}}}}'
+- request:
+    url: https://trace.wandb.ai/agents/spans/stats
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+      x-weave-client-capabilities: trace_id_on_end,eval_child_meta
+    body: '{"project_id":"drtangible-mocha/example","start":"2026-06-10T00:00:00Z","end":"2026-06-23T00:00:00Z","metrics":[{"alias":"span_count","value_type":"string","aggregations":["count"],"value":{"source":"field","key":"span_id"}}],"granularity":86400}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "1088"
+      content-type: application/json
+      date: Fri, 26 Jun 2026 15:04:11 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"start":"2026-06-10T00:00:00Z","end":"2026-06-23T00:00:00Z","granularity":86400,"timezone":"UTC","bucket_type":"time","columns":[{"name":"timestamp","role":"time","value_type":"datetime","metric":null,"aggregation":null},{"name":"count_span_count","role":"metric","value_type":"number","metric":"span_count","aggregation":"count"}],"rows":[{"timestamp":"2026-06-10T00:00:00","count_span_count":15},{"timestamp":"2026-06-11T00:00:00","count_span_count":0},{"timestamp":"2026-06-12T00:00:00","count_span_count":0},{"timestamp":"2026-06-13T00:00:00","count_span_count":0},{"timestamp":"2026-06-14T00:00:00","count_span_count":0},{"timestamp":"2026-06-15T00:00:00","count_span_count":111},{"timestamp":"2026-06-16T00:00:00","count_span_count":20},{"timestamp":"2026-06-17T00:00:00","count_span_count":0},{"timestamp":"2026-06-18T00:00:00","count_span_count":9},{"timestamp":"2026-06-19T00:00:00","count_span_count":0},{"timestamp":"2026-06-20T00:00:00","count_span_count":0},{"timestamp":"2026-06-21T00:00:00","count_span_count":0},{"timestamp":"2026-06-22T00:00:00","count_span_count":27}]}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_errors_with_invalid_project_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_errors_with_invalid_project_id.yaml
@@ -1,0 +1,68 @@
+- request:
+    url: https://trace.wandb.ai/health
+    method: GET
+    headers:
+      authorization: masked
+      user-agent: W&B Weave JS Client unknown
+    body: ""
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "15"
+      content-type: application/json
+      date: Fri, 26 Jun 2026 15:04:12 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"status":"ok"}'
+- request:
+    url: https://api.wandb.ai/graphql
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: Weave JS Client 0.15.1
+    body: '{"query":"\nquery DefaultEntity {\n    viewer
+      {\n        username\n        defaultEntity
+      {\n            name\n        }\n    }\n}\n","variables":{}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-encoding: br
+      content-length: "69"
+      content-type: application/json; charset=utf-8
+      date: Fri, 26 Jun 2026 15:04:12 GMT
+      ratelimit-limit: "1000"
+      ratelimit-remaining: "1000"
+      vary: Origin
+      via: 1.1 google
+      x-content-type-options: nosniff
+      x-ratelimit-limit: "1000"
+      x-ratelimit-remaining: "1000"
+      x-wandb-trace-id: bb87ba12f3301e32e86dd68f89298b88
+    body: '{"data":{"viewer":{"username":"drtangible","defaultEntity":{"name":"drtangible-mocha"}}}}'
+- request:
+    url: https://trace.wandb.ai/agents/spans/stats
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+      x-weave-client-capabilities: trace_id_on_end,eval_child_meta
+    body: '{"project_id":"drtangible-mocha/nonexistent-project","start":"2026-06-10T00:00:00Z","end":"2026-06-23T00:00:00Z"}'
+  response:
+    status: 422
+    statusText: unknown
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "244"
+      content-type: application/json
+      date: Fri, 26 Jun 2026 15:04:12 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"detail":[{"type":"value_error","loc":["body"],"msg":"Value error, at
+      least one metric is
+      required","input":{"project_id":"drtangible-mocha/nonexistent-project","start":"2026-06-10T00:00:00Z","end":"2026-06-23T00:00:00Z"},"ctx":{"error":{}}}]}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_gets_span_stats_over_a_time_window.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_gets_span_stats_over_a_time_window.yaml
@@ -1,0 +1,66 @@
+- request:
+    url: https://trace.wandb.ai/health
+    method: GET
+    headers:
+      authorization: masked
+      user-agent: W&B Weave JS Client unknown
+    body: ""
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "15"
+      content-type: application/json
+      date: Fri, 26 Jun 2026 15:04:11 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"status":"ok"}'
+- request:
+    url: https://api.wandb.ai/graphql
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: Weave JS Client 0.15.1
+    body: '{"query":"\nquery DefaultEntity {\n    viewer
+      {\n        username\n        defaultEntity
+      {\n            name\n        }\n    }\n}\n","variables":{}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-encoding: br
+      content-length: "69"
+      content-type: application/json; charset=utf-8
+      date: Fri, 26 Jun 2026 15:04:12 GMT
+      ratelimit-limit: "1000"
+      ratelimit-remaining: "1000"
+      vary: Origin
+      via: 1.1 google
+      x-content-type-options: nosniff
+      x-ratelimit-limit: "1000"
+      x-ratelimit-remaining: "1000"
+      x-wandb-trace-id: 1bf0c9a779b34abbf54aba79cc4236dd
+    body: '{"data":{"viewer":{"username":"drtangible","defaultEntity":{"name":"drtangible-mocha"}}}}'
+- request:
+    url: https://trace.wandb.ai/agents/spans/stats
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+      x-weave-client-capabilities: trace_id_on_end,eval_child_meta
+    body: '{"project_id":"drtangible-mocha/example","start":"2026-06-10T00:00:00Z","end":"2026-06-23T00:00:00Z","metrics":[{"alias":"total_input_tokens","value_type":"number","aggregations":["sum"],"value":{"source":"field","key":"input_tokens"}}]}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "2052"
+      content-type: application/json
+      date: Fri, 26 Jun 2026 15:04:11 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"start":"2026-06-10T00:00:00Z","end":"2026-06-23T00:00:00Z","granularity":43200,"timezone":"UTC","bucket_type":"time","columns":[{"name":"timestamp","role":"time","value_type":"datetime","metric":null,"aggregation":null},{"name":"sum_total_input_tokens","role":"metric","value_type":"number","metric":"total_input_tokens","aggregation":"sum"}],"rows":[{"timestamp":"2026-06-10T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-10T12:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-11T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-11T12:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-12T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-12T12:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-13T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-13T12:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-14T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-14T12:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-15T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-15T12:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-16T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-16T12:00:00","sum_total_input_tokens":2030.0},{"timestamp":"2026-06-17T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-17T12:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-18T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-18T12:00:00","sum_total_input_tokens":951.0},{"timestamp":"2026-06-19T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-19T12:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-20T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-20T12:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-21T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-21T12:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-22T00:00:00","sum_total_input_tokens":0.0},{"timestamp":"2026-06-22T12:00:00","sum_total_input_tokens":2853.0}]}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_returns_empty_rows_for_a_window_with_no_data.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_returns_empty_rows_for_a_window_with_no_data.yaml
@@ -1,0 +1,66 @@
+- request:
+    url: https://trace.wandb.ai/health
+    method: GET
+    headers:
+      authorization: masked
+      user-agent: W&B Weave JS Client unknown
+    body: ""
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "15"
+      content-type: application/json
+      date: Fri, 26 Jun 2026 15:04:12 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"status":"ok"}'
+- request:
+    url: https://api.wandb.ai/graphql
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: Weave JS Client 0.15.1
+    body: '{"query":"\nquery DefaultEntity {\n    viewer
+      {\n        username\n        defaultEntity
+      {\n            name\n        }\n    }\n}\n","variables":{}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-encoding: br
+      content-length: "69"
+      content-type: application/json; charset=utf-8
+      date: Fri, 26 Jun 2026 15:04:12 GMT
+      ratelimit-limit: "1000"
+      ratelimit-remaining: "1000"
+      vary: Origin
+      via: 1.1 google
+      x-content-type-options: nosniff
+      x-ratelimit-limit: "1000"
+      x-ratelimit-remaining: "1000"
+      x-wandb-trace-id: f01a34a098537eee53486272706edf7b
+    body: '{"data":{"viewer":{"username":"drtangible","defaultEntity":{"name":"drtangible-mocha"}}}}'
+- request:
+    url: https://trace.wandb.ai/agents/spans/stats
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+      x-weave-client-capabilities: trace_id_on_end,eval_child_meta
+    body: '{"project_id":"drtangible-mocha/example","start":"2000-01-01T00:00:00Z","end":"2000-01-02T00:00:00Z","metrics":[{"alias":"span_count","value_type":"string","aggregations":["count"],"value":{"source":"field","key":"span_id"}}]}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "570"
+      content-type: application/json
+      date: Fri, 26 Jun 2026 15:04:11 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"start":"2000-01-01T00:00:00Z","end":"2000-01-02T00:00:00Z","granularity":21600,"timezone":"UTC","bucket_type":"time","columns":[{"name":"timestamp","role":"time","value_type":"datetime","metric":null,"aggregation":null},{"name":"count_span_count","role":"metric","value_type":"number","metric":"span_count","aggregation":"count"}],"rows":[{"timestamp":"2000-01-01T00:00:00","count_span_count":0},{"timestamp":"2000-01-01T06:00:00","count_span_count":0},{"timestamp":"2000-01-01T12:00:00","count_span_count":0},{"timestamp":"2000-01-01T18:00:00","count_span_count":0}]}'

--- a/sdks/node/src/__tests__/live/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/live/weaveClient.test.ts
@@ -1539,4 +1539,336 @@ describe('WeaveClient', () => {
       });
     });
   });
+
+  describe('getAgentSpanStats', () => {
+    vcrTest('gets span stats over a time window', async () => {
+      await authenticate();
+      const client = await init('example');
+      const resp = await client.getAgentSpanStats({
+        start: '2026-06-10T00:00:00Z',
+        end: '2026-06-23T00:00:00Z',
+        metrics: [
+          {
+            alias: 'total_input_tokens',
+            value_type: 'number',
+            aggregations: ['sum'],
+            value: {source: 'field', key: 'input_tokens'},
+          },
+        ],
+      });
+      expect(resp.data).toMatchInlineSnapshot(`
+        {
+          "bucket_type": "time",
+          "columns": [
+            {
+              "aggregation": null,
+              "metric": null,
+              "name": "timestamp",
+              "role": "time",
+              "value_type": "datetime",
+            },
+            {
+              "aggregation": "sum",
+              "metric": "total_input_tokens",
+              "name": "sum_total_input_tokens",
+              "role": "metric",
+              "value_type": "number",
+            },
+          ],
+          "end": "2026-06-23T00:00:00Z",
+          "granularity": 43200,
+          "rows": [
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-10T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-10T12:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-11T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-11T12:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-12T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-12T12:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-13T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-13T12:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-14T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-14T12:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-15T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-15T12:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-16T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 2030,
+              "timestamp": "2026-06-16T12:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-17T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-17T12:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-18T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 951,
+              "timestamp": "2026-06-18T12:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-19T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-19T12:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-20T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-20T12:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-21T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-21T12:00:00",
+            },
+            {
+              "sum_total_input_tokens": 0,
+              "timestamp": "2026-06-22T00:00:00",
+            },
+            {
+              "sum_total_input_tokens": 2853,
+              "timestamp": "2026-06-22T12:00:00",
+            },
+          ],
+          "start": "2026-06-10T00:00:00Z",
+          "timezone": "UTC",
+        }
+      `);
+    });
+
+    vcrTest('bucketed by time granularity', async () => {
+      await authenticate();
+      const client = await init('example');
+      const resp = await client.getAgentSpanStats({
+        start: '2026-06-10T00:00:00Z',
+        end: '2026-06-23T00:00:00Z',
+        granularity: 86400,
+        metrics: [
+          {
+            alias: 'span_count',
+            value_type: 'string',
+            aggregations: ['count'],
+            value: {source: 'field', key: 'span_id'},
+          },
+        ],
+      });
+      expect(resp.data).toMatchInlineSnapshot(`
+        {
+          "bucket_type": "time",
+          "columns": [
+            {
+              "aggregation": null,
+              "metric": null,
+              "name": "timestamp",
+              "role": "time",
+              "value_type": "datetime",
+            },
+            {
+              "aggregation": "count",
+              "metric": "span_count",
+              "name": "count_span_count",
+              "role": "metric",
+              "value_type": "number",
+            },
+          ],
+          "end": "2026-06-23T00:00:00Z",
+          "granularity": 86400,
+          "rows": [
+            {
+              "count_span_count": 15,
+              "timestamp": "2026-06-10T00:00:00",
+            },
+            {
+              "count_span_count": 0,
+              "timestamp": "2026-06-11T00:00:00",
+            },
+            {
+              "count_span_count": 0,
+              "timestamp": "2026-06-12T00:00:00",
+            },
+            {
+              "count_span_count": 0,
+              "timestamp": "2026-06-13T00:00:00",
+            },
+            {
+              "count_span_count": 0,
+              "timestamp": "2026-06-14T00:00:00",
+            },
+            {
+              "count_span_count": 111,
+              "timestamp": "2026-06-15T00:00:00",
+            },
+            {
+              "count_span_count": 20,
+              "timestamp": "2026-06-16T00:00:00",
+            },
+            {
+              "count_span_count": 0,
+              "timestamp": "2026-06-17T00:00:00",
+            },
+            {
+              "count_span_count": 9,
+              "timestamp": "2026-06-18T00:00:00",
+            },
+            {
+              "count_span_count": 0,
+              "timestamp": "2026-06-19T00:00:00",
+            },
+            {
+              "count_span_count": 0,
+              "timestamp": "2026-06-20T00:00:00",
+            },
+            {
+              "count_span_count": 0,
+              "timestamp": "2026-06-21T00:00:00",
+            },
+            {
+              "count_span_count": 27,
+              "timestamp": "2026-06-22T00:00:00",
+            },
+          ],
+          "start": "2026-06-10T00:00:00Z",
+          "timezone": "UTC",
+        }
+      `);
+    });
+
+    vcrTest('returns empty rows for a window with no data', async () => {
+      await authenticate();
+      const client = await init('example');
+      const resp = await client.getAgentSpanStats({
+        start: '2000-01-01T00:00:00Z',
+        end: '2000-01-02T00:00:00Z',
+        metrics: [
+          {
+            alias: 'span_count',
+            value_type: 'string',
+            aggregations: ['count'],
+            value: {source: 'field', key: 'span_id'},
+          },
+        ],
+      });
+      expect(resp.data).toMatchInlineSnapshot(`
+        {
+          "bucket_type": "time",
+          "columns": [
+            {
+              "aggregation": null,
+              "metric": null,
+              "name": "timestamp",
+              "role": "time",
+              "value_type": "datetime",
+            },
+            {
+              "aggregation": "count",
+              "metric": "span_count",
+              "name": "count_span_count",
+              "role": "metric",
+              "value_type": "number",
+            },
+          ],
+          "end": "2000-01-02T00:00:00Z",
+          "granularity": 21600,
+          "rows": [
+            {
+              "count_span_count": 0,
+              "timestamp": "2000-01-01T00:00:00",
+            },
+            {
+              "count_span_count": 0,
+              "timestamp": "2000-01-01T06:00:00",
+            },
+            {
+              "count_span_count": 0,
+              "timestamp": "2000-01-01T12:00:00",
+            },
+            {
+              "count_span_count": 0,
+              "timestamp": "2000-01-01T18:00:00",
+            },
+          ],
+          "start": "2000-01-01T00:00:00Z",
+          "timezone": "UTC",
+        }
+      `);
+    });
+
+    vcrTest('errors with invalid project id', async () => {
+      await authenticate();
+      const client = await init('nonexistent-project');
+
+      expect(
+        client.getAgentSpanStats({
+          start: '2026-06-10T00:00:00Z',
+          end: '2026-06-23T00:00:00Z',
+          metrics: [
+            {
+              alias: 'total_input_tokens',
+              value_type: 'number',
+              aggregations: ['sum'],
+              value: {source: 'field', key: 'input_tokens'},
+            },
+          ],
+        })
+      ).rejects.toMatchObject({
+        data: null,
+        error: {
+          detail: 'Project not found',
+        },
+      });
+    });
+  });
 });

--- a/sdks/node/src/__tests__/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.test.ts
@@ -41,6 +41,7 @@ type MockedTraceServer = jest.Mocked<TraceServerApi<any>> & {
     genaiAgentVersionsQueryAgentsAgentVersionsQueryPost: jest.Mock;
     genaiSearchAgentsSearchPost: jest.Mock;
     genaiSpansQueryAgentsSpansQueryPost: jest.Mock;
+    genaiSpansStatsAgentsSpansStatsPost: jest.Mock;
     genaiTracesChatAgentsTracesChatPost: jest.Mock;
     genaiConversationChatAgentsConversationsChatPost: jest.Mock;
   };
@@ -60,6 +61,7 @@ describe('WeaveClient', () => {
         genaiAgentVersionsQueryAgentsAgentVersionsQueryPost: jest.fn(),
         genaiSearchAgentsSearchPost: jest.fn(),
         genaiSpansQueryAgentsSpansQueryPost: jest.fn(),
+        genaiSpansStatsAgentsSpansStatsPost: jest.fn(),
         genaiTracesChatAgentsTracesChatPost: jest.fn(),
         genaiConversationChatAgentsConversationsChatPost: jest.fn(),
       },
@@ -540,6 +542,97 @@ describe('WeaveClient', () => {
       );
 
       await expect(client.getAgentSpans({})).rejects.toThrow('boom');
+    });
+  });
+
+  describe('getAgentSpanStats', () => {
+    it('gets agent span stats from the server', async () => {
+      const stats = {
+        start: '2026-06-10T00:00:00Z',
+        end: '2026-06-23T00:00:00Z',
+        granularity: 86400,
+        timezone: 'UTC',
+        bucket_type: 'time',
+        columns: [
+          {name: 'started_at_bucket', role: 'time', value_type: 'datetime'},
+          {
+            name: 'total_input_tokens',
+            role: 'metric',
+            value_type: 'number',
+            metric: 'total_input_tokens',
+            aggregation: 'sum',
+          },
+        ],
+        rows: [{started_at_bucket: '2026-06-10T00:00:00Z', total_input_tokens: 450}],
+      };
+      mockTraceServerApi.agents.genaiSpansStatsAgentsSpansStatsPost.mockResolvedValue(
+        {data: stats} as any
+      );
+
+      const metrics = [
+        {
+          alias: 'total_input_tokens',
+          value_type: 'number' as const,
+          aggregations: ['sum' as const],
+          value: {source: 'field' as const, key: 'input_tokens'},
+        },
+      ];
+      const groupBy = [{key: 'agent_name'}];
+      const query = {
+        $expr: {
+          $eq: [{$getField: 'provider_name'}, {$literal: 'openai'}],
+        },
+      };
+
+      const result = await client.getAgentSpanStats({
+        start: '2026-06-10T00:00:00Z',
+        end: '2026-06-23T00:00:00Z',
+        metrics,
+        groupBy,
+        query,
+        granularity: 86400,
+        timezone: 'America/Los_Angeles',
+      });
+
+      expect(
+        mockTraceServerApi.agents.genaiSpansStatsAgentsSpansStatsPost
+      ).toHaveBeenCalledWith({
+        project_id: 'test-project',
+        start: '2026-06-10T00:00:00Z',
+        end: '2026-06-23T00:00:00Z',
+        metrics,
+        group_by: groupBy,
+        query,
+        granularity: 86400,
+        timezone: 'America/Los_Angeles',
+      });
+
+      expect(result).toEqual({data: stats});
+    });
+
+    it('fetches without optional fields', async () => {
+      mockTraceServerApi.agents.genaiSpansStatsAgentsSpansStatsPost.mockResolvedValue(
+        {data: {start: '', end: '', timezone: 'UTC'}} as any
+      );
+
+      await client.getAgentSpanStats({start: '2026-06-10T00:00:00Z'});
+
+      expect(
+        mockTraceServerApi.agents.genaiSpansStatsAgentsSpansStatsPost
+      ).toHaveBeenCalledWith({
+        project_id: 'test-project',
+        start: '2026-06-10T00:00:00Z',
+      });
+    });
+
+    it('propagates errors from the underlying API', async () => {
+      mockTraceServerApi.agents.genaiSpansStatsAgentsSpansStatsPost.mockRejectedValue(
+        new Error('boom')
+      );
+
+      await expect(
+        client.getAgentSpanStats({start: '2026-06-10T00:00:00Z'})
+      ).rejects.toThrow('boom');
     });
   });
 

--- a/sdks/node/src/__tests__/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.test.ts
@@ -563,7 +563,9 @@ describe('WeaveClient', () => {
             aggregation: 'sum',
           },
         ],
-        rows: [{started_at_bucket: '2026-06-10T00:00:00Z', total_input_tokens: 450}],
+        rows: [
+          {started_at_bucket: '2026-06-10T00:00:00Z', total_input_tokens: 450},
+        ],
       };
       mockTraceServerApi.agents.genaiSpansStatsAgentsSpansStatsPost.mockResolvedValue(
         {data: stats} as any

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -25,6 +25,9 @@ import type {
   Api as TraceServerApi,
   HttpResponse,
   HTTPValidationError,
+  AgentGroupByRef,
+  AgentSpanStatsMetricSpec,
+  AgentSpanStatsColumn,
 } from './generated/traceServerApi';
 import {
   type AudioType,
@@ -175,6 +178,35 @@ export interface GetAgentSpansOptions {
 export type GetAgentSpansResult = {
   spans: AgentSpan[];
   total_count?: number;
+};
+
+/**
+ * Options for {@link WeaveClient.getAgentSpanStats}.
+ */
+export interface GetAgentSpanStatsOptions {
+  start: string;
+  end?: string | null;
+  metrics?: AgentSpanStatsMetricSpec[];
+  query?: Query | null;
+  groupBy?: AgentGroupByRef[];
+  granularity?: number | null;
+  /**
+   * @default "UTC"
+   */
+  timezone?: string;
+}
+
+/**
+ * Result shape returned by {@link WeaveClient.getAgentSpanStats}.
+ */
+export type GetAgentSpanStatsResult = {
+  start: string;
+  end: string;
+  granularity?: number | null;
+  timezone: string;
+  bucket_type?: 'time' | 'number';
+  columns?: AgentSpanStatsColumn[];
+  rows?: Record<string, string | number | boolean | null>[];
 };
 
 /**
@@ -491,6 +523,55 @@ export class WeaveClient {
         spans: resp.data.spans ?? [],
       },
     };
+  }
+
+  /**
+   * Agregations over agent spans in the project, returned as rows + column
+   * metadata suitable for time-series / bucketed visualizations.
+   *
+   * `start` (required) and `end` define the time window. Each entry in
+   * `metrics` declares a field to extract and how to aggregate it (`sum`,
+   * `avg`, `count`, percentiles, etc.). Pass `granularity` (seconds) to
+   * bucket rows by time, or `groupBy` to break results out per agent /
+   * provider / model / etc. `query` filters the underlying spans before
+   * aggregation.
+   *
+   * @example
+   * ```ts
+   * const client = await weave.init('entity/project');
+   * const resp = await client.getAgentSpanStats({
+   *   start: '2026-06-10T00:00:00Z',
+   *   end: '2026-06-23T00:00:00Z',
+   *   granularity: 86400, // one row per day
+   *   metrics: [
+   *     {
+   *       alias: 'total_input_tokens',
+   *       value_type: 'number',
+   *       aggregations: ['sum'],
+   *       value: {source: 'field', key: 'input_tokens'},
+   *     },
+   *   ],
+   *   groupBy: [{key: 'agent_name'}],
+   * });
+   *
+   * for (const row of resp.data.rows ?? []) {
+   *   console.log(row.started_at_bucket, row.agent_name, row.total_input_tokens);
+   * }
+   * ```
+   */
+  public async getAgentSpanStats(
+    options: GetAgentSpanStatsOptions
+  ): Promise<Response<GetAgentSpanStatsResult>> {
+    return this.traceServerApi.agents.genaiSpansStatsAgentsSpansStatsPost({
+      project_id: this.projectId,
+      start: options.start,
+      end: options.end,
+      metrics: options.metrics,
+      query: options.query,
+      group_by: options.groupBy,
+      granularity: options.granularity,
+      timezone: options.timezone,
+    });
   }
 
   /**


### PR DESCRIPTION
## Description

* Adds `getAgentSpanStats` to the TS SDK, to mirror API added to the Python SDK here (https://github.com/wandb/weave/pull/7384)
