### PR TITLE
chore(weave): make node SDK cassette matcher version-agnostic

### DIFF
--- a/sdks/node/src/__tests__/helpers/withCassette.ts
+++ b/sdks/node/src/__tests__/helpers/withCassette.ts
@@ -28,6 +28,25 @@ function normalizeVolatileBodyFields(req: HttpRequest): HttpRequest {
 }
 
 /**
+ * Replace the SDK version token in the `user-agent` header with a stable
+ * placeholder, so cassette matching survives version bumps.
+ */
+function normalizeUserAgentVersion(req: HttpRequest): HttpRequest {
+  const userAgent = req.headers['user-agent'];
+  if (!userAgent) {
+    return req;
+  }
+
+  return {
+    ...req,
+    headers: {
+      ...req.headers,
+      'user-agent': userAgent.replace(/(JS Client ).+$/, '$1<VERSION>'),
+    },
+  };
+}
+
+/**
  * Replace per-request multipart boundary with a stable placeholder
  * in both the `content-type` header and the body, so cassette matching works
  * across runs. Non-multipart requests pass through untouched.
@@ -51,10 +70,11 @@ function normalizeMultipartBoundary(req: HttpRequest): HttpRequest {
 }
 
 function normalizeRequest(req: HttpRequest): HttpRequest {
-  return [normalizeMultipartBoundary, normalizeVolatileBodyFields].reduce(
-    (req, normalizer) => normalizer(req),
-    req
-  );
+  return [
+    normalizeMultipartBoundary,
+    normalizeVolatileBodyFields,
+    normalizeUserAgentVersion,
+  ].reduce((req, normalizer) => normalizer(req), req);
 }
 
 class Matcher extends DefaultRequestMatcher {


### PR DESCRIPTION
## Summary
- Every `init()`-driven Node SDK cassette test (`getAgents`/`getAgentVersions`/...) failed after the `0.15.1` -> `0.16.0` SDK bump. The graphql `user-agent` is version-stamped (`Weave JS Client <packageVersion>`) and the cassette matcher compares headers strictly, so the recorded `0.15.1` no longer matched the live `0.16.0`. The harness already normalized `client_version` in the body but not the user-agent header.
- Fix: normalize the version token in the `user-agent` header, mirroring the existing body normalization, so matching survives future version bumps.

Original failure ([CI job](https://github.com/wandb/weave/actions/runs/28252703750/job/83707953605)):
```
Match no found for POST https://api.wandb.ai/graphql
```

## Testing
reproduced locally at `0.16.0`: 38 live `weaveClient` tests fail -> all pass after the fix. test-harness only change.