### PR TITLE
perf(weave): engage op_name ngram index in eval-results filter

### DIFF
--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -48,13 +48,11 @@ def test_cte_chain_calls_merged() -> None:
                 WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
                     OR calls_merged.parent_id IS NULL)
                     AND calls_merged.id NOT IN {pb_1:Array(String)}
-                    AND (position(calls_merged.op_name, {pb_2:String}) > 0
-                        OR position(calls_merged.op_name, {pb_3:String}) > 0
+                    AND (multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
                         OR calls_merged.op_name IS NULL)
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
-                    AND (position(any(calls_merged.op_name), {pb_2:String}) > 0
-                        OR position(any(calls_merged.op_name), {pb_3:String}) > 0)
+                    AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
                     AND any(calls_merged.deleted_at) IS NULL
                     AND any(calls_merged.started_at) IS NOT NULL
             ),
@@ -145,8 +143,7 @@ def test_cte_chain_calls_complete() -> None:
                 PREWHERE calls_complete.project_id = {pb_0:String}
                 WHERE calls_complete.parent_id IN {pb_1:Array(String)}
                     AND calls_complete.id NOT IN {pb_1:Array(String)}
-                    AND (position(calls_complete.op_name, {pb_2:String}) > 0
-                        OR position(calls_complete.op_name, {pb_3:String}) > 0)
+                    AND (multiSearchAny(calls_complete.op_name, [{pb_2:String}, {pb_3:String}]))
                     AND calls_complete.deleted_at = {pb_4:DateTime64(3)}
             ),
 
@@ -280,8 +277,7 @@ def test_cte_chain_sort_and_multi_eval_filters() -> None:
                 PREWHERE calls_complete.project_id = {pb_0:String}
                 WHERE calls_complete.parent_id IN {pb_1:Array(String)}
                     AND calls_complete.id NOT IN {pb_1:Array(String)}
-                    AND (position(calls_complete.op_name, {pb_2:String}) > 0
-                        OR position(calls_complete.op_name, {pb_3:String}) > 0)
+                    AND (multiSearchAny(calls_complete.op_name, [{pb_2:String}, {pb_3:String}]))
                     AND calls_complete.deleted_at = {pb_4:DateTime64(3)}
             ),
 
@@ -410,13 +406,11 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                 WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
                     OR calls_merged.parent_id IS NULL)
                     AND calls_merged.id NOT IN {pb_1:Array(String)}
-                    AND (position(calls_merged.op_name, {pb_2:String}) > 0
-                        OR position(calls_merged.op_name, {pb_3:String}) > 0
+                    AND (multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
                         OR calls_merged.op_name IS NULL)
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
-                    AND (position(any(calls_merged.op_name), {pb_2:String}) > 0
-                        OR position(any(calls_merged.op_name), {pb_3:String}) > 0)
+                    AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
                     AND any(calls_merged.deleted_at) IS NULL
                     AND any(calls_merged.started_at) IS NOT NULL
             ),
@@ -510,13 +504,11 @@ def test_full_query_calls_merged() -> None:
                 WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
                     OR calls_merged.parent_id IS NULL)
                     AND calls_merged.id NOT IN {pb_1:Array(String)}
-                    AND (position(calls_merged.op_name, {pb_2:String}) > 0
-                        OR position(calls_merged.op_name, {pb_3:String}) > 0
+                    AND (multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
                         OR calls_merged.op_name IS NULL)
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
-                    AND (position(any(calls_merged.op_name), {pb_2:String}) > 0
-                        OR position(any(calls_merged.op_name), {pb_3:String}) > 0)
+                    AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
                     AND any(calls_merged.deleted_at) IS NULL
                     AND any(calls_merged.started_at) IS NOT NULL
             ),
@@ -737,8 +729,7 @@ def test_filter_logic_operator_or_produces_match_any() -> None:
                 PREWHERE calls_complete.project_id = {pb_0:String}
                 WHERE calls_complete.parent_id IN {pb_1:Array(String)}
                     AND calls_complete.id NOT IN {pb_1:Array(String)}
-                    AND (position(calls_complete.op_name, {pb_2:String}) > 0
-                        OR position(calls_complete.op_name, {pb_3:String}) > 0)
+                    AND (multiSearchAny(calls_complete.op_name, [{pb_2:String}, {pb_3:String}]))
                     AND calls_complete.deleted_at = {pb_4:DateTime64(3)}
             ),
 
