### PR TITLE
perf(weave): extract-before-aggregate heavy json filters to avoid calls_merged OOM

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -320,9 +320,9 @@ def test_query_heavy_column_simple_filter_with_order_and_limit_and_mixed_query_c
                     AND (calls_merged.inputs_dump LIKE {pb_9:String} OR calls_merged.inputs_dump IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
-                                    ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_2:String}), 'null'), '') = {pb_3:String}))
+                                    ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_2:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_3:String}))
                     AND
-                    ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), '') = {pb_5:String}))
+                    ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_4:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_5:String}))
                 AND
                 ((any(calls_merged.wb_user_id) = {pb_6:String}))
                 AND
@@ -841,7 +841,7 @@ def test_calls_query_with_predicate_filters() -> None:
             WHERE ((calls_merged.inputs_dump LIKE {pb_3:String} OR calls_merged.inputs_dump IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
-                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
+                ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_1:String}))
                 AND ((any(calls_merged.wb_user_id) = {pb_2:String}))
                 AND ((any(calls_merged.deleted_at) IS NULL))
                 AND ((NOT ((any(calls_merged.op_name) IS NULL))))
@@ -899,7 +899,7 @@ def test_query_with_summary_weave_status_sort() -> None:
             WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
             WHEN IFNULL(
                 toInt64OrNull(
-                    coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')
+                    coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.summary_dump, {pb_0:String}), calls_merged.summary_dump IS NOT NULL), 'null'), '')
                 ),
                 0
             ) > 0 THEN {pb_4:String}
@@ -948,7 +948,7 @@ def test_query_with_summary_weave_status_sort_and_filter() -> None:
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((CASE
                 WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
-                WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')), 0) > 0 THEN {pb_4:String}
+                WHEN IFNULL(toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.summary_dump, {pb_0:String}), calls_merged.summary_dump IS NOT NULL), 'null'), '')), 0) > 0 THEN {pb_4:String}
                 WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
                 ELSE {pb_3:String}
             END = {pb_3:String}))
@@ -956,7 +956,7 @@ def test_query_with_summary_weave_status_sort_and_filter() -> None:
         AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
         ORDER BY CASE
             WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
-            WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')), 0) > 0 THEN {pb_4:String}
+            WHEN IFNULL(toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.summary_dump, {pb_0:String}), calls_merged.summary_dump IS NOT NULL), 'null'), '')), 0) > 0 THEN {pb_4:String}
             WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
             ELSE {pb_3:String}
         END DESC
@@ -1012,9 +1012,9 @@ def test_calls_query_with_predicate_filters_multiple_heavy_conditions() -> None:
                     AND (calls_merged.output_dump LIKE {pb_6:String} OR calls_merged.output_dump IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
-                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
+                ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_1:String}))
                 AND
-                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_2:String}), 'null'), '') = {pb_3:String}))
+                ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.output_dump, {pb_2:String}), calls_merged.output_dump IS NOT NULL), 'null'), '') = {pb_3:String}))
                 AND
                 ((any(calls_merged.wb_user_id) = {pb_4:String}))
                 AND ((any(calls_merged.deleted_at) IS NULL))
@@ -1082,9 +1082,9 @@ def test_calls_query_with_or_between_start_and_end_fields() -> None:
                 OR (calls_merged.output_dump LIKE {pb_5:String} OR calls_merged.output_dump IS NULL)))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING ((
-            ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String})
+            ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_1:String})
             OR
