### PR TITLE
perf(weave): scope table_rows_stats storage rollup to requested digests

### DIFF
--- a/tests/trace_server/query_builder/test_table_query_builder.py
+++ b/tests/trace_server/query_builder/test_table_query_builder.py
@@ -4,6 +4,7 @@ from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.table_query_builder import (
     make_table_row_digests_query,
     make_table_stats_basic_query,
+    make_table_stats_query_with_storage_size,
 )
 
 
@@ -64,6 +65,44 @@ def test_make_table_stats_basic_query() -> None:
     FROM tables
     WHERE project_id = {pb_0: String} AND digest IN {pb_1: Array(String)}
     GROUP BY digest
+    """
+
+    expected_params = {
+        "pb_0": "project",
+        "pb_1": ["d1", "d2"],
+    }
+
+    assert_sql(expected_query, expected_params, query, params)
+
+
+def test_make_table_stats_query_with_storage_size() -> None:
+    pb = ParamBuilder("pb")
+    query = make_table_stats_query_with_storage_size(
+        project_id="project",
+        table_digests=["d1", "d2"],
+        pb=pb,
+    )
+    params = pb.get_params()
+
+    expected_query = """
+    WITH requested_tables AS (
+        SELECT digest, row_digests
+        FROM tables
+        WHERE project_id = {pb_0: String} AND digest in {pb_1: Array(String)}
+    )
+    SELECT tb_digest, any(length), sum(size_bytes) FROM
+    (
+        SELECT digest as tb_digest, length(row_digests) as length, row_digests
+        FROM requested_tables
+    ) AS sub ARRAY JOIN row_digests as row_digest
+    LEFT JOIN
+    (
+        SELECT * FROM table_rows_stats
+        WHERE table_rows_stats.project_id = {pb_0: String}
+          AND table_rows_stats.digest IN (SELECT arrayJoin(row_digests) FROM requested_tables)
+    ) as table_rows_stats ON table_rows_stats.digest = row_digest
+
+    GROUP BY tb_digest
     """
 
     expected_params = {

--- a/weave/trace_server/query_builder/table_query_builder.py
+++ b/weave/trace_server/query_builder/table_query_builder.py
@@ -180,16 +180,24 @@ def make_table_stats_query_with_storage_size(
     project_id_name = pb.add_param(project_id)
     digest_ids = pb.add_param(table_digests)
 
+    # Scope the table_rows_stats subquery to only the row digests being joined so
+    # the (project_id, digest) sort key prunes instead of materializing the whole project.
     query = f"""
+    WITH requested_tables AS (
+        SELECT digest, row_digests
+        FROM tables
+        WHERE project_id = {{{project_id_name}: String}} AND digest in {{{digest_ids}: Array(String)}}
+    )
     SELECT tb_digest, any(length), sum(size_bytes) FROM
     (
         SELECT digest as tb_digest, length(row_digests) as length, row_digests
-        FROM tables
-        WHERE project_id = {{{project_id_name}: String}} AND digest in {{{digest_ids}: Array(String)}}
+        FROM requested_tables
     ) AS sub ARRAY JOIN row_digests as row_digest
     LEFT JOIN
     (
-        SELECT * FROM table_rows_stats WHERE table_rows_stats.project_id = {{{project_id_name}: String}}
+        SELECT * FROM table_rows_stats
+        WHERE table_rows_stats.project_id = {{{project_id_name}: String}}
+          AND table_rows_stats.digest IN (SELECT arrayJoin(row_digests) FROM requested_tables)
     ) as table_rows_stats ON table_rows_stats.digest = row_digest
 
     GROUP BY tb_digest


### PR DESCRIPTION
## Summary
- `make_table_stats_query_with_storage_size` LEFT JOINed the whole project's `table_rows_stats`. This lifts `tables` into a `requested_tables` CTE and scopes the stats subquery to `digest IN (those tables' row_digests)` (`digest` = 2nd sort-key col, prunes).

## Performance
Full generated query on prod-ro CH. The isolated-subquery numbers in the first draft overstated this: the win is real only for SMALL tables. The CTE is referenced twice (scanned twice), so when requested tables span most of the project the `digest IN` set is non-selective, nothing prunes, and it regresses:

| case | master | this PR |
|---|---|---|
| small table (10 rows, 1.24M-stat project) | 1.24M rows / 36ms | 141K rows / 26ms (win) |
| giant table (8.84M rows ≈ whole project) | 8.85M rows / 3.4s | 8.90M rows / 10.1s (3x REGRESSION) |

## Production profile (Datadog, 7d)
- 274 table-stats reads (~39/day), avg 74.6K rows. Max read across the full week = 205K rows (0 over 500K): every observed request is the small-table win case; the regression case did not occur in real traffic.
- Latent risk: a large-dataset project viewing its table stats hits the 3x regression, and the builder has no table-size signal to gate on. Recommend a no-regression guard (or accept this as a small-table-only win) before merge.

## Testing
unit test asserting the full generated SQL string.
