### PR TITLE
chore(weave): deprecate add_event / addEvent

### DIFF
--- a/sdks/node/src/genai/spanBase.ts
+++ b/sdks/node/src/genai/spanBase.ts
@@ -72,8 +72,8 @@ export abstract class SpanBase {
    * no-ops after `end()`. Mirrors OTel `Span.addEvent`.
    *
    * @deprecated Record this data via {@link setAttributes} instead.
-   * OpenTelemetry is phasing out the Span Event API (`Span.addEvent`; OTEP
-   * 4430). This method still works and existing span-event data stays valid.
+   * OpenTelemetry is phasing out the Span Event API (`Span.addEvent`). This
+   * method still works and existing span-event data stays valid.
    * See https://opentelemetry.io/blog/2026/deprecating-span-events/
    *
    * @example

--- a/sdks/node/src/genai/spanBase.ts
+++ b/sdks/node/src/genai/spanBase.ts
@@ -73,10 +73,7 @@ export abstract class SpanBase {
    *
    * @deprecated Record this data via {@link setAttributes} instead.
    * OpenTelemetry is phasing out the Span Event API (`Span.addEvent`; OTEP
-   * 4430) in favor of log-based events, but Weave has no Logs API surface yet,
-   * so prefer span attributes — which Weave already surfaces — for the
-   * marker/lifecycle data this recorded. This method still works and existing
-   * span-event data stays valid.
+   * 4430). This method still works and existing span-event data stays valid.
    *
    * @example
    * span.addEvent('context_compacted', {removedMessages: 12});

--- a/sdks/node/src/genai/spanBase.ts
+++ b/sdks/node/src/genai/spanBase.ts
@@ -71,12 +71,12 @@ export abstract class SpanBase {
    * context compaction, tool-loop detection, or guardrail trips. Warns and
    * no-ops after `end()`. Mirrors OTel `Span.addEvent`.
    *
-   * @deprecated OpenTelemetry is phasing out the Span Event API
-   * (`Span.addEvent`) in favor of log-based events emitted via the Logs API
-   * (OTEP 4430). This method still works and existing span-event data stays
-   * valid; there is no Weave replacement yet, so no action is required today.
-   * Forward-looking marker — the upstream OTel SDKs have not removed
-   * `Span.addEvent`, and a Weave log-based-events API is planned.
+   * @deprecated Record this data via {@link setAttributes} instead.
+   * OpenTelemetry is phasing out the Span Event API (`Span.addEvent`; OTEP
+   * 4430) in favor of log-based events, but Weave has no Logs API surface yet,
+   * so prefer span attributes — which Weave already surfaces — for the
+   * marker/lifecycle data this recorded. This method still works and existing
+   * span-event data stays valid.
    *
    * @example
    * span.addEvent('context_compacted', {removedMessages: 12});

--- a/sdks/node/src/genai/spanBase.ts
+++ b/sdks/node/src/genai/spanBase.ts
@@ -74,6 +74,7 @@ export abstract class SpanBase {
    * @deprecated Record this data via {@link setAttributes} instead.
    * OpenTelemetry is phasing out the Span Event API (`Span.addEvent`; OTEP
    * 4430). This method still works and existing span-event data stays valid.
+   * See https://opentelemetry.io/blog/2026/deprecating-span-events/
    *
    * @example
    * span.addEvent('context_compacted', {removedMessages: 12});

--- a/sdks/node/src/genai/spanBase.ts
+++ b/sdks/node/src/genai/spanBase.ts
@@ -71,6 +71,13 @@ export abstract class SpanBase {
    * context compaction, tool-loop detection, or guardrail trips. Warns and
    * no-ops after `end()`. Mirrors OTel `Span.addEvent`.
    *
+   * @deprecated OpenTelemetry is phasing out the Span Event API
+   * (`Span.addEvent`) in favor of log-based events emitted via the Logs API
+   * (OTEP 4430). This method still works and existing span-event data stays
+   * valid; there is no Weave replacement yet, so no action is required today.
+   * Forward-looking marker — the upstream OTel SDKs have not removed
+   * `Span.addEvent`, and a Weave log-based-events API is planned.
+   *
    * @example
    * span.addEvent('context_compacted', {removedMessages: 12});
    */

--- a/tests/conversation/test_span_attributes.py
+++ b/tests/conversation/test_span_attributes.py
@@ -121,14 +121,14 @@ def test_add_event_no_op_after_end(
 def test_add_event_emits_deprecation_warning(
     otel_spans: InMemorySpanExporter,
 ) -> None:
-    """``add_event`` is deprecated (OTel Span Event API / OTEP 4430) yet still records.
+    """``add_event`` is deprecated in favor of ``set_attributes`` yet still records.
 
     The deprecation lives on ``_SpanBase`` so a single span class exercises it,
     matching the warning tests below. The event is still emitted — deprecation
     only marks direction; the method keeps working.
     """
     with Conversation(conversation_id="test-conversation"), Tool(name="t") as tool:
-        with pytest.warns(DeprecationWarning, match="Span Event API"):
+        with pytest.warns(DeprecationWarning, match="set_attributes"):
             tool.add_event("weave.evt", {"event_key": "event_value"})
     finished_span = _only_span(otel_spans.get_finished_spans(), "execute_tool t")
     assert len(finished_span.events) == 1

--- a/tests/conversation/test_span_attributes.py
+++ b/tests/conversation/test_span_attributes.py
@@ -118,6 +118,24 @@ def test_add_event_no_op_after_end(
     assert len(finished_span.events) == 0
 
 
+def test_add_event_emits_deprecation_warning(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    """``add_event`` is deprecated (OTel Span Event API / OTEP 4430) yet still records.
+
+    The deprecation lives on ``_SpanBase`` so a single span class exercises it,
+    matching the warning tests below. The event is still emitted — deprecation
+    only marks direction; the method keeps working.
+    """
+    with Conversation(conversation_id="test-conversation"), Tool(name="t") as tool:
+        with pytest.warns(DeprecationWarning, match="Span Event API"):
+            tool.add_event("weave.evt", {"event_key": "event_value"})
+    finished_span = _only_span(otel_spans.get_finished_spans(), "execute_tool t")
+    assert len(finished_span.events) == 1
+    assert finished_span.events[0].name == "weave.evt"
+    assert finished_span.events[0].attributes["event_key"] == "event_value"
+
+
 # ---------------------------------------------------------------------------
 # Cross-method: chaining + warning behavior
 # ---------------------------------------------------------------------------

--- a/weave/conversation/conversation.py
+++ b/weave/conversation/conversation.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from weave.conversation.conversation_otel import (
     execute_tool_attributes,
@@ -122,6 +122,24 @@ def _capture_info_attrs() -> dict[str, str]:
     every emit, matching ``@op`` semantics in ``weave_client.py``.
     """
     return {f"weave.{k}": v for k, v in get_capture_info().items()}
+
+
+# Forward-looking deprecation: OpenTelemetry is phasing out the Span Event API
+# (``Span.add_event`` / ``Span.record_exception``) in favor of log-based events
+# emitted through the Logs API — see OTEP 4430 and the March 2026 plan
+# (https://opentelemetry.io/blog/2026/span-event-api-deprecation/). We mark the
+# public ``add_event`` surface deprecated to signal direction. Note: the
+# upstream OTel SDKs have NOT removed ``Span.add_event``, and Weave has no
+# log-based-events replacement yet, so there is no migration target today — the
+# method keeps working and existing span-event data stays valid.
+_ADD_EVENT_DEPRECATION_MESSAGE = (
+    "`add_event` is deprecated. OpenTelemetry is phasing out the Span Event "
+    "API (`Span.add_event`) in favor of log-based events emitted via the Logs "
+    "API (OTEP 4430). This method still works and existing span-event data "
+    "stays valid; there is no Weave replacement yet, so no action is required "
+    "today. This is a forward-looking marker — the upstream OTel SDKs have not "
+    "removed `Span.add_event`, and a Weave log-based-events API is planned."
+)
 
 
 class _SpanBase(BaseModel):
@@ -243,6 +261,7 @@ class _SpanBase(BaseModel):
             span.set_attributes(attributes)
         return self
 
+    @deprecated(_ADD_EVENT_DEPRECATION_MESSAGE)
     def add_event(
         self,
         name: str,
@@ -250,6 +269,15 @@ class _SpanBase(BaseModel):
         timestamp: datetime | None = None,
     ) -> Self:
         """Record an OTel span event at a point in time within this span.
+
+        .. deprecated::
+            OpenTelemetry is phasing out the Span Event API
+            (``Span.add_event``) in favor of log-based events emitted via the
+            Logs API (OTEP 4430). This method still works and existing
+            span-event data stays valid, but the surface may change once Weave
+            ships a log-based-events replacement. No action is required today —
+            this is a forward-looking marker; the upstream OTel SDKs have not
+            removed ``Span.add_event``, and a Weave replacement is planned.
 
         Use for marker / lifecycle data — permission prompts (e.g.
         ``weave.permission_request``), lifecycle transitions (e.g.

--- a/weave/conversation/conversation.py
+++ b/weave/conversation/conversation.py
@@ -128,6 +128,7 @@ def _capture_info_attrs() -> dict[str, str]:
 # (``Span.add_event``; OTEP 4430), so we steer callers to ``set_attributes``,
 # which Weave already records and surfaces in the Agents tab. ``add_event``
 # still works and existing span-event data stays valid.
+# https://opentelemetry.io/blog/2026/deprecating-span-events/
 _ADD_EVENT_DEPRECATION_MESSAGE = (
     "`add_event` is deprecated; record this data with `set_attributes` instead. "
     "OpenTelemetry is phasing out the Span Event API (`Span.add_event`; OTEP 4430)."
@@ -266,6 +267,7 @@ class _SpanBase(BaseModel):
             Record this data with ``set_attributes`` instead. OpenTelemetry is
             phasing out the Span Event API (``Span.add_event``; OTEP 4430).
             ``add_event`` still works and existing span-event data stays valid.
+            See https://opentelemetry.io/blog/2026/deprecating-span-events/.
 
         Use for marker / lifecycle data — permission prompts (e.g.
         ``weave.permission_request``), lifecycle transitions (e.g.

--- a/weave/conversation/conversation.py
+++ b/weave/conversation/conversation.py
@@ -128,17 +128,19 @@ def _capture_info_attrs() -> dict[str, str]:
 # (``Span.add_event`` / ``Span.record_exception``) in favor of log-based events
 # emitted through the Logs API — see OTEP 4430 ("Span Event API deprecation
 # plan") and the OpenTelemetry blog "Deprecating Span Events API" (March 2026).
-# We mark the public ``add_event`` surface deprecated to signal direction. Note:
-# the upstream OTel SDKs have NOT removed ``Span.add_event``, and Weave has no
-# log-based-events replacement yet, so there is no migration target today — the
-# method keeps working and existing span-event data stays valid.
+# Weave has no Logs API surface yet, so we steer callers to ``set_attributes``
+# instead: span attributes are recorded today and surface in the Agents tab.
+# (This diverges from OTel's logs-as-events end-state — a pragmatic choice while
+# Weave lacks a Logs API, and a fine fit since this records one-shot markers.)
+# The upstream OTel SDKs have NOT removed ``Span.add_event``; the method keeps
+# working and existing span-event data stays valid.
 _ADD_EVENT_DEPRECATION_MESSAGE = (
-    "`add_event` is deprecated. OpenTelemetry is phasing out the Span Event "
-    "API (`Span.add_event`) in favor of log-based events emitted via the Logs "
-    "API (OTEP 4430). This method still works and existing span-event data "
-    "stays valid; there is no Weave replacement yet, so no action is required "
-    "today. This is a forward-looking marker — the upstream OTel SDKs have not "
-    "removed `Span.add_event`, and a Weave log-based-events API is planned."
+    "`add_event` is deprecated; record this data with `set_attributes` instead. "
+    "OpenTelemetry is phasing out the Span Event API (`Span.add_event`; OTEP "
+    "4430) in favor of log-based events, but Weave has no Logs API surface yet, "
+    "so prefer span attributes — which Weave already surfaces — for the "
+    "marker/lifecycle data this recorded. The method still works and existing "
+    "span-event data stays valid."
 )
 
 
@@ -271,13 +273,13 @@ class _SpanBase(BaseModel):
         """Record an OTel span event at a point in time within this span.
 
         .. deprecated::
-            OpenTelemetry is phasing out the Span Event API
-            (``Span.add_event``) in favor of log-based events emitted via the
-            Logs API (OTEP 4430). This method still works and existing
-            span-event data stays valid, but the surface may change once Weave
-            ships a log-based-events replacement. No action is required today —
-            this is a forward-looking marker; the upstream OTel SDKs have not
-            removed ``Span.add_event``, and a Weave replacement is planned.
+            Record this data with ``set_attributes`` instead. OpenTelemetry is
+            phasing out the Span Event API (``Span.add_event``) in favor of
+            log-based events (OTEP 4430); Weave has no Logs API surface yet, so
+            prefer span attributes — which Weave already surfaces — for the
+            marker / lifecycle data this was used for. The method still works
+            and existing span-event data stays valid; the upstream OTel SDKs
+            have not removed ``Span.add_event``.
 
         Use for marker / lifecycle data — permission prompts (e.g.
         ``weave.permission_request``), lifecycle transitions (e.g.

--- a/weave/conversation/conversation.py
+++ b/weave/conversation/conversation.py
@@ -125,22 +125,12 @@ def _capture_info_attrs() -> dict[str, str]:
 
 
 # Forward-looking deprecation: OpenTelemetry is phasing out the Span Event API
-# (``Span.add_event`` / ``Span.record_exception``) in favor of log-based events
-# emitted through the Logs API — see OTEP 4430 ("Span Event API deprecation
-# plan") and the OpenTelemetry blog "Deprecating Span Events API" (March 2026).
-# Weave has no Logs API surface yet, so we steer callers to ``set_attributes``
-# instead: span attributes are recorded today and surface in the Agents tab.
-# (This diverges from OTel's logs-as-events end-state — a pragmatic choice while
-# Weave lacks a Logs API, and a fine fit since this records one-shot markers.)
-# The upstream OTel SDKs have NOT removed ``Span.add_event``; the method keeps
-# working and existing span-event data stays valid.
+# (``Span.add_event``; OTEP 4430), so we steer callers to ``set_attributes``,
+# which Weave already records and surfaces in the Agents tab. ``add_event``
+# still works and existing span-event data stays valid.
 _ADD_EVENT_DEPRECATION_MESSAGE = (
     "`add_event` is deprecated; record this data with `set_attributes` instead. "
-    "OpenTelemetry is phasing out the Span Event API (`Span.add_event`; OTEP "
-    "4430) in favor of log-based events, but Weave has no Logs API surface yet, "
-    "so prefer span attributes — which Weave already surfaces — for the "
-    "marker/lifecycle data this recorded. The method still works and existing "
-    "span-event data stays valid."
+    "OpenTelemetry is phasing out the Span Event API (`Span.add_event`; OTEP 4430)."
 )
 
 
@@ -274,12 +264,8 @@ class _SpanBase(BaseModel):
 
         .. deprecated::
             Record this data with ``set_attributes`` instead. OpenTelemetry is
-            phasing out the Span Event API (``Span.add_event``) in favor of
-            log-based events (OTEP 4430); Weave has no Logs API surface yet, so
-            prefer span attributes — which Weave already surfaces — for the
-            marker / lifecycle data this was used for. The method still works
-            and existing span-event data stays valid; the upstream OTel SDKs
-            have not removed ``Span.add_event``.
+            phasing out the Span Event API (``Span.add_event``; OTEP 4430).
+            ``add_event`` still works and existing span-event data stays valid.
 
         Use for marker / lifecycle data — permission prompts (e.g.
         ``weave.permission_request``), lifecycle transitions (e.g.

--- a/weave/conversation/conversation.py
+++ b/weave/conversation/conversation.py
@@ -126,10 +126,10 @@ def _capture_info_attrs() -> dict[str, str]:
 
 # Forward-looking deprecation: OpenTelemetry is phasing out the Span Event API
 # (``Span.add_event`` / ``Span.record_exception``) in favor of log-based events
-# emitted through the Logs API — see OTEP 4430 and the March 2026 plan
-# (https://opentelemetry.io/blog/2026/span-event-api-deprecation/). We mark the
-# public ``add_event`` surface deprecated to signal direction. Note: the
-# upstream OTel SDKs have NOT removed ``Span.add_event``, and Weave has no
+# emitted through the Logs API — see OTEP 4430 ("Span Event API deprecation
+# plan") and the OpenTelemetry blog "Deprecating Span Events API" (March 2026).
+# We mark the public ``add_event`` surface deprecated to signal direction. Note:
+# the upstream OTel SDKs have NOT removed ``Span.add_event``, and Weave has no
 # log-based-events replacement yet, so there is no migration target today — the
 # method keeps working and existing span-event data stays valid.
 _ADD_EVENT_DEPRECATION_MESSAGE = (

--- a/weave/conversation/conversation.py
+++ b/weave/conversation/conversation.py
@@ -125,13 +125,13 @@ def _capture_info_attrs() -> dict[str, str]:
 
 
 # Forward-looking deprecation: OpenTelemetry is phasing out the Span Event API
-# (``Span.add_event``; OTEP 4430), so we steer callers to ``set_attributes``,
+# (``Span.add_event``), so we steer callers to ``set_attributes``,
 # which Weave already records and surfaces in the Agents tab. ``add_event``
 # still works and existing span-event data stays valid.
 # https://opentelemetry.io/blog/2026/deprecating-span-events/
 _ADD_EVENT_DEPRECATION_MESSAGE = (
     "`add_event` is deprecated; record this data with `set_attributes` instead. "
-    "OpenTelemetry is phasing out the Span Event API (`Span.add_event`; OTEP 4430)."
+    "OpenTelemetry is phasing out the Span Event API (`Span.add_event`)."
 )
 
 
@@ -265,7 +265,7 @@ class _SpanBase(BaseModel):
 
         .. deprecated::
             Record this data with ``set_attributes`` instead. OpenTelemetry is
-            phasing out the Span Event API (``Span.add_event``; OTEP 4430).
+            phasing out the Span Event API (``Span.add_event``).
             ``add_event`` still works and existing span-event data stays valid.
             See https://opentelemetry.io/blog/2026/deprecating-span-events/.
 


### PR DESCRIPTION
Marks the public span-event methods deprecated in both SDKs; use `set_attributes` / `setAttributes` instead.

- **Python** — `_SpanBase.add_event` (inherited by `Tool` / `LLM` / `SubAgent` / `Turn`) via `typing_extensions.deprecated`; emits a `DeprecationWarning` and is flagged by type checkers / IDEs.
- **TypeScript** — `SpanBase.addEvent` via JSDoc `@deprecated` (static/IDE only; no runtime warning, matching existing TS deprecations).

**Why:** OpenTelemetry is [phasing out the Span Event API](https://opentelemetry.io/blog/2026/deprecating-span-events/) (`Span.addEvent`). We steer callers to span attributes, which Weave already records and surfaces in the Agents tab.

Both methods still work and existing span-event data stays valid. Opened as **draft** because upstream OTel SDKs haven't removed `Span.addEvent` yet — this is forward-looking.

**Testing:** 28 Python conversation tests pass (incl. a new `DeprecationWarning` assertion); 39 TS genai tests pass; ruff + prettier clean.