-            (coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_2:String}), 'null'), '') = {pb_3:String})))
+            (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.output_dump, {pb_2:String}), calls_merged.output_dump IS NOT NULL), 'null'), '') = {pb_3:String})))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
         """,
@@ -1164,11 +1164,11 @@ def test_calls_query_with_complex_heavy_filters() -> None:
                     OR (lower(calls_merged.inputs_dump) LIKE {pb_11:String} OR calls_merged.inputs_dump IS NULL)))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
-                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
+                ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_1:String}))
                 AND
-                ((toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_2:String}), 'null'), '')) > {pb_3:Int64}))
-                AND (((coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_4:String}), 'null'), '') = {pb_5:String})
-                  OR positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_6:String}), 'null'), ''), {pb_7:String}) > 0))
+                ((toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_2:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '')) > {pb_3:Int64}))
+                AND (((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.output_dump, {pb_4:String}), calls_merged.output_dump IS NOT NULL), 'null'), '') = {pb_5:String})
+                  OR positionCaseInsensitive(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_6:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), ''), {pb_7:String}) > 0))
                 AND
                 ((any(calls_merged.wb_user_id) = {pb_8:String}))
                 AND ((any(calls_merged.deleted_at) IS NULL))
@@ -1227,7 +1227,7 @@ def test_calls_query_with_like_optimization() -> None:
         WHERE ((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump IS NULL))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
-            ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
+            ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_1:String}))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.op_name) IS NULL))))
         )
@@ -1267,7 +1267,7 @@ def test_calls_query_with_like_optimization_contains() -> None:
         WHERE ((lower(calls_merged.inputs_dump) LIKE {pb_2:String} OR calls_merged.inputs_dump IS NULL))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
-            (positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), ''), {pb_1:String}) > 0)
+            (positionCaseInsensitive(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), ''), {pb_1:String}) > 0)
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.op_name) IS NULL))))
         )
@@ -1307,7 +1307,7 @@ def test_query_with_json_value_in_condition() -> None:
                 OR calls_merged.inputs_dump IS NULL))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
-            ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') IN ({pb_1:String},{pb_2:String})))
+            ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') IN ({pb_1:String},{pb_2:String})))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.op_name) IS NULL))))
         )
@@ -1506,11 +1506,11 @@ def test_calls_query_with_combined_like_optimizations_and_op_filter() -> None:
                         OR calls_merged.attributes_dump IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
-                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
+                ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.attributes_dump, {pb_0:String}), calls_merged.attributes_dump IS NOT NULL), 'null'), '') = {pb_1:String}))
                 AND
-                (positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_2:String}), 'null'), ''), {pb_3:String}) > 0)
+                (positionCaseInsensitive(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_2:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), ''), {pb_3:String}) > 0)
                 AND
-                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_4:String}), 'null'), '') IN ({pb_5:String},{pb_6:String})))
+                ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.attributes_dump, {pb_4:String}), calls_merged.attributes_dump IS NOT NULL), 'null'), '') IN ({pb_5:String},{pb_6:String})))
                 AND ((any(calls_merged.deleted_at) IS NULL))
                 AND ((NOT ((any(calls_merged.op_name) IS NULL))))
             )
@@ -1567,8 +1567,8 @@ def test_calls_query_with_unoptimizable_or_condition() -> None:
         PREWHERE calls_merged.project_id = {pb_5:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((
-            (coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String})
-            OR (toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_2:String}), 'null'), '')) > {pb_3:Int64})))
+            (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_1:String})
+            OR (toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_2:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '')) > {pb_3:Int64})))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.op_name) IS NULL))))
         )
@@ -1621,12 +1621,12 @@ def test_dynamic_json_filters_infer_casts_from_literals() -> None:
         PREWHERE calls_merged.project_id = {pb_12:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((
-            (toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '')) > {pb_1:Int64})
-            OR ({pb_3:Float64} < toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_2:String}), 'null'), '')))
-            OR (multiIf(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_4:String}), 'null'), '') = 'true', 1, coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_4:String}), 'null'), '') = 'false', 0, toUInt8OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_4:String}), 'null'), ''))) = {pb_5:Bool})
-            OR (toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_6:String}), 'null'), '')) IN ({pb_7:Int64},{pb_8:Int64}))
+            (toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '')) > {pb_1:Int64})
+            OR ({pb_3:Float64} < toFloat64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.output_dump, {pb_2:String}), calls_merged.output_dump IS NOT NULL), 'null'), '')))
+            OR (multiIf(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.attributes_dump, {pb_4:String}), calls_merged.attributes_dump IS NOT NULL), 'null'), '') = 'true', 1, coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.attributes_dump, {pb_4:String}), calls_merged.attributes_dump IS NOT NULL), 'null'), '') = 'false', 0, toUInt8OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.attributes_dump, {pb_4:String}), calls_merged.attributes_dump IS NOT NULL), 'null'), ''))) = {pb_5:Bool})
+            OR (toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.summary_dump, {pb_6:String}), calls_merged.summary_dump IS NOT NULL), 'null'), '')) IN ({pb_7:Int64},{pb_8:Int64}))
             OR (toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), '$'), 'null'), '')) = {pb_9:Int64})
-            OR (coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_10:String}), 'null'), '') = {pb_11:String})
+            OR (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_10:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_11:String})
         ))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.op_name) IS NULL))))
@@ -1719,8 +1719,7 @@ def test_literal_inferred_casts_cover_feedback_and_mixed_numeric_in() -> None:
             OR calls_merged.inputs_dump LIKE {pb_5:String})
             OR calls_merged.inputs_dump IS NULL))
         GROUP BY (calls_merged.project_id, calls_merged.id)
-        HAVING (((toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump),
-            {pb_0:String}), 'null'), '')) IN ({pb_1:Int64},{pb_2:Float64})))
+        HAVING (((toFloat64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '')) IN ({pb_1:Int64},{pb_2:Float64})))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
         """,
