### PR TITLE
fix(weave): scope conversation chat view to its own conversation's spans

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -1608,9 +1608,7 @@ class TestMakeConversationChatSpansQuery:
         expected_pb.add(0, param_type="UInt64")  # genai_3: offset
         source = cost_augmented_source_sql(expected_pb, "p1")
         expected = f"""
-            SELECT {QUALIFIED_CHAT_VIEW_COLS}, {QUALIFIED_SPANS_COST_COLS}
-            FROM {source} s
-            INNER JOIN (
+            WITH turn_page AS (
                 SELECT trace_id, min(started_at) AS turn_started_at
                 FROM spans
                 WHERE project_id = {{genai_0:String}}
@@ -1618,8 +1616,13 @@ class TestMakeConversationChatSpansQuery:
                 GROUP BY trace_id
                 ORDER BY turn_started_at DESC, trace_id DESC
                 LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
-            ) t ON s.trace_id = t.trace_id
+            )
+            SELECT {QUALIFIED_CHAT_VIEW_COLS}, {QUALIFIED_SPANS_COST_COLS}
+            FROM {source} s
+            INNER JOIN turn_page t ON s.trace_id = t.trace_id
             WHERE s.project_id = {{genai_0:String}}
+            AND s.trace_id IN (SELECT trace_id FROM turn_page)
+            AND s.conversation_id IN ({{genai_1:String}}, '')
             ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
         """
         assert_sql(expected, expected_pb.get_params(), query, pb.get_params())
