### PR TITLE
fix(weave): reject negative JSON path array indices (422 not 502)

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -2143,6 +2143,36 @@ def test_unsupported_summary_field_raises_invalid_field_error() -> None:
         cq.as_sql(ParamBuilder())
 
 
+def test_negative_json_array_index_raises_invalid_field_error() -> None:
+    """A negative array index in a dynamic field path must surface as
+    InvalidFieldError (HTTP 422), not a ClickHouse BAD_ARGUMENTS 502.
+
+    ClickHouse's JSON_VALUE JSONPath grammar cannot parse `[-1]`, so a getField
+    like `inputs.turn.user_prompt_parts.-1` (filter or sort) 502'd the whole
+    /calls/query_stats request. We reject it at compile time instead.
+    """
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {"$getField": "inputs.turn.user_prompt_parts.-1"},
+                    {"$literal": "hi"},
+                ]
+            }
+        )
+    )
+    with pytest.raises(InvalidFieldError, match="Negative array index '-1'"):
+        cq.as_sql(ParamBuilder())
+
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_order("inputs.turn.user_prompt_parts.-1", "desc")
+    with pytest.raises(InvalidFieldError, match="Negative array index '-1'"):
+        cq.as_sql(ParamBuilder())
+
+
 def test_unselectable_columns_raise_invalid_field_error() -> None:
     """Selecting columns that the SQL builder can't materialize as a select expression
     must surface as InvalidFieldError (403), not NotImplementedError (500). Regression

--- a/tests/trace_server/test_orm.py
+++ b/tests/trace_server/test_orm.py
@@ -1,6 +1,7 @@
 import pytest
 
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.errors import InvalidFieldError
 from weave.trace_server.orm import (
     Column,
     ParamBuilder,
@@ -8,6 +9,8 @@ from weave.trace_server.orm import (
     _transform_external_field_to_internal_field,
     combine_conditions,
     python_value_to_ch_type,
+    quote_json_path,
+    quote_json_path_parts,
     split_escaped_field_path,
 )
 
@@ -61,6 +64,28 @@ def test_combine_conditions():
         combine_conditions(["foo = 'bar'", "bim = 12"], "OR")
         == "((foo = 'bar') OR (bim = 12))"
     )
+
+
+def test_quote_json_path_array_indices():
+    """Non-negative ints bracket-index; negative indices are rejected.
+
+    ClickHouse JSON_VALUE's JSONPath grammar rejects negative array indices
+    (`[-1]`) with BAD_ARGUMENTS, 502-ing the whole request. We reject them at
+    compile time as a client-facing InvalidFieldError (HTTP 422) instead.
+    """
+    assert quote_json_path_parts(["a", "0", "2"]) == '$."a"[0][2]'
+    assert quote_json_path("output.scores.0") == '$."output"."scores"[0]'
+
+    with pytest.raises(InvalidFieldError, match="Negative array index '-1'"):
+        quote_json_path_parts(["turn", "user_prompt_parts", "-1"])
+    with pytest.raises(InvalidFieldError, match="Negative array index '-1'"):
+        quote_json_path("turn.user_prompt_parts.-1")
+    with pytest.raises(InvalidFieldError, match="Negative array index '-2'"):
+        _transform_external_field_to_internal_field(
+            "payload.turn.user_prompt_parts.-2",
+            all_columns=["payload_dump"],
+            json_columns=["payload"],
+        )
 
 
 def test_transform_external_field_to_internal_field():

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, TypeAlias
 
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import SortBy
+from weave.trace_server.errors import InvalidFieldError
 from weave.trace_server.interface import query as tsi_query
 
 param_builder_count = 0
@@ -686,6 +687,7 @@ def quote_json_path(path: str) -> str:
 
 
 def quote_json_path_parts(parts: list[str]) -> str:
+    assert_parsable_json_path(parts)
     parts_final = []
     for part in parts:
         try:
@@ -694,6 +696,23 @@ def quote_json_path_parts(parts: list[str]) -> str:
         except ValueError:
             parts_final.append('."' + part + '"')
     return "$" + "".join(parts_final)
+
+
+def assert_parsable_json_path(parts: list[str]) -> None:
+    """Reject path segments ClickHouse's JSON_VALUE grammar cannot parse.
+
+    A negative array index compiles to e.g. `[-1]`, which raises BAD_ARGUMENTS
+    in ClickHouse; surface it as a client-facing InvalidFieldError instead.
+    """
+    for part in parts:
+        try:
+            index = int(part)
+        except ValueError:
+            continue
+        if index < 0:
+            raise InvalidFieldError(
+                f"Negative array index {part!r} is not supported in JSON field paths"
+            )
 
 
 def _transform_external_field_to_internal_field(


### PR DESCRIPTION
A `getField` path with a negative array index (e.g. `inputs.turn.user_prompt_parts.-1`) compiled to `$."turn"."user_prompt_parts"[-1]`. ClickHouse's `JSON_VALUE` grammar can't parse negative indices and 502s the whole `/calls/query_stats` request ([DD trace](https://us5.datadoghq.com/apm/trace/6a42e63700000000f6a9a907a17aef0a)).

## Summary
- reject negative array indices at query-compile time as `InvalidFieldError` (HTTP 422) instead of letting ClickHouse 502, via a shared `assert_parsable_json_path` validator on the `quote_json_path_parts` chokepoint (covers filter + sort, all JSON dynamic fields).
- Jira: [WB-36507](https://coreweave.atlassian.net/browse/WB-36507)

## Testing
unit tests: validator rejects negative indices; calls query builder raises `InvalidFieldError` for both a filter and a sort on a negative-index path.


[WB-36507]: https://coreweave.atlassian.net/browse/WB-36507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