### PR TITLE
fix(weave): surface system instructions from chat spans in agent chat view

### DIFF
--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -386,6 +386,141 @@ def test_anonymous_invoke_without_metadata_skips_empty_agent_start() -> None:
     assert messages[0].agent_name is None
 
 
+def test_content_span_system_instructions_surface_as_agent_start() -> None:
+    """System instructions logged on a bare chat span (no invoke_agent) still
+    reach the chat view via a synthesized agent_start card.
+    """
+    messages = build_chat_messages(
+        [
+            _span(
+                span_id="chat",
+                operation_name="chat",
+                request_model="gpt-4o",
+                system_instructions=["You are helpful."],
+                output_messages=[{"role": "assistant", "content": "hello"}],
+            )
+        ]
+    )
+
+    assert [m.type for m in messages] == ["agent_start", "assistant_message"]
+    agent_start = _agent_start_payload(messages[0])
+    assert agent_start.system_instructions == "You are helpful."
+    assert agent_start.model == "gpt-4o"
+
+
+def test_content_span_system_instructions_deduped_across_turns() -> None:
+    """The same system prompt replayed on every turn's chat span renders once."""
+    spans = [
+        _span(
+            span_id=f"chat{i}",
+            operation_name="chat",
+            system_instructions=["You are helpful."],
+            input_messages=[{"role": "user", "content": f"q{i}"}],
+            output_messages=[{"role": "assistant", "content": f"a{i}"}],
+            started_at=datetime.datetime(
+                2026, 1, 1, 0, 0, i, tzinfo=datetime.timezone.utc
+            ),
+        )
+        for i in range(3)
+    ]
+
+    messages = build_chat_messages(spans)
+
+    assert [m.type for m in messages].count("agent_start") == 1
+
+
+def test_content_span_system_instructions_change_emits_new_card() -> None:
+    """A genuinely changed system prompt mid-conversation emits a fresh card."""
+    spans = [
+        _span(
+            span_id="chat0",
+            operation_name="chat",
+            system_instructions=["You are helpful."],
+            output_messages=[{"role": "assistant", "content": "a0"}],
+            started_at=datetime.datetime(
+                2026, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+        ),
+        _span(
+            span_id="chat1",
+            operation_name="chat",
+            system_instructions=["You are terse."],
+            output_messages=[{"role": "assistant", "content": "a1"}],
+            started_at=datetime.datetime(
+                2026, 1, 1, 0, 0, 1, tzinfo=datetime.timezone.utc
+            ),
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+
+    starts = [m for m in messages if m.type == "agent_start"]
+    assert [_agent_start_payload(m).system_instructions for m in starts] == [
+        "You are helpful.",
+        "You are terse.",
+    ]
+
+
+def test_invoke_agent_system_instructions_suppress_descendant_duplicate() -> None:
+    """An invoke_agent's system instructions are not re-emitted by a descendant
+    chat span that replays the same prompt.
+    """
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            span_name="invoke_agent",
+            system_instructions=["You are helpful."],
+        ),
+        _span(
+            span_id="chat",
+            parent_span_id="agent",
+            operation_name="chat",
+            system_instructions=["You are helpful."],
+            output_messages=[{"role": "assistant", "content": "hello"}],
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+
+    assert [m.type for m in messages].count("agent_start") == 1
+
+
+def test_invoke_agent_without_prompt_absorbs_descendant_system_instructions() -> None:
+    """A bare invoke_agent agent_start (identity, no prompt) absorbs a child
+    chat span's system instructions instead of emitting a second card.
+
+    Mirrors the prod WB Agent shape: invoke_agent carries the agent name but no
+    instructions, and the prompt is recorded on the child chat span.
+    """
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            span_name="invoke_agent WB Agent",
+            agent_name="WB Agent",
+        ),
+        _span(
+            span_id="chat",
+            parent_span_id="agent",
+            operation_name="chat",
+            agent_name="WB Agent",
+            request_model="gpt-5.5",
+            system_instructions=["You are ARIA."],
+            output_messages=[{"role": "assistant", "content": "hello"}],
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+
+    starts = [m for m in messages if m.type == "agent_start"]
+    assert len(starts) == 1
+    payload = _agent_start_payload(starts[0])
+    assert payload.system_instructions == "You are ARIA."
+    # Model is folded in from the chat span when the invoke_agent lacked one.
+    assert payload.model == "gpt-5.5"
+
+
 def test_build_span_tree_handles_null_started_at() -> None:
     """build_span_tree must not crash when a span has started_at=None.
 

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -260,6 +260,17 @@ class ChatTraversal:
     # (text, media-digests) of the most recently emitted user message, so the
     # same message replayed by a following LLM span is not emitted twice.
     _last_user_sig: tuple[str, tuple[str, ...]] | None = None
+    # The system-instructions text most recently surfaced (from either an
+    # invoke_agent or a content span), so the same instructions replayed on
+    # every turn's LLM span render once, not once per call. None until the
+    # first instructions are emitted.
+    _last_system_instructions: str | None = None
+    # A just-emitted agent_start that carries an agent identity but no system
+    # prompt (some SDKs record the prompt on the child LLM span, not the
+    # invoke_agent span). A descendant content span's instructions fold into it
+    # rather than emitting a redundant second card. Reset per invoke_agent and
+    # cleared at the turn boundary (user message).
+    _pending_agent_start: AgentChatMessage | None = None
 
     def walk_roots(self, roots: list[SpanNode]) -> None:
         for root in roots:
@@ -295,22 +306,27 @@ class ChatTraversal:
             # TODO: Move type-specific payload construction into AgentChat*
             # constructors once this projection stabilizes, so traversal
             # methods only encode ordering/suppression policy.
-            self.messages.append(
-                AgentChatMessage(
-                    type="agent_start",
-                    span_id=span.span_id,
-                    agent_name=agent_start_label,
-                    agent_version=span.agent_version,
-                    status_code=span.status_code,
-                    started_at=span.started_at,
-                    agent_start=AgentChatAgentStart(
-                        model=span.request_model,
-                        status=span.status_code,
-                        system_instructions=_join_or_none(span.system_instructions),
-                        tool_definitions=span.tool_definitions or None,
-                    ),
-                )
+            instructions = _join_or_none(span.system_instructions)
+            if instructions:
+                self._last_system_instructions = instructions
+            start_msg = AgentChatMessage(
+                type="agent_start",
+                span_id=span.span_id,
+                agent_name=agent_start_label,
+                agent_version=span.agent_version,
+                status_code=span.status_code,
+                started_at=span.started_at,
+                agent_start=AgentChatAgentStart(
+                    model=span.request_model,
+                    status=span.status_code,
+                    system_instructions=instructions,
+                    tool_definitions=span.tool_definitions or None,
+                ),
             )
+            self.messages.append(start_msg)
+            # When the invoke_agent span carried no system prompt, let a
+            # descendant content span fold its instructions into this card.
+            self._pending_agent_start = None if instructions else start_msg
         else:
             logger.debug(
                 "invoke_agent span without agent identity or lifecycle metadata (span_id=%s)",
@@ -384,6 +400,7 @@ class ChatTraversal:
         """
         span = node.span
         agent_name = _agent_label(span, nearest_agent)
+        self._emit_system_instructions(span, agent_name)
         self._emit_user_turn(span)
         subtree_emitted_assistant = self._walk_children(
             node, nearest_agent=agent_name, depth=depth
@@ -396,6 +413,62 @@ class ChatTraversal:
         assistant = msg.assistant_message
         emitted_text = bool(assistant and assistant.text)
         return emitted_text or subtree_emitted_assistant
+
+    def _emit_system_instructions(
+        self, span: AgentSpanSchema, agent_name: str | None
+    ) -> None:
+        """Surface a content span's system instructions as an agent_start card.
+
+        Providers that instrument plain LLM/chat spans (with no enclosing
+        `invoke_agent` span) record ``gen_ai.system_instructions`` on each call.
+        Those instructions are extracted onto every span, but only
+        `_walk_invoke_agent` previously read them, so traces built from bare
+        chat spans dropped their system prompt entirely. Reuse the `agent_start`
+        card the UI already renders for system instructions.
+
+        Deduped against the last-surfaced instructions (set here and by
+        `_walk_invoke_agent`) so the prompt replayed on every turn's span shows
+        once, not once per call; a genuinely changed prompt emits a new card.
+
+        When the enclosing invoke_agent already emitted a bare agent_start for
+        this turn (agent identity but no prompt), the instructions fold into
+        that card instead of emitting a redundant second one.
+        """
+        instructions = _join_or_none(span.system_instructions)
+        if not instructions or instructions == self._last_system_instructions:
+            return
+        self._last_system_instructions = instructions
+
+        pending = self._pending_agent_start
+        self._pending_agent_start = None
+        if (
+            pending is not None
+            and pending.agent_start is not None
+            and pending.agent_name == agent_name
+        ):
+            pending.agent_start.system_instructions = instructions
+            if pending.agent_start.model is None:
+                pending.agent_start.model = span.request_model
+            if pending.agent_start.tool_definitions is None:
+                pending.agent_start.tool_definitions = span.tool_definitions or None
+            return
+
+        self.messages.append(
+            AgentChatMessage(
+                type="agent_start",
+                span_id=span.span_id,
+                agent_name=agent_name,
+                agent_version=span.agent_version,
+                status_code=span.status_code,
+                started_at=span.started_at,
+                agent_start=AgentChatAgentStart(
+                    model=span.request_model,
+                    status=span.status_code,
+                    system_instructions=instructions,
+                    tool_definitions=span.tool_definitions or None,
+                ),
+            )
+        )
 
     def _emit_user_turn(self, span: AgentSpanSchema) -> None:
         """Emit the user message(s) for the new turn this LLM span answers.
@@ -423,6 +496,9 @@ class ChatTraversal:
                 continue
             self._last_user_sig = sig
             self.emitted_user = True
+            # A user message marks a new turn; an unfilled agent_start from an
+            # earlier turn must not absorb this turn's instructions.
+            self._pending_agent_start = None
             self.messages.append(
                 AgentChatMessage(
                     type="user_message",


### PR DESCRIPTION
## Problem

System instructions are logged on spans but don't appear in the Agents-tab conversation (chat) view for some traces.

The chat-view projection (`chat_view.py`) only read `system_instructions` off `invoke_agent` spans, where they're attached to the `agent_start` card the UI renders. But `system_instructions` is extracted onto **every** GenAI span (`genai_extraction.py`), so traces instrumented as plain LLM/chat spans had their system prompt silently dropped from the chat view even though it was present on the spans. This is the common shape in prod — e.g. the **WB Agent**: the `invoke_agent` span carries the agent name but *no* prompt, and the prompt is recorded on each child `chat` span. The frontend renderer was never the issue.

## Fix

Surface system instructions from content (LLM/chat) spans too, reusing the same `agent_start` card the UI already renders (`AgentChatView` reads `agent_start.system_instructions`).

- **Fold, don't duplicate:** when the enclosing `invoke_agent` already emitted a bare `agent_start` for the turn (agent identity, no prompt), the chat span's instructions fold into that card instead of emitting a redundant second one.
- **Dedup:** tracked against the last-surfaced instructions (set by both the `invoke_agent` and content-span paths) so a prompt replayed on every turn's span shows once, not once per call; a genuinely changed prompt emits a new card.

## Verification against a real prod conversation

Pulled the raw spans for a 23-turn `wb-agent-team/wandb-agent-prod` conversation and ran them through the projection:

- Instructions are stored on the `chat` spans via the `gen_ai.system_instructions` attribute; `invoke_agent` spans carry empty instructions.
- **Before:** 0 system-instruction cards (dropped).
- **After:** exactly 1 per turn, folded into the turn's existing `agent_start` — no duplicate cards, no double section headers. Each turn renders `[user_message, agent_start(+system), ...]`.

## Tests

Added coverage in `test_genai_chat_view.py`:
- content-span system instructions surface as an `agent_start` card
- identical instructions across turns are deduped to a single card
- a changed prompt mid-conversation emits a new card
- an `invoke_agent`'s instructions suppress a descendant chat span's duplicate
- a bare `invoke_agent` agent_start absorbs a descendant chat span's instructions (the prod WB Agent shape)

All 32 tests in the file pass; `nox -e lint` passes.

## Not covered (follow-up)

System instructions logged as a `system`-role entry *inside* `input_messages` (rather than via the `gen_ai.system_instructions` attribute) are still filtered out by `_NON_USER_PROMPT_ROLES`. The verified prod conversation does not use that shape, so it's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)