### PR TITLE
feat(weave): add $containsToken query operator

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1609,6 +1609,10 @@ def test_trace_call_filter_contains_token(client):
     for text in ["the example row", "examples", "Example"]:
         token_op({"str": text})
 
+    calls = list(client.get_calls())
+    # Attach a multi-value note feedback to exercise the array-feedback path.
+    calls[0].feedback.add_note("review needed")
+
     def count(query):
         res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq.model_validate(
@@ -1645,6 +1649,29 @@ def test_trace_call_filter_contains_token(client):
             }
         )
         == 2
+    )
+    # Multi-value feedback: token match over the note array.
+    assert (
+        count(
+            {
+                "$containsToken": {
+                    "input": {"$getField": "feedback.[wandb.note.1].payload.note"},
+                    "substr": {"$literal": "review"},
+                }
+            }
+        )
+        == 1
+    )
+    assert (
+        count(
+            {
+                "$containsToken": {
+                    "input": {"$getField": "feedback.[wandb.note.1].payload.note"},
+                    "substr": {"$literal": "missing"},
+                }
+            }
+        )
+        == 0
     )
 
 

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1601,6 +1601,53 @@ def test_trace_call_filter(client):
         )
 
 
+def test_trace_call_filter_contains_token(client):
+    @weave.op
+    def token_op(in_val: dict) -> dict:
+        return in_val
+
+    for text in ["the example row", "examples", "Example"]:
+        token_op({"str": text})
+
+    def count(query):
+        res = get_client_trace_server(client).calls_query(
+            tsi.CallsQueryReq.model_validate(
+                {
+                    "project_id": get_client_project_id(client),
+                    "query": {"$expr": query},
+                }
+            )
+        )
+        return len(res.calls)
+
+    # Whole-token match: "example" is a token of "the example row" only.
+    # "examples" is a different token, "Example" differs by case.
+    assert (
+        count(
+            {
+                "$containsToken": {
+                    "input": {"$getField": "inputs.in_val.str"},
+                    "substr": {"$literal": "example"},
+                }
+            }
+        )
+        == 1
+    )
+    # Case-insensitive also matches "Example".
+    assert (
+        count(
+            {
+                "$containsToken": {
+                    "input": {"$getField": "inputs.in_val.str"},
+                    "substr": {"$literal": "example"},
+                    "case_insensitive": True,
+                }
+            }
+        )
+        == 2
+    )
+
+
 def test_ops_with_default_params(client):
     @weave.op
     def op_with_default(a: int, b: int = 10) -> int:

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -711,6 +711,33 @@ def test_agent_monitor_feedback_filters(client: WeaveClient) -> None:
     )
     assert {m["weave_ref"].rsplit("/", 1)[-1] for m in matches} == {"a", "upper"}
 
+    # $containsToken on scorer_tags also uses array membership (whole-token).
+    matches = _query(
+        {
+            "$expr": {
+                "$containsToken": {
+                    "input": {"$getField": "scorer_tags"},
+                    "substr": {"$literal": "nsfw"},
+                }
+            }
+        }
+    )
+    assert {m["weave_ref"].rsplit("/", 1)[-1] for m in matches} == {"a"}
+
+    # Case-insensitive $containsToken matches the upper-cased tag too.
+    matches = _query(
+        {
+            "$expr": {
+                "$containsToken": {
+                    "input": {"$getField": "scorer_tags"},
+                    "substr": {"$literal": "nsfw"},
+                    "case_insensitive": True,
+                }
+            }
+        }
+    )
+    assert {m["weave_ref"].rsplit("/", 1)[-1] for m in matches} == {"a", "upper"}
+
     # Map value lookup with numeric comparison.
     matches = _query(
         {

--- a/tests/trace/test_saved_view.py
+++ b/tests/trace/test_saved_view.py
@@ -6,13 +6,17 @@ import weave
 from weave.flow.saved_view import (
     Filter,
     Filters,
+    QueryTranslationException,
     filter_to_clause,
     filters_to_query,
+    operand_to_filter,
+    operand_to_filter_contains_token,
     query_to_filters,
     to_seconds,
 )
 from weave.trace.api import ObjectRef
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.interface import query as tsi_query
 
 
 def test_to_seconds():
@@ -99,6 +103,8 @@ def test_query_to_filters_multiple_filters():
 def test_roundtrip_operators():
     cases: Filters = [
         Filter(field="test", operator="(string): contains", value="foo"),
+        Filter(field="test", operator="(string): containsWord", value="foo"),
+        Filter(field="test", operator="(string): notContainsWord", value="foo"),
         Filter(field="test", operator="(string): equals", value="foo"),
         Filter(field="test", operator="(string): in", value=["A", "B", "C"]),
         Filter(field="test", operator="(number): =", value=42),
@@ -123,6 +129,85 @@ def test_roundtrip_operators():
         query = filters_to_query(filters)
         filters2 = query_to_filters(query)
         assert filters == filters2
+
+
+def test_contains_token_operand_filter_round_trip():
+    """$containsToken maps to the locked frontend grid operator and back."""
+    operand = tsi_query.ContainsTokenOperation.model_validate(
+        {
+            "$containsToken": {
+                "input": {"$getField": "inputs.model"},
+                "substr": {"$literal": "gpt"},
+                "case_insensitive": False,
+            }
+        }
+    )
+
+    filter = operand_to_filter(operand)
+    assert filter == Filter(
+        field="inputs.model", operator="(string): containsWord", value="gpt"
+    )
+
+    assert filter_to_clause(filter) == {
+        "$containsToken": {
+            "input": {"$getField": "inputs.model"},
+            "substr": {"$literal": "gpt"},
+        },
+    }
+
+    round_tripped = tsi_query.ContainsTokenOperation.model_validate(
+        filter_to_clause(filter)
+    )
+    assert round_tripped == operand
+
+
+def test_contains_token_negation_round_trip():
+    """$not over $containsToken maps to notContainsWord and double-negation back."""
+    not_operand = tsi_query.NotOperation.model_validate(
+        {
+            "$not": [
+                {
+                    "$containsToken": {
+                        "input": {"$getField": "inputs.model"},
+                        "substr": {"$literal": "gpt"},
+                    }
+                }
+            ]
+        }
+    )
+    assert operand_to_filter(not_operand) == Filter(
+        field="inputs.model", operator="(string): notContainsWord", value="gpt"
+    )
+
+    double_not = tsi_query.NotOperation.model_validate({"$not": [not_operand]})
+    assert operand_to_filter(double_not) == Filter(
+        field="inputs.model", operator="(string): containsWord", value="gpt"
+    )
+
+
+def test_contains_token_non_string_value_rejected():
+    """A non-string token needle and a non-field input both fail to parse."""
+    non_string = tsi_query.ContainsTokenOperation.model_validate(
+        {
+            "$containsToken": {
+                "input": {"$getField": "inputs.model"},
+                "substr": {"$literal": 5},
+            }
+        }
+    )
+    with pytest.raises(QueryTranslationException):
+        operand_to_filter_contains_token(non_string)
+
+    non_field = tsi_query.ContainsTokenOperation.model_validate(
+        {
+            "$containsToken": {
+                "input": {"$literal": "x"},
+                "substr": {"$literal": "gpt"},
+            }
+        }
+    )
+    with pytest.raises(QueryTranslationException):
+        operand_to_filter_contains_token(non_field)
 
 
 def test_number_filter_skips_float_convert_for_typed_columns():

--- a/tests/trace_server/query_builder/test_agent_query_compiler.py
+++ b/tests/trace_server/query_builder/test_agent_query_compiler.py
@@ -273,6 +273,30 @@ class TestOperatorShapes:
             sql == "positionCaseInsensitive(s.reasoning_content, {genai_0:String}) > 0"
         )
 
+    def test_contains_token_emits_has_token(self) -> None:
+        sql, _ = _compile(
+            {
+                "$containsToken": {
+                    "input": {"$getField": "reasoning_content"},
+                    "substr": {"$literal": "thought"},
+                    "case_insensitive": False,
+                }
+            }
+        )
+        assert sql == "hasToken(s.reasoning_content, {genai_0:String})"
+
+    def test_contains_token_case_insensitive(self) -> None:
+        sql, _ = _compile(
+            {
+                "$containsToken": {
+                    "input": {"$getField": "reasoning_content"},
+                    "substr": {"$literal": "thought"},
+                    "case_insensitive": True,
+                }
+            }
+        )
+        assert sql == "hasTokenCaseInsensitive(s.reasoning_content, {genai_0:String})"
+
     def test_convert_forces_custom_attr_map(self) -> None:
         # ``to: "int"`` on a custom_attrs_string field routes to custom_attrs_int
         # and wraps in toInt64OrNull.

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -1403,6 +1403,136 @@ def test_calls_query_with_like_optimization_contains_calls_complete() -> None:
     )
 
 
+def test_calls_query_contains_token_case_sensitive() -> None:
+    """$containsToken on a JSON field compiles to hasToken + a hasToken prefilter."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.ContainsTokenOperation.model_validate(
+            {
+                "$containsToken": {
+                    "input": {"$getField": "inputs.param"},
+                    "substr": {"$literal": "hello"},
+                }
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_2:String}
+        WHERE ((hasToken(calls_merged.inputs_dump, {pb_1:String}) OR calls_merged.inputs_dump IS NULL))
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            (hasToken(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), ''), {pb_1:String}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+        )
+        """,
+        {
+            "pb_0": '$."param"',
+            "pb_1": "hello",
+            "pb_2": "project",
+        },
+    )
+
+
+def test_calls_query_contains_token_case_insensitive() -> None:
+    """Case-insensitive $containsToken compiles to hasTokenCaseInsensitive."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.ContainsTokenOperation.model_validate(
+            {
+                "$containsToken": {
+                    "input": {"$getField": "inputs.param"},
+                    "substr": {"$literal": "hello"},
+                    "case_insensitive": True,
+                }
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_2:String}
+        WHERE ((hasTokenCaseInsensitive(calls_merged.inputs_dump, {pb_1:String}) OR calls_merged.inputs_dump IS NULL))
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            (hasTokenCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), ''), {pb_1:String}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+        )
+        """,
+        {
+            "pb_0": '$."param"',
+            "pb_1": "hello",
+            "pb_2": "project",
+        },
+    )
+
+
+def test_calls_query_contains_token_multi_value_feedback() -> None:
+    """$containsToken on a multi-value feedback field uses arrayExists(hasToken)."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.ContainsTokenOperation.model_validate(
+            {
+                "$containsToken": {
+                    "input": {"$getField": "feedback.[wandb.note.1].payload.note"},
+                    "substr": {"$literal": "hello"},
+                }
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id
+        FROM
+            calls_merged
+                    LEFT JOIN (
+                SELECT * FROM feedback WHERE feedback.project_id = {pb_3:String}
+            ) AS feedback ON (
+            feedback.weave_ref = concat('weave-trace-internal:///',
+            {pb_3:String},
+            '/call/',
+            calls_merged.id))
+        PREWHERE
+            calls_merged.project_id = {pb_3:String}
+        GROUP BY
+            (calls_merged.project_id,
+            calls_merged.id)
+        HAVING
+            ((arrayExists(x -> hasToken(x, {pb_2:String}),
+            groupArrayIf(coalesce(nullIf(JSON_VALUE(feedback.payload_dump,
+            {pb_1:String}), 'null'), ''),
+            feedback.feedback_type = {pb_0:String}
+            AND coalesce(nullIf(JSON_VALUE(feedback.payload_dump,
+            {pb_1:String}), 'null'), '') != '')))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        """,
+        {
+            "pb_0": "wandb.note.1",
+            "pb_1": '$."note"',
+            "pb_2": "hello",
+            "pb_3": "project",
+        },
+    )
+
+
 def test_calls_query_with_like_optimization_in_calls_complete() -> None:
     """Test that IN LIKE optimization on calls_complete does NOT include null checks."""
     cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -1480,7 +1480,16 @@ def test_calls_query_contains_token_case_insensitive() -> None:
     )
 
 