@@ -867,8 +858,7 @@ def test_filter_logic_operator_and_produces_match_all() -> None:
                 PREWHERE calls_complete.project_id = {pb_0:String}
                 WHERE calls_complete.parent_id IN {pb_1:Array(String)}
                     AND calls_complete.id NOT IN {pb_1:Array(String)}
-                    AND (position(calls_complete.op_name, {pb_2:String}) > 0
-                        OR position(calls_complete.op_name, {pb_3:String}) > 0)
+                    AND (multiSearchAny(calls_complete.op_name, [{pb_2:String}, {pb_3:String}]))
                     AND calls_complete.deleted_at = {pb_4:DateTime64(3)}
             ),
 
@@ -978,7 +968,7 @@ def test_filter_logic_operator_or_same_eval_multiple_conditions() -> None:
         filter_logic_operator="or",
     )
     # Even with OR logic, same-eval conditions stay AND'd within the single
-    # eval group, wrapped in parens; the only OR is the op_name match.
+    # eval group, wrapped in parens.
     assert_raw_sql(
         cte,
         """
@@ -996,8 +986,7 @@ def test_filter_logic_operator_or_same_eval_multiple_conditions() -> None:
                 PREWHERE calls_complete.project_id = {pb_0:String}
                 WHERE calls_complete.parent_id IN {pb_1:Array(String)}
                     AND calls_complete.id NOT IN {pb_1:Array(String)}
-                    AND (position(calls_complete.op_name, {pb_2:String}) > 0
-                        OR position(calls_complete.op_name, {pb_3:String}) > 0)
+                    AND (multiSearchAny(calls_complete.op_name, [{pb_2:String}, {pb_3:String}]))
                     AND calls_complete.deleted_at = {pb_4:DateTime64(3)}
             ),
 
@@ -1092,8 +1081,7 @@ def test_full_query_calls_complete() -> None:
                 PREWHERE calls_complete.project_id = {pb_0:String}
                 WHERE calls_complete.parent_id IN {pb_1:Array(String)}
                     AND calls_complete.id NOT IN {pb_1:Array(String)}
-                    AND (position(calls_complete.op_name, {pb_2:String}) > 0
-                        OR position(calls_complete.op_name, {pb_3:String}) > 0)
+                    AND (multiSearchAny(calls_complete.op_name, [{pb_2:String}, {pb_3:String}]))
                     AND calls_complete.deleted_at = {pb_4:DateTime64(3)}
             ),
 

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -41,8 +41,8 @@ END"""
 
 
 def _or_any_prefix_matches(op_name_expr: str, op_prefix_params: list[str]) -> str:
-    """`position(op_name, p) > 0` OR'd across every prefix param."""
-    return " OR ".join(f"position({op_name_expr}, {p}) > 0" for p in op_prefix_params)
+    """`multiSearchAny(op_name, [prefixes])`: matches if any prefix is a substring (engages idx_op_name ngrambf index)."""
+    return f"multiSearchAny({op_name_expr}, [{', '.join(op_prefix_params)}])"
 
 
 def _sort_filter_uses_inputs(


### PR DESCRIPTION
## Summary
- `_or_any_prefix_matches` now emits `multiSearchAny(op_name, [prefixes])` instead of OR-ing `position(op_name, p) > 0`. Identical result set; engages the `idx_op_name` ngrambf index, which `position` cannot use.

## Performance
Local benchmark (CH 25.12, 20M rows, real `ngrambf_v1(8,10000,3,0)` index), the realistic N=3 prefix case:

| metric | `position` OR x3 | `multiSearchAny` x3 |
| --- | --- | --- |
| pure scan (use_skip_indexes=0) | 195 ms | 120 ms (~1.6x) |
| end-to-end | 203 ms | 126 ms (~1.6x) |

Win is one Multi-Volnitsky pass vs N substring scans. Index pruning is data-layout-dependent (0% on uniformly interleaved op_names, ~24% on a hot prod project), a variable bonus rather than the main effect. N=1 is a tie with `position`.

## Testing
SQL-assertion tests updated to the `multiSearchAny` form; functional eval-results tests pass on real ClickHouse with the result set unchanged.
