### PR TITLE
fix(weave): tolerate stored external refs on agent reads instead of 500

### DIFF
--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 
 import pytest
 from pydantic import BaseModel, ConfigDict
@@ -8,8 +9,10 @@ from weave.trace.refs import ObjectRef
 from weave.trace_server.errors import InvalidExternalRef
 from weave.trace_server.interface.query import Query
 from weave.trace_server.trace_server_converter import (
+    InvalidInternalRef,
     replace_external_weave_ref,
     universal_ext_to_int_ref_converter,
+    universal_int_to_ext_ref_converter,
 )
 from weave.trace_server.trace_server_interface import (
     CallStartReq,
@@ -227,3 +230,44 @@ def test_replace_external_weave_ref_rejects_malformed_tail():
     """
     with pytest.raises(InvalidExternalRef):
         replace_external_weave_ref("weave:///just-entity", lambda p: p)
+
+
+@pytest.mark.disable_logging_error_check
+def test_universal_int_to_ext_ref_converter_tolerate_external_refs(caplog):
+    """Egress: internal refs externalize and unresolvable projects fall back to
+    a private ref. A stored external ref raises by default (surfacing
+    corruption), but is logged and passed through when tolerate_external_refs is
+    set, so agent reads don't 500 on a ref their ingest path left external.
+    """
+    internal_project_id = "internal-project"
+    internal_ref = f"weave-trace-internal:///{internal_project_id}/object/name:digest"
+    external_ref = "weave:///entity/project/object/name:digest"
+    private_internal_ref = "weave-trace-internal:///private-project/object/name:digest"
+
+    def int_to_ext(project_id: str) -> str | None:
+        return "entity/project" if project_id == internal_project_id else None
+
+    # Strict default: a stored external ref is a contract violation -> raise.
+    with pytest.raises(InvalidInternalRef):
+        universal_int_to_ext_ref_converter({"bad": external_ref}, int_to_ext)
+
+    payload = {
+        "resolved": internal_ref,
+        "private": private_internal_ref,
+        "stored_external": external_ref,
+        "plain": "no-ref-here",
+    }
+
+    with caplog.at_level(logging.ERROR):
+        converted = universal_int_to_ext_ref_converter(
+            payload, int_to_ext, tolerate_external_refs=True
+        )
+
+    assert converted == {
+        "resolved": external_ref,
+        "private": "weave-private://///object/name:digest",
+        "stored_external": external_ref,
+        "plain": "no-ref-here",
+    }
+    assert "Returning stored external ref unchanged" in caplog.text
+    assert external_ref in caplog.text

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -144,7 +144,11 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         return verify
 
     def _ref_apply(
-        self, method: Callable[[A], B], req: A, internal_project_id: str
+        self,
+        method: Callable[[A], B],
+        req: A,
+        internal_project_id: str,
+        tolerate_external_refs: bool = False,
     ) -> B:
         req_conv = universal_ext_to_int_ref_converter(
             req,
@@ -153,7 +157,7 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         )
         res = method(req_conv)
         res_conv = universal_int_to_ext_ref_converter(
-            res, self._idc.int_to_ext_project_id
+            res, self._idc.int_to_ext_project_id, tolerate_external_refs
         )
         return res_conv
 
@@ -1337,7 +1341,10 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         original_project_id = req.project_id
         req.project_id = self._idc.ext_to_int_project_id(original_project_id)
         res = self._ref_apply(
-            self._internal_trace_server.agent_spans_query, req, req.project_id
+            self._internal_trace_server.agent_spans_query,
+            req,
+            req.project_id,
+            tolerate_external_refs=True,
         )
         for span in res.spans:
             if span.project_id != req.project_id:
@@ -1351,7 +1358,10 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         original_project_id = req.project_id
         req.project_id = self._idc.ext_to_int_project_id(original_project_id)
         return self._ref_apply(
-            self._internal_trace_server.agent_spans_stats, req, req.project_id
+            self._internal_trace_server.agent_spans_stats,
+            req,
+            req.project_id,
+            tolerate_external_refs=True,
         )
 
     def agent_custom_attrs_schema(
@@ -1362,6 +1372,7 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.agent_custom_attrs_schema,
             req,
             req.project_id,
+            tolerate_external_refs=True,
         )
 
     def agent_agents_query(
@@ -1370,7 +1381,10 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         original_project_id = req.project_id
         req.project_id = self._idc.ext_to_int_project_id(original_project_id)
         res = self._ref_apply(
-            self._internal_trace_server.agent_agents_query, req, req.project_id
+            self._internal_trace_server.agent_agents_query,
+            req,
+            req.project_id,
+            tolerate_external_refs=True,
         )
         for agent in res.agents:
             if agent.project_id != req.project_id:
@@ -1384,7 +1398,10 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         original_project_id = req.project_id
         req.project_id = self._idc.ext_to_int_project_id(original_project_id)
         res = self._ref_apply(
-            self._internal_trace_server.agent_versions_query, req, req.project_id
+            self._internal_trace_server.agent_versions_query,
+            req,
+            req.project_id,
+            tolerate_external_refs=True,
         )
         for version in res.versions:
             if version.project_id != req.project_id:
@@ -1397,7 +1414,10 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     ) -> tsi.agent_types.AgentSearchRes:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         return self._ref_apply(
-            self._internal_trace_server.agent_search, req, req.project_id
+            self._internal_trace_server.agent_search,
+            req,
+            req.project_id,
+            tolerate_external_refs=True,
         )
 
     def agent_traces_chat(
@@ -1405,7 +1425,10 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     ) -> tsi.agent_types.AgentTraceChatRes:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         return self._ref_apply(
-            self._internal_trace_server.agent_traces_chat, req, req.project_id
+            self._internal_trace_server.agent_traces_chat,
+            req,
+            req.project_id,
+            tolerate_external_refs=True,
         )
 
     def agent_conversation_chat(
@@ -1416,6 +1439,7 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.agent_conversation_chat,
             req,
             req.project_id,
+            tolerate_external_refs=True,
         )
 
     def agent_conversation_spans(
@@ -1426,6 +1450,7 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.agent_conversation_spans,
             req,
             req.project_id,
+            tolerate_external_refs=True,
         )
 
     def projects_info(self, req: tsi.ProjectsInfoReq) -> list[tsi.ProjectsInfoRes]:

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -17,6 +17,7 @@ does not round-trip dataclasses safely through getattr / setattr.
 """
 
 import dataclasses
+import logging
 from collections.abc import Callable
 from typing import Any, NamedTuple, TypeVar, cast
 
@@ -24,6 +25,8 @@ from pydantic import BaseModel
 
 from weave.shared import refs_internal as ri
 from weave.trace_server.errors import InvalidExternalRef
+
+logger = logging.getLogger(__name__)
 
 A = TypeVar("A")
 B = TypeVar("B")
@@ -131,6 +134,7 @@ D = TypeVar("D")
 def universal_int_to_ext_ref_converter(
     obj: C,
     convert_int_to_ext_project_id: Callable[[str], str | None],
+    tolerate_external_refs: bool = False,
 ) -> C:
     """Takes any object and recursively replaces all internal references with
     external references. The internal references are expected to be in the
@@ -141,6 +145,10 @@ def universal_int_to_ext_ref_converter(
         obj: The object to convert.
         convert_int_to_ext_project_id: A function that takes an internal
             project ID and returns the external project ID.
+        tolerate_external_refs: When True, a ref already in external
+            (`weave:///`) form is logged and passed through instead of
+            raising. Used by agent reads, whose ingest path does not fully
+            convert refs and can therefore persist external refs.
 
     Returns:
         The object with all internal references replaced with external
@@ -170,13 +178,11 @@ def universal_int_to_ext_ref_converter(
             if obj.startswith(weave_internal_prefix):
                 return cast(D, replace_ref(obj))
             elif obj.startswith(weave_prefix):
-                # It is important to raise here as this would be the result of
-                # incorrectly storing an external ref at the database layer,
-                # rather than an internal ref. There is a possibility in the
-                # future that a programming error leads to this situation, in
-                # which case reading this object would consistently fail. We
-                # might want to instead return a private ref in this case.
-                raise InvalidInternalRef("Encountered unexpected ref format.")
+                # External ref stored where an internal one belongs. Agent reads
+                # tolerate it (already external-shaped); other paths raise loudly.
+                if not tolerate_external_refs:
+                    raise InvalidInternalRef("Encountered unexpected ref format.")
+                logger.error("Returning stored external ref unchanged: %s", obj)
         return obj
 
     return _map_values(obj, mapper)


### PR DESCRIPTION
## Summary
- A stored `weave:///` ref where an internal ref belongs makes the egress converter raise `InvalidInternalRef("Encountered unexpected ref format.")`. That class is unregistered in `errors.py`, so it hits the 500 default and every read of the row 500s forever ([13 such 500s on `POST /agents/spans/query` in the last 30d](https://us5.datadoghq.com/apm/traces?end=1782763403789&historicalData=true&paused=true&query=%40error.message%3A%2Aunexpected%5C+ref%5C+format%2A+OR+%40error.type%3AInvalidInternalRef&start=1780171403789)).
- Cause is an ingest/read asymmetry specific to agents: agent ingest only converts the typed `weave.{content,artifact,object}_refs` array keys, so a `weave:///` ref in message content / `raw_span_dump` is stored raw, then the egress walker (which validates every string) chokes on it.
- Add `tolerate_external_refs` to the int->ext converter. The 9 agent read methods pass it (log + pass through, since the string is already external-shaped); all other read paths still raise loudly to surface genuine corruption.

## Testing
unit test covering int->ext conversion, private-ref fallback, strict-default raise, and the tolerant agent pass-through.