### PR TITLE
fix(weave): repair broken doctests and enforce them

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -57,12 +57,17 @@ def lint(session: nox.Session):
 DOCTEST_MODULES = [
     "weave/utils/project_id.py",
     "weave/utils/dict_utils.py",
+    "weave/utils/iterators.py",
+    "weave/utils/sanitize.py",
     "weave/trace/view_utils.py",
     "weave/trace_server/call_stats_helpers.py",
     "weave/trace_server/clickhouse/utilities.py",
     "weave/trace_server/trace_server_common.py",
     "weave/trace_server/feedback_payload_schema.py",
+    "weave/trace_server/object_creation_utils.py",
+    "weave/trace_server/opentelemetry/helpers.py",
     "weave/trace_server/orm.py",
+    "weave/integrations/langchain/helpers.py",
 ]
 
 

--- a/weave/integrations/langchain/helpers.py
+++ b/weave/integrations/langchain/helpers.py
@@ -78,8 +78,10 @@ def _find_full_model_name(output: Any, partial_model_name: str) -> str:
         Full model name if found, otherwise returns the partial model name
 
     Examples:
-        >>> _find_full_model_name(output, "gemini-1.5-pro")
-        "gemini-1.5-pro-002"  # if found in the flattened output
+        >>> _find_full_model_name({"meta": {"model": "gemini-1.5-pro-002"}}, "gemini-1.5-pro")
+        'gemini-1.5-pro-002'
+        >>> _find_full_model_name({}, "gpt-4")
+        'gpt-4'
     """
     # Flatten the entire output to search for model names
     # Look for values that start with the partial model name and are longer

--- a/weave/trace_server/object_creation_utils.py
+++ b/weave/trace_server/object_creation_utils.py
@@ -139,7 +139,7 @@ def build_op_val(file_digest: str, load_op: str | None = None) -> dict[str, Any]
         Dictionary with the complete structure for an Op object ready for storage
 
     Examples:
-        >>> result = build_op_val_with_file_digest("abc123")
+        >>> result = build_op_val("abc123")
         >>> result["files"][OP_SOURCE_FILE_NAME]
         'abc123'
     """

--- a/weave/trace_server/opentelemetry/helpers.py
+++ b/weave/trace_server/opentelemetry/helpers.py
@@ -559,8 +559,8 @@ def shorten_name(
         >>> shorten_name("hello/world.txt", 20)
         'hello/world.txt'
         >>> shorten_name("verylongword", 8)
-        'verylo...'
-        >>> shorten_name("hello/world.txt", 10, ":1234" use_delimiter_in_abbr=False)
+        'veryl...'
+        >>> shorten_name("hello/world.txt", 10, ":1234", use_delimiter_in_abbr=False)
         'hello:1234'
     """
     if len(name) <= max_len:

--- a/weave/utils/iterators.py
+++ b/weave/utils/iterators.py
@@ -28,7 +28,10 @@ def first(iterable: Iterable[T]) -> T:
         'h'
         >>> first(range(5))
         0
-        >>> first([])  # Raises StopIteration
+        >>> first([])
+        Traceback (most recent call last):
+            ...
+        StopIteration
     """
     return next(iter(iterable))
 

--- a/weave/utils/sanitize.py
+++ b/weave/utils/sanitize.py
@@ -19,12 +19,13 @@ def add_redact_key(key: str) -> None:
         key: The key name to add to the redaction list.
              The key will be matched case-insensitively.
 
-    Example:
-        >>> import weave
+    Examples:
         >>> from weave.utils import sanitize
-        >>> weave.init("my-project", settings={"redact_pii": True})
-        >>> sanitize.add_redact_key("token")
-        >>> sanitize.add_redact_key("client_id")
+        >>> sanitize.should_redact("session_token")
+        False
+        >>> sanitize.add_redact_key("session_token")
+        >>> sanitize.should_redact("Session_Token")  # matched case-insensitively
+        True
     """
     _REDACT_KEYS.add(key.lower())
 


### PR DESCRIPTION
- Repairs `>>>` examples that fail under `pytest --doctest-modules`: `iterators.first`, `sanitize.add_redact_key`, `object_creation_utils.build_op_val`, `opentelemetry/helpers.shorten_name`, `langchain/helpers._find_full_model_name`.
- Adds each fixed module to `DOCTEST_MODULES` so they can't rot again; `nox -e doctest` → 25 doctests pass.
- Deferred: `stream_metrics.py`, `object_ref_query_builder.py`, `calls_query_builder/utils.py` have illustrative/non-deterministic `>>>` blocks — intentionally left out of the allowlist (separate effort).
- **PR 2/3** — stacked on #7430.