### PR TITLE
feat(weave): stamp expire_at on table_rows write paths

### DIFF
--- a/tests/trace_server/test_ttl_insert_paths.py
+++ b/tests/trace_server/test_ttl_insert_paths.py
@@ -666,3 +666,119 @@ def test_ttl_objs_query_tombstones_expired_value(internal_server):
     )
     assert len(result.objs) == 1
     assert result.objs[0].val is None
+
+
+def _read_table_rows_expire_at(
+    server: ClickHouseTraceServer, internal_project_id: str
+) -> list[datetime.datetime]:
+    """Raw-read expire_at for every table_rows row in a project."""
+    result = server.ch_client.query(
+        "SELECT expire_at FROM table_rows WHERE project_id = {project_id:String} "
+        "ORDER BY digest",
+        parameters={"project_id": internal_project_id},
+    )
+    return [row[0] for row in result.result_rows]
+
+
+@pytest.mark.parametrize(("retention_days", "expected_delta"), RETENTION_CASES)
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: raw expire_at table reads"
+)
+def test_ttl_table_create_sets_expire_at(
+    internal_server, retention_days, expected_delta
+):
+    """table_create stamps one identical expire_at across all rows (sentinel when no TTL)."""
+    server = internal_server
+    _, pid = _make_project("table_rows")
+    _set_retention_days(server, pid, retention_days)
+
+    before = datetime.datetime.now(datetime.timezone.utc)
+    server.table_create(
+        tsi.TableCreateReq(
+            table=tsi.TableSchemaForInsert(
+                project_id=pid, rows=[{"a": 1}, {"b": 2}, {"c": 3}]
+            )
+        )
+    )
+    after = datetime.datetime.now(datetime.timezone.utc)
+
+    values = _read_table_rows_expire_at(server, pid)
+    assert len(values) == 3
+    # Every row of a table digest shares the same expire_at (no partial expiry).
+    assert len({_as_utc(v) for v in values}) == 1
+    for value in values:
+        _assert_expire_at_in_window(value, before, after, expected_delta)
+
+
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: raw expire_at table reads"
+)
+def test_ttl_table_update_stamps_appended_rows(internal_server):
+    """table_update appends rows that also carry a computed expire_at."""
+    server = internal_server
+    _, pid = _make_project("table_update")
+    _set_retention_days(server, pid, 30)
+
+    created = server.table_create(
+        tsi.TableCreateReq(
+            table=tsi.TableSchemaForInsert(project_id=pid, rows=[{"a": 1}])
+        )
+    )
+    server.table_update(
+        tsi.TableUpdateReq(
+            project_id=pid,
+            base_digest=created.digest,
+            updates=[
+                tsi.TableAppendSpec(append=tsi.TableAppendSpecPayload(row={"b": 2}))
+            ],
+        )
+    )
+
+    values = _read_table_rows_expire_at(server, pid)
+    assert len(values) == 2
+    now = datetime.datetime.now(datetime.timezone.utc)
+    for value in values:
+        assert _as_utc(value) > now
+
+
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND,
+    reason="ClickHouse-only: table read-gate on TTL-cleared rows",
+)
+def test_ttl_table_query_skips_ttl_cleared_rows(internal_server):
+    """A val_dump emptied by column TTL is dropped on read, never json.loads('')'d
+    into a 500. argMax(val_dump, created_at) picks the newer cleared copy.
+    """
+    server = internal_server
+    _, pid = _make_project("table_ttl_clear")
+    created = server.table_create(
+        tsi.TableCreateReq(
+            table=tsi.TableSchemaForInsert(project_id=pid, rows=[{"a": 1}, {"b": 2}])
+        )
+    )
+    expired_digest = created.row_digests[0]
+    past = datetime.datetime(2000, 1, 1, tzinfo=datetime.timezone.utc)
+    newer_created = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        minutes=1
+    )
+    # Simulate the post-TTL state: a newer row for the same digest with val_dump
+    # cleared to '' and a past expire_at.
+    server.ch_client.insert(
+        "table_rows",
+        [[pid, expired_digest, [], "", newer_created, past]],
+        column_names=[
+            "project_id",
+            "digest",
+            "refs",
+            "val_dump",
+            "created_at",
+            "expire_at",
+        ],
+    )
+
+    result = server.table_query(
+        tsi.TableQueryReq(project_id=pid, digest=created.digest)
+    )
+    returned = {row.digest: row.val for row in result.rows}
+    assert expired_digest not in returned
+    assert returned == {created.row_digests[1]: {"b": 2}}

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2624,6 +2624,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @tag_db_insert_path("table_create")
     def table_create(self, req: tsi.TableCreateReq) -> tsi.TableCreateRes:
+        # One expire_at for the whole table so a digest never partially expires.
+        expire_at = compute_expire_at_for_insert(
+            get_object_retention_days(req.table.project_id, self.ch_client),
+            datetime.datetime.now(datetime.timezone.utc),
+        )
         insert_rows = []
         for r in req.table.rows:
             if not isinstance(r, dict):
@@ -2638,6 +2643,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     row_digest,
                     extract_refs_from_values(r),
                     row_json,
+                    expire_at,
                 )
             )
 
@@ -2652,7 +2658,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self._insert(
             "table_rows",
             data=insert_rows,
-            column_names=["project_id", "digest", "refs", "val_dump"],
+            column_names=["project_id", "digest", "refs", "val_dump", "expire_at"],
         )
 
         self._insert(
@@ -2678,6 +2684,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         final_row_digests: list[str] = row_digest_result_query.result_rows[0][2]
         new_rows_needed_to_insert = []
         known_digests = set(final_row_digests)
+        expire_at = compute_expire_at_for_insert(
+            get_object_retention_days(req.project_id, self.ch_client),
+            datetime.datetime.now(datetime.timezone.utc),
+        )
 
         def add_new_row_needed_to_insert(row_data: Any) -> str:
             if not isinstance(row_data, dict):
@@ -2691,6 +2701,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                         row_digest,
                         extract_refs_from_values(row_data),
                         row_json,
+                        expire_at,
                     )
                 )
                 known_digests.add(row_digest)
@@ -2723,7 +2734,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._insert(
                 "table_rows",
                 data=new_rows_needed_to_insert,
-                column_names=["project_id", "digest", "refs", "val_dump"],
+                column_names=["project_id", "digest", "refs", "val_dump", "expire_at"],
             )
 
         digest = compute_table_digest(final_row_digests)
@@ -2873,6 +2884,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         res = self._query_stream(query, parameters=pb.get_params())
 
         for row in res:
+            # A TTL-cleared val_dump is '' (a live row always dumps to at least
+            # '{}'), so an empty payload means the row expired: skip it.
+            if not row[1]:
+                continue
             yield tsi.TableRowSchema(
                 digest=row[0], val=json.loads(row[1]), original_index=row[2]
             )

--- a/weave/trace_server/query_builder/table_query_builder.py
+++ b/weave/trace_server/query_builder/table_query_builder.py
@@ -66,10 +66,11 @@ def make_natural_sort_table_query(
         ARRAY JOIN row_digests AS row_digest, original_indices AS original_index
     ) AS t
     INNER JOIN (
-        SELECT digest, val_dump
+        SELECT digest, argMax(val_dump, created_at) AS val_dump
         FROM table_rows
         WHERE project_id = {{{project_id_name}: String}}
           AND digest IN (SELECT arrayJoin(arr) FROM digests_arr)
+        GROUP BY digest
     ) AS tr ON tr.digest = t.row_digest
     ORDER BY original_index ASC
     """
@@ -156,11 +157,12 @@ def make_standard_table_query(
             ARRAY JOIN row_digests AS row_digest, original_indices AS original_index
         ) AS t
         INNER JOIN (
-            SELECT digest, val_dump
+            SELECT digest, argMax(val_dump, created_at) AS val_dump
             FROM table_rows
             WHERE project_id = {{{project_id_name}: String}}
               {sql_safe_digest_pushdown}
               AND digest IN (SELECT arrayJoin(arr) FROM digests_arr)
+            GROUP BY digest
         ) AS tr ON tr.digest = t.row_digest
         {sql_safe_filter_clause}
     ) AS tr
@@ -244,14 +246,15 @@ def make_table_rows_read_batch_query(
 ) -> str:
     """Generate a query to batch-read table_rows by digest.
 
-    Returns one row per digest with the resolved val_dump.
-    Uses any() because table_rows is a ReplacingMergeTree and
-    may have duplicate rows per digest.
+    Returns one row per digest with the resolved val_dump. Uses
+    argMax(val_dump, created_at) so the freshest insert wins: this both
+    dedupes the ReplacingMergeTree and prefers a live row over a copy
+    whose val_dump TTL has cleared it.
     """
     project_param = pb.add(project_id, None, "String")
     digests_param = pb.add(digests, None, "Array(String)")
     return f"""
-        SELECT digest, any(val_dump) AS val_dump
+        SELECT digest, argMax(val_dump, created_at) AS val_dump
         FROM table_rows
         PREWHERE project_id = {project_param}
         WHERE digest IN {digests_param}


### PR DESCRIPTION
## Summary
- Stamp `expire_at` on table_rows write paths (table_create / table_update).
- Gate reads: `argMax(val_dump, created_at)` dedup across the 3 row queries + skip empty (TTL-cleared) payloads in the stream, so an expired row never 500s on `json.loads('')`.

## Testing
functional: write stamps expire_at; a TTL-cleared row is skipped on read.
