### PR TITLE
feat(weave_ts): carry systemInstructions on Turn (invoke_agent) spans

### DIFF
--- a/sdks/node/src/__tests__/genai/turn.test.ts
+++ b/sdks/node/src/__tests__/genai/turn.test.ts
@@ -5,6 +5,7 @@ import {
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
 } from '../../genai/semconv';
 import {Turn} from '../../genai/turn';
 
@@ -50,6 +51,37 @@ describe('Turn', () => {
     expect(span.status.code).toBe(SpanStatusCode.ERROR);
     expect(span.status.message).toBe('boom');
     expect(span.events.some(e => e.name === 'exception')).toBe(true);
+  });
+});
+
+// Mirrors the Python SDK's `system_instructions` support on the invoke_agent
+// (Turn) span (wandb/weave#7348). The TS SDK has no include_content / PII layer,
+// so only the serialization + empty-omission behavior has a counterpart here.
+describe('Turn.systemInstructions', () => {
+  setupGenAITestEnvironment();
+  const getExporter = setupExporterPerTest();
+
+  it('serializes systemInstructions as a TextPart array on gen_ai.system_instructions', () => {
+    const turn = Turn.create({agentName: 'weather-bot'});
+    turn.systemInstructions = ['Be helpful', 'Be concise'];
+    turn.end();
+
+    const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
+    // Same TextPart array shape as the chat span (per semconv).
+    expect(
+      JSON.parse(span.attributes[ATTR_GEN_AI_SYSTEM_INSTRUCTIONS] as string)
+    ).toEqual([
+      {type: 'text', content: 'Be helpful'},
+      {type: 'text', content: 'Be concise'},
+    ]);
+  });
+
+  it('omits gen_ai.system_instructions when systemInstructions is empty', () => {
+    const turn = Turn.create({agentName: 'weather-bot'});
+    turn.end();
+
+    const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
+    expect(span.attributes[ATTR_GEN_AI_SYSTEM_INSTRUCTIONS]).toBeUndefined();
   });
 });
 