@@ -1765,7 +1764,7 @@ def test_whole_number_float_eq_emits_int_form_like_prefilter() -> None:
         WHERE (((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump LIKE {pb_3:String}) OR calls_merged.inputs_dump IS NULL))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
-            ((toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '')) = {pb_1:Float64}))
+            ((toFloat64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '')) = {pb_1:Float64}))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.op_name) IS NULL))))
         )
@@ -1808,7 +1807,7 @@ def test_bool_eq_emits_numeric_form_like_prefilter() -> None:
         WHERE (((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump LIKE {pb_3:String}) OR calls_merged.inputs_dump IS NULL))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
-            ((multiIf(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = 'true', 1, coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = 'false', 0, toUInt8OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), ''))) = {pb_1:Bool}))
+            ((multiIf(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = 'true', 1, coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = 'false', 0, toUInt8OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), ''))) = {pb_1:Bool}))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.op_name) IS NULL))))
         )
@@ -1844,7 +1843,7 @@ def test_calls_query_filter_by_empty_string() -> None:
         PREWHERE calls_merged.project_id = {pb_2:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
-            ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
+            ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_1:String}))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.op_name) IS NULL))))
         )
@@ -1969,7 +1968,7 @@ def test_summary_weave_field_select_backtick_quoting(
                 END AS `summary.weave.trace_name`,
                 CASE
                     WHEN any({expected_table}.exception) IS NOT NULL THEN {{pb_1:String}}
-                    WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(any({expected_table}.summary_dump), {{pb_0:String}}), 'null'), '')), 0) > 0 THEN {{pb_4:String}}
+                    WHEN IFNULL(toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE({expected_table}.summary_dump, {{pb_0:String}}), {expected_table}.summary_dump IS NOT NULL), 'null'), '')), 0) > 0 THEN {{pb_4:String}}
                     WHEN any({expected_table}.ended_at) IS NULL THEN {{pb_2:String}}
                     ELSE {{pb_3:String}}
                 END AS `summary.weave.status`,
@@ -2879,7 +2878,7 @@ def test_query_with_feedback_filter_and_datetime_and_string_filter() -> None:
                         calls_merged.id)
             HAVING (((coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_1:String}), 'null'), '') > coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_2:String}), 'null'), '')))
                 AND ((any(calls_merged.started_at) > {pb_3:String}))
-                AND ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), '') = {pb_5:String}))
+                AND ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_4:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_5:String}))
                 AND ((any(calls_merged.deleted_at) IS NULL))
                 AND ((NOT ((any(calls_merged.op_name) IS NULL))))))
         SELECT calls_merged.id AS id
@@ -3649,7 +3648,7 @@ def test_query_filter_with_escaped_dots_in_field_names() -> None:
                 OR calls_merged.output_dump IS NULL))
         GROUP BY (calls_merged.project_id,
                 calls_merged.id)
