### PR TITLE
fix(weave_ts): Update cassettes to reflect version bump.

### DIFF
--- a/sdks/node/src/__tests__/__cassettes__/dataset_should_save_a_dataset.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/dataset_should_save_a_dataset.yaml
@@ -4,7 +4,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/publishing_various_data_types_publish_various_data_types.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/publishing_various_data_types_publish_various_data_types.yaml
@@ -4,7 +4,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/table_example.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/table_example.yaml
@@ -4,7 +4,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentcustomattrsschema_errors_with_invalid_project_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentcustomattrsschema_errors_with_invalid_project_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentcustomattrsschema_filters_by_query.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentcustomattrsschema_filters_by_query.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentcustomattrsschema_filters_by_time_window.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentcustomattrsschema_filters_by_time_window.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentcustomattrsschema_gets_the_custom_attrs_schema_for_the_project.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentcustomattrsschema_gets_the_custom_attrs_schema_for_the_project.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentcustomattrsschema_returns_no_attributes_for_a_window_with_no_data.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentcustomattrsschema_returns_no_attributes_for_a_window_with_no_data.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentcustomattrsschema_supports_limit_and_offset.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentcustomattrsschema_supports_limit_and_offset.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagents_errors_with_invalid_project_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagents_errors_with_invalid_project_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagents_gets_agents.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagents_gets_agents.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagents_supports_limit_and_offset.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagents_supports_limit_and_offset.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspans_errors_with_invalid_project_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspans_errors_with_invalid_project_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspans_filters_by_agent_name.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspans_filters_by_agent_name.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspans_gets_agent_spans.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspans_gets_agent_spans.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspans_returns_no_spans_for_nonexistent_agent.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspans_returns_no_spans_for_nonexistent_agent.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspans_supports_limit_and_offset.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspans_supports_limit_and_offset.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_bucketed_by_time_granularity.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_bucketed_by_time_granularity.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_errors_with_invalid_project_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_errors_with_invalid_project_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_gets_span_stats_over_a_time_window.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_gets_span_stats_over_a_time_window.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_returns_empty_rows_for_a_window_with_no_data.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentspanstats_returns_empty_rows_for_a_window_with_no_data.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturn_errors_with_invalid_project_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturn_errors_with_invalid_project_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturn_gets_turn_data_for_a_given_trace_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturn_gets_turn_data_for_a_given_trace_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturn_handles_nonexistent_trace_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturn_handles_nonexistent_trace_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturn_includes_feedback_when_requested.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturn_includes_feedback_when_requested.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturns_errors_with_invalid_project_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturns_errors_with_invalid_project_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturns_gets_turn_data_for_the_given_conversation_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturns_gets_turn_data_for_the_given_conversation_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturns_handles_nonexistent_conversation_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturns_handles_nonexistent_conversation_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturns_includes_feedback_when_requested.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturns_includes_feedback_when_requested.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturns_supports_limit_and_offset.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentturns_supports_limit_and_offset.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentversions_errors_with_invalid_project_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentversions_errors_with_invalid_project_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentversions_gets_agent_versions.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentversions_gets_agent_versions.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentversions_returns_no_versions_for_nonexistent_agent.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentversions_returns_no_versions_for_nonexistent_agent.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentversions_supports_limit_and_offset.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagentversions_supports_limit_and_offset.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_errors_with_invalid_project_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_errors_with_invalid_project_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_filters_by_agent_name.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_filters_by_agent_name.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_filters_by_conversation_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_filters_by_conversation_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_filters_by_trace_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_filters_by_trace_id.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_returns_no_results_for_nonexistent_query.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_returns_no_results_for_nonexistent_query.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_searches_messages_by_query.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_searches_messages_by_query.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_supports_limit_and_offset.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_searchagents_supports_limit_and_offset.yaml
@@ -22,7 +22,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveobject_class_example.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveobject_class_example.yaml
@@ -4,7 +4,7 @@
     headers:
       authorization: masked
       content-type: application/json
-      user-agent: Weave JS Client 0.15.1
+      user-agent: Weave JS Client 0.16.0
     body: '{"query":"\nquery DefaultEntity {\n    viewer
       {\n        username\n        defaultEntity
       {\n            name\n        }\n    }\n}\n","variables":{}}'


### PR DESCRIPTION
## Description

* This "bump version" GH action (https://github.com/wandb/weave/actions/workflows/bump_ts_sdk_version.yaml) pushes a commit that renders recorded TS cassettes as stale, which breaks CI.

* Quick fix to get build green -- I can follow up by masking the client version in our cassettes.

