### PR TITLE
chore(weave): add doctest nox session and CI job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,23 @@ jobs:
       - name: Run nox
         run: nox -e lint
 
+  doctest:
+    name: Python doctests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install nox uv
+      - name: Run nox
+        run: nox -e doctest
+
   trace_no_server:
     name: Trace non-trace server tests
     timeout-minutes: 10

--- a/noxfile.py
+++ b/noxfile.py
@@ -47,6 +47,48 @@ def lint(session: nox.Session):
         session.run("prek", "run", "--hook-stage=pre-push")
 
 
+# Doctest coverage is opt-in per module via this allowlist rather than a
+# repo-wide `pytest --doctest-modules` sweep. Most modules either have no
+# doctests or carry illustrative `>>>` blocks that intentionally don't execute
+# (they construct models, hit the network, or download weights). An explicit
+# list keeps the run green and lets coverage grow deliberately, one reviewed
+# module at a time. Every module listed here must pass `pytest
+# --doctest-modules`; the `doctest` CI job enforces it.
+DOCTEST_MODULES = [
+    "weave/utils/project_id.py",
+    "weave/utils/dict_utils.py",
+    "weave/trace/view_utils.py",
+    "weave/trace_server/call_stats_helpers.py",
+    "weave/trace_server/clickhouse/utilities.py",
+    "weave/trace_server/trace_server_common.py",
+    "weave/trace_server/feedback_payload_schema.py",
+    "weave/trace_server/orm.py",
+]
+
+
+@nox.session
+def doctest(session: nox.Session):
+    """Run doctests for the modules in the DOCTEST_MODULES allowlist.
+
+    Pass file paths as posargs to run a subset, e.g.
+        nox -e doctest -- weave/utils/dict_utils.py
+    """
+    session.run(
+        "uv",
+        "sync",
+        "--active",
+        "--group",
+        "test",
+        "--group",
+        "trace_server",
+        "--frozen",
+    )
+    targets = session.posargs or DOCTEST_MODULES
+    # `-p no:ddtrace` mirrors the tests session: the ddtrace pytest plugin can
+    # hang during initialization.
+    session.run("pytest", "--doctest-modules", "-p", "no:ddtrace", *targets)
+
+
 # Shards that don't have corresponding optional dependencies in pyproject.toml
 # Note: _test/_tests shards are dependency groups, not optional dependencies
 SHARDS_WITHOUT_EXTRAS = {


### PR DESCRIPTION
- Adds a `doctest` nox session + `doctest` CI job — doctests were never executed in CI, so `>>>` examples had rotted unnoticed.
- Runs `pytest --doctest-modules` over an explicit `DOCTEST_MODULES` allowlist (opt-in per module; a repo-wide sweep would break intentionally-illustrative examples like model downloads).
- Seeded with 8 already-passing modules; `nox -e doctest` → 14 doctests pass.
- **PR 1/3** — base of the doctest stack.