-        HAVING (((toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_0:String}), 'null'), '')) = {pb_1:Int64}))
+        HAVING (((toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.output_dump, {pb_0:String}), calls_merged.output_dump IS NOT NULL), 'null'), '')) = {pb_1:Int64}))
                 AND ((any(calls_merged.deleted_at) IS NULL))
                 AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
         """,
@@ -4312,6 +4311,46 @@ def test_is_minimal_filter_empty_turn_ids_not_minimal() -> None:
 # -----------------------------------------------------------------------------
 # build_calls_stats_query() — flat vs subquery shape
 # -----------------------------------------------------------------------------
+
+
+def test_stats_query_heavy_bool_filter_aggregates_scalar_not_dump() -> None:
+    """Heavy sub-path HAVING aggregates the extracted scalar, not the dump blob."""
+    req = tsi.CallsQueryStatsReq(
+        project_id="project",
+        query=tsi.Query.model_validate(
+            {
+                "$expr": {
+                    "$eq": [
+                        {"$getField": "inputs.evaluation.options.enabled"},
+                        {"$literal": True},
+                    ]
+                }
+            }
+        ),
+    )
+    assert_stats_sql(
+        req,
+        """
+        SELECT count() AS count, toUInt8(0) AS has_more
+        FROM (SELECT calls_merged.id AS id
+              FROM calls_merged
+              PREWHERE calls_merged.project_id = {pb_4:String}
+              WHERE (((calls_merged.inputs_dump LIKE {pb_2:String}
+                       OR calls_merged.inputs_dump LIKE {pb_3:String})
+                      OR calls_merged.inputs_dump IS NULL))
+              GROUP BY (calls_merged.project_id, calls_merged.id)
+              HAVING (((multiIf(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = 'true', 1, coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = 'false', 0, toUInt8OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), ''))) = {pb_1:Bool}))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))))
+        """,
+        {
+            "pb_0": '$."evaluation"."options"."enabled"',
+            "pb_1": True,
+            "pb_2": "%true%",
+            "pb_3": "%1%",
+            "pb_4": "project",
+        },
+    )
 
 
 def test_stats_query_calls_complete_flat_count() -> None:

--- a/tests/trace_server/query_builder/test_costs_query.py
+++ b/tests/trace_server/query_builder/test_costs_query.py
@@ -193,7 +193,7 @@ def test_query_with_costs_and_attributes_order() -> None:
    ORDER BY (NOT (JSONType(any(calls_merged.attributes_dump)) = 'Null'
                   OR JSONType(any(calls_merged.attributes_dump)) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, CASE
                                                                                                                                                                                                                                                                                             WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
-                                                                                                                                                                                                                                                                                            WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')), 0) > 0 THEN {pb_4:String}
+                                                                                                                                                                                                                                                                                            WHEN IFNULL(toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.summary_dump, {pb_0:String}), calls_merged.summary_dump IS NOT NULL), 'null'), '')), 0) > 0 THEN {pb_4:String}
                                                                                                                                                                                                                                                                                             WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
                                                                                                                                                                                                                                                                                             ELSE {pb_3:String}
                                                                                                                                                                                                                                                                                         END ASC),
@@ -203,7 +203,7 @@ def test_query_with_costs_and_attributes_order() -> None:
           any(calls_merged.attributes_dump) AS attributes_dump,
           CASE
               WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
-              WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')), 0) > 0 THEN {pb_4:String}
+              WHEN IFNULL(toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.summary_dump, {pb_0:String}), calls_merged.summary_dump IS NOT NULL), 'null'), '')), 0) > 0 THEN {pb_4:String}
               WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
               ELSE {pb_3:String}
           END AS `summary.weave.status`
@@ -214,7 +214,7 @@ def test_query_with_costs_and_attributes_order() -> None:
    ORDER BY (NOT (JSONType(any(calls_merged.attributes_dump)) = 'Null'
                   OR JSONType(any(calls_merged.attributes_dump)) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, CASE
                                                                                                                                                                                                                                                                                             WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
-                                                                                                                                                                                                                                                                                            WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')), 0) > 0 THEN {pb_4:String}
+                                                                                                                                                                                                                                                                                            WHEN IFNULL(toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.summary_dump, {pb_0:String}), calls_merged.summary_dump IS NOT NULL), 'null'), '')), 0) > 0 THEN {pb_4:String}
                                                                                                                                                                                                                                                                                             WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
                                                                                                                                                                                                                                                                                             ELSE {pb_3:String}
                                                                                                                                                                                                                                                                                         END ASC),
@@ -332,7 +332,7 @@ def test_query_with_costs_and_dynamic_summary_order() -> None:
    HAVING (((any(calls_merged.deleted_at) IS NULL))
            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
    ORDER BY (NOT (JSONType(any(calls_merged.summary_dump), {pb_0:String}) = 'Null'
-                  OR JSONType(any(calls_merged.summary_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_1:String}), 'null'), '')) DESC, toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_1:String}), 'null'), '')) DESC),
+                  OR JSONType(any(calls_merged.summary_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.summary_dump, {pb_1:String}), calls_merged.summary_dump IS NOT NULL), 'null'), '')) DESC, toString(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.summary_dump, {pb_1:String}), calls_merged.summary_dump IS NOT NULL), 'null'), '')) DESC),
      all_calls AS
   (SELECT calls_merged.id AS id,
           any(calls_merged.started_at) AS started_at,
@@ -342,7 +342,7 @@ def test_query_with_costs_and_dynamic_summary_order() -> None:
    GROUP BY (calls_merged.project_id,
              calls_merged.id)
    ORDER BY (NOT (JSONType(any(calls_merged.summary_dump), {pb_0:String}) = 'Null'
-                  OR JSONType(any(calls_merged.summary_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_1:String}), 'null'), '')) DESC, toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_1:String}), 'null'), '')) DESC),
+                  OR JSONType(any(calls_merged.summary_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.summary_dump, {pb_1:String}), calls_merged.summary_dump IS NOT NULL), 'null'), '')) DESC, toString(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.summary_dump, {pb_1:String}), calls_merged.summary_dump IS NOT NULL), 'null'), '')) DESC),
      llm_usage AS
   (-- From the all_calls we get the usage data for LLMs
  SELECT *,
@@ -412,7 +412,7 @@ WHERE (rank = {pb_6:UInt64})
 GROUP BY id,
          started_at
 ORDER BY (NOT (JSONType(any(ranked_prices.summary_dump), {pb_0:String}) = 'Null'
-               OR JSONType(any(ranked_prices.summary_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(ranked_prices.summary_dump), {pb_1:String}), 'null'), '')) DESC, toString(coalesce(nullIf(JSON_VALUE(any(ranked_prices.summary_dump), {pb_1:String}), 'null'), '')) DESC""",
+               OR JSONType(any(ranked_prices.summary_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(ranked_prices.summary_dump, {pb_1:String}), ranked_prices.summary_dump IS NOT NULL), 'null'), '')) DESC, toString(coalesce(nullIf(anyIf(JSON_VALUE(ranked_prices.summary_dump, {pb_1:String}), ranked_prices.summary_dump IS NOT NULL), 'null'), '')) DESC""",
         {
             "pb_0": "acuracia",
             "pb_1": '$."acuracia"',
@@ -579,7 +579,7 @@ def test_query_with_costs_and_nested_attributes_order() -> None:
                  HAVING (((any(calls_merged.deleted_at) IS NULL))
                          AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
                  ORDER BY (NOT (JSONType(any(calls_merged.attributes_dump), {pb_0:String}) = 'Null'
-                                OR JSONType(any(calls_merged.attributes_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')) ASC),
+                                OR JSONType(any(calls_merged.attributes_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.attributes_dump, {pb_1:String}), calls_merged.attributes_dump IS NOT NULL), 'null'), '')) ASC, toString(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.attributes_dump, {pb_1:String}), calls_merged.attributes_dump IS NOT NULL), 'null'), '')) ASC),
                  all_calls AS
                 (SELECT calls_merged.id AS id,
                         any(calls_merged.started_at) AS started_at,
@@ -590,7 +590,7 @@ def test_query_with_costs_and_nested_attributes_order() -> None:
                  GROUP BY (calls_merged.project_id,
                            calls_merged.id)
                  ORDER BY (NOT (JSONType(any(calls_merged.attributes_dump), {pb_0:String}) = 'Null'
-                                OR JSONType(any(calls_merged.attributes_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')) ASC),
+                                OR JSONType(any(calls_merged.attributes_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.attributes_dump, {pb_1:String}), calls_merged.attributes_dump IS NOT NULL), 'null'), '')) ASC, toString(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.attributes_dump, {pb_1:String}), calls_merged.attributes_dump IS NOT NULL), 'null'), '')) ASC),
              llm_usage AS
             (-- From the all_calls we get the usage data for LLMs
              SELECT *,

--- a/tests/trace_server/query_builder/test_object_ref_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_object_ref_calls_query_builder.py
@@ -548,7 +548,7 @@ def test_object_ref_filter_duplicates_and_similar() -> None:
              OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                (SELECT ref
                 FROM obj_filter_3)))
-           AND (positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_8:String}), 'null'), ''), {pb_9:String}) > 0)
+           AND (positionCaseInsensitive(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_8:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), ''), {pb_9:String}) > 0)
            AND ((any(calls_merged.deleted_at) IS NULL))
            AND ((NOT ((any(calls_merged.op_name) IS NULL))))))
         SELECT calls_merged.id AS id
@@ -709,7 +709,7 @@ def test_object_ref_filter_complex_mixed_conditions() -> None:
                          OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                            (SELECT ref
                             FROM obj_filter_1)))))
-                  OR ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_8:String}), 'null'), '') = {pb_9:String}))
+                  OR ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_8:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_9:String}))
                   OR ((NOT ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') GLOBAL IN
                              (SELECT ref
                               FROM obj_filter_2)

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -243,6 +243,13 @@ class CallsMergedDynamicField(CallsMergedAggField):
         cast: tsi_query.CastTo | None = None,
         use_agg_fn: bool = True,
     ) -> str:
+        if use_agg_fn and self.extra_path and cast != "exists":
+            # Aggregate the extracted scalar instead of the raw dump so GROUP BY
+            # state stays tiny (see json_dump_field_as_sql).
+            raw = super().as_sql(pb, table_alias, use_agg_fn=False)
+            return json_dump_field_as_sql(
+                pb, table_alias, raw, self.extra_path, cast, agg_fn=self.agg_fn
+            )
         res = super().as_sql(pb, table_alias, use_agg_fn=use_agg_fn)
         return json_dump_field_as_sql(pb, table_alias, res, self.extra_path, cast)
 

--- a/weave/trace_server/calls_query_builder/object_ref_query_builder.py
+++ b/weave/trace_server/calls_query_builder/object_ref_query_builder.py
@@ -271,9 +271,7 @@ class ObjectRefCondition(BaseModel):
         field_sql = f"{table_alias}.{root_field}"
         if use_agg_fn:
             field_sql = f"any({field_sql})"
-        json_extract_sql = json_dump_field_as_sql(
-            pb, table_alias, field_sql, key_parts, use_agg_fn=use_agg_fn
-        )
+        json_extract_sql = json_dump_field_as_sql(pb, table_alias, field_sql, key_parts)
 
         if is_order_join:
             # For joins, we need to handle both object refs and table row refs

--- a/weave/trace_server/calls_query_builder/utils.py
+++ b/weave/trace_server/calls_query_builder/utils.py
@@ -89,6 +89,7 @@ def json_dump_field_as_sql(
     extra_path: list[str] | None = None,
     cast: tsi_query.CastTo | None = None,
     use_agg_fn: bool = True,
+    agg_fn: str | None = None,
 ) -> str:
     """Build SQL for JSON field access with optional type conversion.
 
