### PR TITLE
feat(weave): rename Session SDK to Conversation SDK

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -207,14 +207,14 @@ def tests(session: nox.Session, shard: str):
             "tests/compat/",
             "tests/utils/",
             "tests/wandb_interface/",
-            "tests/session/",
+            "tests/conversation/",
         ],
         "trace_calls_merged_only": [
             "tests/trace/",
             "tests/compat/",
             "tests/utils/",
             "tests/wandb_interface/",
-            "tests/session/",
+            "tests/conversation/",
         ],
         "trace_no_server": [
             "tests/trace/",
@@ -222,7 +222,7 @@ def tests(session: nox.Session, shard: str):
             "tests/utils/",
             "tests/compat/",
             "tests/wandb_interface/",
-            "tests/session/",
+            "tests/conversation/",
         ],
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   # Remove once license content filtering is upstreamed
   "polyfile-weave>=0.5.9",
 
-  # Session SDK — uses OTel GenAI semantic conventions for span emission
+  # Conversation SDK — uses OTel GenAI semantic conventions for span emission
   "opentelemetry-api>=1.28.0",
   "opentelemetry-sdk>=1.28.0",
   "opentelemetry-exporter-otlp-proto-http>=1.28.0",
@@ -602,6 +602,7 @@ forbidden_modules = [
   "weave.agent",
   "weave.chat",
   "weave.compat",
+  "weave.conversation",
   "weave.dataset",
   "weave.durability",
   "weave.evaluation",
@@ -647,6 +648,7 @@ source_modules = [
   "weave.agent",
   "weave.chat",
   "weave.compat",
+  "weave.conversation",
   "weave.dataset",
   "weave.durability",
   "weave.evaluation",
@@ -748,6 +750,7 @@ forbidden_modules = [
   "weave.agent",
   "weave.chat",
   "weave.compat",
+  "weave.conversation",
   "weave.dataset",
   "weave.durability",
   "weave.evaluation",

--- a/tests/conversation/conftest.py
+++ b/tests/conversation/conftest.py
@@ -1,4 +1,4 @@
-"""Shared fixtures for Session SDK tests."""
+"""Shared fixtures for Conversation SDK tests."""
 
 from __future__ import annotations
 
@@ -8,9 +8,9 @@ from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from weave.session.session import (
+from weave.conversation.conversation import (
+    get_current_conversation,
     get_current_llm,
-    get_current_session,
     get_current_turn,
 )
 
@@ -23,8 +23,8 @@ def _reset_contextvars():
         llm.end()
     if (turn := get_current_turn()) is not None:
         turn.end()
-    if (session := get_current_session()) is not None:
-        session.end()
+    if (conversation := get_current_conversation()) is not None:
+        conversation.end()
 
 
 @pytest.fixture

--- a/tests/conversation/test_agent_context.py
+++ b/tests/conversation/test_agent_context.py
@@ -1,6 +1,6 @@
 """Unit tests for the generic agent-name override.
 
-Exercises ``weave.session.agent_name_override`` and the internal
+Exercises ``weave.conversation.agent_name_override`` and the internal
 ``resolve_agent_name`` resolver that auto-instrumentation integrations call.
 """
 
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import pytest
 
-from weave.session import agent_name_override
-from weave.session.agent_context import resolve_agent_name
+from weave.conversation import agent_name_override
+from weave.conversation.agent_context import resolve_agent_name
 
 
 def test_resolve_returns_default_when_unset() -> None:

--- a/tests/conversation/test_conversation.py
+++ b/tests/conversation/test_conversation.py
@@ -1,4 +1,4 @@
-"""Tests for the Session SDK API surface."""
+"""Tests for the Conversation SDK API surface."""
 
 from __future__ import annotations
 
@@ -7,24 +7,24 @@ from unittest.mock import patch
 
 import pytest
 
-from weave.session.session import (
+from weave.conversation.conversation import (
     LLM,
+    Conversation,
     LogResult,
     Message,
     Reasoning,
-    Session,
     SubAgent,
     Tool,
     Turn,
     Usage,
+    end_conversation,
     end_llm,
-    end_session,
     end_turn,
+    get_current_conversation,
     get_current_llm,
-    get_current_session,
     get_current_turn,
+    start_conversation,
     start_llm,
-    start_session,
     start_tool,
     start_turn,
 )
@@ -44,8 +44,8 @@ def _reset_contextvars():
         llm.end()
     if (turn := get_current_turn()) is not None:
         turn.end()
-    if (session := get_current_session()) is not None:
-        session.end()
+    if (conversation := get_current_conversation()) is not None:
+        conversation.end()
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +101,7 @@ class TestReasoning:
 class TestLogResult:
     def test_defaults(self) -> None:
         lr = LogResult()
-        assert lr.session_id == ""
+        assert lr.conversation_id == ""
         assert lr.trace_ids == []
         assert lr.root_span_ids == []
         assert lr.span_count == 0
@@ -157,7 +157,7 @@ class TestLLM:
 
     def test_attach_media_returns_self(self) -> None:
         with patch(
-            "weave.session.session._publish_media_content",
+            "weave.conversation.conversation._publish_media_content",
             side_effect=_fake_publish_media_content,
         ):
             c = LLM(model="gpt-4o")
@@ -179,7 +179,7 @@ class TestAttachMedia:
     @pytest.fixture(autouse=True)
     def _mock_publish(self) -> None:
         with patch(
-            "weave.session.session._publish_media_content",
+            "weave.conversation.conversation._publish_media_content",
             side_effect=_fake_publish_media_content,
         ):
             yield  # type: ignore[misc]
@@ -250,7 +250,7 @@ class TestAttachMediaAsync:
             return "weave:///e/p/object/content:done"
 
         with patch(
-            "weave.session.session._publish_media_content",
+            "weave.conversation.conversation._publish_media_content",
             side_effect=slow_publish,
         ):
             llm = LLM(model="gpt-4o")
@@ -276,7 +276,7 @@ class TestAttachMediaAsync:
             return "weave:///e/p/object/content:v1"
 
         with patch(
-            "weave.session.session._publish_media_content",
+            "weave.conversation.conversation._publish_media_content",
             side_effect=publish,
         ):
             llm = LLM(model="gpt-4o")
@@ -297,7 +297,7 @@ class TestAttachMediaAsync:
             raise RuntimeError("upload failed")
 
         with patch(
-            "weave.session.session._publish_media_content",
+            "weave.conversation.conversation._publish_media_content",
             side_effect=boom,
         ):
             llm = LLM(model="gpt-4o")
@@ -309,7 +309,7 @@ class TestAttachMediaAsync:
     def test_end_awaits_uploads(self) -> None:
         """Refs are populated by the time the span is built at end()."""
         with patch(
-            "weave.session.session._publish_media_content",
+            "weave.conversation.conversation._publish_media_content",
             side_effect=_fake_publish_media_content,
         ):
             llm = LLM(model="gpt-4o")
@@ -358,7 +358,7 @@ class TestSubAgent:
 
 
 # ---------------------------------------------------------------------------
-# Turn and Session
+# Turn and Conversation
 # ---------------------------------------------------------------------------
 
 
@@ -417,26 +417,26 @@ class TestTurn:
         assert t.ended_at is not None
 
 
-class TestSession:
-    def test_auto_generates_session_id(self) -> None:
-        s = Session()
-        assert s.session_id != ""
-        assert len(s.session_id) == 36  # UUID format
+class TestConversation:
+    def test_auto_generates_conversation_id(self) -> None:
+        s = Conversation()
+        assert s.conversation_id != ""
+        assert len(s.conversation_id) == 36  # UUID format
 
-    def test_explicit_session_id(self) -> None:
-        s = Session(session_id="my-session-123")
-        assert s.session_id == "my-session-123"
+    def test_explicit_conversation_id(self) -> None:
+        s = Conversation(conversation_id="my-conversation-123")
+        assert s.conversation_id == "my-conversation-123"
 
     def test_include_content_default_true(self) -> None:
-        s = Session()
+        s = Conversation()
         assert s.include_content is True
 
     def test_include_content_false(self) -> None:
-        s = Session(include_content=False)
+        s = Conversation(include_content=False)
         assert s.include_content is False
 
     def test_start_turn_returns_turn(self) -> None:
-        s = Session(agent_name="weather-bot", model="gpt-4o")
+        s = Conversation(agent_name="weather-bot", model="gpt-4o")
         t = s.start_turn(user_message="What's the weather?")
         assert isinstance(t, Turn)
         assert t.agent_name == "weather-bot"
@@ -446,27 +446,27 @@ class TestSession:
         assert t.messages[0].content == "What's the weather?"
 
     def test_start_turn_inherits_and_overrides_agent_name(self) -> None:
-        s = Session(agent_name="weather-bot")
+        s = Conversation(agent_name="weather-bot")
         t = s.start_turn()
         assert t.agent_name == "weather-bot"
         t2 = s.start_turn(agent_name="custom-bot")
         assert t2.agent_name == "custom-bot"
 
     def test_start_turn_no_user_message(self) -> None:
-        s = Session()
+        s = Conversation()
         t = s.start_turn()
         assert t.messages == []
 
     def test_start_turn_auto_ends_previous(self) -> None:
-        s = Session()
+        s = Conversation()
         t1 = s.start_turn()
         t2 = s.start_turn()
         assert t1._ended is True
         assert t2._ended is False
 
     def test_context_manager(self) -> None:
-        with Session(agent_name="bot") as s:
-            assert s.session_id != ""
+        with Conversation(agent_name="bot") as s:
+            assert s.conversation_id != ""
 
 
 # ---------------------------------------------------------------------------
@@ -477,40 +477,40 @@ class TestSession:
 class TestContextVars:
     """Test contextvar-based cross-module tracing."""
 
-    def test_start_session_sets_contextvar(self) -> None:
-        s = start_session(agent_name="bot")
+    def test_start_conversation_sets_contextvar(self) -> None:
+        s = start_conversation(agent_name="bot")
         try:
-            assert get_current_session() is s
+            assert get_current_conversation() is s
         finally:
             s.end()
-        assert get_current_session() is None
+        assert get_current_conversation() is None
 
-    def test_session_context_manager_sets_contextvar(self) -> None:
-        with Session(agent_name="bot") as s:
-            assert get_current_session() is s
-        assert get_current_session() is None
+    def test_conversation_context_manager_sets_contextvar(self) -> None:
+        with Conversation(agent_name="bot") as s:
+            assert get_current_conversation() is s
+        assert get_current_conversation() is None
 
     def test_start_turn_sets_contextvar(self) -> None:
-        s = start_session(agent_name="bot")
+        s = start_conversation(agent_name="bot")
         try:
             t = start_turn(user_message="hi")
             assert get_current_turn() is t
             assert len(t.messages) == 1
             assert t.messages[0].content == "hi"
-            assert t.agent_name == "bot"  # inherited from session
+            assert t.agent_name == "bot"  # inherited from conversation
             t.end()
             assert get_current_turn() is None
         finally:
             s.end()
 
-    def test_start_turn_without_session_returns_disconnected(self) -> None:
+    def test_start_turn_without_conversation_returns_disconnected(self) -> None:
         t = start_turn(user_message="hi", agent_name="standalone")
         assert t.agent_name == "standalone"
         assert t.messages[0].content == "hi"
         assert get_current_turn() is None  # not set in contextvar
 
     def test_start_llm_sets_contextvar(self) -> None:
-        s = start_session(agent_name="bot")
+        s = start_conversation(agent_name="bot")
         try:
             t = start_turn()
             try:
@@ -530,24 +530,24 @@ class TestContextVars:
         assert get_current_llm() is None  # not set in contextvar
 
     def test_end_convenience_functions(self) -> None:
-        s = start_session()
+        s = start_conversation()
         start_turn()
         start_llm(model="gpt-4o")
         end_llm()
         assert get_current_llm() is None
         end_turn()
         assert get_current_turn() is None
-        end_session()
-        assert get_current_session() is None
+        end_conversation()
+        assert get_current_conversation() is None
 
     def test_end_when_nothing_active(self) -> None:
         # Should not raise
         end_llm()
         end_turn()
-        end_session()
+        end_conversation()
 
     def test_full_context_manager_pattern(self) -> None:
-        with start_session(agent_name="weather-bot") as s:
+        with start_conversation(agent_name="weather-bot") as s:
             with s.start_turn(user_message="What's the weather?") as turn:
                 with turn.llm(model="gpt-4o") as llm:
                     llm.output("Let me check.")
@@ -561,7 +561,7 @@ class TestContextVars:
                 with turn.llm(model="gpt-4o") as llm:
                     llm.output("It's 75F in Tokyo!")
 
-        assert get_current_session() is None
+        assert get_current_conversation() is None
         assert get_current_turn() is None
         assert get_current_llm() is None
 

--- a/tests/conversation/test_conversation_otel.py
+++ b/tests/conversation/test_conversation_otel.py
@@ -74,7 +74,7 @@ def _emit_llm_with(
     """
     otel_spans.clear()
     with (
-        start_conversation(agent_name="bot", conversation_id="sess") as s,
+        start_conversation(agent_name="bot", conversation_id="convo-llm-chain") as s,
         s.start_turn(),
     ):
         with start_llm(model=model, provider_name=provider_name) as llm:
@@ -294,8 +294,8 @@ class TestLLMAttributes:
         ]
 
     def test_conversation_id(self) -> None:
-        attrs = llm_attributes(model="gpt-4o", conversation_id="sess-abc")
-        assert attrs["gen_ai.conversation.id"] == "sess-abc"
+        attrs = llm_attributes(model="gpt-4o", conversation_id="convo-abc")
+        assert attrs["gen_ai.conversation.id"] == "convo-abc"
 
     def test_empty_conversation_id_omitted(self) -> None:
         attrs = llm_attributes(model="gpt-4o", conversation_id="")
@@ -548,8 +548,8 @@ class TestExecuteToolAttributes:
         assert attrs["gen_ai.tool.call.result"] == '{"temp": "75F"}'
 
     def test_conversation_id(self) -> None:
-        attrs = execute_tool_attributes(tool_name="search", conversation_id="sess-abc")
-        assert attrs["gen_ai.conversation.id"] == "sess-abc"
+        attrs = execute_tool_attributes(tool_name="search", conversation_id="convo-abc")
+        assert attrs["gen_ai.conversation.id"] == "convo-abc"
 
     def test_empty_conversation_id_omitted(self) -> None:
         attrs = execute_tool_attributes(tool_name="search", conversation_id="")
@@ -900,7 +900,7 @@ class TestOTelSpanEmission:
     ) -> None:
         with Conversation(
             agent_name="weather-bot",
-            conversation_id="sess-1",
+            conversation_id="convo-1",
             conversation_name="Weather Chat",
         ) as s:
             with s.start_turn(user_message="What's the weather?") as turn:
@@ -913,13 +913,13 @@ class TestOTelSpanEmission:
         attrs = dict(span.attributes or {})
         assert attrs["gen_ai.operation.name"] == "invoke_agent"
         assert attrs["gen_ai.agent.name"] == "weather-bot"
-        assert attrs["gen_ai.conversation.id"] == "sess-1"
+        assert attrs["gen_ai.conversation.id"] == "convo-1"
         assert attrs["gen_ai.conversation.name"] == "Weather Chat"
 
     def test_turn_system_instructions_emitted_on_span(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with Conversation(agent_name="weather-bot", conversation_id="sess-si") as s:
+        with Conversation(agent_name="weather-bot", conversation_id="convo-si") as s:
             with s.start_turn(user_message="hi") as turn:
                 turn.system_instructions = ["You are a weather bot"]
 
@@ -935,7 +935,7 @@ class TestOTelSpanEmission:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         with Conversation(
-            agent_name="bot", conversation_id="sess-si2", include_content=False
+            agent_name="bot", conversation_id="convo-si2", include_content=False
         ) as s:
             with s.start_turn() as turn:
                 turn.system_instructions = ["secret prompt"]
@@ -950,7 +950,7 @@ class TestOTelSpanEmission:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         with Conversation(
-            agent_name="weather-bot", conversation_id="sess-si-param"
+            agent_name="weather-bot", conversation_id="convo-si-param"
         ) as s:
             with s.start_turn(system_instructions=["You are a weather bot"]):
                 pass
@@ -970,7 +970,7 @@ class TestOTelSpanEmission:
         assert turn.system_instructions == ["You are a weather bot"]
 
     def test_llm_creates_chat_span(self, otel_spans: InMemorySpanExporter) -> None:
-        with Conversation(agent_name="bot", conversation_id="sess-llm") as s:
+        with Conversation(agent_name="bot", conversation_id="convo-llm") as s:
             with s.start_turn() as turn:
                 with turn.llm(model="gpt-4o", provider_name="openai") as llm:
                     llm.usage = Usage(input_tokens=100, output_tokens=50)
@@ -984,14 +984,14 @@ class TestOTelSpanEmission:
         assert attrs["gen_ai.operation.name"] == "chat"
         assert attrs["gen_ai.request.model"] == "gpt-4o"
         assert attrs["gen_ai.provider.name"] == "openai"
-        assert attrs["gen_ai.conversation.id"] == "sess-llm"
+        assert attrs["gen_ai.conversation.id"] == "convo-llm"
         assert attrs["gen_ai.usage.input_tokens"] == 100
         assert attrs["gen_ai.usage.output_tokens"] == 50
 
     def test_tool_creates_execute_tool_span(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with Conversation(agent_name="bot", conversation_id="sess-tool") as s:
+        with Conversation(agent_name="bot", conversation_id="convo-tool") as s:
             with s.start_turn() as turn:
                 with turn.tool(
                     name="get_weather",
@@ -1006,7 +1006,7 @@ class TestOTelSpanEmission:
         attrs = dict(tool_spans[0].attributes or {})
         assert attrs["gen_ai.operation.name"] == "execute_tool"
         assert attrs["gen_ai.tool.name"] == "get_weather"
-        assert attrs["gen_ai.conversation.id"] == "sess-tool"
+        assert attrs["gen_ai.conversation.id"] == "convo-tool"
         assert attrs["gen_ai.tool.call.id"] == "tc_1"
         assert attrs["gen_ai.tool.call.arguments"] == '{"city":"Tokyo"}'
         assert attrs["gen_ai.tool.call.result"] == "75F"
@@ -1130,7 +1130,7 @@ class TestOTelSpanEmission:
     def test_start_tool_creates_child_of_turn(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with start_conversation(agent_name="bot", conversation_id="sess-st") as s:
+        with start_conversation(agent_name="bot", conversation_id="convo-st") as s:
             with s.start_turn() as turn:
                 with start_tool(
                     name="get_weather",
@@ -1152,7 +1152,7 @@ class TestOTelSpanEmission:
         attrs = dict(tool_spans[0].attributes or {})
         assert attrs["gen_ai.operation.name"] == "execute_tool"
         assert attrs["gen_ai.tool.name"] == "get_weather"
-        assert attrs["gen_ai.conversation.id"] == "sess-st"
+        assert attrs["gen_ai.conversation.id"] == "convo-st"
         assert attrs["gen_ai.tool.call.id"] == "tc_1"
 
     def test_two_turns_have_different_trace_ids(
@@ -1339,7 +1339,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         result = log_turn(
-            conversation_id="sess-1",
+            conversation_id="convo-1",
             agent_name="weather-bot",
             conversation_name="Weather Chat",
             messages=[Message(role="user", content="What's the weather?")],
@@ -1354,13 +1354,13 @@ class TestLogTurn:
         attrs = dict(sp.attributes or {})
         assert attrs["gen_ai.operation.name"] == "invoke_agent"
         assert attrs["gen_ai.agent.name"] == "weather-bot"
-        assert attrs["gen_ai.conversation.id"] == "sess-1"
+        assert attrs["gen_ai.conversation.id"] == "convo-1"
         assert attrs["gen_ai.conversation.name"] == "Weather Chat"
         assert sp.start_time == int(_ts(0).timestamp() * 1_000_000_000)
         assert sp.end_time == int(_ts(3).timestamp() * 1_000_000_000)
 
         assert isinstance(result, LogResult)
-        assert result.conversation_id == "sess-1"
+        assert result.conversation_id == "convo-1"
         assert len(result.trace_ids) == 1
         assert len(result.root_span_ids) == 1
         assert result.span_count == 1
@@ -1370,7 +1370,7 @@ class TestLogTurn:
 
     def test_with_llm_and_tool_children(self, otel_spans: InMemorySpanExporter) -> None:
         result = log_turn(
-            conversation_id="sess-2",
+            conversation_id="convo-2",
             agent_name="bot",
             messages=[Message(role="user", content="Search for X")],
             spans=[
@@ -1421,7 +1421,7 @@ class TestLogTurn:
 
     def test_with_subagent_child(self, otel_spans: InMemorySpanExporter) -> None:
         log_turn(
-            conversation_id="sess-3",
+            conversation_id="convo-3",
             agent_name="orchestrator",
             spans=[
                 SubAgent(
@@ -1446,7 +1446,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         log_turn(
-            conversation_id="sess-ident",
+            conversation_id="convo-ident",
             agent_name="bot",
             agent_id="agent-7",
             agent_description="A helpful bot",
@@ -1466,7 +1466,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         log_turn(
-            conversation_id="sess-sa-si",
+            conversation_id="convo-sa-si",
             agent_name="orchestrator",
             spans=[
                 SubAgent(
@@ -1491,7 +1491,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         log_turn(
-            conversation_id="sess-sa-si2",
+            conversation_id="convo-sa-si2",
             agent_name="orchestrator",
             include_content=False,
             spans=[
@@ -1519,7 +1519,7 @@ class TestLogTurn:
             outer_trace_id = outer.get_span_context().trace_id
             outer_span_id = outer.get_span_context().span_id
             log_turn(
-                conversation_id="sess-4",
+                conversation_id="convo-4",
                 agent_name="bot",
                 started_at=_ts(0),
                 ended_at=_ts(1),
@@ -1539,7 +1539,7 @@ class TestLogTurn:
         with tracer.start_as_current_span("outer-request") as outer:
             outer_trace_id = outer.get_span_context().trace_id
             log_turn(
-                conversation_id="sess-5",
+                conversation_id="convo-5",
                 agent_name="bot",
                 started_at=_ts(0),
                 ended_at=_ts(1),
@@ -1553,7 +1553,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         log_turn(
-            conversation_id="sess-6",
+            conversation_id="convo-6",
             agent_name="bot",
             messages=[Message(role="user", content="secret")],
             spans=[
@@ -1593,7 +1593,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         log_turn(
-            conversation_id="sess-si-batch",
+            conversation_id="convo-si-batch",
             agent_name="bot",
             system_instructions=["You are a weather bot"],
             started_at=_ts(0),
@@ -1610,7 +1610,7 @@ class TestLogTurn:
 
     def test_no_spans_just_emits_turn(self, otel_spans: InMemorySpanExporter) -> None:
         result = log_turn(
-            conversation_id="sess-7",
+            conversation_id="convo-7",
             agent_name="bot",
             started_at=_ts(0),
             ended_at=_ts(1),
@@ -1624,7 +1624,7 @@ class TestLogTurn:
     ) -> None:
         # Turn timestamps not provided — should derive from children
         log_turn(
-            conversation_id="sess-8",
+            conversation_id="convo-8",
             agent_name="bot",
             spans=[
                 LLM(model="gpt-4o", started_at=_ts(0), ended_at=_ts(1)),
@@ -1641,7 +1641,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         result = log_turn(
-            conversation_id="sess-9",
+            conversation_id="convo-9",
             agent_name="bot",
             started_at=_ts(0),
             ended_at=_ts(1),
@@ -1660,13 +1660,13 @@ class TestLogTurnNoOtel:
 
         monkeypatch.setattr(conversation_mod, "_OTEL_AVAILABLE", False)
         result = log_turn(
-            conversation_id="sess-noop",
+            conversation_id="convo-noop",
             agent_name="bot",
             started_at=_ts(0),
             ended_at=_ts(1),
         )
         assert isinstance(result, LogResult)
-        assert result.conversation_id == "sess-noop"
+        assert result.conversation_id == "convo-noop"
         assert result.trace_ids == []
         assert result.root_span_ids == []
         assert result.span_count == 0
@@ -1680,7 +1680,7 @@ class TestLogTurnNoOtel:
 class TestLogConversation:
     def test_emits_one_trace_per_turn(self, otel_spans: InMemorySpanExporter) -> None:
         result = log_conversation(
-            conversation_id="sess-multi",
+            conversation_id="convo-multi",
             agent_name="bot",
             turns=[
                 Turn(
@@ -1706,7 +1706,7 @@ class TestLogConversation:
         assert len(result.trace_ids) == 2
         assert len(result.root_span_ids) == 2
         assert result.span_count == 2
-        assert result.conversation_id == "sess-multi"
+        assert result.conversation_id == "convo-multi"
 
     def test_auto_generates_conversation_id_when_empty(
         self, otel_spans: InMemorySpanExporter
@@ -1727,7 +1727,7 @@ class TestLogConversation:
         with tracer.start_as_current_span("outer-request") as outer:
             outer_trace_id = outer.get_span_context().trace_id
             log_conversation(
-                conversation_id="sess-nested",
+                conversation_id="convo-nested",
                 turns=[
                     Turn(agent_name="bot", started_at=_ts(0), ended_at=_ts(1)),
                     Turn(agent_name="bot", started_at=_ts(2), ended_at=_ts(3)),
@@ -1744,7 +1744,7 @@ class TestLogConversation:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         log_conversation(
-            conversation_id="sess-children",
+            conversation_id="convo-children",
             turns=[
                 Turn(
                     agent_name="bot",
@@ -1771,7 +1771,7 @@ class TestLogConversation:
         # log_conversation emits the Turn it is handed, so every field survives —
         # not just the subset log_turn historically accepted as kwargs.
         log_conversation(
-            conversation_id="sess-fields",
+            conversation_id="convo-fields",
             turns=[
                 Turn(
                     agent_name="bot",
@@ -1805,7 +1805,7 @@ class TestLogConversation:
         # mutated in place would break this.
         turn = Turn(started_at=_ts(0), ended_at=_ts(1))  # no agent_name / model
         log_conversation(
-            conversation_id="sess-no-mutate",
+            conversation_id="convo-no-mutate",
             agent_name="conversation-bot",
             model="gpt-4o",
             continue_parent_trace=True,
@@ -1818,8 +1818,8 @@ class TestLogConversation:
     def test_empty_turns_returns_empty_log_result(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        result = log_conversation(turns=[], conversation_id="sess-empty")
-        assert result.conversation_id == "sess-empty"
+        result = log_conversation(turns=[], conversation_id="convo-empty")
+        assert result.conversation_id == "convo-empty"
         assert result.trace_ids == []
         assert result.root_span_ids == []
         assert result.span_count == 0
@@ -1866,7 +1866,9 @@ class TestToolStructuredPayloads:
         if field == "arguments":
             kwargs["arguments"] = value
         with (
-            start_conversation(agent_name="bot", conversation_id="sess") as s,
+            start_conversation(
+                agent_name="bot", conversation_id="convo-tool-payload"
+            ) as s,
             s.start_turn(),
         ):
             with start_tool(**kwargs) as t:
@@ -2124,7 +2126,7 @@ class TestTurnRecord:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         """End-to-end: record() values flow through to the OTel attrs."""
-        with Conversation(conversation_id="sess-turn-record") as s:
+        with Conversation(conversation_id="convo-turn-record") as s:
             with s.start_turn(agent_name="weather-bot") as turn:
                 turn.record(
                     system_instructions=["You are a weather bot"],

--- a/tests/conversation/test_conversation_otel.py
+++ b/tests/conversation/test_conversation_otel.py
@@ -1,4 +1,4 @@
-"""Tests for OTel GenAI attribute builders and span emission in session_otel.py."""
+"""Tests for OTel GenAI attribute builders and span emission in conversation_otel.py."""
 
 from __future__ import annotations
 
@@ -13,20 +13,20 @@ from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NoOpTracerProvider, StatusCode
 
-from weave.session.adapters.openai import (
+from weave.conversation.adapters.openai import (
     message_from_openai_responses_input,
     reasoning_from_openai_responses,
     usage_from_openai_responses,
 )
-from weave.session.session import (
+from weave.conversation.conversation import (
     LLM,
     BlobPart,
+    Conversation,
     LogResult,
     MediaAttachment,
     Message,
     Reasoning,
     ReasoningPart,
-    Session,
     SubAgent,
     TextPart,
     Tool,
@@ -35,14 +35,14 @@ from weave.session.session import (
     Turn,
     UriPart,
     Usage,
-    log_session,
+    log_conversation,
     log_turn,
+    start_conversation,
     start_llm,
-    start_session,
     start_tool,
     start_turn,
 )
-from weave.session.session_otel import (
+from weave.conversation.conversation_otel import (
     execute_tool_attributes,
     invoke_agent_attributes,
     llm_attributes,
@@ -64,7 +64,7 @@ def _emit_llm_with(
     # response_model and output_type are intentionally omitted; tests that
     # need them set the field directly on the LLM span before recording.
 ) -> dict[str, Any]:
-    """Build a session+turn+LLM span with the given fields and return the
+    """Build a conversation+turn+LLM span with the given fields and return the
     chat span's emitted OTel attributes.
 
     Used by interface-level tests to assert on what callers actually see
@@ -73,7 +73,10 @@ def _emit_llm_with(
     first so the helper is safe to call multiple times in a single test.
     """
     otel_spans.clear()
-    with start_session(agent_name="bot", session_id="sess") as s, s.start_turn():
+    with (
+        start_conversation(agent_name="bot", conversation_id="sess") as s,
+        s.start_turn(),
+    ):
         with start_llm(model=model, provider_name=provider_name) as llm:
             llm.record(
                 input_messages=input_messages,
@@ -895,8 +898,10 @@ class TestOTelSpanEmission:
     def test_turn_creates_invoke_agent_span(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with Session(
-            agent_name="weather-bot", session_id="sess-1", session_name="Weather Chat"
+        with Conversation(
+            agent_name="weather-bot",
+            conversation_id="sess-1",
+            conversation_name="Weather Chat",
         ) as s:
             with s.start_turn(user_message="What's the weather?") as turn:
                 pass
@@ -914,7 +919,7 @@ class TestOTelSpanEmission:
     def test_turn_system_instructions_emitted_on_span(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with Session(agent_name="weather-bot", session_id="sess-si") as s:
+        with Conversation(agent_name="weather-bot", conversation_id="sess-si") as s:
             with s.start_turn(user_message="hi") as turn:
                 turn.system_instructions = ["You are a weather bot"]
 
@@ -929,8 +934,8 @@ class TestOTelSpanEmission:
     def test_turn_system_instructions_omitted_when_content_excluded(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with Session(
-            agent_name="bot", session_id="sess-si2", include_content=False
+        with Conversation(
+            agent_name="bot", conversation_id="sess-si2", include_content=False
         ) as s:
             with s.start_turn() as turn:
                 turn.system_instructions = ["secret prompt"]
@@ -944,7 +949,9 @@ class TestOTelSpanEmission:
     def test_start_turn_system_instructions_param_emitted_on_span(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with Session(agent_name="weather-bot", session_id="sess-si-param") as s:
+        with Conversation(
+            agent_name="weather-bot", conversation_id="sess-si-param"
+        ) as s:
             with s.start_turn(system_instructions=["You are a weather bot"]):
                 pass
 
@@ -958,12 +965,12 @@ class TestOTelSpanEmission:
 
     def test_module_start_turn_system_instructions_param(self) -> None:
         # weave.start_turn(...) wires the field onto the returned Turn whether
-        # or not a session is active (delegates to Session.start_turn when one is).
+        # or not a conversation is active (delegates to Conversation.start_turn when one is).
         turn = start_turn(system_instructions=["You are a weather bot"])
         assert turn.system_instructions == ["You are a weather bot"]
 
     def test_llm_creates_chat_span(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(agent_name="bot", session_id="sess-llm") as s:
+        with Conversation(agent_name="bot", conversation_id="sess-llm") as s:
             with s.start_turn() as turn:
                 with turn.llm(model="gpt-4o", provider_name="openai") as llm:
                     llm.usage = Usage(input_tokens=100, output_tokens=50)
@@ -984,7 +991,7 @@ class TestOTelSpanEmission:
     def test_tool_creates_execute_tool_span(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with Session(agent_name="bot", session_id="sess-tool") as s:
+        with Conversation(agent_name="bot", conversation_id="sess-tool") as s:
             with s.start_turn() as turn:
                 with turn.tool(
                     name="get_weather",
@@ -1007,7 +1014,7 @@ class TestOTelSpanEmission:
     def test_subagent_creates_nested_invoke_agent_span(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with Session(agent_name="orchestrator") as s:
+        with Conversation(agent_name="orchestrator") as s:
             with s.start_turn() as turn:
                 with turn.subagent(name="research-bot", model="gpt-4o-mini") as sa:
                     pass
@@ -1025,7 +1032,7 @@ class TestOTelSpanEmission:
     def test_subagent_system_instructions_via_factory(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with Session(agent_name="orchestrator") as s:
+        with Conversation(agent_name="orchestrator") as s:
             with s.start_turn() as turn:
                 with turn.subagent(
                     name="research-bot",
@@ -1043,7 +1050,7 @@ class TestOTelSpanEmission:
 
     def test_parent_child_hierarchy(self, otel_spans: InMemorySpanExporter) -> None:
         """LLM and Tool are both children of Turn (flat model)."""
-        with Session(agent_name="bot") as s:
+        with Conversation(agent_name="bot") as s:
             with s.start_turn() as turn:
                 with turn.llm(model="gpt-4o") as llm:
                     llm.output("checking...")
@@ -1077,7 +1084,7 @@ class TestOTelSpanEmission:
         # non-recording spans (no exporter, no recording overhead) and is the
         # canonical OTel pattern for "tracing not configured".
         monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", NoOpTracerProvider())
-        with Session(agent_name="bot") as s:
+        with Conversation(agent_name="bot") as s:
             with s.start_turn() as turn:
                 with turn.llm(model="gpt-4o") as llm:
                     llm.output("Hello")
@@ -1088,7 +1095,7 @@ class TestOTelSpanEmission:
     def test_include_content_false_omits_messages(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with Session(agent_name="bot", include_content=False) as s:
+        with Conversation(agent_name="bot", include_content=False) as s:
             with s.start_turn(user_message="secret input") as turn:
                 with turn.llm(model="gpt-4o") as llm:
                     llm.input_messages.append(Message(role="user", content="secret"))
@@ -1123,7 +1130,7 @@ class TestOTelSpanEmission:
     def test_start_tool_creates_child_of_turn(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with start_session(agent_name="bot", session_id="sess-st") as s:
+        with start_conversation(agent_name="bot", conversation_id="sess-st") as s:
             with s.start_turn() as turn:
                 with start_tool(
                     name="get_weather",
@@ -1151,7 +1158,7 @@ class TestOTelSpanEmission:
     def test_two_turns_have_different_trace_ids(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with start_session(agent_name="bot") as s:
+        with start_conversation(agent_name="bot") as s:
             with s.start_turn(user_message="first") as t1:
                 pass
             with s.start_turn(user_message="second") as t2:
@@ -1170,8 +1177,8 @@ class TestOTelSpanEmission:
 
 class TestErrorRecording:
     def test_llm_records_exception(self, otel_spans: InMemorySpanExporter) -> None:
-        with start_session(agent_name="bot") as session:
-            with session.start_turn() as turn:
+        with start_conversation(agent_name="bot") as conversation:
+            with conversation.start_turn() as turn:
                 try:
                     with turn.llm(model="gpt-4o") as llm:
                         raise ValueError("LLM call failed")
@@ -1187,8 +1194,8 @@ class TestErrorRecording:
         assert chat_span.events[0].name == "exception"
 
     def test_tool_records_exception(self, otel_spans: InMemorySpanExporter) -> None:
-        with start_session(agent_name="bot") as session:
-            with session.start_turn() as turn:
+        with start_conversation(agent_name="bot") as conversation:
+            with conversation.start_turn() as turn:
                 try:
                     with turn.tool(name="search") as tool:
                         raise RuntimeError("tool broke")
@@ -1203,9 +1210,9 @@ class TestErrorRecording:
         assert tool_span.status.status_code == StatusCode.ERROR
 
     def test_turn_records_exception(self, otel_spans: InMemorySpanExporter) -> None:
-        with start_session(agent_name="bot") as session:
+        with start_conversation(agent_name="bot") as conversation:
             try:
-                with session.start_turn() as turn:
+                with conversation.start_turn() as turn:
                     raise RuntimeError("turn broke")
             except RuntimeError:
                 pass
@@ -1218,8 +1225,8 @@ class TestErrorRecording:
         assert turn_span.status.status_code == StatusCode.ERROR
 
     def test_subagent_records_exception(self, otel_spans: InMemorySpanExporter) -> None:
-        with start_session(agent_name="bot") as session:
-            with session.start_turn() as turn:
+        with start_conversation(agent_name="bot") as conversation:
+            with conversation.start_turn() as turn:
                 try:
                     with turn.subagent(name="sub") as sa:
                         raise RuntimeError("sub broke")
@@ -1245,7 +1252,7 @@ class TestContinueParentTrace:
         tracer = otel_trace.get_tracer("test.outer")
         with tracer.start_as_current_span("outer-request") as outer:
             outer_trace_id = outer.get_span_context().trace_id
-            with start_session(agent_name="bot") as s:
+            with start_conversation(agent_name="bot") as s:
                 with s.start_turn() as turn:
                     pass
 
@@ -1261,7 +1268,7 @@ class TestContinueParentTrace:
         with tracer.start_as_current_span("outer-request") as outer:
             outer_trace_id = outer.get_span_context().trace_id
             outer_span_id = outer.get_span_context().span_id
-            with start_session(agent_name="bot", continue_parent_trace=True) as s:
+            with start_conversation(agent_name="bot", continue_parent_trace=True) as s:
                 with s.start_turn() as turn:
                     pass
 
@@ -1283,7 +1290,7 @@ class TestStartTimeFromLogicalConstruction:
     def test_turn_span_start_time_matches_started_at(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with start_session(agent_name="bot") as s:
+        with start_conversation(agent_name="bot") as s:
             turn = s.start_turn()  # constructed here, started_at set
             assert turn.started_at is not None
             expected_ns = int(turn.started_at.timestamp() * 1_000_000_000)
@@ -1301,7 +1308,7 @@ class TestStartTimeFromLogicalConstruction:
     def test_llm_span_start_time_matches_started_at(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        with start_session(agent_name="bot") as s:
+        with start_conversation(agent_name="bot") as s:
             with s.start_turn() as turn:
                 llm = turn.llm(model="gpt-4o")
                 assert llm.started_at is not None
@@ -1332,9 +1339,9 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         result = log_turn(
-            session_id="sess-1",
+            conversation_id="sess-1",
             agent_name="weather-bot",
-            session_name="Weather Chat",
+            conversation_name="Weather Chat",
             messages=[Message(role="user", content="What's the weather?")],
             started_at=_ts(0),
             ended_at=_ts(3),
@@ -1353,7 +1360,7 @@ class TestLogTurn:
         assert sp.end_time == int(_ts(3).timestamp() * 1_000_000_000)
 
         assert isinstance(result, LogResult)
-        assert result.session_id == "sess-1"
+        assert result.conversation_id == "sess-1"
         assert len(result.trace_ids) == 1
         assert len(result.root_span_ids) == 1
         assert result.span_count == 1
@@ -1363,7 +1370,7 @@ class TestLogTurn:
 
     def test_with_llm_and_tool_children(self, otel_spans: InMemorySpanExporter) -> None:
         result = log_turn(
-            session_id="sess-2",
+            conversation_id="sess-2",
             agent_name="bot",
             messages=[Message(role="user", content="Search for X")],
             spans=[
@@ -1414,7 +1421,7 @@ class TestLogTurn:
 
     def test_with_subagent_child(self, otel_spans: InMemorySpanExporter) -> None:
         log_turn(
-            session_id="sess-3",
+            conversation_id="sess-3",
             agent_name="orchestrator",
             spans=[
                 SubAgent(
@@ -1439,7 +1446,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         log_turn(
-            session_id="sess-ident",
+            conversation_id="sess-ident",
             agent_name="bot",
             agent_id="agent-7",
             agent_description="A helpful bot",
@@ -1459,7 +1466,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         log_turn(
-            session_id="sess-sa-si",
+            conversation_id="sess-sa-si",
             agent_name="orchestrator",
             spans=[
                 SubAgent(
@@ -1484,7 +1491,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         log_turn(
-            session_id="sess-sa-si2",
+            conversation_id="sess-sa-si2",
             agent_name="orchestrator",
             include_content=False,
             spans=[
@@ -1512,7 +1519,7 @@ class TestLogTurn:
             outer_trace_id = outer.get_span_context().trace_id
             outer_span_id = outer.get_span_context().span_id
             log_turn(
-                session_id="sess-4",
+                conversation_id="sess-4",
                 agent_name="bot",
                 started_at=_ts(0),
                 ended_at=_ts(1),
@@ -1532,7 +1539,7 @@ class TestLogTurn:
         with tracer.start_as_current_span("outer-request") as outer:
             outer_trace_id = outer.get_span_context().trace_id
             log_turn(
-                session_id="sess-5",
+                conversation_id="sess-5",
                 agent_name="bot",
                 started_at=_ts(0),
                 ended_at=_ts(1),
@@ -1546,7 +1553,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         log_turn(
-            session_id="sess-6",
+            conversation_id="sess-6",
             agent_name="bot",
             messages=[Message(role="user", content="secret")],
             spans=[
@@ -1586,7 +1593,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         log_turn(
-            session_id="sess-si-batch",
+            conversation_id="sess-si-batch",
             agent_name="bot",
             system_instructions=["You are a weather bot"],
             started_at=_ts(0),
@@ -1603,7 +1610,7 @@ class TestLogTurn:
 
     def test_no_spans_just_emits_turn(self, otel_spans: InMemorySpanExporter) -> None:
         result = log_turn(
-            session_id="sess-7",
+            conversation_id="sess-7",
             agent_name="bot",
             started_at=_ts(0),
             ended_at=_ts(1),
@@ -1617,7 +1624,7 @@ class TestLogTurn:
     ) -> None:
         # Turn timestamps not provided — should derive from children
         log_turn(
-            session_id="sess-8",
+            conversation_id="sess-8",
             agent_name="bot",
             spans=[
                 LLM(model="gpt-4o", started_at=_ts(0), ended_at=_ts(1)),
@@ -1634,7 +1641,7 @@ class TestLogTurn:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         result = log_turn(
-            session_id="sess-9",
+            conversation_id="sess-9",
             agent_name="bot",
             started_at=_ts(0),
             ended_at=_ts(1),
@@ -1649,31 +1656,31 @@ class TestLogTurnNoOtel:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Simulate OTel not installed.
-        import weave.session.session as session_mod
+        import weave.conversation.conversation as conversation_mod
 
-        monkeypatch.setattr(session_mod, "_OTEL_AVAILABLE", False)
+        monkeypatch.setattr(conversation_mod, "_OTEL_AVAILABLE", False)
         result = log_turn(
-            session_id="sess-noop",
+            conversation_id="sess-noop",
             agent_name="bot",
             started_at=_ts(0),
             ended_at=_ts(1),
         )
         assert isinstance(result, LogResult)
-        assert result.session_id == "sess-noop"
+        assert result.conversation_id == "sess-noop"
         assert result.trace_ids == []
         assert result.root_span_ids == []
         assert result.span_count == 0
 
 
 # ---------------------------------------------------------------------------
-# log_session
+# log_conversation
 # ---------------------------------------------------------------------------
 
 
-class TestLogSession:
+class TestLogConversation:
     def test_emits_one_trace_per_turn(self, otel_spans: InMemorySpanExporter) -> None:
-        result = log_session(
-            session_id="sess-multi",
+        result = log_conversation(
+            conversation_id="sess-multi",
             agent_name="bot",
             turns=[
                 Turn(
@@ -1699,19 +1706,19 @@ class TestLogSession:
         assert len(result.trace_ids) == 2
         assert len(result.root_span_ids) == 2
         assert result.span_count == 2
-        assert result.session_id == "sess-multi"
+        assert result.conversation_id == "sess-multi"
 
-    def test_auto_generates_session_id_when_empty(
+    def test_auto_generates_conversation_id_when_empty(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        result = log_session(
+        result = log_conversation(
             turns=[
                 Turn(agent_name="bot", started_at=_ts(0), ended_at=_ts(1)),
             ],
         )
-        # Session ID is a UUID4 string when auto-generated
-        assert result.session_id != ""
-        assert len(result.session_id) == 36
+        # Conversation ID is a UUID4 string when auto-generated
+        assert result.conversation_id != ""
+        assert len(result.conversation_id) == 36
 
     def test_continue_parent_trace_keeps_all_under_outer(
         self, otel_spans: InMemorySpanExporter
@@ -1719,8 +1726,8 @@ class TestLogSession:
         tracer = otel_trace.get_tracer("test.outer")
         with tracer.start_as_current_span("outer-request") as outer:
             outer_trace_id = outer.get_span_context().trace_id
-            log_session(
-                session_id="sess-nested",
+            log_conversation(
+                conversation_id="sess-nested",
                 turns=[
                     Turn(agent_name="bot", started_at=_ts(0), ended_at=_ts(1)),
                     Turn(agent_name="bot", started_at=_ts(2), ended_at=_ts(3)),
@@ -1736,8 +1743,8 @@ class TestLogSession:
     def test_propagates_children_from_each_turn(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        log_session(
-            session_id="sess-children",
+        log_conversation(
+            conversation_id="sess-children",
             turns=[
                 Turn(
                     agent_name="bot",
@@ -1761,10 +1768,10 @@ class TestLogSession:
         assert len(spans) == 5
 
     def test_forwards_all_turn_fields(self, otel_spans: InMemorySpanExporter) -> None:
-        # log_session emits the Turn it is handed, so every field survives —
+        # log_conversation emits the Turn it is handed, so every field survives —
         # not just the subset log_turn historically accepted as kwargs.
-        log_session(
-            session_id="sess-fields",
+        log_conversation(
+            conversation_id="sess-fields",
             turns=[
                 Turn(
                     agent_name="bot",
@@ -1791,15 +1798,15 @@ class TestLogSession:
     def test_does_not_mutate_caller_turn(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        # log_session applies session-level defaults / continue_parent_trace to
-        # a model_copy of each Turn, not the caller's instance. Locks in the
-        # "without mutating the caller's object" contract that model_copy exists
-        # to guarantee — a future _emit_turn edit that mutated in place would
-        # break this.
+        # log_conversation applies conversation-level defaults /
+        # continue_parent_trace to a model_copy of each Turn, not the caller's
+        # instance. Locks in the "without mutating the caller's object" contract
+        # that model_copy exists to guarantee — a future _emit_turn edit that
+        # mutated in place would break this.
         turn = Turn(started_at=_ts(0), ended_at=_ts(1))  # no agent_name / model
-        log_session(
-            session_id="sess-no-mutate",
-            agent_name="session-bot",
+        log_conversation(
+            conversation_id="sess-no-mutate",
+            agent_name="conversation-bot",
             model="gpt-4o",
             continue_parent_trace=True,
             turns=[turn],
@@ -1811,8 +1818,8 @@ class TestLogSession:
     def test_empty_turns_returns_empty_log_result(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        result = log_session(turns=[], session_id="sess-empty")
-        assert result.session_id == "sess-empty"
+        result = log_conversation(turns=[], conversation_id="sess-empty")
+        assert result.conversation_id == "sess-empty"
         assert result.trace_ids == []
         assert result.root_span_ids == []
         assert result.span_count == 0
@@ -1858,7 +1865,10 @@ class TestToolStructuredPayloads:
         kwargs: dict = {"name": "tool", "tool_call_id": "tc"}
         if field == "arguments":
             kwargs["arguments"] = value
-        with start_session(agent_name="bot", session_id="sess") as s, s.start_turn():
+        with (
+            start_conversation(agent_name="bot", conversation_id="sess") as s,
+            s.start_turn(),
+        ):
             with start_tool(**kwargs) as t:
                 if field == "result":
                     t.result = value
@@ -1971,7 +1981,7 @@ class TestAttachMediaUrl:
     @pytest.fixture(autouse=True)
     def _mock_publish(self) -> None:
         with patch(
-            "weave.session.session._publish_media_content",
+            "weave.conversation.conversation._publish_media_content",
             return_value=self._FAKE_REF,
         ):
             yield  # type: ignore[misc]
@@ -2114,7 +2124,7 @@ class TestTurnRecord:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         """End-to-end: record() values flow through to the OTel attrs."""
-        with Session(session_id="sess-turn-record") as s:
+        with Conversation(conversation_id="sess-turn-record") as s:
             with s.start_turn(agent_name="weather-bot") as turn:
                 turn.record(
                     system_instructions=["You are a weather bot"],
@@ -2172,7 +2182,7 @@ class TestSubAgentRecord:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         """End-to-end: record() values flow through to the OTel attrs."""
-        with Session(agent_name="orchestrator") as s:
+        with Conversation(agent_name="orchestrator") as s:
             with s.start_turn() as turn:
                 with turn.subagent(name="research-bot") as sa:
                     sa.record(
@@ -2441,7 +2451,7 @@ class TestMessageFromOpenAIResponsesInput:
         attachment binds to the right user turn on the wire.
         """
         with patch(
-            "weave.session.adapters.openai._publish_media_content",
+            "weave.conversation.adapters.openai._publish_media_content",
             return_value="weave:///e/p/object/img:v1",
         ):
             out = self._input_messages_attr(
@@ -2457,7 +2467,7 @@ class TestMessageFromOpenAIResponsesInput:
         self, otel_spans: InMemorySpanExporter
     ) -> None:
         with patch(
-            "weave.session.adapters.openai._publish_media_content",
+            "weave.conversation.adapters.openai._publish_media_content",
             return_value="weave:///e/p/object/img:v1",
         ):
             out = self._input_messages_attr(

--- a/tests/conversation/test_conversation_settings.py
+++ b/tests/conversation/test_conversation_settings.py
@@ -94,7 +94,9 @@ def _spans_with_prefix(otel_spans: InMemorySpanExporter, prefix: str) -> list[An
 
 def test_disabled_streaming_emits_no_spans(otel_spans: InMemorySpanExporter):
     with override_settings(disabled=True):
-        with start_conversation(agent_name="a", conversation_id="s") as s:
+        with start_conversation(
+            agent_name="a", conversation_id="convo-disabled-streaming"
+        ) as s:
             with s.start_turn() as t:
                 with t.llm(model="gpt-4o"):
                     pass
@@ -105,7 +107,7 @@ def test_disabled_streaming_emits_no_spans(otel_spans: InMemorySpanExporter):
 
 def _user_func_log_turn() -> Any:
     return log_turn(
-        conversation_id="s",
+        conversation_id="convo-disabled-log-turn",
         agent_name="a",
         messages=[Message(role="user", content="hi")],
     )
@@ -114,7 +116,7 @@ def _user_func_log_turn() -> Any:
 def _user_func_log_conversation() -> Any:
     return log_conversation(
         turns=[Turn(agent_name="a", messages=[Message(role="user", content="hi")])],
-        conversation_id="s",
+        conversation_id="convo-disabled-log-conversation",
     )
 
 
@@ -145,14 +147,20 @@ def test_disabled_batch_emits_no_spans(
 
 
 def _streaming_tool_with_pii() -> None:
-    with start_conversation(conversation_id="s") as sess, sess.start_turn() as t:
+    with (
+        start_conversation(conversation_id="convo-pii-streaming-tool") as sess,
+        sess.start_turn() as t,
+    ):
         with t.tool(name="lookup") as tool:
             tool.arguments = f'{{"email":"{_PII_EMAIL}"}}'
             tool.result = f"found {_PII_EMAIL}"
 
 
 def _streaming_llm_messages_with_pii() -> None:
-    with start_conversation(conversation_id="s") as sess, sess.start_turn() as t:
+    with (
+        start_conversation(conversation_id="convo-pii-streaming-llm-messages") as sess,
+        sess.start_turn() as t,
+    ):
         with t.llm(
             model="gpt-4o", system_instructions=[f"contact {_PII_EMAIL}"]
         ) as llm:
@@ -164,21 +172,24 @@ def _streaming_llm_messages_with_pii() -> None:
 
 def _streaming_llm_reasoning_with_pii() -> None:
     """Regression case for the pre-existing leak: reasoning bypassing redaction."""
-    with start_conversation(conversation_id="s") as sess, sess.start_turn() as t:
+    with (
+        start_conversation(conversation_id="convo-pii-streaming-llm-reasoning") as sess,
+        sess.start_turn() as t,
+    ):
         with t.llm(model="gpt-4o") as llm:
             llm.reasoning = Reasoning(content=f"think about {_PII_EMAIL}")
             llm.output_messages = [Message(role="assistant", content="ok")]
 
 
 def _streaming_turn_with_pii() -> None:
-    with start_conversation(conversation_id="s") as sess:
+    with start_conversation(conversation_id="convo-pii-streaming-turn") as sess:
         with sess.start_turn(user_message=_PII_EMAIL):
             pass
 
 
 def _batch_turn_messages_with_pii() -> None:
     log_turn(
-        conversation_id="s",
+        conversation_id="convo-pii-batch-turn-messages",
         agent_name="a",
         messages=[Message(role="user", content=_PII_EMAIL)],
     )
@@ -186,7 +197,7 @@ def _batch_turn_messages_with_pii() -> None:
 
 def _batch_child_llm_with_pii() -> None:
     log_turn(
-        conversation_id="s",
+        conversation_id="convo-pii-batch-child-llm",
         agent_name="a",
         spans=[
             LLM(
@@ -199,7 +210,7 @@ def _batch_child_llm_with_pii() -> None:
 
 def _batch_child_tool_with_pii() -> None:
     log_turn(
-        conversation_id="s",
+        conversation_id="convo-pii-batch-child-tool",
         agent_name="a",
         spans=[Tool(name="lookup", arguments=f'{{"email":"{_PII_EMAIL}"}}')],
     )
@@ -281,14 +292,18 @@ def test_redact_pii_applied(
 
 
 def _content_off_tool() -> None:
-    with start_conversation(conversation_id="s", include_content=False) as sess:
+    with start_conversation(
+        conversation_id="convo-content-off-tool", include_content=False
+    ) as sess:
         with sess.start_turn() as t:
             with t.tool(name="lookup") as tool:
                 tool.arguments = f'{{"email":"{_PII_EMAIL}"}}'
 
 
 def _content_off_llm() -> None:
-    with start_conversation(conversation_id="s", include_content=False) as sess:
+    with start_conversation(
+        conversation_id="convo-content-off-llm", include_content=False
+    ) as sess:
         with sess.start_turn() as t:
             with t.llm(model="gpt-4o") as llm:
                 llm.input_messages = [Message(role="user", content=_PII_EMAIL)]
@@ -296,14 +311,16 @@ def _content_off_llm() -> None:
 
 
 def _content_off_turn() -> None:
-    with start_conversation(conversation_id="s", include_content=False) as sess:
+    with start_conversation(
+        conversation_id="convo-content-off-turn", include_content=False
+    ) as sess:
         with sess.start_turn(user_message=_PII_EMAIL):
             pass
 
 
 def _content_off_log_turn() -> None:
     log_turn(
-        conversation_id="s",
+        conversation_id="convo-content-off-log-turn",
         agent_name="a",
         include_content=False,
         messages=[Message(role="user", content=_PII_EMAIL)],
@@ -336,7 +353,9 @@ def test_include_content_false_skips_presidio(
 
 
 def _reasoning_content_off_streaming() -> None:
-    with start_conversation(conversation_id="s", include_content=False) as sess:
+    with start_conversation(
+        conversation_id="convo-reasoning-off-streaming", include_content=False
+    ) as sess:
         with sess.start_turn() as t:
             with t.llm(model="gpt-4o") as llm:
                 llm.reasoning = Reasoning(content="sensitive reasoning")
@@ -344,7 +363,7 @@ def _reasoning_content_off_streaming() -> None:
 
 def _reasoning_content_off_batch() -> None:
     log_turn(
-        conversation_id="s",
+        conversation_id="convo-reasoning-off-batch",
         agent_name="a",
         include_content=False,
         spans=[LLM(model="gpt-4o", reasoning=Reasoning(content="sensitive"))],
@@ -416,7 +435,7 @@ def test_capture_info_settings(
     with override_settings(
         capture_client_info=client_info, capture_system_info=system_info
     ):
-        with start_conversation(conversation_id="s") as sess:
+        with start_conversation(conversation_id="convo-capture-info") as sess:
             with sess.start_turn() as t:
                 with t.tool(name="x"):
                     pass
@@ -438,7 +457,7 @@ def test_capture_info_on_batch_path(otel_spans: InMemorySpanExporter):
     """Batch (log_turn) path uses a separate emit path — same invariant."""
     with override_settings(capture_client_info=True):
         log_turn(
-            conversation_id="s",
+            conversation_id="convo-capture-info-batch",
             agent_name="a",
             spans=[LLM(model="gpt-4o")],
         )
@@ -459,7 +478,10 @@ def test_settings_independent(otel_spans: InMemorySpanExporter, fake_presidio: N
     with override_settings(
         redact_pii=True, capture_client_info=False, capture_system_info=False
     ):
-        with start_conversation(conversation_id="s") as sess, sess.start_turn() as t:
+        with (
+            start_conversation(conversation_id="convo-settings-independent") as sess,
+            sess.start_turn() as t,
+        ):
             with t.tool(name="lookup") as tool:
                 tool.arguments = _PII_EMAIL
 
@@ -472,7 +494,10 @@ def test_settings_independent(otel_spans: InMemorySpanExporter, fake_presidio: N
 def test_defaults_skip_redaction(otel_spans: InMemorySpanExporter):
     """With defaults (redact_pii=False), Presidio engines are never loaded."""
     with patch("weave.utils.pii_redaction._get_engines") as mock_get_engines:
-        with start_conversation(conversation_id="s") as sess, sess.start_turn() as t:
+        with (
+            start_conversation(conversation_id="convo-defaults-skip-redaction") as sess,
+            sess.start_turn() as t,
+        ):
             with t.tool(name="x") as tool:
                 tool.arguments = _PII_EMAIL
     mock_get_engines.assert_not_called()

--- a/tests/conversation/test_conversation_settings.py
+++ b/tests/conversation/test_conversation_settings.py
@@ -1,10 +1,10 @@
-"""Tests that the Session SDK respects weave global settings.
+"""Tests that the Conversation SDK respects weave global settings.
 
 Covers four settings + one bug fix:
 
 - ``WEAVE_DISABLED`` — silences span emission in streaming + batch paths.
 - ``WEAVE_REDACT_PII`` — routes content fields through ``redact_pii`` /
-  ``redact_pii_string`` so Session SDK redaction matches ``@op``.
+  ``redact_pii_string`` so Conversation SDK redaction matches ``@op``.
 - ``WEAVE_CAPTURE_CLIENT_INFO`` / ``WEAVE_CAPTURE_SYSTEM_INFO`` — emits
   ``weave.*`` metadata attrs on every span (matches ``@op`` defaults).
 - Reasoning leak fix — ``LLM.reasoning`` is now gated by ``include_content``
@@ -30,15 +30,15 @@ import pytest
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from weave import version
-from weave.session.session import (
+from weave.conversation.conversation import (
     LLM,
     Message,
     Reasoning,
     Tool,
     Turn,
-    log_session,
+    log_conversation,
     log_turn,
-    start_session,
+    start_conversation,
 )
 from weave.trace.settings import override_settings
 
@@ -94,7 +94,7 @@ def _spans_with_prefix(otel_spans: InMemorySpanExporter, prefix: str) -> list[An
 
 def test_disabled_streaming_emits_no_spans(otel_spans: InMemorySpanExporter):
     with override_settings(disabled=True):
-        with start_session(agent_name="a", session_id="s") as s:
+        with start_conversation(agent_name="a", conversation_id="s") as s:
             with s.start_turn() as t:
                 with t.llm(model="gpt-4o"):
                     pass
@@ -105,16 +105,16 @@ def test_disabled_streaming_emits_no_spans(otel_spans: InMemorySpanExporter):
 
 def _user_func_log_turn() -> Any:
     return log_turn(
-        session_id="s",
+        conversation_id="s",
         agent_name="a",
         messages=[Message(role="user", content="hi")],
     )
 
 
-def _user_func_log_session() -> Any:
-    return log_session(
+def _user_func_log_conversation() -> Any:
+    return log_conversation(
         turns=[Turn(agent_name="a", messages=[Message(role="user", content="hi")])],
-        session_id="s",
+        conversation_id="s",
     )
 
 
@@ -122,7 +122,7 @@ def _user_func_log_session() -> Any:
     "user_func",
     [
         pytest.param(_user_func_log_turn, id="log_turn"),
-        pytest.param(_user_func_log_session, id="log_session"),
+        pytest.param(_user_func_log_conversation, id="log_conversation"),
     ],
 )
 def test_disabled_batch_emits_no_spans(
@@ -137,7 +137,7 @@ def test_disabled_batch_emits_no_spans(
 # ---------------------------------------------------------------------------
 # WEAVE_REDACT_PII — applied across streaming + batch paths
 #
-# Each helper below sets up a session that emits PII through one code path.
+# Each helper below sets up a conversation that emits PII through one code path.
 # The test runs the helper under ``redact_pii=True`` and asserts that the
 # resulting span's content attrs are redacted (no raw email, ``<EMAIL>``
 # present).
@@ -145,14 +145,14 @@ def test_disabled_batch_emits_no_spans(
 
 
 def _streaming_tool_with_pii() -> None:
-    with start_session(session_id="s") as sess, sess.start_turn() as t:
+    with start_conversation(conversation_id="s") as sess, sess.start_turn() as t:
         with t.tool(name="lookup") as tool:
             tool.arguments = f'{{"email":"{_PII_EMAIL}"}}'
             tool.result = f"found {_PII_EMAIL}"
 
 
 def _streaming_llm_messages_with_pii() -> None:
-    with start_session(session_id="s") as sess, sess.start_turn() as t:
+    with start_conversation(conversation_id="s") as sess, sess.start_turn() as t:
         with t.llm(
             model="gpt-4o", system_instructions=[f"contact {_PII_EMAIL}"]
         ) as llm:
@@ -164,21 +164,21 @@ def _streaming_llm_messages_with_pii() -> None:
 
 def _streaming_llm_reasoning_with_pii() -> None:
     """Regression case for the pre-existing leak: reasoning bypassing redaction."""
-    with start_session(session_id="s") as sess, sess.start_turn() as t:
+    with start_conversation(conversation_id="s") as sess, sess.start_turn() as t:
         with t.llm(model="gpt-4o") as llm:
             llm.reasoning = Reasoning(content=f"think about {_PII_EMAIL}")
             llm.output_messages = [Message(role="assistant", content="ok")]
 
 
 def _streaming_turn_with_pii() -> None:
-    with start_session(session_id="s") as sess:
+    with start_conversation(conversation_id="s") as sess:
         with sess.start_turn(user_message=_PII_EMAIL):
             pass
 
 
 def _batch_turn_messages_with_pii() -> None:
     log_turn(
-        session_id="s",
+        conversation_id="s",
         agent_name="a",
         messages=[Message(role="user", content=_PII_EMAIL)],
     )
@@ -186,7 +186,7 @@ def _batch_turn_messages_with_pii() -> None:
 
 def _batch_child_llm_with_pii() -> None:
     log_turn(
-        session_id="s",
+        conversation_id="s",
         agent_name="a",
         spans=[
             LLM(
@@ -199,7 +199,7 @@ def _batch_child_llm_with_pii() -> None:
 
 def _batch_child_tool_with_pii() -> None:
     log_turn(
-        session_id="s",
+        conversation_id="s",
         agent_name="a",
         spans=[Tool(name="lookup", arguments=f'{{"email":"{_PII_EMAIL}"}}')],
     )
@@ -281,14 +281,14 @@ def test_redact_pii_applied(
 
 
 def _content_off_tool() -> None:
-    with start_session(session_id="s", include_content=False) as sess:
+    with start_conversation(conversation_id="s", include_content=False) as sess:
         with sess.start_turn() as t:
             with t.tool(name="lookup") as tool:
                 tool.arguments = f'{{"email":"{_PII_EMAIL}"}}'
 
 
 def _content_off_llm() -> None:
-    with start_session(session_id="s", include_content=False) as sess:
+    with start_conversation(conversation_id="s", include_content=False) as sess:
         with sess.start_turn() as t:
             with t.llm(model="gpt-4o") as llm:
                 llm.input_messages = [Message(role="user", content=_PII_EMAIL)]
@@ -296,14 +296,14 @@ def _content_off_llm() -> None:
 
 
 def _content_off_turn() -> None:
-    with start_session(session_id="s", include_content=False) as sess:
+    with start_conversation(conversation_id="s", include_content=False) as sess:
         with sess.start_turn(user_message=_PII_EMAIL):
             pass
 
 
 def _content_off_log_turn() -> None:
     log_turn(
-        session_id="s",
+        conversation_id="s",
         agent_name="a",
         include_content=False,
         messages=[Message(role="user", content=_PII_EMAIL)],
@@ -336,7 +336,7 @@ def test_include_content_false_skips_presidio(
 
 
 def _reasoning_content_off_streaming() -> None:
-    with start_session(session_id="s", include_content=False) as sess:
+    with start_conversation(conversation_id="s", include_content=False) as sess:
         with sess.start_turn() as t:
             with t.llm(model="gpt-4o") as llm:
                 llm.reasoning = Reasoning(content="sensitive reasoning")
@@ -344,7 +344,7 @@ def _reasoning_content_off_streaming() -> None:
 
 def _reasoning_content_off_batch() -> None:
     log_turn(
-        session_id="s",
+        conversation_id="s",
         agent_name="a",
         include_content=False,
         spans=[LLM(model="gpt-4o", reasoning=Reasoning(content="sensitive"))],
@@ -416,7 +416,7 @@ def test_capture_info_settings(
     with override_settings(
         capture_client_info=client_info, capture_system_info=system_info
     ):
-        with start_session(session_id="s") as sess:
+        with start_conversation(conversation_id="s") as sess:
             with sess.start_turn() as t:
                 with t.tool(name="x"):
                     pass
@@ -438,7 +438,7 @@ def test_capture_info_on_batch_path(otel_spans: InMemorySpanExporter):
     """Batch (log_turn) path uses a separate emit path — same invariant."""
     with override_settings(capture_client_info=True):
         log_turn(
-            session_id="s",
+            conversation_id="s",
             agent_name="a",
             spans=[LLM(model="gpt-4o")],
         )
@@ -459,7 +459,7 @@ def test_settings_independent(otel_spans: InMemorySpanExporter, fake_presidio: N
     with override_settings(
         redact_pii=True, capture_client_info=False, capture_system_info=False
     ):
-        with start_session(session_id="s") as sess, sess.start_turn() as t:
+        with start_conversation(conversation_id="s") as sess, sess.start_turn() as t:
             with t.tool(name="lookup") as tool:
                 tool.arguments = _PII_EMAIL
 
@@ -472,7 +472,7 @@ def test_settings_independent(otel_spans: InMemorySpanExporter, fake_presidio: N
 def test_defaults_skip_redaction(otel_spans: InMemorySpanExporter):
     """With defaults (redact_pii=False), Presidio engines are never loaded."""
     with patch("weave.utils.pii_redaction._get_engines") as mock_get_engines:
-        with start_session(session_id="s") as sess, sess.start_turn() as t:
+        with start_conversation(conversation_id="s") as sess, sess.start_turn() as t:
             with t.tool(name="x") as tool:
                 tool.arguments = _PII_EMAIL
     mock_get_engines.assert_not_called()

--- a/tests/conversation/test_deprecation.py
+++ b/tests/conversation/test_deprecation.py
@@ -1,0 +1,66 @@
+"""The deprecated ``session`` aliases forward to the Conversation SDK.
+
+These cover the back-compat surface added when the Session SDK was renamed
+to the Conversation SDK: the old ``weave.start_session`` / ``Session`` / etc.
+names still work, emit a ``DeprecationWarning``, and translate the old
+``session_id`` / ``session_name`` arguments to their ``conversation`` forms.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import weave
+
+
+def test_start_session_forwards_and_warns() -> None:
+    with pytest.warns(DeprecationWarning, match="start_session"):
+        conv = weave.start_session(
+            agent_name="bot", session_id="c1", session_name="demo"
+        )
+    assert type(conv).__name__ == "Conversation"
+    assert conv.conversation_id == "c1"
+    assert conv.conversation_name == "demo"
+    conv.end()
+
+
+def test_session_class_maps_old_fields_and_warns() -> None:
+    with pytest.warns(DeprecationWarning, match="Session"):
+        s = weave.Session(session_id="c2", session_name="d2")
+    assert s.conversation_id == "c2"
+    assert s.conversation_name == "d2"
+
+
+def test_end_and_get_current_session_warn() -> None:
+    with pytest.warns(DeprecationWarning, match="start_session"):
+        s = weave.start_session(session_id="c3")
+    with pytest.warns(DeprecationWarning, match="get_current_session"):
+        assert weave.get_current_session() is s
+    with pytest.warns(DeprecationWarning, match="end_session"):
+        weave.end_session()
+    with pytest.warns(DeprecationWarning, match="get_current_session"):
+        assert weave.get_current_session() is None
+
+
+def test_log_session_forwards_and_warns() -> None:
+    with pytest.warns(DeprecationWarning, match="log_session"):
+        result = weave.log_session(turns=[], session_id="c4")
+    assert result.conversation_id == "c4"
+
+
+def test_legacy_import_path_warns_and_reexports() -> None:
+    import weave.session as legacy
+
+    # Re-importing the deprecated path emits the module-level warning.
+    with pytest.warns(DeprecationWarning, match="weave.session has been renamed"):
+        importlib.reload(legacy)
+
+    # Unchanged names are still re-exported from the old path, identical to
+    # the canonical objects; the session-named callables forward to weave's.
+    from weave.conversation import TextPart
+
+    assert legacy.TextPart is TextPart
+    assert legacy.start_session is weave.start_session
+    assert legacy.Session is weave.Session

--- a/tests/conversation/test_deprecation.py
+++ b/tests/conversation/test_deprecation.py
@@ -33,6 +33,28 @@ def test_session_class_maps_old_fields_and_warns() -> None:
     assert s.conversation_name == "d2"
 
 
+def test_session_instance_supports_old_field_read_and_write() -> None:
+    """``session_id`` / ``session_name`` work as instance properties.
+
+    The original ``Session`` had these as model fields, so old code that reads
+    or assigns them on an instance must keep working; they proxy to the
+    ``conversation_*`` fields in both directions.
+    """
+    with pytest.warns(DeprecationWarning, match="Session"):
+        s = weave.Session(session_id="c5", session_name="d5")
+
+    assert s.session_id == "c5"
+    assert s.session_name == "d5"
+
+    s.session_id = "c5-updated"
+    s.session_name = "d5-updated"
+
+    assert s.session_id == "c5-updated"
+    assert s.session_name == "d5-updated"
+    assert s.conversation_id == "c5-updated"
+    assert s.conversation_name == "d5-updated"
+
+
 def test_end_and_get_current_session_warn() -> None:
     with pytest.warns(DeprecationWarning, match="start_session"):
         s = weave.start_session(session_id="c3")

--- a/tests/conversation/test_post_hoc_times.py
+++ b/tests/conversation/test_post_hoc_times.py
@@ -6,7 +6,7 @@ emitted OTel span carried now() regardless of what the SDK object held.
 SubAgent.__enter__ did the same for started_at.
 
 Post-fix: streaming end() emits OTel spans byte-identical to the batch
-path (log_turn / log_session) for the same inputs.
+path (log_turn / log_conversation) for the same inputs.
 """
 
 from __future__ import annotations
@@ -16,7 +16,14 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from weave.session.session import LLM, Session, SubAgent, Tool, Turn, log_turn
+from weave.conversation.conversation import (
+    LLM,
+    Conversation,
+    SubAgent,
+    Tool,
+    Turn,
+    log_turn,
+)
 
 
 def _at(seconds_offset: int) -> datetime:
@@ -80,7 +87,7 @@ def test_otel_span_times_match_caller_values(
 ) -> None:
     """Emitted OTel span's ``start_time`` and ``end_time`` match caller values."""
     started_at, ended_at = _at(0), _at(3)
-    with Session(session_id="test-session"):
+    with Conversation(conversation_id="test-conversation"):
         span_obj = factory(started_at=started_at, ended_at=ended_at)
         with span_obj:
             pass
@@ -109,7 +116,7 @@ def test_streaming_matches_batch_for_llm(otel_spans: InMemorySpanExporter) -> No
 
     otel_spans.clear()
     with (
-        Session(session_id="test-session"),
+        Conversation(conversation_id="test-conversation"),
         Turn(agent_name="weather-bot", started_at=started_at, ended_at=ended_at),
     ):
         with LLM(
@@ -123,7 +130,7 @@ def test_streaming_matches_batch_for_llm(otel_spans: InMemorySpanExporter) -> No
 
     otel_spans.clear()
     log_turn(
-        session_id="test-session",
+        conversation_id="test-conversation",
         agent_name="weather-bot",
         started_at=started_at,
         ended_at=ended_at,

--- a/tests/conversation/test_span_attributes.py
+++ b/tests/conversation/test_span_attributes.py
@@ -173,7 +173,9 @@ def test_conversation_attributes_on_every_streaming_span(
 ) -> None:
     """A conversation's attributes land on the turn root and every child span."""
     attrs = {"weave.integration.name": "wb-agent", "custom.tier": "gold"}
-    with Conversation(conversation_id="s", attributes=attrs) as conversation:
+    with Conversation(
+        conversation_id="convo-attrs-streaming", attributes=attrs
+    ) as conversation:
         turn = conversation.start_turn(agent_name="bot")
         with turn:
             with turn.llm(model="gpt-4o"):
@@ -200,7 +202,7 @@ def test_conversation_attributes_on_every_batch_span(
 ) -> None:
     """log_turn applies attributes to the turn and its child spans."""
     log_turn(
-        conversation_id="s",
+        conversation_id="convo-attrs-batch",
         agent_name="bot",
         spans=[LLM(model="gpt-4o"), Tool(name="Edit")],
         attributes={"weave.integration.name": "wb-agent"},
@@ -220,7 +222,7 @@ def test_conversation_attributes_on_every_log_conversation_span(
             Turn(agent_name="bot", spans=[LLM(model="gpt-4o")]),
             Turn(agent_name="bot", spans=[Tool(name="Edit")]),
         ],
-        conversation_id="s",
+        conversation_id="convo-attrs-log-conversation",
         attributes={"weave.integration.name": "wb-agent"},
     )
     spans = otel_spans.get_finished_spans()
@@ -232,7 +234,7 @@ def test_conversation_attributes_on_every_log_conversation_span(
 def test_no_conversation_attributes_by_default(
     otel_spans: InMemorySpanExporter,
 ) -> None:
-    with Conversation(conversation_id="s") as conversation:
+    with Conversation(conversation_id="convo-attrs-default") as conversation:
         with conversation.start_turn(agent_name="bot"):
             pass
     span = _only_span(otel_spans.get_finished_spans(), "invoke_agent bot")

--- a/tests/conversation/test_span_attributes.py
+++ b/tests/conversation/test_span_attributes.py
@@ -13,13 +13,13 @@ import logging
 import pytest
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from weave.session.session import (
+from weave.conversation.conversation import (
     LLM,
-    Session,
+    Conversation,
     SubAgent,
     Tool,
     Turn,
-    log_session,
+    log_conversation,
     log_turn,
 )
 
@@ -51,7 +51,7 @@ def _only_span(spans: list, span_name: str):
 def test_set_attributes_lands_on_span(
     otel_spans: InMemorySpanExporter, _class_label, factory, span_name
 ) -> None:
-    with Session(session_id="test-session"), factory() as span_obj:
+    with Conversation(conversation_id="test-conversation"), factory() as span_obj:
         span_obj.set_attributes({"weave.first": "one", "weave.second": "two"})
     finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
     assert finished_span.attributes["weave.first"] == "one"
@@ -64,7 +64,7 @@ def test_set_attributes_lands_on_span(
 def test_set_attributes_no_op_after_end(
     otel_spans: InMemorySpanExporter, _class_label, factory, span_name
 ) -> None:
-    with Session(session_id="test-session"):
+    with Conversation(conversation_id="test-conversation"):
         span_obj = factory()
         with span_obj:
             pass
@@ -78,7 +78,7 @@ def test_set_attributes_accepts_sequence_value(
     otel_spans: InMemorySpanExporter,
 ) -> None:
     """OTel accepts ``Sequence[str]`` — used for e.g. ``gen_ai.response.finish_reasons``."""
-    with Session(session_id="test-session"), LLM(model="gpt-4o") as llm:
+    with Conversation(conversation_id="test-conversation"), LLM(model="gpt-4o") as llm:
         llm.set_attributes({"gen_ai.response.finish_reasons": ["stop"]})
     chat_span = _only_span(otel_spans.get_finished_spans(), "chat gpt-4o")
     assert tuple(chat_span.attributes["gen_ai.response.finish_reasons"]) == ("stop",)
@@ -95,7 +95,7 @@ def test_set_attributes_accepts_sequence_value(
 def test_add_event_records_on_span(
     otel_spans: InMemorySpanExporter, _class_label, factory, span_name
 ) -> None:
-    with Session(session_id="test-session"), factory() as span_obj:
+    with Conversation(conversation_id="test-conversation"), factory() as span_obj:
         span_obj.add_event("weave.evt", {"event_key": "event_value"})
     finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
     assert len(finished_span.events) == 1
@@ -109,7 +109,7 @@ def test_add_event_records_on_span(
 def test_add_event_no_op_after_end(
     otel_spans: InMemorySpanExporter, _class_label, factory, span_name
 ) -> None:
-    with Session(session_id="test-session"):
+    with Conversation(conversation_id="test-conversation"):
         span_obj = factory()
         with span_obj:
             pass
@@ -130,7 +130,7 @@ def test_returns_self_for_chaining(
     otel_spans: InMemorySpanExporter, _class_label, factory, _span_name
 ) -> None:
     """Both mutators return ``self`` for fluent chaining on a live span."""
-    with Session(session_id="test-session"), factory() as span_obj:
+    with Conversation(conversation_id="test-conversation"), factory() as span_obj:
         assert span_obj.set_attributes({"key": "value"}) is span_obj
         assert span_obj.add_event("event-name") is span_obj
 
@@ -139,7 +139,7 @@ def test_warns_when_span_not_started(
     caplog: pytest.LogCaptureFixture, otel_spans: InMemorySpanExporter
 ) -> None:
     """Both mutators warn and emit no span when called before ``with``."""
-    caplog.set_level(logging.WARNING, logger="weave.session.session")
+    caplog.set_level(logging.WARNING, logger="weave.conversation.conversation")
     tool = Tool(name="test-tool")
     tool.set_attributes({"weave.first": "one"})
     tool.add_event("weave.evt")
@@ -151,8 +151,8 @@ def test_warns_when_span_not_started(
 
 def test_warns_when_span_already_ended(caplog: pytest.LogCaptureFixture) -> None:
     """Both mutators warn when called after ``end()``."""
-    caplog.set_level(logging.WARNING, logger="weave.session.session")
-    with Session(session_id="test-session"):
+    caplog.set_level(logging.WARNING, logger="weave.conversation.conversation")
+    with Conversation(conversation_id="test-conversation"):
         tool = Tool(name="test-tool")
         with tool:
             pass
@@ -164,17 +164,17 @@ def test_warns_when_span_already_ended(caplog: pytest.LogCaptureFixture) -> None
 
 
 # ---------------------------------------------------------------------------
-# Session attributes (stamped on every span)
+# Conversation attributes (stamped on every span)
 # ---------------------------------------------------------------------------
 
 
-def test_session_attributes_on_every_streaming_span(
+def test_conversation_attributes_on_every_streaming_span(
     otel_spans: InMemorySpanExporter,
 ) -> None:
-    """A session's attributes land on the turn root and every child span."""
+    """A conversation's attributes land on the turn root and every child span."""
     attrs = {"weave.integration.name": "wb-agent", "custom.tier": "gold"}
-    with Session(session_id="s", attributes=attrs) as session:
-        turn = session.start_turn(agent_name="bot")
+    with Conversation(conversation_id="s", attributes=attrs) as conversation:
+        turn = conversation.start_turn(agent_name="bot")
         with turn:
             with turn.llm(model="gpt-4o"):
                 pass
@@ -195,12 +195,12 @@ def test_session_attributes_on_every_streaming_span(
         assert span.attributes["custom.tier"] == "gold"
 
 
-def test_session_attributes_on_every_batch_span(
+def test_conversation_attributes_on_every_batch_span(
     otel_spans: InMemorySpanExporter,
 ) -> None:
     """log_turn applies attributes to the turn and its child spans."""
     log_turn(
-        session_id="s",
+        conversation_id="s",
         agent_name="bot",
         spans=[LLM(model="gpt-4o"), Tool(name="Edit")],
         attributes={"weave.integration.name": "wb-agent"},
@@ -211,16 +211,16 @@ def test_session_attributes_on_every_batch_span(
         assert span.attributes["weave.integration.name"] == "wb-agent"
 
 
-def test_session_attributes_on_every_log_session_span(
+def test_conversation_attributes_on_every_log_conversation_span(
     otel_spans: InMemorySpanExporter,
 ) -> None:
-    """log_session applies attributes to every turn root and child span."""
-    log_session(
+    """log_conversation applies attributes to every turn root and child span."""
+    log_conversation(
         turns=[
             Turn(agent_name="bot", spans=[LLM(model="gpt-4o")]),
             Turn(agent_name="bot", spans=[Tool(name="Edit")]),
         ],
-        session_id="s",
+        conversation_id="s",
         attributes={"weave.integration.name": "wb-agent"},
     )
     spans = otel_spans.get_finished_spans()
@@ -229,11 +229,11 @@ def test_session_attributes_on_every_log_session_span(
         assert span.attributes["weave.integration.name"] == "wb-agent"
 
 
-def test_no_session_attributes_by_default(
+def test_no_conversation_attributes_by_default(
     otel_spans: InMemorySpanExporter,
 ) -> None:
-    with Session(session_id="s") as session:
-        with session.start_turn(agent_name="bot"):
+    with Conversation(conversation_id="s") as conversation:
+        with conversation.start_turn(agent_name="bot"):
             pass
     span = _only_span(otel_spans.get_finished_spans(), "invoke_agent bot")
     assert "weave.integration.name" not in (span.attributes or {})

--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
@@ -22,17 +22,17 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import StatusCode
 
 from tests.integrations.claude_agent_sdk.conftest import ReplayTransport, load_cassette
+from weave.conversation import agent_name_override
 from weave.integrations.claude_agent_sdk.otel_integration import (
     get_claude_agent_sdk_otel_patcher,
 )
-from weave.session import agent_name_override
 
 
 @pytest.fixture
 def otel_spans(monkeypatch: pytest.MonkeyPatch) -> Generator[InMemorySpanExporter]:
     """Install an in-memory OTel exporter as the global provider.
 
-    Mirrors the session-SDK / openai_agents_otel fixture: overrides the
+    Mirrors the conversation-SDK / openai_agents_otel fixture: overrides the
     private ``_TRACER_PROVIDER`` so prior state is restored cleanly and the
     "set once" warning is avoided.
     """

--- a/tests/integrations/openai_agents/openai_agents_otel_test.py
+++ b/tests/integrations/openai_agents/openai_agents_otel_test.py
@@ -33,11 +33,11 @@ from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+from weave.conversation import agent_name_override
 from weave.integrations.openai_agents.otel_processor import (
     WeaveOtelTracingProcessor,
     _iso_to_ns,
 )
-from weave.session import agent_name_override
 from weave.trace.weave_client import WeaveClient
 
 
@@ -45,7 +45,7 @@ from weave.trace.weave_client import WeaveClient
 def otel_spans(monkeypatch: pytest.MonkeyPatch):
     """Install an in-memory OTel exporter and return it for assertions.
 
-    Mirrors the fixture in ``tests/session/test_session_otel.py`` — overrides
+    Mirrors the fixture in ``tests/conversation/test_conversation_otel.py`` — overrides
     the global tracer provider via ``monkeypatch.setattr`` so prior state is
     restored cleanly between tests.
     """

--- a/tests/integrations/openai_realtime/test_otel_state_exporter.py
+++ b/tests/integrations/openai_realtime/test_otel_state_exporter.py
@@ -29,10 +29,10 @@ from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+from weave.conversation.agent_context import agent_name_override
 from weave.integrations.openai_realtime.conversation_manager import ConversationManager
 from weave.integrations.openai_realtime.otel_state_exporter import OTelStateExporter
 from weave.integrations.openai_realtime.state_exporter import StateExporter
-from weave.session.agent_context import agent_name_override
 
 _MODEL = "gpt-4o-realtime-preview"
 _SESSION_ID = "sess_1"

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -50,6 +50,37 @@ wandb_init_hook()
 
 from weave.agent.agent import Agent as Agent
 from weave.agent.agent import AgentState as AgentState
+from weave.conversation._deprecated import (
+    Session,
+    end_session,
+    get_current_session,
+    log_session,
+    start_session,
+)
+from weave.conversation.conversation import (
+    LLM,
+    Conversation,
+    LogResult,
+    MediaAttachment,
+    Message,
+    SubAgent,
+    Tool,
+    Turn,
+    Usage,
+    end_conversation,
+    end_llm,
+    end_turn,
+    get_current_conversation,
+    get_current_llm,
+    get_current_turn,
+    log_conversation,
+    log_turn,
+    start_conversation,
+    start_llm,
+    start_subagent,
+    start_tool,
+    start_turn,
+)
 from weave.dataset.dataset import Dataset
 from weave.evaluation.eval import Evaluation
 from weave.evaluation.eval_imperative import EvaluationLogger
@@ -60,30 +91,6 @@ from weave.flow.saved_view import SavedView
 from weave.flow.scorer import Scorer
 from weave.object.obj import Object
 from weave.prompt.prompt import EasyPrompt, MessagesPrompt, Prompt, StringPrompt
-from weave.session.session import (
-    LLM,
-    LogResult,
-    MediaAttachment,
-    Message,
-    Session,
-    SubAgent,
-    Tool,
-    Turn,
-    Usage,
-    end_llm,
-    end_session,
-    end_turn,
-    get_current_llm,
-    get_current_session,
-    get_current_turn,
-    log_session,
-    log_turn,
-    start_llm,
-    start_session,
-    start_subagent,
-    start_tool,
-    start_turn,
-)
 from weave.trace.log_call import log_call
 from weave.trace.urls import otel_traces_endpoint
 from weave.trace.util import Thread as Thread
@@ -104,6 +111,7 @@ __all__ = [
     "Audio",
     "ClassifierMonitor",
     "Content",
+    "Conversation",
     "Dataset",
     "EasyPrompt",
     "Evaluation",
@@ -132,6 +140,7 @@ __all__ = [
     "add_tags",
     "as_op",
     "attributes",
+    "end_conversation",
     "end_llm",
     "end_session",
     "end_turn",
@@ -140,6 +149,7 @@ __all__ = [
     "get_aliases",
     "get_client",
     "get_current_call",
+    "get_current_conversation",
     "get_current_llm",
     "get_current_session",
     "get_current_turn",
@@ -150,6 +160,7 @@ __all__ = [
     "list_aliases",
     "list_tags",
     "log_call",
+    "log_conversation",
     "log_session",
     "log_turn",
     "op",
@@ -161,6 +172,7 @@ __all__ = [
     "require_current_call",
     "set_aliases",
     "set_view",
+    "start_conversation",
     "start_llm",
     "start_session",
     "start_subagent",

--- a/weave/conversation/__init__.py
+++ b/weave/conversation/__init__.py
@@ -1,0 +1,79 @@
+"""Public namespace for the Weave Conversation SDK.
+
+Imports everything user code needs to construct conversations, turns, llm
+spans, tool spans, and structured messages. Concrete message parts
+(``TextPart``, ``ToolCallPart``, etc.) and the ``MessagePart`` union
+live here rather than at the top-level ``weave`` namespace, mirroring
+the ``langchain_core.messages`` pattern: callers building structured
+messages do ``from weave.conversation import TextPart, ToolCallPart``.
+"""
+
+from weave.conversation.agent_context import agent_name_override
+from weave.conversation.conversation import (
+    LLM,
+    BlobPart,
+    Conversation,
+    FilePart,
+    LogResult,
+    MediaAttachment,
+    Message,
+    MessagePart,
+    Reasoning,
+    ReasoningPart,
+    SubAgent,
+    TextPart,
+    Tool,
+    ToolCallPart,
+    ToolCallResponsePart,
+    Turn,
+    UriPart,
+    Usage,
+    end_conversation,
+    end_llm,
+    end_turn,
+    get_current_conversation,
+    get_current_llm,
+    get_current_turn,
+    log_conversation,
+    log_turn,
+    start_conversation,
+    start_llm,
+    start_subagent,
+    start_tool,
+    start_turn,
+)
+
+__all__ = [
+    "LLM",
+    "BlobPart",
+    "Conversation",
+    "FilePart",
+    "LogResult",
+    "MediaAttachment",
+    "Message",
+    "MessagePart",
+    "Reasoning",
+    "ReasoningPart",
+    "SubAgent",
+    "TextPart",
+    "Tool",
+    "ToolCallPart",
+    "ToolCallResponsePart",
+    "Turn",
+    "UriPart",
+    "Usage",
+    "agent_name_override",
+    "end_conversation",
+    "end_llm",
+    "end_turn",
+    "get_current_conversation",
+    "get_current_llm",
+    "get_current_turn",
+    "log_conversation",
+    "log_turn",
+    "start_conversation",
+    "start_llm",
+    "start_subagent",
+    "start_tool",
+    "start_turn",
+]

--- a/weave/conversation/_deprecated.py
+++ b/weave/conversation/_deprecated.py
@@ -1,0 +1,132 @@
+"""Deprecated ``session``-named aliases for the Conversation SDK.
+
+The SDK was renamed from "Session" to "Conversation". These thin wrappers
+keep the old public names working and emit a ``DeprecationWarning``; they
+translate the old ``session_id`` / ``session_name`` keyword arguments to
+``conversation_id`` / ``conversation_name``. Quarantined here so the renamed
+core stays free of legacy naming. Remove in a future release.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any
+
+from weave.conversation.conversation import (
+    Conversation,
+    LogResult,
+    Turn,
+    end_conversation,
+    get_current_conversation,
+    log_conversation,
+    start_conversation,
+)
+
+if TYPE_CHECKING:
+    from opentelemetry.util.types import Attributes
+
+__all__ = [
+    "Session",
+    "end_session",
+    "get_current_session",
+    "log_session",
+    "start_session",
+]
+
+
+def _warn(old: str, new: str) -> None:
+    """Emit the rename ``DeprecationWarning`` for ``weave.<old>``.
+
+    ``stacklevel=3`` points the warning at the user's call site (caller →
+    public alias → ``_warn``) rather than at this module.
+    """
+    warnings.warn(
+        f"weave.{old} is deprecated and will be removed in a future release; "
+        f"use weave.{new} instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def start_session(
+    *,
+    agent_name: str = "",
+    model: str = "",
+    session_id: str = "",
+    session_name: str = "",
+    include_content: bool = True,
+    continue_parent_trace: bool = False,
+    attributes: Attributes = None,
+) -> Conversation:
+    """Deprecated alias of :func:`weave.start_conversation`.
+
+    ``session_id`` / ``session_name`` map to ``conversation_id`` /
+    ``conversation_name``.
+    """
+    _warn("start_session", "start_conversation")
+    return start_conversation(
+        agent_name=agent_name,
+        model=model,
+        conversation_id=session_id,
+        conversation_name=session_name,
+        include_content=include_content,
+        continue_parent_trace=continue_parent_trace,
+        attributes=attributes,
+    )
+
+
+def log_session(
+    *,
+    turns: list[Turn],
+    session_id: str = "",
+    session_name: str = "",
+    agent_name: str = "",
+    model: str = "",
+    include_content: bool = True,
+    continue_parent_trace: bool = False,
+    attributes: Attributes = None,
+) -> LogResult:
+    """Deprecated alias of :func:`weave.log_conversation`.
+
+    ``session_id`` / ``session_name`` map to ``conversation_id`` /
+    ``conversation_name``.
+    """
+    _warn("log_session", "log_conversation")
+    return log_conversation(
+        turns=turns,
+        conversation_id=session_id,
+        conversation_name=session_name,
+        agent_name=agent_name,
+        model=model,
+        include_content=include_content,
+        continue_parent_trace=continue_parent_trace,
+        attributes=attributes,
+    )
+
+
+def end_session() -> None:
+    """Deprecated alias of :func:`weave.end_conversation`."""
+    _warn("end_session", "end_conversation")
+    end_conversation()
+
+
+def get_current_session() -> Conversation | None:
+    """Deprecated alias of :func:`weave.get_current_conversation`."""
+    _warn("get_current_session", "get_current_conversation")
+    return get_current_conversation()
+
+
+class Session(Conversation):
+    """Deprecated alias of :class:`weave.Conversation`.
+
+    Accepts the old ``session_id`` / ``session_name`` constructor fields and
+    maps them to ``conversation_id`` / ``conversation_name``.
+    """
+
+    def __init__(self, **data: Any) -> None:
+        _warn("Session", "Conversation")
+        if "session_id" in data:
+            data.setdefault("conversation_id", data.pop("session_id"))
+        if "session_name" in data:
+            data.setdefault("conversation_name", data.pop("session_name"))
+        super().__init__(**data)

--- a/weave/conversation/_deprecated.py
+++ b/weave/conversation/_deprecated.py
@@ -120,7 +120,10 @@ class Session(Conversation):
     """Deprecated alias of :class:`weave.Conversation`.
 
     Accepts the old ``session_id`` / ``session_name`` constructor fields and
-    maps them to ``conversation_id`` / ``conversation_name``.
+    also exposes them as read/write properties that proxy to
+    ``conversation_id`` / ``conversation_name``. The original ``Session`` had
+    these as model fields, so old code that reads or assigns ``s.session_id``
+    keeps working.
     """
 
     def __init__(self, **data: Any) -> None:
@@ -130,3 +133,21 @@ class Session(Conversation):
         if "session_name" in data:
             data.setdefault("conversation_name", data.pop("session_name"))
         super().__init__(**data)
+
+    @property
+    def session_id(self) -> str:
+        """Deprecated alias of :attr:`conversation_id`."""
+        return self.conversation_id
+
+    @session_id.setter
+    def session_id(self, value: str) -> None:
+        self.conversation_id = value
+
+    @property
+    def session_name(self) -> str:
+        """Deprecated alias of :attr:`conversation_name`."""
+        return self.conversation_name
+
+    @session_name.setter
+    def session_name(self, value: str) -> None:
+        self.conversation_name = value

--- a/weave/conversation/adapters/__init__.py
+++ b/weave/conversation/adapters/__init__.py
@@ -1,8 +1,8 @@
-"""Provider adapters for the Weave Session SDK.
+"""Provider adapters for the Weave Conversation SDK.
 
 These modules convert provider-specific wire formats (OpenAI Responses,
 Anthropic Messages, etc.) into the provider-agnostic types defined in
-``weave.session.types``. Each adapter is a leaf module — it imports
+``weave.conversation.types``. Each adapter is a leaf module — it imports
 types but is not imported by them, so ``types.py`` stays free of
 provider knowledge.
 

--- a/weave/conversation/adapters/anthropic.py
+++ b/weave/conversation/adapters/anthropic.py
@@ -1,4 +1,4 @@
-"""Adapters from Anthropic's wire format to the Weave Session SDK types.
+"""Adapters from Anthropic's wire format to the Weave Conversation SDK types.
 
 Use these when manually instrumenting calls to ``client.messages.create``
 (the autopatched Anthropic integration handles conversion automatically).
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from weave.session.types import Usage
+from weave.conversation.types import Usage
 
 if TYPE_CHECKING:
     from anthropic.types import Message as AnthropicMessage

--- a/weave/conversation/adapters/openai.py
+++ b/weave/conversation/adapters/openai.py
@@ -1,4 +1,4 @@
-"""Adapters from OpenAI's wire format to the Weave Session SDK types.
+"""Adapters from OpenAI's wire format to the Weave Conversation SDK types.
 
 Use these when manually instrumenting calls to ``client.responses.create``
 (the autopatched OpenAI integration handles conversion automatically).
@@ -20,8 +20,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from weave.session.session import _publish_media_content
-from weave.session.types import (
+from weave.conversation.conversation import _publish_media_content
+from weave.conversation.types import (
     MediaAttachment,
     Message,
     Reasoning,

--- a/weave/conversation/agent_context.py
+++ b/weave/conversation/agent_context.py
@@ -7,7 +7,7 @@ on it. Some SDKs expose a native agent name (OpenAI Agents); others don't
 lets a user name those auto-created spans for a block of work, regardless of
 which integration produced them.
 
-This is deliberately distinct from ``weave.session.start_turn(agent_name=...)``,
+This is deliberately distinct from ``weave.conversation.start_turn(agent_name=...)``,
 which *creates* a manual ``invoke_agent`` span. The override here only relabels a
 span created elsewhere — it never creates a span of its own.
 """
@@ -33,7 +33,7 @@ def agent_name_override(agent_name: str) -> Iterator[None]:
     integrations stamp on their ``invoke_agent`` span::
 
         import weave
-        from weave.session import agent_name_override
+        from weave.conversation import agent_name_override
 
         weave.init("my-project")
 

--- a/weave/conversation/conversation.py
+++ b/weave/conversation/conversation.py
@@ -1,4 +1,4 @@
-"""Weave Session SDK — structured logging for agent conversations.
+"""Weave Conversation SDK — structured logging for agent conversations.
 
 Provides Python classes and functions for logging agent conversations
 to Weave's Agents tab. All data flows through OpenTelemetry — the SDK
@@ -20,12 +20,12 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from typing_extensions import Self
 
-from weave.session.session_otel import (
+from weave.conversation.conversation_otel import (
     execute_tool_attributes,
     invoke_agent_attributes,
     llm_attributes,
 )
-from weave.session.types import (
+from weave.conversation.types import (
     BlobPart,
     FilePart,
     JSONString,
@@ -67,11 +67,12 @@ if TYPE_CHECKING:
 
 
 # Re-export types for backwards compatibility with existing imports of
-# `weave.session.session.Message` etc. The data classes themselves live
-# in `weave.session.types` to break the import cycle with `session_otel`.
+# `weave.conversation.conversation.Message` etc. The data classes themselves live
+# in `weave.conversation.types` to break the import cycle with `conversation_otel`.
 __all__ = [
     "LLM",
     "BlobPart",
+    "Conversation",
     "FilePart",
     "LogResult",
     "MediaAttachment",
@@ -79,7 +80,6 @@ __all__ = [
     "MessagePart",
     "Reasoning",
     "ReasoningPart",
-    "Session",
     "SubAgent",
     "TextPart",
     "Tool",
@@ -88,16 +88,16 @@ __all__ = [
     "Turn",
     "UriPart",
     "Usage",
+    "end_conversation",
     "end_llm",
-    "end_session",
     "end_turn",
+    "get_current_conversation",
     "get_current_llm",
-    "get_current_session",
     "get_current_turn",
-    "log_session",
+    "log_conversation",
     "log_turn",
+    "start_conversation",
     "start_llm",
-    "start_session",
     "start_subagent",
     "start_tool",
     "start_turn",
@@ -109,8 +109,8 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 
-# OTel tracer name — identifies the Session SDK as the source of these spans.
-_TRACER_NAME = "weave.session"
+# OTel tracer name — identifies the Conversation SDK as the source of these spans.
+_TRACER_NAME = "weave.conversation"
 
 logger = logging.getLogger(__name__)
 
@@ -158,12 +158,12 @@ class _SpanBase(BaseModel):
         self._otel_token = otel_context.attach(
             otel_trace.set_span_in_context(self._otel_span)
         )
-        # Stamp the active session's attributes on every span. Read from the
-        # session contextvar (not OTel context) so they reach the root turn
+        # Stamp the active conversation's attributes on every span. Read from the
+        # conversation contextvar (not OTel context) so they reach the root turn
         # span too, which starts in a fresh OTel Context to force a new trace.
-        session = get_current_session()
-        if session is not None and session.attributes:
-            self._otel_span.set_attributes(session.attributes)
+        conversation = get_current_conversation()
+        if conversation is not None and conversation.attributes:
+            self._otel_span.set_attributes(conversation.attributes)
 
     def _end_otel_span(
         self, attrs: dict[str, Any], *, end_time_ns: int | None = None
@@ -237,7 +237,7 @@ class _SpanBase(BaseModel):
         Must be called between span start and span end — i.e. inside a
         ``with`` block. Outside that window the call is a no-op and logs
         a warning. For batch ingest, populate the object's declared fields
-        directly and pass it to ``log_turn`` / ``log_session``.
+        directly and pass it to ``log_turn`` / ``log_conversation``.
         """
         if span := self._recording_span("set_attributes", list(attributes)):
             span.set_attributes(attributes)
@@ -329,7 +329,9 @@ class Tool(_SpanBase):
 
     _ended: bool = PrivateAttr(default=False)
 
-    def _build_attrs(self, *, session_id: str, include_content: bool) -> dict[str, Any]:
+    def _build_attrs(
+        self, *, conversation_id: str, include_content: bool
+    ) -> dict[str, Any]:
         """Build the full OTel attribute dict for this tool span.
 
         Single chokepoint shared by streaming (``end``) and batch
@@ -348,7 +350,7 @@ class Tool(_SpanBase):
             result = ""
         attrs = execute_tool_attributes(
             tool_name=self.name,
-            conversation_id=session_id,
+            conversation_id=conversation_id,
             tool_call_arguments=arguments,
             tool_call_result=result,
             tool_call_id=self.tool_call_id,
@@ -369,10 +371,10 @@ class Tool(_SpanBase):
             elapsed = self.ended_at - self.started_at
             self.duration_ms = int(elapsed.total_seconds() * 1000)
 
-        session = get_current_session()
+        conversation = get_current_conversation()
         attrs = self._build_attrs(
-            session_id=session.session_id if session else "",
-            include_content=session.include_content if session else True,
+            conversation_id=conversation.conversation_id if conversation else "",
+            include_content=conversation.include_content if conversation else True,
         )
         self._end_otel_span(attrs, end_time_ns=_to_ns(self.ended_at))
 
@@ -487,7 +489,7 @@ class LLM(_SpanBase):
                 "file_id": file_id,
                 "mime_type": mime_type,
             },
-            name="weave-session-media-upload",
+            name="weave-conversation-media-upload",
             daemon=True,
         )
         thread.start()
@@ -599,7 +601,9 @@ class LLM(_SpanBase):
             self.output_type = output_type
         return self
 
-    def _build_attrs(self, *, session_id: str, include_content: bool) -> dict[str, Any]:
+    def _build_attrs(
+        self, *, conversation_id: str, include_content: bool
+    ) -> dict[str, Any]:
         """Build the full OTel attribute dict for this chat span.
 
         Single chokepoint shared by streaming (``end``) and batch
@@ -642,7 +646,7 @@ class LLM(_SpanBase):
         attrs = llm_attributes(
             model=self.model,
             provider_name=self.provider_name,
-            conversation_id=session_id,
+            conversation_id=conversation_id,
             input_messages=input_messages,
             output_messages=output_messages,
             media_attachments=media_attachments,
@@ -672,10 +676,10 @@ class LLM(_SpanBase):
         if self.ended_at is None:
             self.ended_at = datetime.now(timezone.utc)
 
-        session = get_current_session()
+        conversation = get_current_conversation()
         attrs = self._build_attrs(
-            session_id=session.session_id if session else "",
-            include_content=session.include_content if session else True,
+            conversation_id=conversation.conversation_id if conversation else "",
+            include_content=conversation.include_content if conversation else True,
         )
 
         if self._token is not None:
@@ -787,7 +791,7 @@ class SubAgent(_SpanBase):
         return self
 
     def _build_attrs(
-        self, *, session_id: str, session_name: str, include_content: bool
+        self, *, conversation_id: str, conversation_name: str, include_content: bool
     ) -> dict[str, Any]:
         """Build the full OTel attribute dict for this sub-agent span.
 
@@ -808,8 +812,8 @@ class SubAgent(_SpanBase):
         attrs = invoke_agent_attributes(
             agent_name=self.name,
             model=self.model,
-            conversation_id=session_id,
-            conversation_name=session_name,
+            conversation_id=conversation_id,
+            conversation_name=conversation_name,
             system_instructions=system_instructions,
             agent_id=self.agent_id,
             agent_description=self.agent_description,
@@ -825,11 +829,11 @@ class SubAgent(_SpanBase):
         if self.ended_at is None:
             self.ended_at = datetime.now(timezone.utc)
 
-        session = get_current_session()
+        conversation = get_current_conversation()
         attrs = self._build_attrs(
-            session_id=session.session_id if session else "",
-            session_name=session.session_name if session else "",
-            include_content=session.include_content if session else True,
+            conversation_id=conversation.conversation_id if conversation else "",
+            conversation_name=conversation.conversation_name if conversation else "",
+            include_content=conversation.include_content if conversation else True,
         )
         self._end_otel_span(attrs, end_time_ns=_to_ns(self.ended_at))
 
@@ -853,7 +857,7 @@ class SubAgent(_SpanBase):
 
 
 # ---------------------------------------------------------------------------
-# Turn and Session
+# Turn and Conversation
 # ---------------------------------------------------------------------------
 
 
@@ -862,7 +866,7 @@ class Turn(_SpanBase):
 
     By default each turn starts its own OTel trace (``continue_parent_trace=False``)
     so the Agents tab shows one trace per turn. Set ``continue_parent_trace=True``
-    on the Session (or directly on the Turn) when an outer trace is already
+    on the Conversation (or directly on the Turn) when an outer trace is already
     active and you want the agent invocation to nest inside it — e.g. inside
     a fastapi-instrumented request.
     """
@@ -973,7 +977,7 @@ class Turn(_SpanBase):
         return self
 
     def _build_attrs(
-        self, *, session_id: str, session_name: str, include_content: bool
+        self, *, conversation_id: str, conversation_name: str, include_content: bool
     ) -> dict[str, Any]:
         """Build the full OTel attribute dict for this turn span.
 
@@ -996,8 +1000,8 @@ class Turn(_SpanBase):
             system_instructions = None
         attrs = invoke_agent_attributes(
             agent_name=self.agent_name,
-            conversation_id=session_id,
-            conversation_name=session_name,
+            conversation_id=conversation_id,
+            conversation_name=conversation_name,
             model=self.model,
             input_messages=messages,
             system_instructions=system_instructions,
@@ -1015,11 +1019,11 @@ class Turn(_SpanBase):
         if self.ended_at is None:
             self.ended_at = datetime.now(timezone.utc)
 
-        session = get_current_session()
+        conversation = get_current_conversation()
         attrs = self._build_attrs(
-            session_id=session.session_id if session else "",
-            session_name=session.session_name if session else "",
-            include_content=session.include_content if session else True,
+            conversation_id=conversation.conversation_id if conversation else "",
+            conversation_name=conversation.conversation_name if conversation else "",
+            include_content=conversation.include_content if conversation else True,
         )
 
         if self._token is not None:
@@ -1055,11 +1059,11 @@ class Turn(_SpanBase):
         return False
 
 
-class Session(BaseModel):
-    """A conversation session. Groups turns by conversation_id (no span).
+class Conversation(BaseModel):
+    """A conversation. Groups turns by conversation_id (no span).
 
     ``continue_parent_trace`` controls trace isolation for the turns this
-    session creates. Default ``False`` means each turn starts its own OTel
+    conversation creates. Default ``False`` means each turn starts its own OTel
     trace (the right choice for the standalone Agents tab view). Set ``True``
     when the application has an outer trace (e.g. a fastapi-instrumented
     request) that should contain the agent invocation.
@@ -1067,24 +1071,24 @@ class Session(BaseModel):
 
     model_config = ConfigDict(protected_namespaces=())
 
-    session_id: str = ""
-    session_name: str = ""
+    conversation_id: str = ""
+    conversation_name: str = ""
     agent_name: str = ""
     model: str = ""
     include_content: bool = True
     continue_parent_trace: bool = False
-    # Attributes stamped on every span this session emits (e.g. an integration
+    # Attributes stamped on every span this conversation emits (e.g. an integration
     # identity). dict[str, Any] like set_attributes — Attributes is a
     # TYPE_CHECKING-only import, but Pydantic resolves field types at runtime.
     attributes: dict[str, Any] = Field(default_factory=dict)
 
     _ended: bool = PrivateAttr(default=False)
-    _token: Token[Session | None] | None = PrivateAttr(default=None)
+    _token: Token[Conversation | None] | None = PrivateAttr(default=None)
     _current_turn: Turn | None = PrivateAttr(default=None)
 
     def model_post_init(self, context: Any, /) -> None:
-        if not self.session_id:
-            self.session_id = str(uuid.uuid4())
+        if not self.conversation_id:
+            self.conversation_id = str(uuid.uuid4())
 
     def start_turn(
         self,
@@ -1098,7 +1102,7 @@ class Session(BaseModel):
 
         Sets the ``_current_turn`` contextvar so the turn is visible via
         ``get_current_turn()`` regardless of whether a context manager is used.
-        Propagates ``continue_parent_trace`` from this session.
+        Propagates ``continue_parent_trace`` from this conversation.
 
         ``system_instructions`` (the agent's system prompt) is carried on the
         turn's invoke_agent span; it can also be set later via attribute
@@ -1125,12 +1129,12 @@ class Session(BaseModel):
         if self._current_turn is not None and not self._current_turn._ended:
             self._current_turn.end()
         if self._token is not None:
-            _current_session.reset(self._token)
+            _current_conversation.reset(self._token)
             self._token = None
 
     def __enter__(self) -> Self:
         if self._token is None:
-            self._token = _current_session.set(self)
+            self._token = _current_conversation.set(self)
         return self
 
     def __exit__(
@@ -1147,8 +1151,8 @@ class Session(BaseModel):
 # Contextvars
 # ---------------------------------------------------------------------------
 
-_current_session: ContextVar[Session | None] = ContextVar(
-    "_current_session", default=None
+_current_conversation: ContextVar[Conversation | None] = ContextVar(
+    "_current_conversation", default=None
 )
 _current_turn: ContextVar[Turn | None] = ContextVar("_current_turn", default=None)
 _current_llm: ContextVar[LLM | None] = ContextVar("_current_llm", default=None)
@@ -1159,36 +1163,36 @@ _current_llm: ContextVar[LLM | None] = ContextVar("_current_llm", default=None)
 # ---------------------------------------------------------------------------
 
 
-def start_session(
+def start_conversation(
     *,
     agent_name: str = "",
     model: str = "",
-    session_id: str = "",
-    session_name: str = "",
+    conversation_id: str = "",
+    conversation_name: str = "",
     include_content: bool = True,
     continue_parent_trace: bool = False,
     attributes: Attributes = None,
-) -> Session:
-    """Create and activate a session. Sets the contextvar for cross-module access.
+) -> Conversation:
+    """Create and activate a conversation. Sets the contextvar for cross-module access.
 
-    ``attributes`` are stamped on every span this session emits (e.g. an
+    ``attributes`` are stamped on every span this conversation emits (e.g. an
     integration identity like ``weave.integration.*``). Use custom,
     non-semconv keys: set semantic-convention fields via the typed params
-    (``session_name``, ``model``, ...). A key that collides with a span's
+    (``conversation_name``, ``model``, ...). A key that collides with a span's
     own ``gen_ai.*`` / ``weave.*`` attribute is unsupported; which value
     wins is path-dependent (streaming vs ``log_turn``).
     """
-    session = Session(
+    conversation = Conversation(
         agent_name=agent_name,
         model=model,
-        session_id=session_id,
-        session_name=session_name,
+        conversation_id=conversation_id,
+        conversation_name=conversation_name,
         include_content=include_content,
         continue_parent_trace=continue_parent_trace,
         attributes=attributes or {},
     )
-    session._token = _current_session.set(session)
-    return session
+    conversation._token = _current_conversation.set(conversation)
+    return conversation
 
 
 def start_turn(
@@ -1198,16 +1202,16 @@ def start_turn(
     agent_name: str = "",
     system_instructions: list[str] | None = None,
 ) -> Turn:
-    """Create and activate a turn. Uses the current session if available.
+    """Create and activate a turn. Uses the current conversation if available.
 
-    If no session is active, returns a disconnected Turn that is NOT set
+    If no conversation is active, returns a disconnected Turn that is NOT set
     in the contextvar. This means ``get_current_turn()`` will return None.
-    Use ``session.start_turn()`` instead if you need contextvar-based
+    Use ``conversation.start_turn()`` instead if you need contextvar-based
     cross-module access.
     """
-    session = get_current_session()
-    if session is not None:
-        return session.start_turn(
+    conversation = get_current_conversation()
+    if conversation is not None:
+        return conversation.start_turn(
             user_message=user_message,
             model=model,
             agent_name=agent_name,
@@ -1258,7 +1262,7 @@ def start_tool(*, name: str, arguments: str = "", tool_call_id: str = "") -> Too
     The Tool's OTel span automatically becomes a child of whatever span is
     current in OTel context — typically a Turn span if one is active. No
     explicit turn delegation is needed: parent-child propagation happens
-    via OTel context, not via the Session SDK contextvars.
+    via OTel context, not via the Conversation SDK contextvars.
     """
     return Tool(name=name, arguments=arguments, tool_call_id=tool_call_id)
 
@@ -1278,11 +1282,11 @@ def start_subagent(
     )
 
 
-def end_session() -> None:
-    """End the current session (from contextvar)."""
-    session = get_current_session()
-    if session is not None:
-        session.end()
+def end_conversation() -> None:
+    """End the current conversation (from contextvar)."""
+    conversation = get_current_conversation()
+    if conversation is not None:
+        conversation.end()
 
 
 def end_turn() -> None:
@@ -1299,9 +1303,9 @@ def end_llm() -> None:
         llm.end()
 
 
-def get_current_session() -> Session | None:
-    """Return the active session from contextvar, or None."""
-    return _current_session.get()
+def get_current_conversation() -> Conversation | None:
+    """Return the active conversation from contextvar, or None."""
+    return _current_conversation.get()
 
 
 def get_current_turn() -> Turn | None:
@@ -1339,7 +1343,7 @@ def _emit_span_now(
 ) -> Any:
     """Emit a fully-formed span without touching contextvars.
 
-    Used by the batch-logging path (``log_turn`` / ``log_session``) to
+    Used by the batch-logging path (``log_turn`` / ``log_conversation``) to
     create children of a parent span without attaching them to the calling
     thread's OTel context. Returns the finished Span so the caller can
     read trace_id / span_id, or None if OTel is unavailable.
@@ -1387,8 +1391,8 @@ def _resolve_turn_timestamps(
 def _attrs_for_span(
     span: LLM | Tool | SubAgent,
     *,
-    session_id: str,
-    session_name: str,
+    conversation_id: str,
+    conversation_name: str,
     include_content: bool,
 ) -> tuple[str, dict[str, Any]]:
     """Build (otel_span_name, attribute_dict) for a child span.
@@ -1398,15 +1402,15 @@ def _attrs_for_span(
     """
     if isinstance(span, LLM):
         return f"chat {span.model}", span._build_attrs(
-            session_id=session_id, include_content=include_content
+            conversation_id=conversation_id, include_content=include_content
         )
     if isinstance(span, Tool):
         return f"execute_tool {span.name}", span._build_attrs(
-            session_id=session_id, include_content=include_content
+            conversation_id=conversation_id, include_content=include_content
         )
     return f"invoke_agent {span.name}", span._build_attrs(
-        session_id=session_id,
-        session_name=session_name,
+        conversation_id=conversation_id,
+        conversation_name=conversation_name,
         include_content=include_content,
     )
 
@@ -1414,15 +1418,15 @@ def _attrs_for_span(
 def _emit_turn(
     turn: Turn,
     *,
-    session_id: str,
-    session_name: str,
+    conversation_id: str,
+    conversation_name: str,
     include_content: bool,
     attributes: Attributes = None,
 ) -> LogResult:
     """Emit one fully-built ``Turn`` (and its child spans) to OTel.
 
     Shared by ``log_turn`` (which builds the Turn from scalar kwargs) and
-    ``log_session`` (which is handed Turns directly), so every Turn field —
+    ``log_conversation`` (which is handed Turns directly), so every Turn field —
     ``system_instructions``, ``agent_id`` / ``agent_description`` /
     ``agent_version``, etc. — is honored identically on both batch paths.
     ``continue_parent_trace`` is read from the Turn. Timestamp resolution is
@@ -1435,8 +1439,8 @@ def _emit_turn(
     )
 
     turn_attrs = turn._build_attrs(
-        session_id=session_id,
-        session_name=session_name,
+        conversation_id=conversation_id,
+        conversation_name=conversation_name,
         include_content=include_content,
     )
     if attributes:
@@ -1451,14 +1455,14 @@ def _emit_turn(
         attrs=turn_attrs,
     )
     if turn_span is None:
-        return LogResult(session_id=session_id)
+        return LogResult(conversation_id=conversation_id)
 
     child_ctx = otel_trace.set_span_in_context(turn_span)
     for child in turn.spans:
         name, attrs = _attrs_for_span(
             child,
-            session_id=session_id,
-            session_name=session_name,
+            conversation_id=conversation_id,
+            conversation_name=conversation_name,
             include_content=include_content,
         )
         if attributes:
@@ -1472,7 +1476,7 @@ def _emit_turn(
         )
 
     return LogResult(
-        session_id=session_id,
+        conversation_id=conversation_id,
         trace_ids=[_format_trace_id(turn_span.context.trace_id)],
         root_span_ids=[_format_span_id(turn_span.context.span_id)],
         span_count=1 + len(turn.spans),
@@ -1481,9 +1485,9 @@ def _emit_turn(
 
 def log_turn(
     *,
-    session_id: str,
+    conversation_id: str,
     agent_name: str = "",
-    session_name: str = "",
+    conversation_name: str = "",
     model: str = "",
     agent_id: str = "",
     agent_description: str = "",
@@ -1507,12 +1511,12 @@ def log_turn(
     ``agent_description`` / ``agent_version``) mirror the streaming path.
 
     ``attributes`` are stamped on every emitted span; the streaming path reads
-    these from the active session instead. Use custom, non-semconv keys: a
+    these from the active conversation instead. Use custom, non-semconv keys: a
     key that collides with a span's own ``gen_ai.*`` / ``weave.*`` attribute
     is unsupported (which value wins is path-dependent).
     """
     if not _OTEL_AVAILABLE or should_disable_weave():
-        return LogResult(session_id=session_id)
+        return LogResult(conversation_id=conversation_id)
 
     resolved_spans = spans or []
     # Resolve timestamps before constructing the Turn so model_post_init
@@ -1538,48 +1542,48 @@ def log_turn(
     )
     return _emit_turn(
         turn,
-        session_id=session_id,
-        session_name=session_name,
+        conversation_id=conversation_id,
+        conversation_name=conversation_name,
         include_content=include_content,
         attributes=attributes,
     )
 
 
-def log_session(
+def log_conversation(
     *,
     turns: list[Turn],
-    session_id: str = "",
-    session_name: str = "",
+    conversation_id: str = "",
+    conversation_name: str = "",
     agent_name: str = "",
     model: str = "",
     include_content: bool = True,
     continue_parent_trace: bool = False,
     attributes: Attributes = None,
 ) -> LogResult:
-    """Imperatively emit a complete session.
+    """Imperatively emit a complete conversation.
 
     Each Turn's ``.spans`` attribute provides its children. Auto-generates
-    ``session_id`` if empty. By default each turn gets its own OTel trace.
-    ``agent_name`` / ``model`` are session-level defaults — a Turn's own value
-    wins; the session value only fills in when the Turn leaves it empty. The
-    session's ``continue_parent_trace`` applies to every turn (a per-Turn
+    ``conversation_id`` if empty. By default each turn gets its own OTel trace.
+    ``agent_name`` / ``model`` are conversation-level defaults — a Turn's own value
+    wins; the conversation value only fills in when the Turn leaves it empty. The
+    conversation's ``continue_parent_trace`` applies to every turn (a per-Turn
     ``continue_parent_trace`` is intentionally superseded here).
 
     ``attributes`` are stamped on every emitted span. Use custom, non-semconv
     keys: a key that collides with a span's own ``gen_ai.*`` / ``weave.*``
     attribute is unsupported (which value wins is path-dependent).
     """
-    sid = session_id or str(uuid.uuid4())
+    sid = conversation_id or str(uuid.uuid4())
     if not _OTEL_AVAILABLE or should_disable_weave():
-        return LogResult(session_id=sid)
+        return LogResult(conversation_id=sid)
 
     trace_ids: list[str] = []
     root_span_ids: list[str] = []
     span_count = 0
     for turn in turns:
         # Emit the caller's Turn directly so every field survives (not just the
-        # subset log_turn accepts as kwargs). Fill in session-level
-        # agent_name/model defaults and apply the session's
+        # subset log_turn accepts as kwargs). Fill in conversation-level
+        # agent_name/model defaults and apply the conversation's
         # continue_parent_trace, without mutating the caller's object.
         result = _emit_turn(
             turn.model_copy(
@@ -1589,8 +1593,8 @@ def log_session(
                     "continue_parent_trace": continue_parent_trace,
                 }
             ),
-            session_id=sid,
-            session_name=session_name,
+            conversation_id=sid,
+            conversation_name=conversation_name,
             include_content=include_content,
             attributes=attributes,
         )
@@ -1599,7 +1603,7 @@ def log_session(
         span_count += result.span_count
 
     return LogResult(
-        session_id=sid,
+        conversation_id=sid,
         trace_ids=trace_ids,
         root_span_ids=root_span_ids,
         span_count=span_count,

--- a/weave/conversation/conversation_otel.py
+++ b/weave/conversation/conversation_otel.py
@@ -1,4 +1,4 @@
-"""OTel attribute builders for the Weave Session SDK.
+"""OTel attribute builders for the Weave Conversation SDK.
 
 Each function returns a dict of GenAI semantic convention attributes
 for a specific span type. These are pure functions that build attribute
@@ -37,7 +37,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from weave.session.types import MediaAttachment, Message, Reasoning, Usage
+from weave.conversation.types import MediaAttachment, Message, Reasoning, Usage
 
 
 def _media_to_part(media: MediaAttachment) -> dict[str, Any]:

--- a/weave/conversation/types.py
+++ b/weave/conversation/types.py
@@ -1,7 +1,7 @@
-"""Data types for the Weave Session SDK.
+"""Data types for the Weave Conversation SDK.
 
-Lives in its own module to break the import cycle between session.py
-(span classes) and session_otel.py (attribute builders). Both modules
+Lives in its own module to break the import cycle between conversation.py
+(span classes) and conversation_otel.py (attribute builders). Both modules
 import from here.
 """
 
@@ -256,7 +256,7 @@ class MediaAttachment(BaseModel):
 class LogResult(BaseModel):
     """Result of a batch log_* call."""
 
-    session_id: str = ""
+    conversation_id: str = ""
     trace_ids: list[str] = Field(default_factory=list)
     root_span_ids: list[str] = Field(default_factory=list)
     span_count: int = 0

--- a/weave/evaluation/otel_eval_linker.py
+++ b/weave/evaluation/otel_eval_linker.py
@@ -9,7 +9,7 @@ It also injects eval metadata (call ID, evaluation name, project) onto the
 span so the agent traces UI can deep-link and filter by eval run.
 
 Register this processor alongside the ``BatchSpanProcessor`` during
-``_setup_session_tracing`` in ``weave_init.py``.
+``_setup_conversation_tracing`` in ``weave_init.py``.
 """
 
 from __future__ import annotations

--- a/weave/integrations/claude_agent_sdk/otel_integration.py
+++ b/weave/integrations/claude_agent_sdk/otel_integration.py
@@ -11,7 +11,7 @@ span per tool call. The SDK reports token usage only on the final
 
 The Claude Agent SDK has no agent-name concept, so ``invoke_agent`` spans
 default to ``claude_agent_sdk``. Users relabel them for a block of work with the
-generic ``weave.session.agent_name_override(...)`` context manager; the name is
+generic ``weave.conversation.agent_name_override(...)`` context manager; the name is
 resolved per turn at span creation, so it is robust to (implicit) patch timing
 and correct under concurrent async queries.
 """
@@ -40,15 +40,15 @@ from opentelemetry import context as otel_context
 from opentelemetry import trace as otel_trace
 from opentelemetry.trace import StatusCode
 
-from weave.integrations.integration_metadata import library_integration
-from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
-from weave.session.agent_context import resolve_agent_name
-from weave.session.session_otel import (
+from weave.conversation.agent_context import resolve_agent_name
+from weave.conversation.conversation_otel import (
     execute_tool_attributes,
     invoke_agent_attributes,
     llm_attributes,
 )
-from weave.session.types import Message, Reasoning, ToolCallPart, Usage
+from weave.conversation.types import Message, Reasoning, ToolCallPart, Usage
+from weave.integrations.integration_metadata import library_integration
+from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings
 from weave.trace.settings import should_disable_weave
 

--- a/weave/integrations/openai_agents/otel_processor.py
+++ b/weave/integrations/openai_agents/otel_processor.py
@@ -61,24 +61,24 @@ from opentelemetry import context as otel_context
 from opentelemetry import trace as otel_trace
 from opentelemetry.trace import StatusCode
 
+from weave.conversation.adapters.openai import (
+    message_from_openai_responses_input,
+    reasoning_from_openai_responses,
+    usage_from_openai_responses,
+)
+from weave.conversation.agent_context import resolve_agent_name
+from weave.conversation.conversation_otel import (
+    execute_tool_attributes,
+    invoke_agent_attributes,
+    llm_attributes,
+)
+from weave.conversation.types import Message, Reasoning, Usage
 from weave.integrations.openai_agents.openai_agents import (
     OPENAI_AGENTS_INTEGRATION,
     _call_name,
     _is_task_span_data,
     _is_turn_span_data,
 )
-from weave.session.adapters.openai import (
-    message_from_openai_responses_input,
-    reasoning_from_openai_responses,
-    usage_from_openai_responses,
-)
-from weave.session.agent_context import resolve_agent_name
-from weave.session.session_otel import (
-    execute_tool_attributes,
-    invoke_agent_attributes,
-    llm_attributes,
-)
-from weave.session.types import Message, Reasoning, Usage
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +95,7 @@ _warned_unhandled_span_types: set[type] = set()
 
 # Keys we extract from ``GenerationSpanData.model_config`` into the equivalent
 # ``llm_attributes`` request_* kwargs. The map keeps the wire shape (raw openai
-# request body keys) → the Session SDK kwarg name in one place.
+# request body keys) → the Conversation SDK kwarg name in one place.
 _GENERATION_MODEL_CONFIG_KEYS = {
     "temperature": "request_temperature",
     "top_p": "request_top_p",

--- a/weave/integrations/openai_realtime/otel_state_exporter.py
+++ b/weave/integrations/openai_realtime/otel_state_exporter.py
@@ -21,7 +21,7 @@ connection); ``gen_ai.conversation.id`` carries the API's conversation_id,
 falling back to the session id when absent (e.g. Beta).
 
 Audio is published as a Weave ``Content`` object and referenced from the
-message by a ``weave://`` ``UriPart``, as the Session SDK handles media.
+message by a ``weave://`` ``UriPart``, as the Conversation SDK handles media.
 """
 
 from __future__ import annotations
@@ -36,6 +36,20 @@ from opentelemetry import trace as otel_trace
 from opentelemetry.trace import StatusCode
 from pydantic import PrivateAttr
 
+from weave.conversation.agent_context import resolve_agent_name
+from weave.conversation.conversation_otel import (
+    execute_tool_attributes,
+    invoke_agent_attributes,
+    llm_attributes,
+)
+from weave.conversation.types import (
+    Message,
+    TextPart,
+    ToolCallPart,
+    ToolCallResponsePart,
+    UriPart,
+    Usage,
+)
 from weave.integrations.integration_metadata import library_integration
 from weave.integrations.openai_realtime.encoding import pcm_to_wav
 from weave.integrations.openai_realtime.state_exporter import (
@@ -43,20 +57,6 @@ from weave.integrations.openai_realtime.state_exporter import (
     OUTPUT_AUDIO_TYPES,
     SessionSpan,
     StateExporter,
-)
-from weave.session.agent_context import resolve_agent_name
-from weave.session.session_otel import (
-    execute_tool_attributes,
-    invoke_agent_attributes,
-    llm_attributes,
-)
-from weave.session.types import (
-    Message,
-    TextPart,
-    ToolCallPart,
-    ToolCallResponsePart,
-    UriPart,
-    Usage,
 )
 from weave.trace import urls
 from weave.trace.api import publish

--- a/weave/session/__init__.py
+++ b/weave/session/__init__.py
@@ -1,15 +1,22 @@
-"""Public namespace for the Weave Session SDK.
+"""Deprecated import path for the Weave Conversation SDK.
 
-Imports everything user code needs to construct sessions, turns, llm
-spans, tool spans, and structured messages. Concrete message parts
-(``TextPart``, ``ToolCallPart``, etc.) and the ``MessagePart`` union
-live here rather than at the top-level ``weave`` namespace, mirroring
-the ``langchain_core.messages`` pattern: callers building structured
-messages do ``from weave.session import TextPart, ToolCallPart``.
+The Weave **Session SDK** was renamed to the **Conversation SDK**. Importing
+from ``weave.session`` still works but emits a ``DeprecationWarning`` and will
+be removed in a future release — import from ``weave.conversation`` instead::
+
+    from weave.conversation import TextPart, ToolCallPart, start_conversation
+
+The ``session``-named callables re-exported here (``start_session``,
+``Session``, ``end_session``, ``log_session``, ``get_current_session``) are
+deprecated aliases that forward to their ``conversation`` equivalents and
+translate the old ``session_id`` / ``session_name`` arguments.
 """
 
-from weave.session.agent_context import agent_name_override
-from weave.session.session import (
+from __future__ import annotations
+
+import warnings
+
+from weave.conversation import (
     LLM,
     BlobPart,
     FilePart,
@@ -19,7 +26,6 @@ from weave.session.session import (
     MessagePart,
     Reasoning,
     ReasoningPart,
-    Session,
     SubAgent,
     TextPart,
     Tool,
@@ -28,19 +34,30 @@ from weave.session.session import (
     Turn,
     UriPart,
     Usage,
+    agent_name_override,
     end_llm,
-    end_session,
     end_turn,
     get_current_llm,
-    get_current_session,
     get_current_turn,
-    log_session,
     log_turn,
     start_llm,
-    start_session,
     start_subagent,
     start_tool,
     start_turn,
+)
+from weave.conversation._deprecated import (
+    Session,
+    end_session,
+    get_current_session,
+    log_session,
+    start_session,
+)
+
+warnings.warn(
+    "weave.session has been renamed to weave.conversation; importing from "
+    "weave.session is deprecated and will be removed in a future release.",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 __all__ = [

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -108,11 +108,11 @@ def _get_server_info(server: TraceServerClientInterface) -> ServerInfoRes | None
         return None
 
 
-def _setup_session_tracing(entity: str, project: str, api_key: str | None) -> None:
-    """Configure OTel TracerProvider for the Session SDK using weave credentials.
+def _setup_conversation_tracing(entity: str, project: str, api_key: str | None) -> None:
+    """Configure OTel TracerProvider for the Conversation SDK using weave credentials.
 
     Called automatically by init_weave() once version checks have passed.
-    Sets the global OTel TracerProvider so that ``trace.get_tracer("weave.session")``
+    Sets the global OTel TracerProvider so that ``trace.get_tracer("weave.conversation")``
     returns a real tracer.
 
     No-ops if the trace server URL is not configured. Logs a warning and
@@ -131,7 +131,7 @@ def _setup_session_tracing(entity: str, project: str, api_key: str | None) -> No
         from weave.evaluation.otel_eval_linker import EvalLinkSpanProcessor
     except ImportError as e:
         logger.warning(
-            "Session SDK tracing skipped: opentelemetry not available (%s)", e
+            "Conversation SDK tracing skipped: opentelemetry not available (%s)", e
         )
         return
 
@@ -157,7 +157,7 @@ def _setup_session_tracing(entity: str, project: str, api_key: str | None) -> No
 
     resource = Resource.create(
         {
-            "service.name": "weave-session-sdk",
+            "service.name": "weave-conversation-sdk",
             "wandb.entity": entity,
             "wandb.project": project,
         }
@@ -269,11 +269,11 @@ def init_weave(
     ):
         return init_weave_disabled()
 
-    # Configure Session SDK OTel tracing using the same server credentials.
+    # Configure Conversation SDK OTel tracing using the same server credentials.
     # Placed after the version checks so a disabled init never installs a
     # global TracerProvider that would keep exporting spans to an
     # incompatible server.
-    _setup_session_tracing(entity_name, project_name, api_key)
+    _setup_conversation_tracing(entity_name, project_name, api_key)
 
     init_message.print_init_message(
         username, entity_name, project_name, read_only=not ensure_project_exists

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -612,8 +612,8 @@ def _content_refs(span: AgentSpanSchema) -> list[str]:
 
 
 # Content part types that reference uploaded media by ref rather than inlining
-# text. The session SDK emits attached media as ``uri`` parts (see
-# weave/session/session_otel.py::_media_to_part); ``blob``/``file`` are accepted
+# text. The conversation SDK emits attached media as ``uri`` parts (see
+# weave/conversation/conversation_otel.py::_media_to_part); ``blob``/``file`` are accepted
 # defensively in case other producers use a ref-bearing variant.
 _MEDIA_PART_TYPES = {"uri", "blob", "file"}
 

--- a/weave/trace_server/agents/semconv.py
+++ b/weave/trace_server/agents/semconv.py
@@ -139,7 +139,7 @@ USAGE_REASONING_TOKENS = Attribute(
         # at our floor of 0.62b1; switch to importing the constant once it
         # ships.
         "gen_ai.usage.reasoning.output_tokens",
-        # Earlier Weave-internal name emitted by the Session SDK before the
+        # Earlier Weave-internal name emitted by the Conversation SDK before the
         # upstream spec landed; spans on the wire still use this form.
         "gen_ai.usage.reasoning_tokens",
         # What ADK emits natively before our integration enriches the span.

--- a/weave/utils/capture_info.py
+++ b/weave/utils/capture_info.py
@@ -1,4 +1,4 @@
-"""Shared client/system info capture — used by both @op tracer and Session SDK.
+"""Shared client/system info capture — used by both @op tracer and Conversation SDK.
 
 Returns ``weave.*`` metadata key/value pairs gated by
 ``should_capture_client_info()`` / ``should_capture_system_info()``. Call

--- a/weave/utils/pii_redaction.py
+++ b/weave/utils/pii_redaction.py
@@ -1,10 +1,10 @@
-"""PII redaction — used by both @op tracer and Session SDK.
+"""PII redaction — used by both @op tracer and Conversation SDK.
 
 Two layers:
 
 - ``redact_pii`` / ``redact_pii_string`` are the primitives that walk
   dicts, lists, and dataclasses applying Presidio.
-- ``redact_messages`` / ``redact_system_instructions`` are the Session
+- ``redact_messages`` / ``redact_system_instructions`` are the Conversation
   SDK helpers shaped for typed Message payloads (dump → redact →
   revalidate).
 
@@ -20,7 +20,7 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING, Any, cast
 
-from weave.session.types import Message
+from weave.conversation.types import Message
 from weave.telemetry import trace_sentry
 from weave.trace.settings import redact_pii_exclude_fields, redact_pii_fields
 from weave.utils.sanitize import REDACTED_VALUE, redact_dataclass_fields, should_redact
@@ -123,7 +123,7 @@ def redact_messages(messages: list[Message]) -> list[Message]:
     """Redact PII in each Message via dump → redact → revalidate.
 
     Routes through the same recursive ``redact_pii`` used by ``@op`` so
-    Session SDK content is redacted identically. Discriminator literals
+    Conversation SDK content is redacted identically. Discriminator literals
     (``role``, part ``type``) aren't matched by Presidio's default
     recognizers, so the round-trip preserves the typed shape.
     """


### PR DESCRIPTION
## Description

Renames the **Session SDK** to the **Conversation SDK**. The canonical surface now lives under `weave.conversation`; `weave.session` is kept as a deprecation shim.

**Core rename**

- `weave/session/` → `weave/conversation/`
- `Session` → `Conversation`, `start_session` → `start_conversation`, etc.

**Backward compat**

- `weave.session` + `Session` / `start_session` / … aliases still work, emitting a `DeprecationWarning`
- Old `session_id` / `session_name` kwargs translate to `conversation_id` / `conversation_name`
