### PR TITLE
feat(weave): stamp expire_at on object write paths

### DIFF
--- a/tests/trace_server/test_ttl_insert_paths.py
+++ b/tests/trace_server/test_ttl_insert_paths.py
@@ -456,3 +456,103 @@ def test_migration_036_ttl_clauses_present(internal_server):
         "TTL toDateTime(expire_at)\n"
         "SETTINGS index_granularity = 8192"
     )
+
+
+def _read_object_expire_at(
+    server: ClickHouseTraceServer, internal_project_id: str, object_id: str
+) -> list[datetime.datetime]:
+    """Raw-read expire_at for an object's version rows in object_versions."""
+    result = server.ch_client.query(
+        "SELECT expire_at FROM object_versions "
+        "WHERE project_id = {project_id:String} AND object_id = {object_id:String} "
+        "ORDER BY expire_at",
+        parameters={"project_id": internal_project_id, "object_id": object_id},
+    )
+    return [row[0] for row in result.result_rows]
+
+
+def _assert_expire_at_in_window(
+    value: datetime.datetime,
+    before: datetime.datetime,
+    after: datetime.datetime,
+    expected_delta: datetime.timedelta | None,
+) -> None:
+    """Server-anchored expire_at falls in [before+delta, after+delta] (or sentinel)."""
+    actual = _as_utc(value)
+    if expected_delta is None:
+        assert actual == _as_utc(EXPIRE_AT_NEVER)
+        return
+    # 1s slack absorbs DateTime64(3) millisecond truncation.
+    low = _as_utc(before) + expected_delta - datetime.timedelta(seconds=1)
+    high = _as_utc(after) + expected_delta + datetime.timedelta(seconds=1)
+    assert low <= actual <= high, f"expire_at {actual} not in [{low}, {high}]"
+
+
+@pytest.mark.parametrize(("retention_days", "expected_delta"), RETENTION_CASES)
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: raw expire_at table reads"
+)
+def test_ttl_object_writes_set_expire_at(
+    internal_server, retention_days, expected_delta
+):
+    """obj_create and obj_create_batch stamp expire_at (sentinel when no TTL)."""
+    server = internal_server
+    _, internal_project_id = _make_project("objects")
+    _set_retention_days(server, internal_project_id, retention_days)
+
+    before = datetime.datetime.now(datetime.timezone.utc)
+    server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=internal_project_id, object_id="single", val={"a": 1}
+            )
+        )
+    )
+    server.obj_create_batch(
+        [
+            tsi.ObjSchemaForInsert(
+                project_id=internal_project_id, object_id="batch_a", val={"a": 1}
+            ),
+            tsi.ObjSchemaForInsert(
+                project_id=internal_project_id, object_id="batch_b", val={"b": 2}
+            ),
+        ]
+    )
+    after = datetime.datetime.now(datetime.timezone.utc)
+
+    for object_id in ("single", "batch_a", "batch_b"):
+        values = _read_object_expire_at(server, internal_project_id, object_id)
+        assert len(values) == 1, f"{object_id}: expected one row, got {values!r}"
+        _assert_expire_at_in_window(values[0], before, after, expected_delta)
+
+
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: raw expire_at table reads"
+)
+def test_ttl_obj_delete_stamps_tombstone_expire_at(internal_server):
+    """obj_delete's tombstone row carries a computed expire_at, never NULL."""
+    server = internal_server
+    _, pid = _make_project("obj_delete")
+    _set_retention_days(server, pid, 30)
+    res = server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(project_id=pid, object_id="o", val={"a": 1})
+        )
+    )
+
+    before = datetime.datetime.now(datetime.timezone.utc)
+    server.obj_delete(
+        tsi.ObjDeleteReq(project_id=pid, object_id="o", digests=[res.digest])
+    )
+    after = datetime.datetime.now(datetime.timezone.utc)
+
+    # Original row + tombstone row; every row carries a future expire_at.
+    values = _read_object_expire_at(server, pid, "o")
+    assert len(values) == 2
+    for value in values:
+        _assert_expire_at_in_window(
+            value,
+            before - datetime.timedelta(seconds=5),
+            after,
+            datetime.timedelta(days=30),
+        )

--- a/weave/trace_server/clickhouse_schema.py
+++ b/weave/trace_server/clickhouse_schema.py
@@ -185,6 +185,7 @@ class ObjCHInsertable(BaseModel):
     refs: list[str]
     val_dump: str
     digest: str
+    expire_at: datetime.datetime | None = None
 
     _wb_user_id_v = field_validator("wb_user_id")(validation.wb_user_id_validator)
     _project_id_v = field_validator("project_id")(validation.project_id_validator)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -322,6 +322,8 @@ from weave.trace_server.trace_server_interface import (
 from weave.trace_server.tracing import traced, traced_generator
 from weave.trace_server.ttl_settings import (
     RETENTION_DAYS_NO_TTL,
+    compute_expire_at_for_insert,
+    get_object_retention_days,
     get_project_retention_days,
     invalidate_ttl_cache,
 )
@@ -2062,6 +2064,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             new_base_object_class=digest_result.base_object_class,
         )
 
