### PR TITLE
feat(weave): gate object reads on expire_at, tombstone expired payloads

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1242,19 +1242,30 @@ def test_select_objs_query_partial_value_miss_returns_empty():
 
     assert result == []
 
-    # Sanity: when the value row is present, we get a populated result.
+    # Sanity: when the value row is present, we get a populated result. The
+    # value query projects argMax((val_dump, expire_at)) as one tuple column;
+    # a far-future expire_at is live.
     with patch.object(
         chts.ClickHouseTraceServer,
         "_query_stream",
         side_effect=[
             iter([metadata_row]),
-            iter([("obj-id-1", "digest-abc", '{"x": 1}')]),
+            iter(
+                [
+                    (
+                        "obj-id-1",
+                        "digest-abc",
+                        ('{"x": 1}', datetime(2100, 1, 1, tzinfo=timezone.utc)),
+                    )
+                ]
+            ),
         ],
     ):
         result = server._select_objs_query(builder, metadata_only=False)
 
     assert len(result) == 1
     assert result[0].val_dump == '{"x": 1}'
+    assert result[0].expired is False
 
 
 def test_file_content_read_retries_eventual_consistency():

--- a/tests/trace_server/test_ttl_insert_paths.py
+++ b/tests/trace_server/test_ttl_insert_paths.py
@@ -22,7 +22,7 @@ from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
-from weave.trace_server.errors import InvalidRequest
+from weave.trace_server.errors import InvalidRequest, NotFoundError
 from weave.trace_server.project_version.types import CallsStorageServerMode
 from weave.trace_server.ttl_settings import reset_ttl_cache
 
@@ -556,3 +556,113 @@ def test_ttl_obj_delete_stamps_tombstone_expire_at(internal_server):
             after,
             datetime.timedelta(days=30),
         )
+
+
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: object read-gate determinism"
+)
+def test_ttl_object_read_gate_republish_keeps_value_live(internal_server):
+    """Re-publish extends lifetime (latest expire_at wins) and reads stay live."""
+    server = internal_server
+    _, pid = _make_project("obj_live")
+    _set_retention_days(server, pid, 30)
+    req = tsi.ObjCreateReq(
+        obj=tsi.ObjSchemaForInsert(project_id=pid, object_id="o", val={"v": 1})
+    )
+    res1 = server.obj_create(req)
+    res2 = server.obj_create(req)
+    assert res1.digest == res2.digest
+
+    server.ch_client.command("OPTIMIZE TABLE object_versions FINAL")
+    values = _read_object_expire_at(server, pid, "o")
+    assert len(values) == 1
+    assert _as_utc(values[0]) > datetime.datetime.now(datetime.timezone.utc)
+
+    read = server.obj_read(
+        tsi.ObjReadReq(project_id=pid, object_id="o", digest=res1.digest)
+    )
+    assert read.obj.val == {"v": 1}
+
+
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: object read-gate tombstone"
+)
+def test_ttl_object_read_gate_tombstones_expired_payload(internal_server):
+    """Gate on expire_at < now, not on empty val_dump: a non-empty but expired
+    payload still 404s instead of deserializing.
+    """
+    server = internal_server
+    _, pid = _make_project("obj_exp")
+    res = server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(project_id=pid, object_id="o", val={"v": 1})
+        )
+    )
+
+    # Newer row (later created_at) with content intact but a past expire_at:
+    # argMax picks the past expire_at, so the read must tombstone.
+    past = datetime.datetime(2000, 1, 1, tzinfo=datetime.timezone.utc)
+    newer_created = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        minutes=1
+    )
+    server.ch_client.insert(
+        "object_versions",
+        [[pid, "object", "o", [], '{"v": 1}', res.digest, newer_created, past]],
+        column_names=[
+            "project_id",
+            "kind",
+            "object_id",
+            "refs",
+            "val_dump",
+            "digest",
+            "created_at",
+            "expire_at",
+        ],
+    )
+
+    with pytest.raises(NotFoundError):
+        server.obj_read(
+            tsi.ObjReadReq(project_id=pid, object_id="o", digest=res.digest)
+        )
+
+
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: object read-gate listing"
+)
+def test_ttl_objs_query_tombstones_expired_value(internal_server):
+    """A listing keeps the expired version's metadata row but tombstones its value
+    to None (the metadata row survives; obj_read 404s the value).
+    """
+    server = internal_server
+    _, pid = _make_project("obj_query_exp")
+    res = server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(project_id=pid, object_id="o", val={"v": 1})
+        )
+    )
+    past = datetime.datetime(2000, 1, 1, tzinfo=datetime.timezone.utc)
+    newer_created = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        minutes=1
+    )
+    server.ch_client.insert(
+        "object_versions",
+        [[pid, "object", "o", [], '{"v": 1}', res.digest, newer_created, past]],
+        column_names=[
+            "project_id",
+            "kind",
+            "object_id",
+            "refs",
+            "val_dump",
+            "digest",
+            "created_at",
+            "expire_at",
+        ],
+    )
+
+    result = server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=pid, filter=tsi.ObjectVersionFilter(object_ids=["o"])
+        )
+    )
+    assert len(result.objs) == 1
+    assert result.objs[0].val is None

