### PR TITLE
chore(weave): fix flaky test_server_cache_size_limit

### DIFF
--- a/tests/trace/test_client_server_caching.py
+++ b/tests/trace/test_client_server_caching.py
@@ -26,6 +26,11 @@ from weave.trace_server.trace_server_interface import (
     TraceServerInterface,
 )
 
+# diskcache's volume() is a page_count-based estimate; SQLite can keep a few
+# un-checkpointed WAL pages past the soft size_limit, so the estimate jitters a
+# couple pages above it. The on-disk cache.db file is the real footprint bound.
+DISK_CACHE_VOLUME_SLACK_BYTES = 4 * 4096
+
 
 def create_random_pil_image():
     im = PIL.Image.new("RGB", (100, 100), color=(255, 255, 255))
@@ -187,7 +192,10 @@ def test_server_cache_size_limit():
             )
 
             # Internally, the cache estimates its own size
-            assert caching_server.disk_cache_volume() <= limit * 1.1
+            assert (
+                caching_server.disk_cache_volume()
+                <= limit + DISK_CACHE_VOLUME_SLACK_BYTES
+            )
 
             # Allows us to test the on-disk size
             sizes = get_cache_sizes(temp_dir)


### PR DESCRIPTION
## Summary
- `disk_cache_volume()` is diskcache's `page_count * page_size` estimate. SQLite keeps un-checkpointed WAL pages past the soft `size_limit`, so the estimate jitters a couple pages above it. diskcache culls `volume()` to ~`size_limit` (settles at 49152 locally), leaving `limit * 1.1` only ~1 page of headroom -> intermittent overflow on slower CI.
- Bound the estimate by `limit + a few pages`; the on-disk `cache.db` file assertion stays tight (that's the real footprint guarantee). Checkpointing is not an option: it shifts the WAL pages into `cache.db` and would break that assertion instead.

Original failure ([CI job](https://github.com/wandb/weave/actions/runs/28402645066/job/84157493944)):
```
FAILED tests/trace/test_client_server_caching.py::test_server_cache_size_limit - assert 57344 <= (50000 * 1.1)
```

## Testing
test only change.