### PR TITLE
feat(weave): full-fidelity batch turn logging + Turn/SubAgent.record()

### DIFF
--- a/tests/session/test_session_otel.py
+++ b/tests/session/test_session_otel.py
@@ -1788,6 +1788,26 @@ class TestLogSession:
         assert attrs["gen_ai.agent.description"] == "A helpful bot"
         assert attrs["gen_ai.agent.version"] == "v2"
 
+    def test_does_not_mutate_caller_turn(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        # log_session applies session-level defaults / continue_parent_trace to
+        # a model_copy of each Turn, not the caller's instance. Locks in the
+        # "without mutating the caller's object" contract that model_copy exists
+        # to guarantee — a future _emit_turn edit that mutated in place would
+        # break this.
+        turn = Turn(started_at=_ts(0), ended_at=_ts(1))  # no agent_name / model
+        log_session(
+            session_id="sess-no-mutate",
+            agent_name="session-bot",
+            model="gpt-4o",
+            continue_parent_trace=True,
+            turns=[turn],
+        )
+        assert turn.agent_name == ""
+        assert turn.model == ""
+        assert turn.continue_parent_trace is False
+
     def test_empty_turns_returns_empty_log_result(
         self, otel_spans: InMemorySpanExporter
     ) -> None:

--- a/tests/session/test_session_otel.py
+++ b/tests/session/test_session_otel.py
@@ -2115,6 +2115,65 @@ class TestTurnRecord:
         assert attrs["gen_ai.agent.version"] == "v4"
 
 
+class TestSubAgentRecord:
+    """SubAgent.record(...) collapses N attribute assignments into one call."""
+
+    def test_partial_record_preserves_existing(self) -> None:
+        """Fields not passed (None) keep their existing values."""
+        sa = SubAgent(name="research-bot")
+        sa.agent_id = "preset"
+        sa.record(system_instructions=["You research things"])
+        assert sa.agent_id == "preset"
+        assert sa.name == "research-bot"
+        assert sa.system_instructions == ["You research things"]
+
+    def test_sets_all_fields(self) -> None:
+        sa = SubAgent()
+        sa.record(
+            name="research-bot",
+            model="gpt-4o-mini",
+            system_instructions=["sys"],
+            agent_id="id-1",
+            agent_description="desc",
+            agent_version="v1",
+        )
+        assert sa.name == "research-bot"
+        assert sa.model == "gpt-4o-mini"
+        assert sa.system_instructions == ["sys"]
+        assert sa.agent_id == "id-1"
+        assert sa.agent_description == "desc"
+        assert sa.agent_version == "v1"
+
+    def test_returns_self_for_chaining(self) -> None:
+        sa = SubAgent()
+        assert sa.record(agent_id="x") is sa
+
+    def test_recorded_fields_emitted_on_span(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        """End-to-end: record() values flow through to the OTel attrs."""
+        with Session(agent_name="orchestrator") as s:
+            with s.start_turn() as turn:
+                with turn.subagent(name="research-bot") as sa:
+                    sa.record(
+                        system_instructions=["You research things"],
+                        agent_id="agent-9",
+                        agent_description="A research bot",
+                        agent_version="v4",
+                    )
+
+        spans = otel_spans.get_finished_spans()
+        sa_spans = [sp for sp in spans if sp.name == "invoke_agent research-bot"]
+        assert len(sa_spans) == 1
+        attrs = dict(sa_spans[0].attributes or {})
+        assert json.loads(attrs["gen_ai.system_instructions"]) == [
+            {"type": "text", "content": "You research things"},
+        ]
+        assert attrs["gen_ai.agent.id"] == "agent-9"
+        assert attrs["gen_ai.agent.description"] == "A research bot"
+        assert attrs["gen_ai.agent.version"] == "v4"
+
+
 class TestUsageFromOpenAIResponses:
     """``usage_from_openai_responses`` populates ``gen_ai.usage.*`` on the chat span.
 

--- a/tests/session/test_session_otel.py
+++ b/tests/session/test_session_otel.py
@@ -1435,6 +1435,26 @@ class TestLogTurn:
         assert len(turn_spans) == 1
         assert sa_spans[0].parent.span_id == turn_spans[0].context.span_id
 
+    def test_agent_identity_fields_emitted(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        log_turn(
+            session_id="sess-ident",
+            agent_name="bot",
+            agent_id="agent-7",
+            agent_description="A helpful bot",
+            agent_version="v3",
+            started_at=_ts(0),
+            ended_at=_ts(1),
+        )
+        spans = otel_spans.get_finished_spans()
+        turn_spans = [sp for sp in spans if sp.name == "invoke_agent bot"]
+        assert len(turn_spans) == 1
+        attrs = dict(turn_spans[0].attributes or {})
+        assert attrs["gen_ai.agent.id"] == "agent-7"
+        assert attrs["gen_ai.agent.description"] == "A helpful bot"
+        assert attrs["gen_ai.agent.version"] == "v3"
+
     def test_subagent_system_instructions_emitted(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
@@ -1740,6 +1760,34 @@ class TestLogSession:
         # 2 turns + 2 LLMs + 1 tool = 5
         assert len(spans) == 5
 
+    def test_forwards_all_turn_fields(self, otel_spans: InMemorySpanExporter) -> None:
+        # log_session emits the Turn it is handed, so every field survives —
+        # not just the subset log_turn historically accepted as kwargs.
+        log_session(
+            session_id="sess-fields",
+            turns=[
+                Turn(
+                    agent_name="bot",
+                    agent_id="agent-123",
+                    agent_description="A helpful bot",
+                    agent_version="v2",
+                    system_instructions=["You are a weather bot"],
+                    started_at=_ts(0),
+                    ended_at=_ts(1),
+                ),
+            ],
+        )
+        spans = otel_spans.get_finished_spans()
+        turn_spans = [sp for sp in spans if sp.name == "invoke_agent bot"]
+        assert len(turn_spans) == 1
+        attrs = dict(turn_spans[0].attributes or {})
+        assert json.loads(attrs["gen_ai.system_instructions"]) == [
+            {"type": "text", "content": "You are a weather bot"},
+        ]
+        assert attrs["gen_ai.agent.id"] == "agent-123"
+        assert attrs["gen_ai.agent.description"] == "A helpful bot"
+        assert attrs["gen_ai.agent.version"] == "v2"
+
     def test_empty_turns_returns_empty_log_result(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
@@ -2005,6 +2053,66 @@ class TestLLMRecord:
             {"type": "reasoning", "content": "thinking..."},
             {"type": "text", "content": "hello"},
         ]
+
+
+class TestTurnRecord:
+    """Turn.record(...) collapses N attribute assignments into one call."""
+
+    def test_partial_record_preserves_existing(self) -> None:
+        """Fields not passed (None) keep their existing values."""
+        turn = Turn(agent_name="bot")
+        turn.agent_id = "preset"
+        turn.record(system_instructions=["You are a bot"])
+        assert turn.agent_id == "preset"
+        assert turn.agent_name == "bot"
+        assert turn.system_instructions == ["You are a bot"]
+
+    def test_sets_all_fields(self) -> None:
+        turn = Turn()
+        turn.record(
+            messages=[Message.user("hi")],
+            system_instructions=["sys"],
+            agent_name="bot",
+            model="gpt-4o",
+            agent_id="id-1",
+            agent_description="desc",
+            agent_version="v1",
+        )
+        assert turn.messages == [Message.user("hi")]
+        assert turn.system_instructions == ["sys"]
+        assert turn.agent_name == "bot"
+        assert turn.model == "gpt-4o"
+        assert turn.agent_id == "id-1"
+        assert turn.agent_description == "desc"
+        assert turn.agent_version == "v1"
+
+    def test_returns_self_for_chaining(self) -> None:
+        turn = Turn()
+        assert turn.record(agent_id="x") is turn
+
+    def test_recorded_fields_emitted_on_span(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        """End-to-end: record() values flow through to the OTel attrs."""
+        with Session(session_id="sess-turn-record") as s:
+            with s.start_turn(agent_name="weather-bot") as turn:
+                turn.record(
+                    system_instructions=["You are a weather bot"],
+                    agent_id="agent-9",
+                    agent_description="A helpful bot",
+                    agent_version="v4",
+                )
+
+        spans = otel_spans.get_finished_spans()
+        turn_spans = [sp for sp in spans if sp.name == "invoke_agent weather-bot"]
+        assert len(turn_spans) == 1
+        attrs = dict(turn_spans[0].attributes or {})
+        assert json.loads(attrs["gen_ai.system_instructions"]) == [
+            {"type": "text", "content": "You are a weather bot"},
+        ]
+        assert attrs["gen_ai.agent.id"] == "agent-9"
+        assert attrs["gen_ai.agent.description"] == "A helpful bot"
+        assert attrs["gen_ai.agent.version"] == "v4"
 
 
 class TestUsageFromOpenAIResponses:

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -891,6 +891,47 @@ class Turn(_SpanBase):
             system_instructions=system_instructions or [],
         )
 
+    def record(
+        self,
+        *,
+        messages: list[Message] | None = None,
+        system_instructions: list[str] | None = None,
+        agent_name: str | None = None,
+        model: str | None = None,
+        agent_id: str | None = None,
+        agent_description: str | None = None,
+        agent_version: str | None = None,
+    ) -> Turn:
+        """Set multiple turn fields in one call.
+
+        Collapses the per-field assignments a manually-instrumented agent
+        otherwise makes on a turn (``system_instructions``, ``agent_id``,
+        ...) into a single keyword call. Only fields explicitly passed
+        (non-``None``) are applied — existing values are preserved. Returns
+        ``self`` for chaining. Mirrors ``LLM.record``.
+
+        Note: on the streaming (``with``) path the turn span is named from
+        ``agent_name`` at ``__enter__``, so set ``agent_name`` via
+        ``start_turn`` rather than ``record`` if you need the span name to
+        reflect it; ``record`` still updates the ``gen_ai.agent.name``
+        attribute.
+        """
+        if messages is not None:
+            self.messages = messages
+        if system_instructions is not None:
+            self.system_instructions = system_instructions
+        if agent_name is not None:
+            self.agent_name = agent_name
+        if model is not None:
+            self.model = model
+        if agent_id is not None:
+            self.agent_id = agent_id
+        if agent_description is not None:
+            self.agent_description = agent_description
+        if agent_version is not None:
+            self.agent_version = agent_version
+        return self
+
     def _build_attrs(
         self, *, session_id: str, session_name: str, include_content: bool
     ) -> dict[str, Any]:
@@ -1330,52 +1371,27 @@ def _attrs_for_span(
     )
 
 
-def log_turn(
+def _emit_turn(
+    turn: Turn,
     *,
     session_id: str,
-    agent_name: str = "",
-    session_name: str = "",
-    model: str = "",
-    messages: list[Message] | None = None,
-    system_instructions: list[str] | None = None,
-    spans: list[LLM | Tool | SubAgent] | None = None,
-    started_at: datetime | None = None,
-    ended_at: datetime | None = None,
-    include_content: bool = True,
-    continue_parent_trace: bool = False,
+    session_name: str,
+    include_content: bool,
     attributes: Attributes = None,
 ) -> LogResult:
-    """Imperatively emit one turn and its child spans to OTel.
+    """Emit one fully-built ``Turn`` (and its child spans) to OTel.
 
-    Use when context managers aren't viable (stateless containers, callbacks,
-    queue workers). Each child span passed in should have ``started_at`` /
-    ``ended_at`` set; the emitted OTel span timestamps come from those fields.
-    Falls back to the earliest/latest child timestamp, then ``now()``, when
-    the turn doesn't supply its own.
-
-    ``attributes`` are stamped on every emitted span; the streaming path reads
-    these from the active session instead. Use custom, non-semconv keys: a
-    key that collides with a span's own ``gen_ai.*`` / ``weave.*`` attribute
-    is unsupported (which value wins is path-dependent).
+    Shared by ``log_turn`` (which builds the Turn from scalar kwargs) and
+    ``log_session`` (which is handed Turns directly), so every Turn field —
+    ``system_instructions``, ``agent_id`` / ``agent_description`` /
+    ``agent_version``, etc. — is honored identically on both batch paths.
+    ``continue_parent_trace`` is read from the Turn. Timestamp resolution is
+    idempotent when the Turn already carries both timestamps.
     """
-    if not _OTEL_AVAILABLE or should_disable_weave():
-        return LogResult(session_id=session_id)
-
-    resolved_spans = spans or []
     turn_started_at, turn_ended_at = _resolve_turn_timestamps(
-        started_at=started_at,
-        ended_at=ended_at,
-        spans=resolved_spans,
-    )
-    turn = Turn(
-        agent_name=agent_name,
-        model=model,
-        system_instructions=system_instructions or [],
-        messages=messages or [],
-        spans=resolved_spans,
-        started_at=turn_started_at,
-        ended_at=turn_ended_at,
-        continue_parent_trace=continue_parent_trace,
+        started_at=turn.started_at,
+        ended_at=turn.ended_at,
+        spans=turn.spans,
     )
 
     turn_attrs = turn._build_attrs(
@@ -1386,7 +1402,7 @@ def log_turn(
     if attributes:
         turn_attrs.update(attributes)
 
-    parent_ctx = Context() if not continue_parent_trace else None
+    parent_ctx = Context() if not turn.continue_parent_trace else None
     turn_span = _emit_span_now(
         f"invoke_agent {turn.agent_name}",
         parent_ctx=parent_ctx,
@@ -1423,6 +1439,71 @@ def log_turn(
     )
 
 
+def log_turn(
+    *,
+    session_id: str,
+    agent_name: str = "",
+    session_name: str = "",
+    model: str = "",
+    agent_id: str = "",
+    agent_description: str = "",
+    agent_version: str = "",
+    messages: list[Message] | None = None,
+    system_instructions: list[str] | None = None,
+    spans: list[LLM | Tool | SubAgent] | None = None,
+    started_at: datetime | None = None,
+    ended_at: datetime | None = None,
+    include_content: bool = True,
+    continue_parent_trace: bool = False,
+    attributes: Attributes = None,
+) -> LogResult:
+    """Imperatively emit one turn and its child spans to OTel.
+
+    Use when context managers aren't viable (stateless containers, callbacks,
+    queue workers). Each child span passed in should have ``started_at`` /
+    ``ended_at`` set; the emitted OTel span timestamps come from those fields.
+    Falls back to the earliest/latest child timestamp, then ``now()``, when
+    the turn doesn't supply its own.
+
+    ``attributes`` are stamped on every emitted span; the streaming path reads
+    these from the active session instead. Use custom, non-semconv keys: a
+    key that collides with a span's own ``gen_ai.*`` / ``weave.*`` attribute
+    is unsupported (which value wins is path-dependent).
+    """
+    if not _OTEL_AVAILABLE or should_disable_weave():
+        return LogResult(session_id=session_id)
+
+    resolved_spans = spans or []
+    # Resolve timestamps before constructing the Turn so model_post_init
+    # doesn't override a missing started_at with now() ahead of the
+    # earliest-child fallback.
+    turn_started_at, turn_ended_at = _resolve_turn_timestamps(
+        started_at=started_at,
+        ended_at=ended_at,
+        spans=resolved_spans,
+    )
+    turn = Turn(
+        agent_name=agent_name,
+        model=model,
+        agent_id=agent_id,
+        agent_description=agent_description,
+        agent_version=agent_version,
+        system_instructions=system_instructions or [],
+        messages=messages or [],
+        spans=resolved_spans,
+        started_at=turn_started_at,
+        ended_at=turn_ended_at,
+        continue_parent_trace=continue_parent_trace,
+    )
+    return _emit_turn(
+        turn,
+        session_id=session_id,
+        session_name=session_name,
+        include_content=include_content,
+        attributes=attributes,
+    )
+
+
 def log_session(
     *,
     turns: list[Turn],
@@ -1451,17 +1532,21 @@ def log_session(
     root_span_ids: list[str] = []
     span_count = 0
     for turn in turns:
-        result = log_turn(
+        # Emit the caller's Turn directly so every field survives (not just the
+        # subset log_turn accepts as kwargs). Fill in session-level
+        # agent_name/model defaults and apply the session's
+        # continue_parent_trace, without mutating the caller's object.
+        result = _emit_turn(
+            turn.model_copy(
+                update={
+                    "agent_name": turn.agent_name or agent_name,
+                    "model": turn.model or model,
+                    "continue_parent_trace": continue_parent_trace,
+                }
+            ),
             session_id=sid,
             session_name=session_name,
-            agent_name=turn.agent_name or agent_name,
-            model=turn.model or model,
-            messages=turn.messages,
-            spans=turn.spans,
-            started_at=turn.started_at,
-            ended_at=turn.ended_at,
             include_content=include_content,
-            continue_parent_trace=continue_parent_trace,
             attributes=attributes,
         )
         trace_ids.extend(result.trace_ids)

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -945,7 +945,9 @@ class Turn(_SpanBase):
         Collapses the per-field assignments a manually-instrumented agent
         otherwise makes on a turn (``system_instructions``, ``agent_id``,
         ...) into a single keyword call. Only fields explicitly passed
-        (non-``None``) are applied — existing values are preserved. Returns
+        (non-``None``) are applied — existing values are preserved.
+        ``messages`` **replaces** the turn's existing messages (unlike
+        ``Turn.user(...)``, which appends a single message). Returns
         ``self`` for chaining. Mirrors ``LLM.record``.
 
         Note: on the streaming (``with``) path the turn span is named from

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -1503,7 +1503,8 @@ def log_turn(
     queue workers). Each child span passed in should have ``started_at`` /
     ``ended_at`` set; the emitted OTel span timestamps come from those fields.
     Falls back to the earliest/latest child timestamp, then ``now()``, when
-    the turn doesn't supply its own.
+    the turn doesn't supply its own. The agent-identity fields (``agent_id`` /
+    ``agent_description`` / ``agent_version``) mirror the streaming path.
 
     ``attributes`` are stamped on every emitted span; the streaming path reads
     these from the active session instead. Use custom, non-semconv keys: a
@@ -1559,6 +1560,10 @@ def log_session(
 
     Each Turn's ``.spans`` attribute provides its children. Auto-generates
     ``session_id`` if empty. By default each turn gets its own OTel trace.
+    ``agent_name`` / ``model`` are session-level defaults — a Turn's own value
+    wins; the session value only fills in when the Turn leaves it empty. The
+    session's ``continue_parent_trace`` applies to every turn (a per-Turn
+    ``continue_parent_trace`` is intentionally superseded here).
 
     ``attributes`` are stamped on every emitted span. Use custom, non-semconv
     keys: a key that collides with a span's own ``gen_ai.*`` / ``weave.*``

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -748,6 +748,44 @@ class SubAgent(_SpanBase):
         """Start a tool execution within this sub-agent."""
         return Tool(name=name, arguments=arguments, tool_call_id=tool_call_id)
 
+    def record(
+        self,
+        *,
+        name: str | None = None,
+        model: str | None = None,
+        system_instructions: list[str] | None = None,
+        agent_id: str | None = None,
+        agent_description: str | None = None,
+        agent_version: str | None = None,
+    ) -> SubAgent:
+        """Set multiple sub-agent fields in one call.
+
+        Collapses the per-field assignments a manually-instrumented agent
+        otherwise makes on a sub-agent (``system_instructions``, ``agent_id``,
+        ...) into a single keyword call. Only fields explicitly passed
+        (non-``None``) are applied — existing values are preserved. Returns
+        ``self`` for chaining. Mirrors ``Turn.record`` / ``LLM.record``.
+
+        Note: on the streaming (``with``) path the sub-agent span is named
+        from ``name`` at ``__enter__``, so set ``name`` via ``start_subagent``
+        / ``turn.subagent`` rather than ``record`` if you need the span name
+        to reflect it; ``record`` still updates the ``gen_ai.agent.name``
+        attribute.
+        """
+        if name is not None:
+            self.name = name
+        if model is not None:
+            self.model = model
+        if system_instructions is not None:
+            self.system_instructions = system_instructions
+        if agent_id is not None:
+            self.agent_id = agent_id
+        if agent_description is not None:
+            self.agent_description = agent_description
+        if agent_version is not None:
+            self.agent_version = agent_version
+        return self
+
     def _build_attrs(
         self, *, session_id: str, session_name: str, include_content: bool
     ) -> dict[str, Any]:


### PR DESCRIPTION
Stacked on #7348.

- `log_session` emits each `Turn` directly (shared `_emit_turn`) — stops dropping `system_instructions` / `agent_id` / `agent_description` / `agent_version`.
- `log_turn` gains `agent_id` / `agent_description` / `agent_version` params.
- `Turn.record(...)` and `SubAgent.record(...)` bulk setters (mirror `LLM.record`).

`log_session` rebuilt each `Turn` through `log_turn`'s scalar kwargs and silently dropped non-param fields; emitting the `Turn` directly fixes the class.

`SubAgent.record(...)` closes the same parity gap for sub-agents that `Turn.record()` closes for turns (raised in review on #7348): the identity fields (`agent_id` / `agent_description` / `agent_version`) were reachable only via individual attribute assignment. Factories stay lean (`name` / `model` / `system_instructions`); `.record()` is the bulk path for the full field set, consistent with `Turn`/`LLM`.

Tests: `pytest tests/session/` — 295 pass.