@@ -99,6 +100,13 @@ def json_dump_field_as_sql(
         extra_path: Optional list of JSON path components
         cast: Optional type to cast the result to
         use_agg_fn: Whether to use aggregate functions
+        agg_fn: When set, `root_field_sanitized` is the raw (un-aggregated)
+            column and the aggregate wraps the extracted scalar, not the dump:
+            `{agg_fn}If(JSON_VALUE(col, path), col IS NOT NULL)`. This keeps
+            GROUP BY state at one scalar per group instead of the whole JSON
+            dump, avoiding the memory blow-up of `{agg_fn}(dump)`-then-extract.
+            NULL-guarded so only rows carrying the dump contribute, matching
+            the aggregate-then-extract result.
 
     Returns:
         str: SQL expression for accessing the JSON field
@@ -116,7 +124,10 @@ def json_dump_field_as_sql(
         if extra_path:
             param_name = pb.add_param(quote_json_path_parts(extra_path))
             path_str = param_slot(param_name, "String")
-        val = f"coalesce(nullIf(JSON_VALUE({root_field_sanitized}, {path_str}), 'null'), '')"
+        json_value = f"JSON_VALUE({root_field_sanitized}, {path_str})"
+        if agg_fn:
+            json_value = f"{agg_fn}If({json_value}, {root_field_sanitized} IS NOT NULL)"
+        val = f"coalesce(nullIf({json_value}, 'null'), '')"
         return clickhouse_cast_json_value(val, cast)
     else:
         # Note: ClickHouse has limitations in distinguishing between null, non-existent, empty string, and "null".

--- a/weave/trace_server/calls_query_builder/utils.py
+++ b/weave/trace_server/calls_query_builder/utils.py
@@ -88,7 +88,6 @@ def json_dump_field_as_sql(
     root_field_sanitized: str,
     extra_path: list[str] | None = None,
     cast: tsi_query.CastTo | None = None,
-    use_agg_fn: bool = True,
     agg_fn: str | None = None,
 ) -> str:
     """Build SQL for JSON field access with optional type conversion.
@@ -99,7 +98,6 @@ def json_dump_field_as_sql(
         root_field_sanitized: The root field name (already sanitized)
         extra_path: Optional list of JSON path components
         cast: Optional type to cast the result to
-        use_agg_fn: Whether to use aggregate functions
         agg_fn: When set, `root_field_sanitized` is the raw (un-aggregated)
             column and the aggregate wraps the extracted scalar, not the dump:
             `{agg_fn}If(JSON_VALUE(col, path), col IS NOT NULL)`. This keeps
@@ -117,9 +115,6 @@ def json_dump_field_as_sql(
         'toFloat64(JSON_VALUE(any(inputs_dump), {param_1:String}))'
     """
     if cast != "exists":
-        if cast is None and not use_agg_fn and not extra_path:
-            return f"{root_field_sanitized}"
-
         path_str = "'$'"
         if extra_path:
             param_name = pb.add_param(quote_json_path_parts(extra_path))


### PR DESCRIPTION
## Summary
- Heavy sub-path filters/orders on `calls_merged` rendered `JSON_VALUE(any(inputs_dump), path)`, which holds the whole JSON dump per group in GROUP BY state and OOMs on large projects.
- Now render `anyIf(JSON_VALUE(inputs_dump, path), inputs_dump IS NOT NULL)` so only the extracted scalar enters aggregation state. NULL-guarded -> identical results.
- Scope: `CallsMergedDynamicField` sub-paths (value casts). Full-column selects, `exists`, and object-ref CTEs unchanged. Read cost is inherent to `calls_merged`; the read-side win lives in `calls_complete` (tokenbf skip index), tracked separately.

## Example
Filtering on a nested field (`inputs.options.enabled == true`):

```sql
-- before: aggregate the whole dump per group, then extract (one ~KB blob/group in GROUP BY state)
HAVING JSON_VALUE(any(inputs_dump), '$."options"."enabled"') = 'true'

-- after: extract per row, aggregate only the scalar (one tiny value/group)
HAVING anyIf(JSON_VALUE(inputs_dump, '$."options"."enabled"'), inputs_dump IS NOT NULL) = 'true'
```

(real output wraps the extraction in the existing `coalesce(nullIf(...))` + `multiIf` bool cast; only the `any(dump)` -> `anyIf(scalar)` part changes.)

## Performance
Local benchmark, ClickHouse 26.6, `AggregatingMergeTree` mirroring `calls_merged`: 400k calls, ~10 KiB `inputs_dump` each, 25% match. `mem` = peak `query_log.memory_usage`; read bytes and result count identical across shapes.

| scenario | rows/grp | paths | shape | peak mem | read | time |
|---|---|---|---|---|---|---|
| single path | 1 | 1 | old | 7.00 GB | 4.06 GB | 1203 ms |
| single path | 1 | 1 | **new** | **0.32 GB** | 4.06 GB | **215 ms** |
| prod shape | 1 | 10 | old | 7.03 GB | 4.06 GB | 4418 ms |
| prod shape | 1 | 10 | **new** | **0.68 GB** | 4.06 GB | **1323 ms** |
| start+end split | 2 | 10 | old | 6.95 GB | 4.07 GB | 4358 ms |
| start+end split | 2 | 10 | **new** | **1.22 GB** | 4.07 GB | **1467 ms** |
| 2 GB mem cap | 1 | 1 | old | **OOM (code 241)** | - | - |
| 2 GB mem cap | 1 | 1 | **new** | **0.31 GB** | 4.06 GB | 206 ms |

~6-22x lower peak memory and 3-5x faster (the dump no longer gets hashed into GROUP BY state); gain scales with groups x dump size. Read unchanged. Under a fixed memory budget the old shape OOMs where the new completes - the reported prod failure (1.6M-row project: old OOMs at the 12 GB cap, new finishes in ~17s).

Example on live data:
<img width="701" height="121" alt="image" src="https://github.com/user-attachments/assets/62b908e1-e8fa-4377-b737-4f56421b5d07" />


**Regression check:** the new shape evaluates `JSON_VALUE` per-row vs once-per-group, but in `calls_merged` only the start row carries inputs (end rows are NULL -> skipped by `anyIf`), so the split-row case above still wins on both axes. `JSON_VALUE` returns only scalar leaves, so aggregation state stays small regardless of which path is filtered. No read or correctness change (counts identical here; prod windowed old-vs-new diff was 0).

## Testing
updates query-builder SQL snapshots + adds a stats-count assertion pinning the new shape.