--- a/weave/trace_server/clickhouse_schema.py
+++ b/weave/trace_server/clickhouse_schema.py
@@ -218,6 +218,9 @@ class SelectableCHObjSchema(BaseModel):
     is_latest: int
     deleted_at: datetime.datetime | None = None
     size_bytes: int | None = None
+    # True when the version's payload has expired (argMax(expire_at) < now); the
+    # metadata row survives but val_dump is treated as gone, not deserialized.
+    expired: bool = False
 
 
 CallCHInsertable = (

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2256,6 +2256,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 f"{req.object_id}:v{obj.version_index} was deleted at {obj.deleted_at}",
                 deleted_at=obj.deleted_at,
             )
+        if obj.expired:
+            raise NotFoundError(f"Obj {req.object_id}:{req.digest} payload expired")
 
         obj_schema = ch_obj_to_obj_schema(obj)
         if req.include_tags_and_aliases:
@@ -3791,6 +3793,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 f"Op {req.object_id}:v{obj.version_index} was deleted at {obj.deleted_at}",
                 deleted_at=obj.deleted_at,
             )
+        if obj.expired:
+            raise NotFoundError(f"Op {req.object_id}:{req.digest} payload expired")
 
         # For ops, the object_id is the function name since ops don't have
         # a "name" field in their val object. Ops are stored as CustomWeaveType
@@ -7175,11 +7179,19 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             digests=list({row.digest for row in metadata_result}),
         )
         query_result = self._query_stream(value_query, value_parameters)
-        # Map (object_id, digest) to val_dump
-        object_values: dict[tuple[str, str], Any] = {}
+        # Map (object_id, digest) to (val_dump, expire_at). expire_at gates
+        # expiry deterministically under ReplacingMergeTree dedup: argMax picks
+        # the latest version's expire_at, so a re-publish extends the lifetime.
+        now = datetime.datetime.now(datetime.timezone.utc)
+        object_values: dict[tuple[str, str], tuple[str, bool]] = {}
         for row in query_result:
-            (object_id, digest, val_dump) = row
-            object_values[object_id, digest] = val_dump
+            (object_id, digest, (val_dump, expire_at)) = row
+            expired = ensure_datetimes_have_tz_strict(expire_at) < now
+            # Tombstone expired payloads: never hand a TTL-cleared (or stale)
+            # val_dump to the deserializer; "null" reads back as None.
+            object_values[object_id, digest] = (
+                ("null", True) if expired else (val_dump, False)
+            )
 
         # All-or-nothing: if any metadata row is missing its value row (e.g. due
         # to ClickHouse replication lag), return empty so callers raise
@@ -7190,7 +7202,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if not all_value_rows_found:
             return []
         for obj in metadata_result:
-            obj.val_dump = object_values[obj.object_id, obj.digest]
+            obj.val_dump, obj.expired = object_values[obj.object_id, obj.digest]
         return metadata_result
 
     def _run_migrations(self) -> None:

--- a/weave/trace_server/query_builder/objects_query_builder.py
+++ b/weave/trace_server/query_builder/objects_query_builder.py
@@ -443,8 +443,13 @@ FROM object_versions_with_index AS {main_table_alias}
 def make_objects_val_query_and_parameters(
     project_id: str, object_ids: list[str], digests: list[str]
 ) -> tuple[str, dict[str, Any]]:
+    # argMax over the (val_dump, expire_at) tuple so both come from the SAME
+    # latest row; two independent argMax could diverge on a created_at tie.
     query = """
-        SELECT object_id, digest, argMax(val_dump, created_at)
+        SELECT
+            object_id,
+            digest,
+            argMax((val_dump, expire_at), created_at) AS val_and_expire
         FROM object_versions
         WHERE project_id = {project_id: String} AND
             object_id IN {object_ids: Array(String)} AND


### PR DESCRIPTION
## Summary
- Gate object reads on `expire_at < now`: an expired version 404s on read and tombstones its value to null in listings, instead of deserializing a TTL-cleared payload.
- Value query uses `argMax((val_dump, expire_at), created_at)` so the freshest version's expiry wins.

## Testing
functional: republish-keeps-live, expired-payload-tombstones, listing-tombstone.