--- a/sdks/node/src/__tests__/genai/turn.test.ts
+++ b/sdks/node/src/__tests__/genai/turn.test.ts
@@ -67,7 +67,23 @@ describe('Turn.systemInstructions', () => {
     turn.end();
 
     const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
-    // Same TextPart array shape as the chat span (per semconv).
+    // TextPart array shape (`[{type:'text', content}]`) per the GenAI semconv.
+    expect(
+      JSON.parse(span.attributes[ATTR_GEN_AI_SYSTEM_INSTRUCTIONS] as string)
+    ).toEqual([
+      {type: 'text', content: 'Be helpful'},
+      {type: 'text', content: 'Be concise'},
+    ]);
+  });
+
+  it('accepts systemInstructions via the create() factory', () => {
+    const turn = Turn.create({
+      agentName: 'weather-bot',
+      systemInstructions: ['Be helpful', 'Be concise'],
+    });
+    turn.end();
+
+    const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
     expect(
       JSON.parse(span.attributes[ATTR_GEN_AI_SYSTEM_INSTRUCTIONS] as string)
     ).toEqual([

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -26,6 +26,8 @@ import {Tool, type ToolInit} from './tool';
 export interface TurnInit extends SpanInitBase {
   agentName?: string;
   model?: string;
+  /** The agent's system prompt. See {@link Turn.systemInstructions}. */
+  systemInstructions?: string[];
 }
 
 /**
@@ -52,11 +54,16 @@ export interface TurnInit extends SpanInitBase {
  */
 export class Turn extends SpanBase {
   /**
-   * The agent's system prompt. Flushed to `gen_ai.system_instructions` on
-   * `end()` as a TextPart array (the same shape the chat span uses, per
-   * semconv) so the Agents tab can surface it on the agent-start marker.
-   * Empty → the attribute is omitted. Mirrors the Python SDK's
-   * `Turn.system_instructions`.
+   * The agent's system prompt. Set directly
+   * (`turn.systemInstructions = [...]`) or via the factory
+   * (`weave.startTurn({systemInstructions: [...]})`). Flushed to
+   * `gen_ai.system_instructions` on `end()` as a TextPart array
+   * (`[{type: 'text', content}]`) per the GenAI semconv, so the Agents tab can
+   * surface it on the agent-start marker. Empty → the attribute is omitted.
+   * Mirrors the Python SDK's `Turn.system_instructions`.
+   *
+   * Note: unlike the Python SDK, the TS SDK has no `include_content` / PII
+   * redaction layer, so the prompt is emitted verbatim when set.
    */
   systemInstructions: string[] = [];
 
@@ -106,6 +113,7 @@ export class Turn extends SpanBase {
       opts.agentName ?? '',
       opts.model ?? ''
     );
+    turn.systemInstructions = opts.systemInstructions ?? [];
     state.turn = turn;
     return turn;
   }

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -17,6 +17,7 @@ import {
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   WEAVE_GENAI_TRACER_NAME,
 } from './semconv';
 import {SubAgent, type SubAgentInit} from './subagent';
@@ -50,6 +51,15 @@ export interface TurnInit extends SpanInitBase {
  * }
  */
 export class Turn extends SpanBase {
+  /**
+   * The agent's system prompt. Flushed to `gen_ai.system_instructions` on
+   * `end()` as a TextPart array (the same shape the chat span uses, per
+   * semconv) so the Agents tab can surface it on the agent-start marker.
+   * Empty → the attribute is omitted. Mirrors the Python SDK's
+   * `Turn.system_instructions`.
+   */
+  systemInstructions: string[] = [];
+
   private constructor(
     span: Span,
     private readonly context: Context,
@@ -146,6 +156,16 @@ export class Turn extends SpanBase {
       return;
     }
     this._ended = true;
+
+    if (this.systemInstructions.length > 0) {
+      this.span.setAttribute(
+        ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
+        JSON.stringify(
+          this.systemInstructions.map(content => ({type: 'text', content}))
+        )
+      );
+    }
+
     this._closeSpan(opts);
     const state = getGenaiState();
     if (state.turn === this) {


### PR DESCRIPTION
## What

TypeScript Node SDK parity for #7348 (Python), which added `system_instructions` to the Session SDK's `invoke_agent` (`Turn`) span.

- `Turn` gains a mutable `systemInstructions: string[]` field, flushed to `gen_ai.system_instructions` on `end()` as a **TextPart array** (`[{type:"text", content:"…"}]`) — the same shape the chat span uses, per semconv.
- Empty → the attribute is omitted.

## Why

The Agents chat projection builds its agent-start lifecycle marker from the `invoke_agent` span's `system_instructions`. Previously only the `chat` (LLM) span could carry `gen_ai.system_instructions` on the TS side, so an agent that records its prompt on the turn had no way to surface it on the agent-start marker. This lets the turn span carry the prompt directly, matching the Python SDK.

## Implementation notes

- The field mirrors how `LLM` carries `inputMessages` (a mutable field flushed at `end()`) and the Python SDK's `Turn.system_instructions` (also a mutable field). Identity/config stays in `TurnInit`; content lives as a flushed field — consistent with the existing `LLM` surface.
- Serialized to the TextPart array per semconv, matching Python's `_serialize_system_instructions`.

## Scope notes

- The TS genai SDK has **no `include_content` / PII-redaction layer**, so those aspects of the Python PR have no counterpart here.
- `SubAgent` (also an `invoke_agent` span) can adopt the same field in a follow-up — matching the Python PR's note.
- The existing `piCodingAgent` integration already emits `gen_ai.system_instructions`, but as a plain string array rather than the TextPart shape. That's a pre-existing divergence, left out of scope for this parity PR.

## Testing

- `pnpm exec jest src/__tests__/genai/turn.test.ts` — 15 pass (13 existing + 2 new: TextPart serialization, empty-omission).
- `eslint`, `prettier --check`, and `tsc --noEmit` clean on the changed files.

Companion to #7348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)