### PR TITLE
feat(weave): add migration 036 TTL for objects, table_rows, files

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -1875,3 +1875,35 @@ def test_split_migration_sql_equivalent_on_all_shipped_migrations() -> None:
             f"  old ({len(old_norm)}): {old_norm}\n"
             f"  new ({len(new_norm)}): {new_norm}"
         )
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_local_only"),
+    [
+        # Column TTL (migration 036) must skip the distributed twin.
+        (
+            "ALTER TABLE object_versions MODIFY COLUMN val_dump String TTL toDateTime(expire_at)",
+            True,
+        ),
+        ("ALTER TABLE object_versions MODIFY COLUMN val_dump REMOVE TTL", True),
+        # Table TTL and indexes/mutations stay local-only as before.
+        ("ALTER TABLE files MODIFY TTL toDateTime(expire_at) DELETE", True),
+        ("ALTER TABLE files REMOVE TTL", True),
+        ("ALTER TABLE calls_merged ADD INDEX idx id TYPE bloom_filter", True),
+        ("ALTER TABLE calls_merged DELETE WHERE id = 'x'", True),
+        # Column add and plain type change apply to both local and distributed.
+        (
+            "ALTER TABLE object_versions ADD COLUMN expire_at DateTime64(3) DEFAULT toDateTime64('2100-01-01 00:00:00', 3)",
+            False,
+        ),
+        ("ALTER TABLE object_versions MODIFY COLUMN val_dump String", False),
+        ("ALTER TABLE files DROP COLUMN expire_at", False),
+        # A column literally named `ttl` must not be mistaken for a TTL clause.
+        ("ALTER TABLE x MODIFY COLUMN ttl Int32", False),
+    ],
+)
+def test_is_local_only_operation_classifies_column_ttl(command, expected_local_only):
+    assert (
+        DistributedClickHouseTraceServerMigrator._is_local_only_operation(command)
+        is expected_local_only
+    )

--- a/tests/trace_server/test_ttl_insert_paths.py
+++ b/tests/trace_server/test_ttl_insert_paths.py
@@ -385,3 +385,74 @@ def test_project_ttl_settings_endpoints_round_trip(trace_server):
                 wb_user_id=None,
             )
         )