-def test_calls_query_contains_token_multi_value_feedback() -> None:
+@pytest.mark.parametrize(
+    ("case_insensitive", "expected_fn"),
+    [
+        (False, "hasToken"),
+        (True, "hasTokenCaseInsensitive"),
+    ],
+)
+def test_calls_query_contains_token_multi_value_feedback(
+    case_insensitive, expected_fn
+) -> None:
     """$containsToken on a multi-value feedback field uses arrayExists(hasToken)."""
     cq = CallsQuery(project_id="project")
     cq.add_field("id")
@@ -1490,6 +1499,7 @@ def test_calls_query_contains_token_multi_value_feedback() -> None:
                 "$containsToken": {
                     "input": {"$getField": "feedback.[wandb.note.1].payload.note"},
                     "substr": {"$literal": "hello"},
+                    "case_insensitive": case_insensitive,
                 }
             }
         )
@@ -1497,30 +1507,30 @@ def test_calls_query_contains_token_multi_value_feedback() -> None:
 
     assert_sql(
         cq,
-        """
+        f"""
         SELECT
             calls_merged.id AS id
         FROM
             calls_merged
                     LEFT JOIN (
-                SELECT * FROM feedback WHERE feedback.project_id = {pb_3:String}
+                SELECT * FROM feedback WHERE feedback.project_id = {{pb_3:String}}
             ) AS feedback ON (
             feedback.weave_ref = concat('weave-trace-internal:///',
-            {pb_3:String},
+            {{pb_3:String}},
             '/call/',
             calls_merged.id))
         PREWHERE
-            calls_merged.project_id = {pb_3:String}
+            calls_merged.project_id = {{pb_3:String}}
         GROUP BY
             (calls_merged.project_id,
             calls_merged.id)
         HAVING
-            ((arrayExists(x -> hasToken(x, {pb_2:String}),
+            ((arrayExists(x -> {expected_fn}(x, {{pb_2:String}}),
             groupArrayIf(coalesce(nullIf(JSON_VALUE(feedback.payload_dump,
-            {pb_1:String}), 'null'), ''),
-            feedback.feedback_type = {pb_0:String}
+            {{pb_1:String}}), 'null'), ''),
+            feedback.feedback_type = {{pb_0:String}}
             AND coalesce(nullIf(JSON_VALUE(feedback.payload_dump,
-            {pb_1:String}), 'null'), '') != '')))
+            {{pb_1:String}}), 'null'), '') != '')))
                 AND ((any(calls_merged.deleted_at) IS NULL))
                     AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
         """,

--- a/tests/trace_server/query_builder/test_object_ref_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_object_ref_calls_query_builder.py
@@ -79,6 +79,77 @@ def test_object_ref_filter_simple() -> None:
     )
 
 
+def test_object_ref_filter_contains_token() -> None:
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.ContainsTokenOperation.model_validate(
+            {
+                "$containsToken": {
+                    "input": {"$getField": "output.model.name"},
+                    "substr": {"$literal": "gpt4"},
+                }
+            }
+        )
+    )
+    cq.add_order("started_at", "desc")
+    cq.set_expand_columns(["output.model"])
+    assert_sql(
+        cq,
+        """
+        WITH obj_filter_0 AS
+          (SELECT digest,
+                  concat('weave-trace-internal:///', project_id, '/object/', object_id, ':', digest) AS ref
+           FROM object_versions
+           WHERE project_id = {pb_0:String}
+             AND hasToken(JSON_VALUE(val_dump, {pb_1:String}), {pb_2:String})
+           GROUP BY project_id,
+                    object_id,
+                    digest
+
+           UNION ALL
+
+           SELECT digest,
+                  digest as ref
+           FROM table_rows
+           WHERE project_id = {pb_0:String}
+             AND hasToken(JSON_VALUE(val_dump, {pb_1:String}), {pb_2:String})
+           GROUP BY project_id,
+                    digest),
+             filtered_calls AS
+          (SELECT calls_merged.id AS id
+           FROM calls_merged
+           PREWHERE calls_merged.project_id = {pb_0:String}
+           WHERE (length(calls_merged.output_refs) > 0
+                  OR calls_merged.ended_at IS NULL)
+           GROUP BY (calls_merged.project_id,
+                     calls_merged.id)
+           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), '') GLOBAL IN
+                      (SELECT ref
+                       FROM obj_filter_0)
+                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
+                      (SELECT ref
+                       FROM obj_filter_0)))
+                   AND ((any(calls_merged.deleted_at) IS NULL))
+                   AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+           ORDER BY any(calls_merged.started_at) DESC)
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_0:String}
+        WHERE (calls_merged.id IN filtered_calls)
+        GROUP BY (calls_merged.project_id,
+                  calls_merged.id)
+        ORDER BY any(calls_merged.started_at) DESC
+        """,
+        {
+            "pb_0": "project",
+            "pb_1": '$."name"',
+            "pb_2": "gpt4",
+            "pb_3": '$."model"',
+        },
+    )
+
+
 def test_object_ref_filter_lt() -> None:
     cq = CallsQuery(project_id="project")
     cq.add_field("id")

--- a/tests/trace_server/query_builder/test_optimization_builder.py
+++ b/tests/trace_server/query_builder/test_optimization_builder.py
@@ -287,6 +287,97 @@ def test_heavy_field_contains_inside_not_skips_optimization() -> None:
     assert result is None
 
 
+@pytest.mark.parametrize(
+    ("case_insensitive", "expected_fn"),
+    [
+        (False, "hasToken"),
+        (True, "hasTokenCaseInsensitive"),
+    ],
+)
+def test_heavy_field_contains_token_prefilter(case_insensitive, expected_fn) -> None:
+    """$containsToken on a heavy field emits a hasToken pre-aggregation prefilter."""
+    pb = ParamBuilder("pb")
+    processor = HeavyFieldOptimizationProcessor(pb, "calls_merged", use_null_check=True)
+
+    op = tsi_query.ContainsTokenOperation.model_validate(
+        {
+            "$containsToken": {
+                "input": {"$getField": "inputs.param"},
+                "substr": {"$literal": "hello"},
+                "case_insensitive": case_insensitive,
+            }
+        }
+    )
+    result = apply_processor(processor, op)
+
+    assert result == (
+        f"({expected_fn}(calls_merged.inputs_dump, {{pb_0:String}}) "
+        "OR calls_merged.inputs_dump IS NULL)"
+    )
+    assert pb.get_params() == {"pb_0": "hello"}
+
+
+@pytest.mark.parametrize(
+    "op_dict",
+    [
+        # Input is not a bare field -> no prefilter.
+        {
+            "$containsToken": {
+                "input": {"$literal": "x"},
+                "substr": {"$literal": "hello"},
+            }
+        },
+        # Substr is not a string literal -> no prefilter.
+        {
+            "$containsToken": {
+                "input": {"$getField": "inputs.param"},
+                "substr": {"$getField": "inputs.other"},
+            }
+        },
+        # Empty substr -> no prefilter.
+        {
+            "$containsToken": {
+                "input": {"$getField": "inputs.param"},
+                "substr": {"$literal": ""},
+            }
+        },
+        # Non-heavy field -> no prefilter.
+        {
+            "$containsToken": {
+                "input": {"$getField": "id"},
+                "substr": {"$literal": "hello"},
+            }
+        },
+    ],
+)
+def test_heavy_field_contains_token_prefilter_skips(op_dict) -> None:
+    """$containsToken shapes that can't safely prefilter return None."""
+    pb = ParamBuilder("pb")
+    processor = HeavyFieldOptimizationProcessor(pb, "calls_merged", use_null_check=True)
+    op = tsi_query.ContainsTokenOperation.model_validate(op_dict)
+    assert apply_processor(processor, op) is None
+
+
+def test_heavy_field_contains_token_inside_not_skips_optimization() -> None:
+    """$containsToken on a heavy field inside NOT skips optimization (superset trap)."""
+    pb = ParamBuilder()
+    processor = HeavyFieldOptimizationProcessor(pb, "calls_merged", use_null_check=True)
+
+    op = tsi_query.NotOperation.model_validate(
+        {
+            "$not": [
+                {
+                    "$containsToken": {
+                        "input": {"$getField": "attributes.key"},
+                        "substr": {"$literal": "val"},
+                    }
+                }
+            ]
+        }
+    )
+    assert apply_processor(processor, op) is None
+
+
 def test_heavy_field_in_inside_not_skips_optimization() -> None:
     """IN on a heavy field inside NOT also skips optimization."""
     pb = ParamBuilder()

