### PR TITLE
chore(weave): drop dead op_name IS NULL arm from calls_complete queries

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -2395,8 +2395,7 @@ def test_total_storage_size_calls_complete(with_filter: bool):
                 SELECT calls_complete.id AS id
                 FROM calls_complete
                 PREWHERE calls_complete.project_id = {pb_2:String}
-                WHERE ((calls_complete.op_name IN {pb_1:Array(String)})
-                    OR (calls_complete.op_name IS NULL))
+                WHERE calls_complete.op_name IN {pb_1:Array(String)}
                     AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
                 LIMIT 50
             )
@@ -2427,8 +2426,7 @@ def test_total_storage_size_calls_complete(with_filter: bool):
             GROUP BY trace_id) AS rolled_up_cms
             ON calls_complete.trace_id = rolled_up_cms.trace_id
             PREWHERE calls_complete.project_id = {pb_2:String}
-            WHERE ((calls_complete.op_name IN {pb_5:Array(String)})
-                OR (calls_complete.op_name IS NULL))
+            WHERE calls_complete.op_name IN {pb_5:Array(String)}
                 AND (calls_complete.deleted_at = {pb_4:DateTime64(3)})
             LIMIT 50
             """,
@@ -3899,8 +3897,7 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
             calls_complete.ended_at AS ended_at
         FROM calls_complete
         PREWHERE calls_complete.project_id = {pb_12:String}
-        WHERE ((calls_complete.op_name IN {pb_3:Array(String)})
-                OR (calls_complete.op_name IS NULL))
+        WHERE calls_complete.op_name IN {pb_3:Array(String)}
             AND (calls_complete.trace_id = {pb_4:String})
         AND (
             ((toInt64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.summary_dump, {pb_0:String}), 'null'), '')) > {pb_1:Int64}))
@@ -4522,8 +4519,7 @@ def test_stats_query_calls_complete_flat_count_with_filter() -> None:
         SELECT count() AS count, toUInt8(0) AS has_more
         FROM calls_complete
         PREWHERE calls_complete.project_id = {pb_2:String}
-        WHERE ((calls_complete.op_name IN {pb_1:Array(String)})
-               OR (calls_complete.op_name IS NULL))
+        WHERE calls_complete.op_name IN {pb_1:Array(String)}
           AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
         """,
         {

--- a/tests/trace_server/query_builder/test_costs_query.py
+++ b/tests/trace_server/query_builder/test_costs_query.py
@@ -701,8 +701,7 @@ def test_query_calls_complete_with_costs_light_fields() -> None:
           (SELECT calls_complete.id AS id,
                   calls_complete.started_at AS started_at
            FROM calls_complete PREWHERE calls_complete.project_id = {pb_2:String}
-           WHERE ((calls_complete.op_name IN {pb_1:Array(String)})
-                  OR (calls_complete.op_name IS NULL))
+           WHERE calls_complete.op_name IN {pb_1:Array(String)}
              AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})),
              llm_usage AS
           (-- From the all_calls we get the usage data for LLMs

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1385,7 +1385,9 @@ class CallsQuery(BaseModel):
         # all rows returned at least have a call start. op_name is the orphan-end
         # signal (start-only) because started_at now rides on call_end rows too.
 
-        op_name = process_op_name_filter_to_sql(self.hardcoded_filter, pb, table_alias)
+        op_name = process_op_name_filter_to_sql(
+            self.hardcoded_filter, pb, table_alias, self.read_table
+        )
         trace_id = process_trace_id_filter_to_sql(
             self.hardcoded_filter, pb, table_alias, self.read_table
         )
@@ -2491,6 +2493,7 @@ def process_op_name_filter_to_sql(
     hardcoded_filter: HardCodedFilter | None,
     param_builder: ParamBuilder,
     table_alias: str,
+    read_table: ReadTable,
 ) -> str:
     """Pulls out the op_name and returns a sql string if there are any op_names."""
     if hardcoded_filter is None or not hardcoded_filter.filter.op_names:
@@ -2532,8 +2535,10 @@ def process_op_name_filter_to_sql(
     if not or_conditions:
         return ""
 
-    # Account for unmerged call parts by including null op_name (call ends)
-    or_conditions += [f"{op_field_sql} IS NULL"]
+    # calls_merged's call-end rows carry a NULL op_name, so the OR-IS-NULL arm
+    # keeps them; calls_complete's op_name is non-nullable, so skip the dead arm.
+    if read_table == ReadTable.CALLS_MERGED:
+        or_conditions.append(f"{op_field_sql} IS NULL")
 
     return " AND " + combine_conditions(or_conditions, "OR")
 


### PR DESCRIPTION
## Summary
- `op_name` is non-nullable in `calls_complete` (one complete row per call), so the `OR op_name IS NULL` arm we emit on every op_names filter is dead SQL there. It exists to keep `calls_merged`'s split call-end rows (NULL op_name).
- `process_op_name_filter_to_sql` now takes `read_table` and only adds the arm for `CALLS_MERGED`, mirroring `process_trace_id_filter_to_sql`. `calls_merged` is unchanged.

## Testing
existing query-builder/cost SQL assertions updated for calls_complete; calls_merged assertions unchanged.