+
+
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: SHOW CREATE TABLE TTL clauses"
+)
+def test_migration_036_ttl_clauses_present(internal_server):
+    """object_versions/table_rows clear val_dump via column TTL; files row-TTLs.
+
+    Asserts the full SHOW CREATE DDL of each table: objects/table_rows carry a
+    column TTL on val_dump + the expire_at sentinel column, files carries the
+    expire_at column + a table-level row TTL (no column TTL on val_bytes).
+    """
+    server = internal_server
+    db = server.ch_client.database
+
+    def show_create(table: str) -> str:
+        return server.ch_client.query(f"SHOW CREATE TABLE {table}").result_rows[0][0]
+
+    assert show_create("object_versions") == (
+        f"CREATE TABLE {db}.object_versions\n"
+        "(\n"
+        "    `project_id` String,\n"
+        "    `object_id` String,\n"
+        "    `kind` Enum8('op' = 1, 'object' = 2),\n"
+        "    `base_object_class` Nullable(String),\n"
+        "    `refs` Array(String),\n"
+        "    `val_dump` String TTL toDateTime(expire_at),\n"
+        "    `digest` String,\n"
+        "    `created_at` DateTime64(3) DEFAULT now64(3),\n"
+        "    `deleted_at` Nullable(DateTime64(3)) DEFAULT NULL,\n"
+        "    `wb_user_id` Nullable(String) DEFAULT NULL,\n"
+        "    `leaf_object_class` Nullable(String) DEFAULT NULL,\n"
+        "    `expire_at` DateTime64(3) DEFAULT toDateTime64('2100-01-01 00:00:00', 3)\n"
+        ")\n"
+        "ENGINE = ReplacingMergeTree\n"
+        "ORDER BY (project_id, kind, object_id, digest)\n"
+        "SETTINGS index_granularity = 8192"
+    )
+    assert show_create("table_rows") == (
+        f"CREATE TABLE {db}.table_rows\n"
+        "(\n"
+        "    `project_id` String,\n"
+        "    `digest` String,\n"
+        "    `refs` Array(String),\n"
+        "    `val_dump` String TTL toDateTime(expire_at),\n"
+        "    `created_at` DateTime64(3) DEFAULT now64(3),\n"
+        "    `expire_at` DateTime64(3) DEFAULT toDateTime64('2100-01-01 00:00:00', 3)\n"
+        ")\n"
+        "ENGINE = ReplacingMergeTree\n"
+        "ORDER BY (project_id, digest)\n"
+        "SETTINGS index_granularity = 8192"
+    )
+    assert show_create("files") == (
+        f"CREATE TABLE {db}.files\n"
+        "(\n"
+        "    `project_id` String,\n"
+        "    `digest` String,\n"
+        "    `chunk_index` UInt32,\n"
+        "    `n_chunks` UInt32,\n"
+        "    `name` String,\n"
+        "    `val_bytes` String,\n"
+        "    `created_at` DateTime64(3) DEFAULT now64(3),\n"
+        "    `bytes_stored` Nullable(UInt32),\n"
+        "    `file_storage_uri` Nullable(String),\n"
+        "    `expire_at` DateTime64(3) DEFAULT toDateTime64('2100-01-01 00:00:00', 3)\n"
+        ")\n"
+        "ENGINE = ReplacingMergeTree\n"
+        "ORDER BY (project_id, digest, chunk_index)\n"
+        "TTL toDateTime(expire_at)\n"
+        "SETTINGS index_granularity = 8192"
+    )

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -1645,8 +1645,13 @@ class SQLPatterns:
     INSERT_SELECT_STMT: Pattern = re.compile(
         r"\bINSERT\s+INTO\b.*\bSELECT\b", re.IGNORECASE | re.DOTALL
     )
+    # Column-level TTL (MODIFY COLUMN <name> ... TTL) is local-only like table
+    # TTL: distributed tables reject TTL, so it must skip the distributed twin.
+    # The (?!TTL) lookahead excludes a column literally named `ttl`; a TTL token
+    # inside a DEFAULT string literal is not distinguished (no such migration).
     LOCAL_ONLY_OPS: Pattern = re.compile(
-        r"\b(ADD|DROP)\s+INDEX\b|\b(DELETE|UPDATE)\b|\b(MODIFY|REMOVE)\s+TTL\b",
+        r"\b(ADD|DROP)\s+INDEX\b|\b(DELETE|UPDATE)\b|\b(MODIFY|REMOVE)\s+TTL\b"
+        r"|\bMODIFY\s+COLUMN\s+(?!TTL\b)\w+[^;]*\bTTL\b",
         re.IGNORECASE,
     )
 

--- a/weave/trace_server/migrations/036_add_ttl_objects_files.down.sql
+++ b/weave/trace_server/migrations/036_add_ttl_objects_files.down.sql
@@ -1,0 +1,11 @@
+-- Rollback Migration 036: remove object/table_rows/files TTL.
+-- Drop the TTL clauses before the expire_at columns they reference.
+
+ALTER TABLE files REMOVE TTL;
+ALTER TABLE files DROP COLUMN expire_at;
+
+ALTER TABLE table_rows MODIFY COLUMN val_dump REMOVE TTL;
+ALTER TABLE table_rows DROP COLUMN expire_at;
+
+ALTER TABLE object_versions MODIFY COLUMN val_dump REMOVE TTL;
+ALTER TABLE object_versions DROP COLUMN expire_at;