@@ -1640,9 +1643,7 @@ class TestMakeConversationChatSpansQuery:
         expected_pb.add(20, param_type="UInt64")  # genai_3: offset
         source = cost_augmented_source_sql(expected_pb, "p1")
         expected = f"""
-            SELECT {QUALIFIED_CHAT_VIEW_COLS}, {QUALIFIED_SPANS_COST_COLS}
-            FROM {source} s
-            INNER JOIN (
+            WITH turn_page AS (
                 SELECT trace_id, min(started_at) AS turn_started_at
                 FROM spans
                 WHERE project_id = {{genai_0:String}}
@@ -1650,8 +1651,13 @@ class TestMakeConversationChatSpansQuery:
                 GROUP BY trace_id
                 ORDER BY turn_started_at DESC, trace_id DESC
                 LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
-            ) t ON s.trace_id = t.trace_id
+            )
+            SELECT {QUALIFIED_CHAT_VIEW_COLS}, {QUALIFIED_SPANS_COST_COLS}
+            FROM {source} s
+            INNER JOIN turn_page t ON s.trace_id = t.trace_id
             WHERE s.project_id = {{genai_0:String}}
+            AND s.trace_id IN (SELECT trace_id FROM turn_page)
+            AND s.conversation_id IN ({{genai_1:String}}, '')
             ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
         """
         assert_sql(expected, expected_pb.get_params(), query, pb.get_params())

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -1942,8 +1942,11 @@ def test_conversation_chat_excludes_foreign_conversation_sharing_trace_id(ch_ser
 
     Agent-eval workloads reuse trace_id across conversations, so the page of
     turn trace_ids matches spans from other conversations too. The chat view
-    must return only the target conversation's spans plus untagged children on
-    those traces, never another conversation's tagged spans.
+    must never return another conversation's tagged spans.
+
+    Untagged children are a known limitation: producers tag conversation_id
+    only on the root span, so a foreign conversation's untagged children on a
+    shared trace_id cannot be attributed and still bleed (see PR #7450).
     """
     project_id = _make_project_id("conv_chat_bleed")
     conv_a = f"conv-a-{uuid.uuid4().hex[:8]}"
@@ -1951,6 +1954,7 @@ def test_conversation_chat_excludes_foreign_conversation_sharing_trace_id(ch_ser
     shared_trace = uuid.uuid4().hex  # reused by both conversations
     a_only_trace = uuid.uuid4().hex  # conv A's second turn, its own trace
     root_a = uuid.uuid4().hex
+    root_b = uuid.uuid4().hex
     now = datetime.datetime.now(tz=datetime.timezone.utc)
 
     spans = [
@@ -1978,11 +1982,23 @@ def test_conversation_chat_excludes_foreign_conversation_sharing_trace_id(ch_ser
         _make_span(
             project_id,
             trace_id=shared_trace,
+            span_id=root_b,
             conversation_id=conv_b,
             operation_name="invoke_agent",
             input_messages=[NormalizedMessage(role="user", content="userB-foreign")],
             output_messages=[
                 NormalizedMessage(role="assistant", content="assistantB-foreign")
+            ],
+            started_at=now + datetime.timedelta(seconds=1),
+            ended_at=now + datetime.timedelta(seconds=2),
+        ),
+        _make_span(
+            project_id,
+            trace_id=shared_trace,
+            parent_span_id=root_b,
+            operation_name="chat",
+            output_messages=[
+                NormalizedMessage(role="assistant", content="childB-foreign")
             ],
             started_at=now + datetime.timedelta(seconds=1),
             ended_at=now + datetime.timedelta(seconds=2),
@@ -2016,8 +2032,12 @@ def test_conversation_chat_excludes_foreign_conversation_sharing_trace_id(ch_ser
     assert "userA-shared" in texts
     assert "childA-text" in texts
     assert "userA-only" in texts
+    # conv B's tagged root is excluded by conversation_id scoping.
     assert "userB-foreign" not in texts
     assert "assistantB-foreign" not in texts
+    # Known limitation (PR #7450 discussion): conv B's untagged child shares
+    # the trace_id, so it currently bleeds. Flip to `not in` when fixed.
+    assert "childB-foreign" in texts
 
 
 # ---------------------------------------------------------------------------

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -1937,6 +1937,89 @@ def test_conversation_chat_includes_child_spans_without_conversation_id(ch_serve
     assert tool.tool_call.tool_result == '{"ok":true}'
 
 
+def test_conversation_chat_excludes_foreign_conversation_sharing_trace_id(ch_server):
+    """A reused trace_id must not bleed foreign conversations into the chat view.
+
+    Agent-eval workloads reuse trace_id across conversations, so the page of
+    turn trace_ids matches spans from other conversations too. The chat view
+    must return only the target conversation's spans plus untagged children on
+    those traces, never another conversation's tagged spans.
+    """
+    project_id = _make_project_id("conv_chat_bleed")
+    conv_a = f"conv-a-{uuid.uuid4().hex[:8]}"
+    conv_b = f"conv-b-{uuid.uuid4().hex[:8]}"
+    shared_trace = uuid.uuid4().hex  # reused by both conversations
+    a_only_trace = uuid.uuid4().hex  # conv A's second turn, its own trace
+    root_a = uuid.uuid4().hex
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    spans = [
+        _make_span(
+            project_id,
+            trace_id=shared_trace,
+            span_id=root_a,
+            conversation_id=conv_a,
+            operation_name="invoke_agent",
+            input_messages=[NormalizedMessage(role="user", content="userA-shared")],
+            started_at=now,
+            ended_at=now + datetime.timedelta(seconds=2),
+        ),
+        _make_span(
+            project_id,
+            trace_id=shared_trace,
+            parent_span_id=root_a,
+            operation_name="chat",
+            output_messages=[
+                NormalizedMessage(role="assistant", content="childA-text")
+            ],
+            started_at=now + datetime.timedelta(seconds=1),
+            ended_at=now + datetime.timedelta(seconds=2),
+        ),
+        _make_span(
+            project_id,
+            trace_id=shared_trace,
+            conversation_id=conv_b,
+            operation_name="invoke_agent",
+            input_messages=[NormalizedMessage(role="user", content="userB-foreign")],
+            output_messages=[
+                NormalizedMessage(role="assistant", content="assistantB-foreign")
+            ],
+            started_at=now + datetime.timedelta(seconds=1),
+            ended_at=now + datetime.timedelta(seconds=2),
+        ),
+        _make_span(
+            project_id,
+            trace_id=a_only_trace,
+            conversation_id=conv_a,
+            operation_name="invoke_agent",
+            input_messages=[NormalizedMessage(role="user", content="userA-only")],
+            started_at=now + datetime.timedelta(minutes=1),
+            ended_at=now + datetime.timedelta(minutes=1, seconds=1),
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_conversation_chat(
+        AgentConversationChatReq(project_id=project_id, conversation_id=conv_a)
+    )
+
+    assert res.total_turns == 2
+    assert {turn.trace_id for turn in res.turns} == {shared_trace, a_only_trace}
+
+    texts = [
+        payload.text
+        for turn in res.turns
+        for msg in turn.messages
+        for payload in (msg.user_message, msg.assistant_message)
+        if payload is not None
+    ]
+    assert "userA-shared" in texts
+    assert "childA-text" in texts
+    assert "userA-only" in texts
+    assert "userB-foreign" not in texts
+    assert "assistantB-foreign" not in texts
+
+
 # ---------------------------------------------------------------------------
 # Test: Message search
 # ---------------------------------------------------------------------------

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1741,10 +1741,12 @@ def make_conversation_chat_spans_query(
     # Always cost-augmented so the multi-turn chat view can render per-message
     # and per-turn cost; bounded to one conversation's turns, so cheap.
     source = cost_augmented_source_sql(pb, req.project_id)
+    # trace_id is reused across conversations in agent-eval workloads, so the
+    # page's trace_ids alone would pull in foreign conversations' spans. Scope
+    # the outer scan to the page's trace_ids (idx_trace_id prune) and keep only
+    # this conversation's spans plus untagged children (conversation_id = '').
     return f"""
-        SELECT {QUALIFIED_CHAT_VIEW_COLS}, {QUALIFIED_SPANS_COST_COLS}
-        FROM {source} s
-        INNER JOIN (
+        WITH turn_page AS (
             SELECT trace_id, min(started_at) AS turn_started_at
             FROM spans
             WHERE {_project_filter_sql("project_id", pid)}
@@ -1752,8 +1754,13 @@ def make_conversation_chat_spans_query(
             GROUP BY trace_id
             ORDER BY turn_started_at DESC, trace_id DESC
             LIMIT {limit_slot} OFFSET {offset_slot}
-        ) t ON s.trace_id = t.trace_id
+        )
+        SELECT {QUALIFIED_CHAT_VIEW_COLS}, {QUALIFIED_SPANS_COST_COLS}
+        FROM {source} s
+        INNER JOIN turn_page t ON s.trace_id = t.trace_id
         WHERE {_project_filter_sql("s.project_id", pid)}
+          AND s.trace_id IN (SELECT trace_id FROM turn_page)
+          AND s.conversation_id IN ({cid}, '')
         ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
     """
 

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1741,10 +1741,9 @@ def make_conversation_chat_spans_query(
     # Always cost-augmented so the multi-turn chat view can render per-message
     # and per-turn cost; bounded to one conversation's turns, so cheap.
     source = cost_augmented_source_sql(pb, req.project_id)
-    # trace_id is reused across conversations in agent-eval workloads, so the
-    # page's trace_ids alone would pull in foreign conversations' spans. Scope
-    # the outer scan to the page's trace_ids (idx_trace_id prune) and keep only
-    # this conversation's spans plus untagged children (conversation_id = '').
+    # Scope to this conversation's spans + untagged children. The duplicate
+    # `trace_id IN (turn_page)` is the index prune CH won't derive from the
+    # JOIN; keep turn_page's total ORDER BY so both inlined scans agree.
     return f"""
         WITH turn_page AS (
             SELECT trace_id, min(started_at) AS turn_started_at


### PR DESCRIPTION
## Summary
- The multi-turn conversation chat view joins spans on the page's trace_ids but filtered the outer scan only by `project_id`. `trace_id` is reused across conversations in agent-eval workloads, so the view bled foreign conversations' spans and scanned the whole project (129-turn whale conversation: 805 spans returned, only 357 were the conversation's; 348 foreign across 114 other conversations).
- Scope the outer scan to the page's trace_ids (`idx_trace_id` prune) and keep only this conversation's spans plus untagged children (`conversation_id IN (cid, '')`), matching the inner page subquery + the turn-count query.

## Performance
prod whale (5.3M spans), warm interleaved, scoped vs master:

| shape | read_rows | p50 |
|---|---|---|
| point | 5.47M -> 0.35M (15.8x) | 423 -> 59ms |
| list50 | 5.47M -> 2.40M (2.3x) | 446 -> 139ms |
| deep_offset | 5.47M -> 2.37M (2.3x) | 433 -> 139ms |

2nd whale confirms 2.2-21x fewer rows, no regression on any shape.

## Testing
full-SQL unit test + functional CH test proving foreign-conversation spans no longer bleed while untagged children stay included.