--- a/tests/trace_server/test_in_memory_contains_token.py
+++ b/tests/trace_server/test_in_memory_contains_token.py
@@ -1,0 +1,122 @@
+import pytest
+
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.in_memory_trace_server import (
+    _ch_has_token,
+    _orm_eval_query,
+    _QueryFilterEvaluator,
+)
+from weave.trace_server.orm import Column, Table
+
+
+@pytest.mark.parametrize(
+    ("haystack", "needle", "case_insensitive", "expected"),
+    [
+        ("the example row", "example", False, True),
+        ("examples", "example", False, False),
+        ("Example", "example", False, False),
+        ("Example", "example", True, True),
+        ("the example row", "example", True, True),
+        ("a.b-c", "b", False, True),
+        (123, "example", False, False),
+        ("example", 123, False, False),
+    ],
+)
+def test_ch_has_token_semantics(haystack, needle, case_insensitive, expected) -> None:
+    """Whole-token match only; non-strings never match (hasToken semantics)."""
+    assert _ch_has_token(haystack, needle, case_insensitive) is expected
+
+
+def _token_table() -> Table:
+    return Table(
+        "calls",
+        [
+            Column("id", "string"),
+            Column("op_name", "string"),
+            Column("input_refs", "array_string"),
+        ],
+    )
+
+
+def _token_query(field: str, needle: str, case_insensitive: bool = False) -> tsi.Query:
+    return tsi.Query.model_validate(
+        {
+            "$expr": {
+                "$containsToken": {
+                    "input": {"$getField": field},
+                    "substr": {"$literal": needle},
+                    "case_insensitive": case_insensitive,
+                }
+            }
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("row", "query", "expected"),
+    [
+        # String column, case-sensitive: whole-token match only.
+        ({"op_name": "the example row"}, _token_query("op_name", "example"), True),
+        ({"op_name": "examples"}, _token_query("op_name", "example"), False),
+        ({"op_name": "Example"}, _token_query("op_name", "example"), False),
+        # String column, case-insensitive.
+        (
+            {"op_name": "Example"},
+            _token_query("op_name", "example", case_insensitive=True),
+            True,
+        ),
+        # Array(String) column, case-sensitive membership.
+        ({"input_refs": ["alpha", "beta"]}, _token_query("input_refs", "alpha"), True),
+        ({"input_refs": ["alphas"]}, _token_query("input_refs", "alpha"), False),
+        # Array(String) column, case-insensitive membership.
+        (
+            {"input_refs": ["Alpha"]},
+            _token_query("input_refs", "alpha", case_insensitive=True),
+            True,
+        ),
+        ({"input_refs": []}, _token_query("input_refs", "alpha"), False),
+        # Nested under $and: exercises the operand-dispatch branch.
+        (
+            {"op_name": "the example row"},
+            tsi.Query.model_validate(
+                {
+                    "$expr": {
+                        "$and": [
+                            {
+                                "$containsToken": {
+                                    "input": {"$getField": "op_name"},
+                                    "substr": {"$literal": "example"},
+                                }
+                            }
+                        ]
+                    }
+                }
+            ),
+            True,
+        ),
+    ],
+)
+def test_orm_eval_query_contains_token(row, query, expected) -> None:
+    """_orm_eval_query mirrors hasToken for strings and array membership for
+    Array(String) columns (case-sensitive and -insensitive).
+    """
+    assert bool(_orm_eval_query(_token_table(), row, query)) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "needle", "case_insensitive", "expected"),
+    [
+        ("the example row", "example", False, True),
+        ("examples", "example", False, False),
+        ("Example", "example", True, True),
+    ],
+)
+def test_query_filter_evaluator_contains_token(
+    value, needle, case_insensitive, expected
+) -> None:
+    """The shared filter evaluator mirrors hasToken token semantics."""
+    evaluator = _QueryFilterEvaluator(lambda field_path, cast: value)
+    assert (
+        evaluator.matches(_token_query("display_name", needle, case_insensitive))
+        is expected
+    )

--- a/tests/trace_server/test_in_memory_contains_token.py
+++ b/tests/trace_server/test_in_memory_contains_token.py
@@ -12,14 +12,12 @@ from weave.trace_server.orm import Column, Table
 @pytest.mark.parametrize(
     ("haystack", "needle", "case_insensitive", "expected"),
     [
-        ("the example row", "example", False, True),
-        ("examples", "example", False, False),
-        ("Example", "example", False, False),
-        ("Example", "example", True, True),
-        ("the example row", "example", True, True),
-        ("a.b-c", "b", False, True),
-        (123, "example", False, False),
-        ("example", 123, False, False),
+        ("the example row", "example", False, True),  # whole-token hit
+        ("examples", "example", False, False),  # substring is not a token
+        ("Example", "example", True, True),  # case-insensitive match
+        ("a.b-c", "b", False, True),  # separator-split tokenization
+        (123, "example", False, False),  # non-string haystack guard
+        ("example", 123, False, False),  # non-string needle guard
     ],
 )
 def test_ch_has_token_semantics(haystack, needle, case_insensitive, expected) -> None:
@@ -52,23 +50,36 @@ def _token_query(field: str, needle: str, case_insensitive: bool = False) -> tsi
     )
 
 
+_NESTED_AND_QUERY = tsi.Query.model_validate(
+    {
+        "$expr": {
+            "$and": [
+                {
+                    "$containsToken": {
+                        "input": {"$getField": "op_name"},
+                        "substr": {"$literal": "example"},
+                    }
+                }
+            ]
+        }
+    }
+)
+
+
 @pytest.mark.parametrize(
     ("row", "query", "expected"),
     [
-        # String column, case-sensitive: whole-token match only.
+        # String column: hasToken whole-token match, case-sensitive then -insensitive.
         ({"op_name": "the example row"}, _token_query("op_name", "example"), True),
         ({"op_name": "examples"}, _token_query("op_name", "example"), False),
-        ({"op_name": "Example"}, _token_query("op_name", "example"), False),
-        # String column, case-insensitive.
         (
             {"op_name": "Example"},
             _token_query("op_name", "example", case_insensitive=True),
             True,
         ),
-        # Array(String) column, case-sensitive membership.
+        # Array(String) column: membership, case-sensitive (hit + miss), -insensitive, empty.
         ({"input_refs": ["alpha", "beta"]}, _token_query("input_refs", "alpha"), True),
         ({"input_refs": ["alphas"]}, _token_query("input_refs", "alpha"), False),
-        # Array(String) column, case-insensitive membership.
         (
             {"input_refs": ["Alpha"]},
             _token_query("input_refs", "alpha", case_insensitive=True),
@@ -76,24 +87,7 @@ def _token_query(field: str, needle: str, case_insensitive: bool = False) -> tsi
         ),
         ({"input_refs": []}, _token_query("input_refs", "alpha"), False),
         # Nested under $and: exercises the operand-dispatch branch.
-        (
-            {"op_name": "the example row"},
-            tsi.Query.model_validate(
-                {
-                    "$expr": {
-                        "$and": [
-                            {
-                                "$containsToken": {
-                                    "input": {"$getField": "op_name"},
-                                    "substr": {"$literal": "example"},
-                                }
-                            }
-                        ]
-                    }
-                }
-            ),
-            True,
-        ),
+        ({"op_name": "the example row"}, _NESTED_AND_QUERY, True),
     ],
 )
 def test_orm_eval_query_contains_token(row, query, expected) -> None:
