### PR TITLE
perf(weave): scope agent trace-attribution fallback to filtered traces

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -59,6 +59,7 @@ from weave.trace_server.query_builder.agent_query_builder import (
 )
 from weave.trace_server.query_builder.agent_trace_attribution import (
     attributed_spans_source,
+    trace_id_scope_subquery,
 )
 
 
@@ -93,13 +94,22 @@ class _AttrSrc:
         project_id: str = "p1",
         started_after: datetime.datetime | None = None,
         started_before: datetime.datetime | None = None,
+        scope_trace_ids: list[str] | None = None,
     ) -> None:
         pb = ParamBuilder("genai")
+        scope = (
+            trace_id_scope_subquery(
+                pb, project_id=project_id, trace_ids=scope_trace_ids
+            )
+            if scope_trace_ids is not None
+            else None
+        )
         sql = attributed_spans_source(
             pb,
             project_id=project_id,
             started_after=started_after,
             started_before=started_before,
+            trace_scope_subquery=scope,
         )
         self.sql = re.sub(
             r"genai_(\d+)", lambda m: f"genai_{int(m.group(1)) + offset}", sql
@@ -258,6 +268,94 @@ class TestMakeSpansListQuery:
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
         """
         expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0, **src.params}
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+    def test_single_trace_read_scopes_attribution_fallback(self) -> None:
+        """A non-identity `trace_id = X` read scopes the attribution fallback to
+        that trace, so the `tf` rollup stops scanning the whole project. The
+        fallback still GROUPs BY trace_id over every span of the scoped trace,
+        so per-trace attribution is identical to the unscoped scan.
+        """
+        pb = ParamBuilder("genai")
+        query = make_spans_list_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                query=Query.model_validate(
+                    {"$expr": {"$eq": [{"$getField": "trace_id"}, {"$literal": "t1"}]}}
+                ),
+            ),
+        )
+
+        src = _AttrSrc(4, scope_trace_ids=["t1"])
+        expected = f"""
+            SELECT {SPANS_LIST_COLS}
+            FROM {src.sql} s
+            WHERE s.project_id = {{genai_0:String}}
+            AND (s.trace_id = {{genai_1:String}})
+            ORDER BY started_at DESC
+            LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
+        """
+        expected_params = {
+            "genai_0": "p1",
+            "genai_1": "t1",
+            "genai_2": 100,
+            "genai_3": 0,
+            **src.params,
+        }
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+    def test_identity_filtered_read_leaves_fallback_unscoped(self) -> None:
+        """Filtering on an attributed column (`agent.name`) must NOT scope the
+        fallback: the scope subquery runs against raw spans, where the
+        attributed `agent_name` does not yet exist, so scoping there would
+        corrupt attribution. The `trace_id` conjunct is ignored for scoping.
+        """
+        pb = ParamBuilder("genai")
+        query = make_spans_list_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                query=Query.model_validate(
+                    {
+                        "$expr": {
+                            "$and": [
+                                {
+                                    "$eq": [
+                                        {"$getField": "trace_id"},
+                                        {"$literal": "t1"},
+                                    ]
+                                },
+                                {
+                                    "$eq": [
+                                        {"$getField": "agent.name"},
+                                        {"$literal": "bot"},
+                                    ]
+                                },
+                            ]
+                        }
+                    }
+                ),
+            ),
+        )
+
+        src = _AttrSrc(5)
+        expected = f"""
+            SELECT {SPANS_LIST_COLS}
+            FROM {src.sql} s
+            WHERE s.project_id = {{genai_0:String}}
+            AND ((s.trace_id = {{genai_1:String}}) AND (s.agent_name = {{genai_2:String}}))
+            ORDER BY started_at DESC
+            LIMIT {{genai_3:UInt64}} OFFSET {{genai_4:UInt64}}
+        """
+        expected_params = {
+            "genai_0": "p1",
+            "genai_1": "t1",
+            "genai_2": "bot",
+            "genai_3": 100,
+            "genai_4": 0,
+            **src.params,
+        }
         assert_sql(expected, expected_params, query, pb.get_params())
 
     def test_projects_and_sorts_selected_custom_attr_columns(self) -> None:

--- a/tests/trace_server/query_builder/test_agent_trace_attribution.py
+++ b/tests/trace_server/query_builder/test_agent_trace_attribution.py
@@ -13,8 +13,10 @@ from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.agent_trace_attribution import (
     IDENTITY_COLUMNS,
     attributed_spans_source,
+    extract_scopable_trace_ids,
     fields_reference_identity,
     query_references_identity,
+    trace_id_scope_subquery,
 )
 
 
@@ -107,3 +109,103 @@ def test_fields_reference_identity() -> None:
     assert fields_reference_identity(["operation_name", "agent_id"])
     assert not fields_reference_identity(["operation_name", "request_model"])
     assert not fields_reference_identity([])
+
+
+def _q(expr: dict) -> Query:
+    return Query.model_validate({"$expr": expr})
+
+
+def _eq(field: str, lit: object) -> dict:
+    return {"$eq": [{"$getField": field}, {"$literal": lit}]}
+
+
+def test_extract_scopable_trace_ids_gates_exactly() -> None:
+    # Extractable: bare trace_id eq, trace_id IN (sorted+deduped), and
+    # trace_id ANDed with a non-identity predicate.
+    assert extract_scopable_trace_ids(_q(_eq("trace_id", "t1"))) == ["t1"]
+    assert extract_scopable_trace_ids(
+        _q(
+            {
+                "$in": [
+                    {"$getField": "trace_id"},
+                    [{"$literal": "tb"}, {"$literal": "ta"}],
+                ]
+            }
+        )
+    ) == ["ta", "tb"]
+    assert extract_scopable_trace_ids(
+        _q({"$and": [_eq("trace_id", "t1"), _eq("operation_name", "invoke_agent")]})
+    ) == ["t1"]
+
+    # Not extractable: no query, no trace_id predicate, identity referenced
+    # (the whole query is poisoned), $or root, and a non-string trace_id literal.
+    assert extract_scopable_trace_ids(None) is None
+    assert extract_scopable_trace_ids(_q(_eq("operation_name", "x"))) is None
+    assert (
+        extract_scopable_trace_ids(
+            _q({"$and": [_eq("trace_id", "t1"), _eq("agent.name", "bot")]})
+        )
+        is None
+    )
+    assert (
+        extract_scopable_trace_ids(
+            _q({"$or": [_eq("trace_id", "t1"), _eq("trace_id", "t2")]})
+        )
+        is None
+    )
+    assert extract_scopable_trace_ids(_q(_eq("trace_id", 5))) is None
+
+
+def test_trace_id_scope_subquery_sql() -> None:
+    pb = ParamBuilder("genai")
+    sql = trace_id_scope_subquery(pb, project_id="p1", trace_ids=["t1", "t2"])
+    assert (
+        sql == "SELECT trace_id FROM spans WHERE project_id = {genai_0:String}"
+        " AND trace_id IN {genai_1:Array(String)}"
+    )
+    assert pb.get_params() == {"genai_0": "p1", "genai_1": ["t1", "t2"]}
+
+
+def test_attributed_source_scopes_fallback_to_trace_ids() -> None:
+    pb = ParamBuilder("genai")
+    scope = trace_id_scope_subquery(pb, project_id="p1", trace_ids=["t1"])
+    sql = attributed_spans_source(
+        pb,
+        project_id="p1",
+        started_after=None,
+        started_before=None,
+        trace_scope_subquery=scope,
+    )
+    # Only the fallback `tf` scan is scoped; the outer/base scans are untouched,
+    # and `tf` still GROUPs BY trace_id over all spans of the scoped trace, so
+    # per-trace attribution is identical to the unscoped query (lossless).
+    expected = """
+        (SELECT * EXCEPT (agent_name, agent_version, agent_id, conversation_id,
+                          has_own_agent_identity, fb_agent_identity, fb_conversation_id),
+            if(has_own_agent_identity, agent_name, fb_agent_identity.1) AS agent_name,
+            if(has_own_agent_identity, agent_version, fb_agent_identity.2) AS agent_version,
+            if(has_own_agent_identity, agent_id, fb_agent_identity.3) AS agent_id,
+            if(conversation_id != '', conversation_id, fb_conversation_id) AS conversation_id
+         FROM (
+           SELECT s0.*, (s0.agent_name != '') AS has_own_agent_identity,
+                  tf.fb_agent_identity, tf.fb_conversation_id
+           FROM spans s0
+           LEFT JOIN (
+             SELECT trace_id,
+                 argMinIf((agent_name, agent_version, agent_id), started_at, agent_name != '')
+                   AS fb_agent_identity,
+                 anyIf(conversation_id, conversation_id != '') AS fb_conversation_id
+             FROM spans
+             WHERE project_id = {genai_2:String}
+               AND trace_id IN (SELECT trace_id FROM spans
+                                WHERE project_id = {genai_0:String}
+                                  AND trace_id IN {genai_1:Array(String)})
+             GROUP BY trace_id) tf ON s0.trace_id = tf.trace_id
+           WHERE s0.project_id = {genai_2:String}))
+    """
+    assert _fmt(sql) == _fmt(expected)
+    assert pb.get_params() == {
+        "genai_0": "p1",
+        "genai_1": ["t1"],
+        "genai_2": "p1",
+    }

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -892,16 +892,40 @@ def _spans_source(
     four identity columns inherit from their trace when unset (see
     `agent_trace_attribution`); otherwise the base is used directly so
     non-identity queries skip the extra trace scan.
+
+    When the query restricts to concrete `trace_id`s without touching any
+    attributed column, the attribution fallback is scoped to those traces (see
+    `_trace_scope_subquery`) so it stops rolling up every trace in the project.
     """
     base = cost_augmented_source_sql(pb, req.project_id) if include_costs else "spans"
     if not attribute:
         return base
+    trace_scope_subquery = _trace_scope_subquery(pb, req)
     return agent_trace_attribution.attributed_spans_source(
         pb,
         project_id=req.project_id,
         started_after=req.started_after,
         started_before=req.started_before,
         base_relation=base,
+        trace_scope_subquery=trace_scope_subquery,
+    )
+
+
+def _trace_scope_subquery(pb: ParamBuilder, req: AgentSpansQueryReq) -> str | None:
+    """Scope subquery for the attribution fallback, or None to leave it unscoped.
+
+    Only returned when the request narrows to concrete `trace_id`s via a query
+    that references no attributed identity column. Both halves of the gate are
+    required: the non-identity check keeps the raw-`spans` scan from filtering
+    on a value that only exists post-attribution, and the extracted trace_ids
+    are the real narrowing predicate that makes scoping a win over a bare
+    project (plus optional time window) scan.
+    """
+    trace_ids = agent_trace_attribution.extract_scopable_trace_ids(req.query)
+    if not trace_ids:
+        return None
+    return agent_trace_attribution.trace_id_scope_subquery(
+        pb, project_id=req.project_id, trace_ids=trace_ids
     )
 
 

--- a/weave/trace_server/query_builder/agent_trace_attribution.py
+++ b/weave/trace_server/query_builder/agent_trace_attribution.py
@@ -119,6 +119,7 @@ def attributed_spans_source(
     started_after: datetime.datetime | None,
     started_before: datetime.datetime | None,
     base_relation: str = "spans",
+    trace_scope_subquery: str | None = None,
 ) -> str:
     """Return a parenthesized subquery that stands in for the `spans` table.
 
@@ -136,10 +137,19 @@ def attributed_spans_source(
     The inner scan is bounded to `project_id` and the outer time window so it
     prunes by primary key; the fallback scan is bounded to the same window
     widened by one trace-duration of slack so edge spans still resolve.
+
+    `trace_scope_subquery` further restricts the fallback scan to
+    `trace_id IN ({subquery})`. The subquery must select trace_ids from raw
+    `spans` using ONLY non-identity predicates (the caller is responsible for
+    that gate). The fallback still GROUPs BY trace_id over every span of each
+    scoped trace, so per-trace attribution is identical to the unscoped scan
+    (lossless); it just skips traces the consuming query cannot return.
     """
     pid_slot = pb.add(project_id, param_type="String")
 
     fallback_conds = [f"project_id = {pid_slot}"]
+    if trace_scope_subquery is not None:
+        fallback_conds.append(f"trace_id IN ({trace_scope_subquery})")
     base_conds = [f"s0.project_id = {pid_slot}"]
     if started_after is not None:
         fb_after = pb.add(
@@ -207,3 +217,106 @@ def attributed_spans_source(
     WHERE {" AND ".join(base_conds)}
   )
 )"""
+
+
+def extract_scopable_trace_ids(query: tsi_query.Query | None) -> list[str] | None:
+    """Pull concrete `trace_id` values a query restricts to, when provably safe.
+
+    Returns the sorted trace_ids iff the query is a top-level AND-chain (or a
+    single comparison) whose `trace_id` constraints are all `trace_id = '<lit>'`
+    / `trace_id IN ['<lit>', ...]` against string literals AND it references no
+    attributed identity column. Any `$or` / `$not` / `$contains`, a non-literal
+    trace_id comparison, or a missing trace_id constraint yields None, so the
+    fallback stays unscoped (current behavior).
+
+    A trace_id predicate filters the *raw* span identically before and after
+    attribution (trace_id is never attributed), so narrowing the fallback to
+    these traces is lossless.
+    """
+    if query is None or query_references_identity(query):
+        return None
+    operands = _top_level_and_operands(query.expr_)
+    found: set[str] = set()
+    for operand in operands:
+        values = _trace_id_literals(operand)
+        if values is not None:
+            found.update(values)
+    return sorted(found) if found else None
+
+
+def trace_id_scope_subquery(
+    pb: ParamBuilder, *, project_id: str, trace_ids: list[str]
+) -> str:
+    """Build `SELECT trace_id FROM spans WHERE project + trace_id IN (...)`.
+
+    Uses only non-identity raw columns so it is safe to feed as the
+    `trace_scope_subquery` of `attributed_spans_source`.
+    """
+    pid_slot = pb.add(project_id, param_type="String")
+    ids_slot = pb.add(trace_ids, param_type="Array(String)")
+    return (
+        f"SELECT trace_id FROM spans "
+        f"WHERE project_id = {pid_slot} AND trace_id IN {ids_slot}"
+    )
+
+
+def _top_level_and_operands(op: tsi_query.Operation) -> list[tsi_query.Operand]:
+    """The conjuncts of a top-level `$and`, or the single op as a one-element list.
+
+    Only a flat top-level AND is unwrapped; a bare comparison is treated as a
+    single conjunct. Anything else (an OR/NOT at the root) returns itself as the
+    sole operand and will simply not yield trace_id literals.
+    """
+    if isinstance(op, tsi_query.AndOperation):
+        return list(op.and_)
+    return [op]
+
+
+def _trace_id_literals(operand: tsi_query.Operand) -> list[str] | None:
+    """String literals a single `trace_id = X` / `trace_id IN [...]` restricts to.
+
+    Returns None when `operand` is not such a comparison or any operand is not
+    a `trace_id` field vs. string literal(s).
+    """
+    if isinstance(operand, tsi_query.EqOperation):
+        lhs, rhs = operand.eq_
+        field, literal = _field_and_str_literal(lhs, rhs)
+        if field == "trace_id" and literal is not None:
+            return [literal]
+        return None
+    if isinstance(operand, tsi_query.InOperation):
+        field_operand, list_operand = operand.in_
+        if _get_field_name(field_operand) != "trace_id":
+            return None
+        values: list[str] = []
+        for item in list_operand:
+            literal = _str_literal(item)
+            if literal is None:
+                return None
+            values.append(literal)
+        return values or None
+    return None
+
+
+def _field_and_str_literal(
+    lhs: tsi_query.Operand, rhs: tsi_query.Operand
+) -> tuple[str | None, str | None]:
+    """Resolve a comparison to (field_name, str_literal) regardless of side."""
+    field = _get_field_name(lhs)
+    if field is not None:
+        return field, _str_literal(rhs)
+    return _get_field_name(rhs), _str_literal(lhs)
+
+
+def _get_field_name(operand: tsi_query.Operand) -> str | None:
+    if isinstance(operand, tsi_query.GetFieldOperator):
+        return operand.get_field_
+    return None
+
+
+def _str_literal(operand: tsi_query.Operand) -> str | None:
+    if isinstance(operand, tsi_query.LiteralOperation) and isinstance(
+        operand.literal_, str
+    ):
+        return operand.literal_
+    return None


### PR DESCRIPTION
## Summary
- The agent trace-attribution `tf` fallback rolls up every trace in the project even when the consuming query reads one trace. Scope it to `trace_id IN (...)` when the query restricts to concrete trace_ids.
- Speculative + aggressively gated: scope applies ONLY when the query references no attributed identity column (agent_name/agent_version/agent_id/conversation_id) AND carries literal trace_id predicates. Identity-filtered and plain-list reads are byte-for-byte unchanged.
- Narrow-but-correct: extracts literal `trace_id = X` / `trace_id IN [...]` from a top-level AND-chain rather than re-compiling an arbitrary filter against raw spans.
- Review scrutiny: the attribution-correctness gating in `extract_scopable_trace_ids` (does any path let an identity predicate or a non-literal reach the raw-spans scope scan?). `tf` still GROUPs BY trace_id over all spans of the scoped traces, so per-trace attribution is lossless.

## Performance
53M -> 798K rows, 187ms -> 50ms on a single-trace read (prod read-only CH).

## Testing
dense unit tests for the scoped single-trace SQL and the unchanged identity-filtered SQL; all 89 existing attribution tests unchanged.