--- a/weave/trace_server/migrations/036_add_ttl_objects_files.up.sql
+++ b/weave/trace_server/migrations/036_add_ttl_objects_files.up.sql
@@ -1,0 +1,29 @@
+-- Migration 036: TTL for stored objects, dataset rows, and files.
+--
+-- Mirrors the calls-TTL pattern (029): a non-null expire_at column defaulting to
+-- the 2100-01-01 sentinel, then a TTL clause. object_versions and table_rows get
+-- a column TTL clearing only the heavy val_dump payload (the metadata row
+-- survives), files get a row TTL. Bucket blobs expire via object-store
+-- lifecycle, not here.
+--
+-- Safe to deploy alone: every row defaults to the sentinel, so nothing expires
+-- until a write path stamps a real expire_at. The toDateTime() wrapper is
+-- required for CH < 25.6 compatibility (PR #80710).
+
+-- Objects: column TTL nulls val_dump, keeps refs/lineage/aliases.
+ALTER TABLE object_versions
+    ADD COLUMN expire_at DateTime64(3) DEFAULT toDateTime64('2100-01-01 00:00:00', 3);
+ALTER TABLE object_versions
+    MODIFY COLUMN val_dump String TTL toDateTime(expire_at);
+
+-- Dataset rows: same column-TTL treatment.
+ALTER TABLE table_rows
+    ADD COLUMN expire_at DateTime64(3) DEFAULT toDateTime64('2100-01-01 00:00:00', 3);
+ALTER TABLE table_rows
+    MODIFY COLUMN val_dump String TTL toDateTime(expire_at);
+
+-- Files: row TTL drops the CH row and inline val_bytes (exactly like calls).
+ALTER TABLE files
+    ADD COLUMN expire_at DateTime64(3) DEFAULT toDateTime64('2100-01-01 00:00:00', 3);
+ALTER TABLE files
+    MODIFY TTL toDateTime(expire_at) DELETE;


### PR DESCRIPTION
## Summary
- Migration 036: per-project TTL for `object_versions`, `table_rows`, `files`, mirroring calls TTL (029). Objects/table_rows get column-TTL clearing only `val_dump`; files get row-TTL DELETE.
- Why the split: objects/table_rows carry metadata (refs/lineage/digests/aliases) that must outlive the payload, so only the heavy `val_dump` blob is cleared and the row survives. `files` is a pure blob (inline `val_bytes` + storage pointer) with nothing to preserve, so the whole row is deleted (same as calls). Actual file bytes expire via object-store lifecycle, not here.
- Extends the distributed migrator's `LOCAL_ONLY_OPS` so column-TTL `MODIFY COLUMN ... TTL` targets `_local` tables only (Distributed tables reject TTL).
- First of a 6-PR stack implementing the ttl-objects-files spec.
- Jira: [WB-37508](https://coreweave.atlassian.net/browse/WB-37508)

## Dedup / RMT collapse safety
These tables are content-addressed `ReplacingMergeTree()` with no version column, so re-uploads and cross-dataset shared rows produce duplicate rows differing only in `expire_at`. Red-teamed against real ClickHouse:
- Re-upload (object/file) and `table_rows` shared across datasets: SAFE. Each re-reference writes a fresh future `expire_at` in the newest part; reads use `argMax(.., created_at)` (no FINAL/any) and collapse keeps the newest part, so the freshest copy always wins. Deleting one dataset never deletes shared rows (no such code path; rows age out by their own refreshed `expire_at`).
- `files` (row-TTL DELETE) drops expired rows on merge: safe in all orderings.
- Sharp edge: collapse keys on part-recency, not `expire_at`. An already-expired row landing in a part NEWER than a live duplicate would collapse to the cleared payload (data loss). Normal API writes cannot produce this (a fresh insert always carries a future `expire_at`); only a backfill/dual-write of historical rows could, so such tooling must stamp a fresh/sentinel `expire_at`, never a past one.

## Testing
unit test on the migrator local-only regex + a migration-clauses-present check (asserts the full SHOW CREATE DDL).


[WB-37508]: https://coreweave.atlassian.net/browse/WB-37508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