### PR TITLE
feat(weave): filter agent spans by online-scorer signal tags

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -360,6 +360,44 @@ class TestMakeSpansListQuery:
                 include_details=True,
             )
 
+    def test_with_signal_tags(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_spans_list_query(
+            pb,
+            AgentSpansQueryReq(project_id="p1", signal_tags=["lowquality"]),
+        )
+
+        feedback_sub = (
+            "SELECT weave_ref FROM feedback "
+            "WHERE project_id = {genai_2:String} "
+            "AND feedback_type = {genai_3:String} "
+            "AND hasAny(scorer_tags, {genai_1:Array(String)})"
+        )
+        src = _AttrSrc(9)
+        expected = f"""
+            SELECT {SPANS_LIST_COLS}
+            FROM {src.sql} s
+            WHERE s.project_id = {{genai_0:String}}
+              AND (concat({{genai_4:String}}, s.trace_id) IN ({feedback_sub})
+              OR concat({{genai_5:String}}, encodeURLComponent(s.conversation_id)) IN ({feedback_sub})
+              OR concat({{genai_6:String}}, s.span_id) IN ({feedback_sub}))
+            ORDER BY started_at DESC
+            LIMIT {{genai_7:UInt64}} OFFSET {{genai_8:UInt64}}
+        """
+        expected_params = {
+            "genai_0": "p1",
+            "genai_1": ["lowquality"],
+            "genai_2": "p1",
+            "genai_3": "wandb.agent_monitor",
+            "genai_4": "weave-trace-internal:///p1/agent_turn/",
+            "genai_5": "weave-trace-internal:///p1/agent_conversation/",
+            "genai_6": "weave-trace-internal:///p1/agent_span/",
+            "genai_7": 100,
+            "genai_8": 0,
+            **src.params,
+        }
+        assert_sql(expected, expected_params, query, pb.get_params())
+
 
 # ============================================================================
 # make_spans_count_query (grouped)

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -784,6 +784,10 @@ class AgentSpansQueryReq(BaseModel):
     offset: int = Field(default=0, ge=0)
     started_after: datetime.datetime | None = None  # filter started_at >= start
     started_before: datetime.datetime | None = None  # filter started_at < end
+    # Keep only spans carrying online-scorer (signal) feedback whose
+    # scorer_tags contain any of these values, matched via the feedback's
+    # weave_ref against the span / its trace / its conversation.
+    signal_tags: list[str] | None = None
 
     @model_validator(mode="after")
     def validate_spans_query_request(self) -> AgentSpansQueryReq:

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -17,6 +17,7 @@ from collections.abc import Callable, Collection, Sequence
 from dataclasses import dataclass
 from typing import Any, NamedTuple, TypeAlias, TypeVar
 
+from weave.shared.refs_internal import WEAVE_INTERNAL_SCHEME
 from weave.trace_server.agents import semconv
 from weave.trace_server.agents.constants import (
     MAX_CONVERSATION_SPANS,
@@ -52,6 +53,7 @@ from weave.trace_server.agents.types import (
     AgentVersionsQueryReq,
     group_by_ref_alias,
 )
+from weave.trace_server.interface.feedback_types import AGENT_MONITOR_FEEDBACK_TYPE
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder import agent_trace_attribution
 from weave.trace_server.query_builder.agent_custom_attrs import (
@@ -841,6 +843,43 @@ def _and_conditions(*conditions: str) -> str:
     return " AND ".join(condition for condition in conditions if condition)
 
 
+def _signal_tags_filter_sql(
+    pb: ParamBuilder, project_id: str, signal_tags: Sequence[str]
+) -> str:
+    """Keep spans carrying online-scorer feedback with any of `signal_tags`.
+
+    Feedback links to its target by `weave_ref`, a `weave-trace-internal:///`
+    URI whose kind segment is `agent_turn` (trace_id), `agent_conversation`
+    (URL-encoded conversation_id), or `agent_span` (span_id). A span matches
+    when one of its three reconstructed refs is in the set of matching-feedback
+    refs, so feedback attached at span, trace, or conversation level all count.
+    """
+    tags_slot = pb.add(list(signal_tags), param_type="Array(String)")
+    pid_slot = pb.add(project_id, param_type="String")
+    type_slot = pb.add(AGENT_MONITOR_FEEDBACK_TYPE, param_type="String")
+    turn_prefix = pb.add(
+        f"{WEAVE_INTERNAL_SCHEME}:///{project_id}/agent_turn/", param_type="String"
+    )
+    conv_prefix = pb.add(
+        f"{WEAVE_INTERNAL_SCHEME}:///{project_id}/agent_conversation/",
+        param_type="String",
+    )
+    span_prefix = pb.add(
+        f"{WEAVE_INTERNAL_SCHEME}:///{project_id}/agent_span/", param_type="String"
+    )
+    subquery = (
+        f"SELECT weave_ref FROM feedback "
+        f"WHERE project_id = {pid_slot} "
+        f"AND feedback_type = {type_slot} "
+        f"AND hasAny(scorer_tags, {tags_slot})"
+    )
+    return (
+        f"(concat({turn_prefix}, s.trace_id) IN ({subquery}) "
+        f"OR concat({conv_prefix}, encodeURLComponent(s.conversation_id)) IN ({subquery}) "
+        f"OR concat({span_prefix}, s.span_id) IN ({subquery}))"
+    )
+
+
 def _spans_filter_sql(
     pb: ParamBuilder,
     req: AgentSpansQueryReq | AgentCustomAttrsSchemaReq,
@@ -859,6 +898,11 @@ def _spans_filter_sql(
         from weave.trace_server.query_builder import agent_query_compiler
 
         where_conditions.append(agent_query_compiler.compile_agent_query(req.query, pb))
+    signal_tags = getattr(req, "signal_tags", None)
+    if signal_tags:
+        where_conditions.append(
+            _signal_tags_filter_sql(pb, req.project_id, signal_tags)
+        )
     return _FilterSQL(where=" AND ".join(where_conditions))
 
 


### PR DESCRIPTION
Adds `signal:` filtering for agent search: keep spans (and the conversations they roll up to) that carry online-scorer feedback with a given tag.

- New `AgentSpansQueryReq.signal_tags: list[str] | None`. Spans are kept when they have `wandb.agent_monitor` feedback whose `scorer_tags` contains any listed tag.
- Implemented as a **non-correlated membership test** against the `feedback` table, matching on the span's / trace's / conversation's reconstructed `weave_ref` (`agent_span` / `agent_turn` / `agent_conversation`). No JOIN fan-out — span cardinality is unchanged. All literals go through `ParamBuilder`.
- Threads through `_spans_filter_sql`, so count/list/grouped queries all honor it; `group_by=conversation_id` rolls matches up to conversations.
- Unit test asserts the full generated SQL + params (no ClickHouse needed): `uv run --python 3.12 --group test python -m pytest tests/trace_server/query_builder/test_agent_query_builder.py` → 67 passed. `ruff` clean.

Backend half of the "search should include signals" requirement; the frontend `signal:` omnibar wiring is a separate wandb/core PR.

### Reviewer note (needs ClickHouse-access verification)
- **Ref encoding parity:** the conversation case compares `encodeURLComponent(s.conversation_id)` (ClickHouse) against the stored ref's URL-encoded id. trace_id/span_id are slash-free and unquoted (straightforward); the conversation percent-encoding should be confirmed against a live conversation-level feedback row.
- **feedback_type scope:** constrained to `wandb.agent_monitor`. Confirm online scorer results are always written under that type.

## PR Testing
- [ ] Manual
- [ ] Unit
- [ ] QA