@@ -106,9 +100,9 @@ def test_orm_eval_query_contains_token(row, query, expected) -> None:
 @pytest.mark.parametrize(
     ("value", "needle", "case_insensitive", "expected"),
     [
-        ("the example row", "example", False, True),
-        ("examples", "example", False, False),
-        ("Example", "example", True, True),
+        ("the example row", "example", False, True),  # token hit
+        ("examples", "example", False, False),  # token miss
+        ("Example", "example", True, True),  # case-insensitive match
     ],
 )
 def test_query_filter_evaluator_contains_token(

--- a/tests/trace_server/test_orm.py
+++ b/tests/trace_server/test_orm.py
@@ -1,6 +1,7 @@
 import pytest
 
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.errors import InvalidRequest
 from weave.trace_server.orm import (
     Column,
     ParamBuilder,
@@ -590,6 +591,97 @@ def test_feedback_query_in_homogeneous_literal_list_casts_field() -> None:
         "WHERE (toInt64OrNull(JSON_VALUE(payload_dump, {pb_0:String})) "
         "IN ({pb_1:Int64},{pb_2:Int64},{pb_3:Int64}))"
     )
+
+
+def _token_table() -> Table:
+    return Table(
+        "calls",
+        [
+            Column("id", "string"),
+            Column("op_name", "string"),
+            Column("input_refs", "array_string"),
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_cond"),
+    [
+        # String field, case-sensitive -> hasToken (no `> 0`).
+        (
+            {
+                "$containsToken": {
+                    "input": {"$getField": "op_name"},
+                    "substr": {"$literal": "predict"},
+                }
+            },
+            "hasToken(op_name, {pb_0:String})",
+        ),
+        # String field, case-insensitive -> hasTokenCaseInsensitive.
+        (
+            {
+                "$containsToken": {
+                    "input": {"$getField": "op_name"},
+                    "substr": {"$literal": "predict"},
+                    "case_insensitive": True,
+                }
+            },
+            "hasTokenCaseInsensitive(op_name, {pb_0:String})",
+        ),
+        # Array(String) field, case-sensitive -> array membership (has).
+        (
+            {
+                "$containsToken": {
+                    "input": {"$getField": "input_refs"},
+                    "substr": {"$literal": "predict"},
+                }
+            },
+            "has(input_refs, {pb_0:String})",
+        ),
+        # Array(String) field, case-insensitive -> arrayExists(lower(...)).
+        (
+            {
+                "$containsToken": {
+                    "input": {"$getField": "input_refs"},
+                    "substr": {"$literal": "predict"},
+                    "case_insensitive": True,
+                }
+            },
+            "arrayExists(x -> lower(x) = lower({pb_0:String}), input_refs)",
+        ),
+    ],
+)
+def test_contains_token_compiles_to_has_token(query, expected_cond) -> None:
+    """$containsToken compiles to hasToken on strings and array membership on
+    Array(String) columns, mirroring $contains' array branch.
+    """
+    select = _token_table().select().fields(["id"]).where(tsi.Query(**{"$expr": query}))
+    prepared = _prepare_clickhouse(select)
+    assert prepared.sql == ("SELECT id\nFROM calls\nWHERE " + expected_cond)
+    assert prepared.parameters == {"pb_0": "predict"}
+
+
+def test_contains_token_multi_token_needle_raises() -> None:
+    """A needle spanning token separators is rejected before SQL generation."""
+    select = (
+        _token_table()
+        .select()
+        .fields(["id"])
+        .where(
+            tsi.Query(
+                **{
+                    "$expr": {
+                        "$containsToken": {
+                            "input": {"$getField": "op_name"},
+                            "substr": {"$literal": "two words"},
+                        }
+                    }
+                }
+            )
+        )
+    )
+    with pytest.raises(InvalidRequest, match="single token"):
+        _prepare_clickhouse(select)
 
 
 def test_feedback_query_inference_threads_through_and_or_not() -> None:

--- a/weave/flow/saved_view.py
+++ b/weave/flow/saved_view.py
@@ -133,6 +133,8 @@ DEFAULT_PIN = Pin(left=["CustomCheckbox", "op_name"], right=[])
 OPERATOR_MAP = {
     "contains": "(string): contains",
     "does not contain": "(string): notContains",
+    "contains word": "(string): containsWord",
+    "does not contain word": "(string): notContainsWord",
     "equals": "(string): equals",
     "does not equal": "(string): notEquals",
     "in": "(string): in",
@@ -201,6 +203,24 @@ def filter_to_clause(item: Filter) -> dict[str, Any]:
             "$not": [
                 {
                     "$contains": {
+                        "input": {"$getField": item.field},
+                        "substr": {"$literal": item.value},
+                    },
+                }
+            ],
+        }
+    elif item.operator == "(string): containsWord":
+        return {
+            "$containsToken": {
+                "input": {"$getField": item.field},
+                "substr": {"$literal": item.value},
+            },
+        }
+    elif item.operator == "(string): notContainsWord":
+        return {
+            "$not": [
+                {
+                    "$containsToken": {
                         "input": {"$getField": item.field},
                         "substr": {"$literal": item.value},
                     },
@@ -334,6 +354,24 @@ def operand_to_filter_contains(operand: tsi_query.ContainsOperation) -> Filter:
     raise QueryTranslationException(f"Could not parse {operand}")
 
 
+def operand_to_filter_contains_token(
+    operand: tsi_query.ContainsTokenOperation,
+) -> Filter:
+    input = operand.contains_token_.input
+    substr = operand.contains_token_.substr
+    if isinstance(input, tsi_query.GetFieldOperator) and isinstance(
+        substr, tsi_query.LiteralOperation
+    ):
+        value = substr.literal_
+        if isinstance(value, str):
+            operator = "(string): containsWord"
+        else:
+            raise QueryTranslationException(f"Could not parse {operand}")
+        field = input.get_field_
+        return Filter(field=field, operator=operator, value=value)
+    raise QueryTranslationException(f"Could not parse {operand}")
+
+
 def operand_to_filter_gt(operand: tsi_query.GtOperation) -> Filter:
     first = operand.gt_[0]
     second = operand.gt_[1]
@@ -384,6 +422,8 @@ def operand_to_filter(operand: tsi_query.Operand) -> Filter:
         return operand_to_filter_eq(operand)
     if isinstance(operand, tsi_query.ContainsOperation):
         return operand_to_filter_contains(operand)
+    if isinstance(operand, tsi_query.ContainsTokenOperation):
+        return operand_to_filter_contains_token(operand)
     if isinstance(operand, tsi_query.GtOperation):
         return operand_to_filter_gt(operand)
     if isinstance(operand, tsi_query.GteOperation):
@@ -404,6 +444,10 @@ def operand_to_filter(operand: tsi_query.Operand) -> Filter:
             filter.operator = "(string): notContains"
         elif filter.operator == "(string): notContains":
             filter.operator = "(string): contains"
+        elif filter.operator == "(string): containsWord":
+            filter.operator = "(string): notContainsWord"
+        elif filter.operator == "(string): notContainsWord":
+            filter.operator = "(string): containsWord"
         elif filter.operator == "(date): after":
             filter.operator = "(date): before"
         elif filter.operator == "(date): before":
@@ -445,6 +489,7 @@ def query_to_filters(query: tsi.Query | None) -> Filters | None:
             tsi_query.GteOperation,
             tsi_query.NotOperation,
             tsi_query.ContainsOperation,
+            tsi_query.ContainsTokenOperation,
         ),
     ):
         return [operand_to_filter(query.expr_)]

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -77,6 +77,7 @@ from weave.trace_server.orm import (
     assert_single_token,
     clickhouse_cast,
     combine_conditions,
+    has_token_fn,
     maybe_convert_datetime_operands,
     python_value_to_ch_type,
     split_escaped_field_path,
@@ -2344,28 +2345,21 @@ def process_query_to_conditions(
                     position_operation = "positionCaseInsensitive"
                 cond = f"{position_operation}({lhs_part}, {rhs_part}) > 0"
         elif isinstance(operation, tsi_query.ContainsTokenOperation):
+            assert_single_token(operation.contains_token_.substr)
+            has_token = has_token_fn(bool(operation.contains_token_.case_insensitive))
             mv_field = (
                 _get_multi_value_feedback_field(operation.contains_token_.input)
                 if use_agg_fn
                 else None
             )
             if mv_field is not None:
-                assert_single_token(operation.contains_token_.substr)
                 array_expr = mv_field.as_array_sql(param_builder)
                 rhs_part = process_operand(operation.contains_token_.substr)
                 raw_fields_used[mv_field.feedback_type] = mv_field
-                has_token = "hasToken"
-                if operation.contains_token_.case_insensitive:
-                    has_token = "hasTokenCaseInsensitive"
                 cond = f"arrayExists(x -> {has_token}(x, {rhs_part}), {array_expr})"
             else:
-                assert_single_token(operation.contains_token_.substr)
                 lhs_part = process_operand(operation.contains_token_.input)
                 rhs_part = process_operand(operation.contains_token_.substr)
-                # hasTokenCaseInsensitive cannot use the tokenbf skip index.
-                has_token = "hasToken"
-                if operation.contains_token_.case_insensitive:
-                    has_token = "hasTokenCaseInsensitive"
                 cond = f"{has_token}({lhs_part}, {rhs_part})"
         else:
             raise TypeError(f"Unknown operation type: {operation}")

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -74,6 +74,7 @@ from weave.trace_server.interface.query import (
 from weave.trace_server.orm import (
     ParamBuilder,
     _format_table_name_with_cluster,
+    assert_single_token,
     clickhouse_cast,
     combine_conditions,
     maybe_convert_datetime_operands,
@@ -2342,6 +2343,30 @@ def process_query_to_conditions(
                 if operation.contains_.case_insensitive:
                     position_operation = "positionCaseInsensitive"
                 cond = f"{position_operation}({lhs_part}, {rhs_part}) > 0"
+        elif isinstance(operation, tsi_query.ContainsTokenOperation):
+            mv_field = (
+                _get_multi_value_feedback_field(operation.contains_token_.input)
+                if use_agg_fn
+                else None
+            )
+            if mv_field is not None:
+                assert_single_token(operation.contains_token_.substr)
+                array_expr = mv_field.as_array_sql(param_builder)
+                rhs_part = process_operand(operation.contains_token_.substr)
+                raw_fields_used[mv_field.feedback_type] = mv_field
+                has_token = "hasToken"
+                if operation.contains_token_.case_insensitive:
+                    has_token = "hasTokenCaseInsensitive"
+                cond = f"arrayExists(x -> {has_token}(x, {rhs_part}), {array_expr})"
+            else:
+                assert_single_token(operation.contains_token_.substr)
+                lhs_part = process_operand(operation.contains_token_.input)
+                rhs_part = process_operand(operation.contains_token_.substr)
+                # hasTokenCaseInsensitive cannot use the tokenbf skip index.
+                has_token = "hasToken"
+                if operation.contains_token_.case_insensitive:
+                    has_token = "hasTokenCaseInsensitive"
+                cond = f"{has_token}({lhs_part}, {rhs_part})"
         else:
             raise TypeError(f"Unknown operation type: {operation}")
 
@@ -2398,6 +2423,7 @@ def process_query_to_conditions(
                 tsi_query.LteOperation,
                 tsi_query.InOperation,
                 tsi_query.ContainsOperation,
+                tsi_query.ContainsTokenOperation,
             ),
         ):
             return process_operation(operand)

--- a/weave/trace_server/calls_query_builder/object_ref_query_builder.py
+++ b/weave/trace_server/calls_query_builder/object_ref_query_builder.py
@@ -63,6 +63,7 @@ from weave.trace_server.calls_query_builder.utils import (
 )
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.orm import (
+    assert_single_token_value,
     clickhouse_cast,
     combine_conditions,
     python_value_to_ch_type,
@@ -412,6 +413,27 @@ class ObjectRefConditionHandler:
         else:
             return f"{json_extract} LIKE {param_slot(filter_param, 'String')}"
 
+    def handle_contains_token_operation(
+        self, condition: ObjectRefFilterCondition
+    ) -> str:
+        """Handle contains-token operations for object references.
+
+        Args:
+            condition: The object reference filter condition
+
+        Returns:
+            str: SQL condition for whole-token match
+        """
+        assert_single_token_value(condition.value)
+        filter_param = self.pb.add_param(condition.value)
+        json_extract = self._create_json_extract_expression()
+
+        # hasTokenCaseInsensitive cannot use the tokenbf skip index.
+        has_token = (
+            "hasTokenCaseInsensitive" if condition.case_insensitive else "hasToken"
+        )
+        return f"{has_token}({json_extract}, {param_slot(filter_param, 'String')})"
+
     def handle_in_operation(self, condition: ObjectRefFilterCondition) -> str:
         """Handle IN operations for object references.
 
@@ -623,6 +645,26 @@ class ObjectRefFilterToCTEProcessor(QueryOptimizationProcessor):
                 self.object_ref_conditions.append(obj_condition)
         return None
 
+    def process_contains_token(
+        self, operation: tsi_query.ContainsTokenOperation
+    ) -> str | None:
+        """Process contains-token operation for object refs."""
+        if isinstance(operation.contains_token_.input, tsi_query.GetFieldOperator):
+            field_path = operation.contains_token_.input.get_field_
+            if self._is_object_ref_field(field_path) and isinstance(
+                operation.contains_token_.substr, tsi_query.LiteralOperation
+            ):
+                obj_condition = ObjectRefFilterCondition(
+                    field_path=field_path,
+                    operation_type="contains_token",
+                    value=operation.contains_token_.substr.literal_,
+                    expand_columns=self.expand_columns,
+                    case_insensitive=operation.contains_token_.case_insensitive
+                    or False,
+                )
+                self.object_ref_conditions.append(obj_condition)
+        return None
+
     def process_gt(self, operation: tsi_query.GtOperation) -> str | None:
         """Process greater than operation for object refs."""
         self._process_binary_operation(operation.gt_, "gt")
@@ -749,6 +791,8 @@ def build_object_ref_ctes(
                 val_condition = handler.handle_comparison_operation(condition, "=")
             elif condition.operation_type == "contains":
                 val_condition = handler.handle_contains_operation(condition)
+            elif condition.operation_type == "contains_token":
+                val_condition = handler.handle_contains_token_operation(condition)
             elif condition.operation_type == "gt":
                 val_condition = handler.handle_comparison_operation(condition, ">")
             elif condition.operation_type == "gte":
@@ -918,6 +962,8 @@ def is_object_ref_operand(
             )  # Only check the field being compared
         elif isinstance(op, tsi_query.ContainsOperation):
             return check_operand_recursive(op.contains_.input)
+        elif isinstance(op, tsi_query.ContainsTokenOperation):
+            return check_operand_recursive(op.contains_token_.input)
         elif isinstance(op, tsi_query.ConvertOperation):
             return check_operand_recursive(op.convert_.input)
         return False

--- a/weave/trace_server/calls_query_builder/object_ref_query_builder.py
+++ b/weave/trace_server/calls_query_builder/object_ref_query_builder.py
@@ -66,6 +66,7 @@ from weave.trace_server.orm import (
     assert_single_token_value,
     clickhouse_cast,
     combine_conditions,
+    has_token_fn,
     python_value_to_ch_type,
     quote_json_path,
     split_escaped_field_path,
@@ -427,11 +428,7 @@ class ObjectRefConditionHandler:
         assert_single_token_value(condition.value)
         filter_param = self.pb.add_param(condition.value)
         json_extract = self._create_json_extract_expression()
-
-        # hasTokenCaseInsensitive cannot use the tokenbf skip index.
-        has_token = (
-            "hasTokenCaseInsensitive" if condition.case_insensitive else "hasToken"
-        )
+        has_token = has_token_fn(condition.case_insensitive)
         return f"{has_token}({json_extract}, {param_slot(filter_param, 'String')})"
 
     def handle_in_operation(self, condition: ObjectRefFilterCondition) -> str:

--- a/weave/trace_server/calls_query_builder/optimization_builder.py
+++ b/weave/trace_server/calls_query_builder/optimization_builder.py
@@ -171,6 +171,13 @@ class QueryOptimizationProcessor(ABC):
         pass
 
     @abstractmethod
+    def process_contains_token(
+        self, operation: tsi_query.ContainsTokenOperation
+    ) -> str | None:
+        """Process contains-token operation."""
+        pass
+
+    @abstractmethod
     def process_in(self, operation: tsi_query.InOperation) -> str | None:
         """Process in operation."""
         pass
@@ -248,6 +255,19 @@ class HeavyFieldOptimizationProcessor(QueryOptimizationProcessor):
             operation, self.pb, self.table_alias, self.use_null_check
         )
 
+    def process_contains_token(
+        self, operation: tsi_query.ContainsTokenOperation
+    ) -> str | None:
+        """Process contains-token operation on heavy fields.
+
+        Creates a hasToken prefilter on the raw JSON dump, a superset of the
+        post-aggregation hasToken on the extracted value (any token of the
+        extracted value is also a token of the dump).
+        """
+        return _create_hastoken_optimized_contains_token_condition(
+            operation, self.pb, self.table_alias, self.use_null_check
+        )
+
     def process_in(self, operation: tsi_query.InOperation) -> str | None:
         """Process IN operation on heavy fields.
 
@@ -290,6 +310,12 @@ class SortableDatetimeOptimizationProcessor(QueryOptimizationProcessor):
         return None
 
     def process_contains(self, operation: tsi_query.ContainsOperation) -> str | None:
+        """Not implemented for sortable_datetime optimization."""
+        return None
+
+    def process_contains_token(
+        self, operation: tsi_query.ContainsTokenOperation
+    ) -> str | None:
         """Not implemented for sortable_datetime optimization."""
         return None
 
@@ -347,6 +373,8 @@ def apply_processor(
         return processor.process_eq(operation)
     elif isinstance(operation, tsi_query.ContainsOperation):
         return processor.process_contains(operation)
+    elif isinstance(operation, tsi_query.ContainsTokenOperation):
+        return processor.process_contains_token(operation)
     elif isinstance(operation, tsi_query.InOperation):
         return processor.process_in(operation)
     elif isinstance(operation, tsi_query.GtOperation):
@@ -601,6 +629,56 @@ def _create_like_optimized_contains_condition(
         field, like_pattern, pb, table_alias, case_insensitive
     )
     return _maybe_use_null_check(like_condition, field, table_alias, use_null_check)
+
+
+def _create_hastoken_optimized_contains_token_condition(
+    operation: tsi_query.ContainsTokenOperation,
+    pb: "ParamBuilder",
+    table_alias: str,
+    use_null_check: bool = True,
+) -> str | None:
+    """Creates a hasToken-optimized prefilter for contains-token operations.
+
+    Args:
+        operation: The contains-token operation to optimize.
+        pb: Parameter builder for query parameterization.
+        table_alias: The table alias to use in SQL.
+        use_null_check: Whether to add OR IS NULL for start/end fields.
+            True for calls_merged (unmerged parts may have NULL fields).
+            False for calls_complete (every row is a complete call).
+    """
+    if not isinstance(operation.contains_token_.input, tsi_query.GetFieldOperator):
+        return None
+    if not isinstance(
+        operation.contains_token_.substr, tsi_query.LiteralOperation
+    ) or not isinstance(operation.contains_token_.substr.literal_, str):
+        return None
+
+    from weave.trace_server.calls_query_builder.calls_query_builder import (
+        get_field_by_name,
+    )
+
+    field = get_field_by_name(operation.contains_token_.input.get_field_).field
+    substr_value = operation.contains_token_.substr.literal_
+    if not substr_value:
+        return None
+    if not _can_optimize_heavy_field(field):
+        return None
+
+    field_name = f"{table_alias}.{field}"
+    # hasTokenCaseInsensitive cannot use the tokenbf skip index.
+    has_token = (
+        "hasTokenCaseInsensitive"
+        if operation.contains_token_.case_insensitive
+        else "hasToken"
+    )
+    param_name = pb.add_param(substr_value)
+    has_token_condition = (
+        f"{has_token}({field_name}, {param_slot(param_name, 'String')})"
+    )
+    return _maybe_use_null_check(
+        has_token_condition, field, table_alias, use_null_check
+    )
 
 
 def _create_like_optimized_in_condition(

--- a/weave/trace_server/calls_query_builder/optimization_builder.py
+++ b/weave/trace_server/calls_query_builder/optimization_builder.py
@@ -654,6 +654,7 @@ def _create_hastoken_optimized_contains_token_condition(
     ) or not isinstance(operation.contains_token_.substr.literal_, str):
         return None
 
+    # Lazy import mirrors this file's existing circular-import workaround.
     from weave.trace_server.calls_query_builder.calls_query_builder import (
         get_field_by_name,
     )

--- a/weave/trace_server/calls_query_builder/optimization_builder.py
+++ b/weave/trace_server/calls_query_builder/optimization_builder.py
@@ -25,6 +25,7 @@ from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.orm import (
     clickhouse_cast,
     datetime_literal_to_timestamp,
+    has_token_fn,
     timestamp_to_datetime_str,
 )
 from weave.trace_server.project_version.types import ReadTable, TableConfig
@@ -667,12 +668,7 @@ def _create_hastoken_optimized_contains_token_condition(
         return None
 
     field_name = f"{table_alias}.{field}"
-    # hasTokenCaseInsensitive cannot use the tokenbf skip index.
-    has_token = (
-        "hasTokenCaseInsensitive"
-        if operation.contains_token_.case_insensitive
-        else "hasToken"
-    )
+    has_token = has_token_fn(bool(operation.contains_token_.case_insensitive))
     param_name = pb.add_param(substr_value)
     has_token_condition = (
         f"{has_token}({field_name}, {param_slot(param_name, 'String')})"

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -475,6 +475,24 @@ def _ch_position(haystack: Any, needle: Any, case_insensitive: bool) -> bool:
     return needle in haystack
 
 
+def _ch_has_token(haystack: Any, needle: Any, case_insensitive: bool) -> bool:
+    """ClickHouse hasToken()/hasTokenCaseInsensitive() over strings.
+
+    Matches when needle equals one of haystack's tokens (split on
+    non-alphanumeric runs).
+    """
+    if not isinstance(haystack, str) or not isinstance(needle, str):
+        return False
+    tokens = _TOKEN_SEPARATOR_RE.split(haystack)
+    if case_insensitive:
+        needle = needle.lower()
+        return any(token.lower() == needle for token in tokens if token)
+    return any(token == needle for token in tokens if token)
+
+
+_TOKEN_SEPARATOR_RE = re.compile(r"[^a-zA-Z0-9]+")
+
+
 def _ch_sorted_by_terms(
     rows: list[Any],
     terms: Sequence[tuple[Any, str]],
@@ -1063,6 +1081,12 @@ class _QueryFilterEvaluator:
                 self._operand_value(operation.contains_.input),
                 self._operand_value(operation.contains_.substr),
                 bool(operation.contains_.case_insensitive),
+            )
+        if isinstance(operation, tsi_query.ContainsTokenOperation):
+            return _ch_has_token(
+                self._operand_value(operation.contains_token_.input),
+                self._operand_value(operation.contains_token_.substr),
+                bool(operation.contains_token_.case_insensitive),
             )
         raise TypeError(f"Unknown operation type: {operation}")
 
@@ -1941,6 +1965,25 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                 return lambda rec: _ch_position(
                     input_fn(rec), substr_fn(rec), case_insensitive
                 )
+            elif isinstance(operation, tsi_query.ContainsTokenOperation):
+                case_insensitive = bool(operation.contains_token_.case_insensitive)
+                if is_multi_value_feedback(operation.contains_token_.input):
+                    field_path = operation.contains_token_.input.get_field_
+                    substr_fn = compile_operand(operation.contains_token_.substr)
+
+                    def evaluate_array_contains_token(rec: _CallRec) -> bool:
+                        needle = substr_fn(rec)
+                        return any(
+                            _ch_has_token(value, needle, case_insensitive)
+                            for value in self._feedback_values_array(rec, field_path)
+                        )
+
+                    return evaluate_array_contains_token
+                input_fn = compile_operand(operation.contains_token_.input)
+                substr_fn = compile_operand(operation.contains_token_.substr)
+                return lambda rec: _ch_has_token(
+                    input_fn(rec), substr_fn(rec), case_insensitive
+                )
             else:
                 raise TypeError(f"Unknown operation type: {operation}")
 
@@ -2071,6 +2114,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                     tsi_query.LteOperation,
                     tsi_query.InOperation,
                     tsi_query.ContainsOperation,
+                    tsi_query.ContainsTokenOperation,
                 ),
             ):
                 return compile_operation(operand)
@@ -7201,6 +7245,27 @@ def _orm_eval_query(table: Table, row: dict[str, Any], query: tsi.Query) -> Any:
                     )
                 )
             return _ch_position(lhs, rhs, bool(operation.contains_.case_insensitive))
+        elif isinstance(operation, tsi_query.ContainsTokenOperation):
+            input_operand = operation.contains_token_.input
+            if (
+                isinstance(input_operand, tsi_query.GetFieldOperator)
+                and input_operand.get_field_ in table.array_string_cols
+            ):
+                # Array membership semantics for Array(String) columns.
+                rhs = process_operand(operation.contains_token_.substr)
+                values = row.get(input_operand.get_field_) or []
+                if operation.contains_token_.case_insensitive:
+                    rhs_text = _to_sql_text(rhs)
+                    rhs_lower = rhs_text.lower() if rhs_text is not None else None
+                    return any(
+                        isinstance(v, str) and v.lower() == rhs_lower for v in values
+                    )
+                return rhs in values
+            lhs = process_operand(input_operand)
+            rhs = process_operand(operation.contains_token_.substr)
+            return _ch_has_token(
+                lhs, rhs, bool(operation.contains_token_.case_insensitive)
+            )
         else:
             raise TypeError(f"Unknown operation type: {operation}")
 
@@ -7249,6 +7314,7 @@ def _orm_eval_query(table: Table, row: dict[str, Any], query: tsi.Query) -> Any:
                 tsi_query.LteOperation,
                 tsi_query.InOperation,
                 tsi_query.ContainsOperation,
+                tsi_query.ContainsTokenOperation,
             ),
         ):
             return process_operation(operand)

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -115,7 +115,11 @@ from weave.trace_server.model_providers.model_providers import (
 )
 from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
 from weave.trace_server.opentelemetry.python_spans import Resource, Span
-from weave.trace_server.orm import Table, split_escaped_field_path
+from weave.trace_server.orm import (
+    TOKEN_SEPARATOR_CLASS,
+    Table,
+    split_escaped_field_path,
+)
 from weave.trace_server.secret_fetcher_context import _secret_fetcher_context
 from weave.trace_server.token_costs import (
     DEFAULT_PRICING_LEVEL_ID,
@@ -490,7 +494,7 @@ def _ch_has_token(haystack: Any, needle: Any, case_insensitive: bool) -> bool:
     return any(token == needle for token in tokens if token)
 
 
-_TOKEN_SEPARATOR_RE = re.compile(r"[^a-zA-Z0-9]+")
+_TOKEN_SEPARATOR_RE = re.compile(TOKEN_SEPARATOR_CLASS + "+")
 
 
 def _ch_sorted_by_terms(

--- a/weave/trace_server/interface/query.py
+++ b/weave/trace_server/interface/query.py
@@ -335,6 +335,43 @@ class ContainsSpec(BaseModel):
     case_insensitive: bool | None = False
 
 
+class ContainsTokenOperation(BaseModel):
+    """Whole-token match. Compiles to ClickHouse `hasToken`.
+
+    Not part of MongoDB. Weave-specific addition. Matches when `substr` equals
+    one of the tokens in `input` (tokens split on non-alphanumeric runs),
+    unlike `$contains` which does a substring search.
+
+    Example:
+        ```
+        {
+            "$containsToken": {
+                "input": {"$getField": "display_name"},
+                "substr": {"$literal": "llm"},
+                "case_insensitive": true
+            }
+        }
+        ```
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    contains_token_: "ContainsTokenSpec" = Field(alias="$containsToken")
+
+
+class ContainsTokenSpec(BaseModel):
+    """Specification for the `$containsToken` operation.
+
+    - `input`: The string to search.
+    - `substr`: The whole token to search for.
+    - `case_insensitive`: If true, match is case-insensitive.
+    """
+
+    input: "Operand"
+    substr: "Operand"
+    case_insensitive: bool | None = False
+
+
 # Convenience type for all Operands and Operations
 Operation = (
     AndOperation
@@ -347,6 +384,7 @@ Operation = (
     | LteOperation
     | InOperation
     | ContainsOperation
+    | ContainsTokenOperation
 )
 Operand = LiteralOperation | GetFieldOperator | ConvertOperation | Operation
 
@@ -363,6 +401,7 @@ GteOperation.model_rebuild()
 LteOperation.model_rebuild()
 InOperation.model_rebuild()
 ContainsOperation.model_rebuild()
+ContainsTokenOperation.model_rebuild()
 
 
 def infer_literal_filter_cast(operand: Operand) -> CastTo | None:

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -829,8 +829,8 @@ def _operand_array_string_column(
     operand: tsi_query.Operand, array_string_columns: Sequence[str]
 ) -> str | None:
     """Return the column name if `operand` is a bare $getField on an
-    Array(String) column, else None. Used by ContainsOperation to switch
-    from substring search to array membership.
+    Array(String) column, else None. Used by $contains/$containsToken to
+    switch from substring/token search to array membership.
     """
     if not array_string_columns:
         return None
@@ -841,7 +841,23 @@ def _operand_array_string_column(
     return None
 
 
-_TOKEN_SEPARATOR_RE = re.compile(r"[^a-zA-Z0-9]")
+# ClickHouse's default tokenizer splits on runs of non-alphanumeric chars.
+TOKEN_SEPARATOR_CLASS = r"[^a-zA-Z0-9]"
+_TOKEN_SEPARATOR_RE = re.compile(TOKEN_SEPARATOR_CLASS)
+
+
+def has_token_fn(case_insensitive: bool) -> str:
+    """ClickHouse token-membership fn; CI variant cannot use the tokenbf skip index."""
+    return "hasTokenCaseInsensitive" if case_insensitive else "hasToken"
+
+
+def _array_membership_cond(
+    array_col: str, rhs_part: str, case_insensitive: bool
+) -> str:
+    """SQL for whole-value membership in an Array(String) column."""
+    if case_insensitive:
+        return f"arrayExists(x -> lower(x) = lower({rhs_part}), {array_col})"
+    return f"has({array_col}, {rhs_part})"
 
 
 def assert_single_token(operand: tsi_query.Operand) -> None:
@@ -940,12 +956,9 @@ def _process_query_to_conditions(
             if array_col is not None:
                 rhs_part = process_operand(operation.contains_.substr)
                 raw_fields_used.add(array_col)
-                if operation.contains_.case_insensitive:
-                    cond = (
-                        f"arrayExists(x -> lower(x) = lower({rhs_part}), {array_col})"
-                    )
-                else:
-                    cond = f"has({array_col}, {rhs_part})"
+                cond = _array_membership_cond(
+                    array_col, rhs_part, bool(operation.contains_.case_insensitive)
+                )
             else:
                 lhs_part = process_operand(operation.contains_.input)
                 rhs_part = process_operand(operation.contains_.substr)
@@ -954,28 +967,26 @@ def _process_query_to_conditions(
                     position_operation = "positionCaseInsensitive"
                 cond = f"{position_operation}({lhs_part}, {rhs_part}) > 0"
         elif isinstance(operation, tsi_query.ContainsTokenOperation):
-            # Array(String) columns reuse the array-membership branch identical
-            # to $contains; everything else compiles to hasToken whole-token match.
+            # Array(String) columns match by membership (as $contains); scalars
+            # compile to a hasToken whole-token match.
             array_col = _operand_array_string_column(
                 operation.contains_token_.input, array_string_columns
             )
             if array_col is not None:
                 rhs_part = process_operand(operation.contains_token_.substr)
                 raw_fields_used.add(array_col)
-                if operation.contains_token_.case_insensitive:
-                    cond = (
-                        f"arrayExists(x -> lower(x) = lower({rhs_part}), {array_col})"
-                    )
-                else:
-                    cond = f"has({array_col}, {rhs_part})"
+                cond = _array_membership_cond(
+                    array_col,
+                    rhs_part,
+                    bool(operation.contains_token_.case_insensitive),
+                )
             else:
                 assert_single_token(operation.contains_token_.substr)
                 lhs_part = process_operand(operation.contains_token_.input)
                 rhs_part = process_operand(operation.contains_token_.substr)
-                # hasTokenCaseInsensitive cannot use the tokenbf skip index.
-                has_token = "hasToken"
-                if operation.contains_token_.case_insensitive:
-                    has_token = "hasTokenCaseInsensitive"
+                has_token = has_token_fn(
+                    bool(operation.contains_token_.case_insensitive)
+                )
                 cond = f"{has_token}({lhs_part}, {rhs_part})"
         else:
             raise TypeError(f"Unknown operation type: {operation}")

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, TypeAlias
 
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import SortBy
+from weave.trace_server.errors import InvalidRequest
 from weave.trace_server.interface import query as tsi_query
 
 param_builder_count = 0
@@ -840,6 +841,25 @@ def _operand_array_string_column(
     return None
 
 
+_TOKEN_SEPARATOR_RE = re.compile(r"[^a-zA-Z0-9]")
+
+
+def assert_single_token(operand: tsi_query.Operand) -> None:
+    """Reject a literal hasToken needle that spans token separators.
+
+    ClickHouse `hasToken` errors on needles containing non-alphanumeric
+    characters. Non-literal needles pass through unchecked.
+    """
+    if isinstance(operand, tsi_query.LiteralOperation):
+        assert_single_token_value(operand.literal_)
+
+
+def assert_single_token_value(value: object) -> None:
+    """Reject a raw hasToken needle that spans token separators."""
+    if isinstance(value, str) and _TOKEN_SEPARATOR_RE.search(value):
+        raise InvalidRequest(f"$containsToken needle must be a single token: {value!r}")
+
+
 def _process_query_to_conditions(
     query: tsi.Query,
     *,
@@ -933,6 +953,30 @@ def _process_query_to_conditions(
                 if operation.contains_.case_insensitive:
                     position_operation = "positionCaseInsensitive"
                 cond = f"{position_operation}({lhs_part}, {rhs_part}) > 0"
+        elif isinstance(operation, tsi_query.ContainsTokenOperation):
+            # Array(String) columns reuse the array-membership branch identical
+            # to $contains; everything else compiles to hasToken whole-token match.
+            array_col = _operand_array_string_column(
+                operation.contains_token_.input, array_string_columns
+            )
+            if array_col is not None:
+                rhs_part = process_operand(operation.contains_token_.substr)
+                raw_fields_used.add(array_col)
+                if operation.contains_token_.case_insensitive:
+                    cond = (
+                        f"arrayExists(x -> lower(x) = lower({rhs_part}), {array_col})"
+                    )
+                else:
+                    cond = f"has({array_col}, {rhs_part})"
+            else:
+                assert_single_token(operation.contains_token_.substr)
+                lhs_part = process_operand(operation.contains_token_.input)
+                rhs_part = process_operand(operation.contains_token_.substr)
+                # hasTokenCaseInsensitive cannot use the tokenbf skip index.
+                has_token = "hasToken"
+                if operation.contains_token_.case_insensitive:
+                    has_token = "hasTokenCaseInsensitive"
+                cond = f"{has_token}({lhs_part}, {rhs_part})"
         else:
             raise TypeError(f"Unknown operation type: {operation}")
 

--- a/weave/trace_server/query_builder/agent_query_compiler.py
+++ b/weave/trace_server/query_builder/agent_query_compiler.py
@@ -31,6 +31,7 @@ from weave.trace_server.agents.semconv import FILTERABLE_KEY_TO_COLUMN
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.orm import (
     ParamBuilder,
+    assert_single_token,
     clickhouse_cast,
     python_value_to_ch_type,
 )
@@ -187,6 +188,21 @@ def _compile_operation(
         fn = "positionCaseInsensitive" if op.contains_.case_insensitive else "position"
         return f"{fn}({lhs_sql}, {rhs_sql}) > 0"
 
+    if isinstance(op, tsi_query.ContainsTokenOperation):
+        # $containsToken always compares strings — force sibling hint to str.
+        assert_single_token(op.contains_token_.substr)
+        lhs_sql = _compile_operand(
+            op.contains_token_.input, pb, alias, sibling_hint=str
+        )
+        rhs_sql = _compile_operand(op.contains_token_.substr, pb, alias)
+        # hasTokenCaseInsensitive cannot use the tokenbf skip index.
+        fn = (
+            "hasTokenCaseInsensitive"
+            if op.contains_token_.case_insensitive
+            else "hasToken"
+        )
+        return f"{fn}({lhs_sql}, {rhs_sql})"
+
     raise TypeError(f"Unknown operation type: {type(op).__name__}")
 
 
@@ -232,6 +248,7 @@ def _compile_operand(
             tsi_query.LteOperation,
             tsi_query.InOperation,
             tsi_query.ContainsOperation,
+            tsi_query.ContainsTokenOperation,
         ),
     ):
         return _compile_operation(operand, pb, alias)

--- a/weave/trace_server/query_builder/agent_query_compiler.py
+++ b/weave/trace_server/query_builder/agent_query_compiler.py
@@ -33,6 +33,7 @@ from weave.trace_server.orm import (
     ParamBuilder,
     assert_single_token,
     clickhouse_cast,
+    has_token_fn,
     python_value_to_ch_type,
 )
 from weave.trace_server.query_builder.agent_custom_attrs import (
@@ -195,12 +196,7 @@ def _compile_operation(
             op.contains_token_.input, pb, alias, sibling_hint=str
         )
         rhs_sql = _compile_operand(op.contains_token_.substr, pb, alias)
-        # hasTokenCaseInsensitive cannot use the tokenbf skip index.
-        fn = (
-            "hasTokenCaseInsensitive"
-            if op.contains_token_.case_insensitive
-            else "hasToken"
-        )
+        fn = has_token_fn(bool(op.contains_token_.case_insensitive))
         return f"{fn}({lhs_sql}, {rhs_sql})"
 
     raise TypeError(f"Unknown operation type: {type(op).__name__}")


### PR DESCRIPTION
## Summary
- New `$containsToken` trace-server query operator: whole-token match compiling to ClickHouse `hasToken` (case-sensitive) / `hasTokenCaseInsensitive` (case-insensitive, cannot use the tokenbf skip index).
- `Array(String)` fields (input_refs/output_refs, multi-value feedback) reuse the same array-membership branch as `$contains`.
- Single-token guard rejects literal needles spanning token separators (InvalidRequest); non-literal needles pass through.

## Testing
unit tests assert generated SQL (orm / calls_query_builder / object_ref / agent compiler) + in-memory token semantics against both backends.