### PR TITLE
fix(weave_ts): print Weave data URL on Node init

### DIFF
--- a/sdks/node/src/clientApi.ts
+++ b/sdks/node/src/clientApi.ts
@@ -137,7 +137,7 @@ export async function init(
     setGlobalClient(client);
     setGlobalDomain(domain);
     registerEvalLinkSpanProcessor(getGlobalClient);
-    console.log(`Initializing project: ${projectId}`);
+    console.log(`View Weave data at https://${domain}/${projectId}/weave`);
     return client;
   } catch (error) {
     console.error('Error during initialization:', error);


### PR DESCRIPTION
Print `View Weave data at https://<domain>/<entity>/<project>/weave` on Node `init()`, matching the Python SDK. Node previously logged only `Initializing project: <entity>/<project>` with no link.