### PR TITLE
perf(weave): scope object_versions_stats storage rollup to matched object_ids

### DIFF
--- a/tests/trace_server/query_builder/test_objects_query_builder.py
+++ b/tests/trace_server/query_builder/test_objects_query_builder.py
@@ -317,6 +317,154 @@ ORDER BY created_at ASC""",
     }
 
 
+def _expected_storage_metadata_query(
+    where_clause: str, stats_scope: str, outer_clauses: str = ""
+) -> str:
+    """Build expected SQL for the include_storage_size metadata query.
+
+    Args:
+        where_clause: The WHERE condition for latest_row_per_digest.
+        stats_scope: Extra predicate appended to the object_versions_stats
+            inner subquery (e.g. " AND object_id = {object_id: String}").
+        outer_clauses: Optional WHERE/ORDER/LIMIT/OFFSET after the join.
+    """
+    return f"""
+WITH latest_row_per_digest AS (
+    SELECT
+        ov.project_id,
+        ov.object_id,
+        ov.created_at,
+        COALESCE(fc.first_created_at, ov.created_at) AS _first_created_at,
+        ov.deleted_at,
+        ov.kind,
+        ov.base_object_class,
+        ov.leaf_object_class,
+        ov.refs,
+        ov.digest,
+        ov.wb_user_id,
+        if (ov.kind = 'op', 1, 0) AS is_op,
+        row_number() OVER (
+            PARTITION BY ov.project_id, ov.kind, ov.object_id, ov.digest
+            ORDER BY ov.created_at DESC, (ov.deleted_at IS NULL) ASC
+        ) AS rn
+    FROM object_versions AS ov
+    LEFT JOIN (
+        SELECT object_id, digest, min(first_created_at) AS first_created_at
+        FROM object_version_first_seen
+        WHERE project_id = {{project_id: String}}
+        GROUP BY object_id, digest
+    ) AS fc USING (object_id, digest)
+    WHERE {where_clause}
+),
+latest_alias_per_object AS (
+    SELECT project_id, object_id, argMax(digest, created_at) AS digest
+    FROM aliases
+    PREWHERE project_id = {{project_id: String}}
+    WHERE alias = 'latest'
+    GROUP BY project_id, object_id, alias
+    HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
+),
+object_versions_with_index AS (
+    SELECT
+        *,
+        row_number() OVER (
+            PARTITION BY project_id, kind, object_id
+            ORDER BY _first_created_at ASC, digest ASC
+        ) - 1 AS version_index,
+        count(*) OVER (
+            PARTITION BY project_id, kind, object_id
+        ) AS version_count,
+        row_number() OVER (
+            PARTITION BY project_id, kind, object_id
+            ORDER BY (deleted_at IS NULL) DESC, _first_created_at DESC, digest DESC
+        ) AS _computed_latest_rank,
+        if(
+            (project_id, object_id, digest) IN
+                (SELECT project_id, object_id, digest FROM latest_alias_per_object)
+            OR (
+                _computed_latest_rank = 1
+                AND (project_id, object_id) NOT IN
+                    (SELECT project_id, object_id FROM latest_alias_per_object)
+            ),
+            1, 0
+        ) AS is_latest
+    FROM latest_row_per_digest
+    WHERE rn = 1
+)
+SELECT
+    project_id,
+    object_id,
+    created_at,
+    refs,
+    kind,
+    base_object_class,
+    leaf_object_class,
+    digest,
+    version_index,
+    is_latest,
+    deleted_at,
+    wb_user_id,
+    version_count,
+    is_op,
+    size_bytes
+FROM object_versions_with_index AS main
+    LEFT JOIN (
+        SELECT * FROM object_versions_stats WHERE object_versions_stats.project_id = {{project_id: String}}{stats_scope}
+    ) as object_versions_stats ON object_versions_stats.digest = main.digest
+{outer_clauses}"""
+
+
+def test_metadata_query_storage_size_scoped_to_object_id():
+    builder = ObjectMetadataQueryBuilder(project_id="test_project")
+    builder.include_storage_size = True
+    builder.add_object_ids_condition(["my_obj"])
+    builder.add_digests_conditions("latest")
+
+    assert_sql(
+        builder.make_metadata_query(),
+        _expected_storage_metadata_query(
+            "ov.project_id = {project_id: String} AND object_id = {object_id: String}",
+            " AND object_id = {object_id: String}",
+            "WHERE ((is_latest = 1) AND (deleted_at IS NULL))\nORDER BY created_at ASC",
+        ),
+    )
+    assert builder.parameters == {"project_id": "test_project", "object_id": "my_obj"}
+
+
+def test_metadata_query_storage_size_scoped_to_object_ids():
+    builder = ObjectMetadataQueryBuilder(project_id="test_project")
+    builder.include_storage_size = True
+    builder.add_object_ids_condition(["a", "b"])
+
+    assert_sql(
+        builder.make_metadata_query(),
+        _expected_storage_metadata_query(
+            "ov.project_id = {project_id: String} AND object_id IN {object_ids: Array(String)}",
+            " AND object_id IN {object_ids: Array(String)}",
+            "WHERE deleted_at IS NULL\nORDER BY created_at ASC",
+        ),
+    )
+    assert builder.parameters == {
+        "project_id": "test_project",
+        "object_ids": ["a", "b"],
+    }
+
+
+def test_metadata_query_storage_size_unscoped_without_object_id():
+    builder = ObjectMetadataQueryBuilder(project_id="test_project")
+    builder.include_storage_size = True
+
+    assert_sql(
+        builder.make_metadata_query(),
+        _expected_storage_metadata_query(
+            "ov.project_id = {project_id: String}",
+            "",
+            "WHERE deleted_at IS NULL\nORDER BY created_at ASC",
+        ),
+    )
+    assert builder.parameters == {"project_id": "test_project"}
+
+
 def test_make_objects_val_query_and_parameters():
     project_id = "test_project"
     object_ids = ["object_1"]

--- a/weave/trace_server/query_builder/objects_query_builder.py
+++ b/weave/trace_server/query_builder/objects_query_builder.py
@@ -334,9 +334,16 @@ class ObjectMetadataQueryBuilder:
 
         join_clause = ""
         if self.include_storage_size:
+            # object_versions_stats is ORDER BY (project_id, kind, object_id,
+            # digest) with no skip indexes, so scope the inner subquery by
+            # object_id (a sort-key prefix column that prunes) when an
+            # object_id predicate exists. digest scoping would not prune.
+            stats_object_id_scope = _make_object_id_conditions_part(
+                self._object_id_conditions
+            )
             join_clause = f"""
             LEFT JOIN (
-                SELECT * FROM object_versions_stats WHERE object_versions_stats.project_id = {{project_id: String}}
+                SELECT * FROM object_versions_stats WHERE object_versions_stats.project_id = {{project_id: String}}{stats_object_id_scope}
             ) as object_versions_stats ON object_versions_stats.digest = {main_table_alias}.digest
             """
 


### PR DESCRIPTION
## Summary
- The `include_storage_size` LEFT JOIN aggregated the whole project's `object_versions_stats` even for a single-object read. Master already scopes the `object_versions` scan by object_id; this closes the same gap on the stats subquery.
- Scopes the inner stats subquery by `object_id` (3rd sort-key col, prunes; `digest`, the 4th, would not) when an object_id predicate is present. Join key stays `digest`; results unchanged. List-all reads stay unscoped.

## Performance
Full generated query on prod-ro CH (the isolated-subquery numbers in the first draft overstated this):

| case | master | this PR |
|---|---|---|
| selective object (1 version), 539K-stat project | 565,248 rows / 106ms | 32,768 rows / 32ms |
| pathological object (2.06M versions) | 6.49M rows / 2.1s | 6.22M rows / 2.1s (wash) |

Never regresses: it only adds a predicate to an existing scan, no second pass. Worst case (object with many versions, or tiny stats table) is a wash.

## Production profile (Datadog, 7d)
- 2,421 object-storage reads (~346/day); 100% carry an object_id predicate, so all are scopeable.
- They land almost entirely on projects with a tiny `object_versions_stats` table (top read-volume projects <2K rows); the large-stats projects where this wins did ~0 such reads in 7d. So it's safe and future-proof but low realized yield today.

## Testing
unit tests asserting full SQL for object_id / object_ids scoping and the unscoped list-all path.