+        retention_days = get_object_retention_days(req.obj.project_id, self.ch_client)
+        expire_at = compute_expire_at_for_insert(
+            retention_days, datetime.datetime.now(datetime.timezone.utc)
+        )
         ch_obj = ObjCHInsertable(
             project_id=req.obj.project_id,
             object_id=req.obj.object_id,
@@ -2072,6 +2078,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             refs=extract_refs_from_values(processed_val),
             val_dump=json_val,
             digest=digest,
+            expire_at=expire_at,
         )
 
         self._insert(
@@ -2152,6 +2159,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 f"obj_create_batch only supports updating a single project. Supplied projects: {unique_projects}"
             )
 
+        # Single project, single insert: one expire_at for the whole batch.
+        retention_days = get_object_retention_days(batch[0].project_id, self.ch_client)
+        expire_at = compute_expire_at_for_insert(
+            retention_days, datetime.datetime.now(datetime.timezone.utc)
+        )
+
         alias_rows: list[tuple[str, str, str, str]] = []
         for obj in batch:
             digest_result = compute_object_digest_result(
@@ -2171,6 +2184,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 refs=extract_refs_from_values(processed_val),
                 val_dump=json_val,
                 digest=digest,
+                expire_at=expire_at,
             )
             insert_data = list(ch_obj.model_dump().values())
             # Add the data to be inserted
@@ -2325,6 +2339,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         delete_insertables = []
         now = datetime.datetime.now(datetime.timezone.utc)
+        # Tombstone re-anchors expire_at at delete time; deleted_at, not
+        # expire_at, governs read visibility, so the created_at tie with the
+        # original row is harmless.
+        retention_days = get_object_retention_days(req.project_id, self.ch_client)
+        expire_at = compute_expire_at_for_insert(retention_days, now)
         for obj in object_versions:
             original_created_at = ensure_datetimes_have_tz_strict(obj.created_at)
             delete_insertables.append(
@@ -2341,6 +2360,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     wb_user_id=obj.wb_user_id,
                     # Keep the original created_at timestamp
                     created_at=original_created_at,
+                    expire_at=expire_at,
                 )
             )
 

--- a/weave/trace_server/ttl_settings.py
+++ b/weave/trace_server/ttl_settings.py
@@ -23,6 +23,7 @@ from cachetools import TTLCache
 from clickhouse_connect.driver.client import Client as CHClient
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
+from weave.trace_server.ch_sentinel_values import to_ch_value
 from weave.trace_server.datadog import set_current_span_dd_tags
 from weave.trace_server.redis_client import get_redis_client
 from weave.trace_server.tracing import _tracer, traced
@@ -39,6 +40,11 @@ REDIS_TTL_EXPIRY_SECS = 300
 # Stored retention_days value meaning "no TTL configured for this project".
 # Used as the on-disk encoding for "unset" since the column is non-null.
 RETENTION_DAYS_NO_TTL = 0
+
+# Objects can outlive the calls that reference them; scaling the shared
+# per-project retention keeps a reused dataset's val_dump alive past its
+# calls. 1 = objects expire on the same schedule as their calls.
+OBJECT_RETENTION_MULTIPLIER = 1
 
 # Global cache shared across all threads. Keyed by project_id.
 # Value is retention_days (int). RETENTION_DAYS_NO_TTL means no TTL.
@@ -89,6 +95,16 @@ def get_project_retention_days(
         return retention_days
 
 
+def get_object_retention_days(project_id: str, ch_client: CHClient) -> int:
+    """Per-project retention for stored objects: calls retention x multiplier.
+
+    RETENTION_DAYS_NO_TTL (0) stays 0 (no TTL); see OBJECT_RETENTION_MULTIPLIER.
+    """
+    return (
+        get_project_retention_days(project_id, ch_client) * OBJECT_RETENTION_MULTIPLIER
+    )
+
+
 def compute_expire_at(
     retention_days: int, started_at: datetime.datetime
 ) -> datetime.datetime | None:
@@ -109,6 +125,19 @@ def compute_expire_at(
         return anchor + datetime.timedelta(days=retention_days)
     # Negative values encode minutes-based retention (e.g. -5 = 5 minutes) for admin/testing use only
     return anchor + datetime.timedelta(minutes=-retention_days)
+
+
+def compute_expire_at_for_insert(
+    retention_days: int, anchor: datetime.datetime
+) -> datetime.datetime:
+    """expire_at for non-null sentinel columns (objects, table_rows, files).
+
+    Unlike calls, these rows insert via the generic path that does not apply
+    sentinels, so collapse None (no TTL) to EXPIRE_AT_NEVER here at the boundary.
+    """
+    value = to_ch_value("expire_at", compute_expire_at(retention_days, anchor))
+    assert isinstance(value, datetime.datetime)
+    return value
 
 
 def invalidate_ttl_cache(project_id: str) -> None:


### PR DESCRIPTION
## Summary
- Stamp `expire_at` on object write paths (obj_create / obj_create_batch / obj_delete) from per-project retention.
- Adds `OBJECT_RETENTION_MULTIPLIER` (D1=B, default 1: objects expire on the same schedule as their calls) and `compute_expire_at_for_insert`.

## Testing
functional: set retention, write via each path, raw-read expire_at.
