### PR TITLE
feat(weave): stamp expire_at on files write paths

### DIFF
--- a/tests/trace_server/test_parallel_bucket_uploads.py
+++ b/tests/trace_server/test_parallel_bucket_uploads.py
@@ -7,6 +7,7 @@ by the GCS-backed integration tests in tests/trace/test_server_file_storage.py.
 
 from __future__ import annotations
 
+import datetime
 from typing import cast
 
 import pytest
@@ -17,6 +18,8 @@ from weave.trace_server.file_storage import FileStorageClient
 from weave.trace_server.parallel_bucket_uploads import BucketUploadBatch
 from weave.trace_server.trace_server_interface import FileCreateReq
 
+EXPIRE_AT = datetime.datetime(2100, 1, 1, tzinfo=datetime.timezone.utc)
+
 
 def _req(content: bytes, name: str = "f.bin") -> FileCreateReq:
     return FileCreateReq(project_id="entity/project", name=name, content=content)
@@ -24,16 +27,16 @@ def _req(content: bytes, name: str = "f.bin") -> FileCreateReq:
 
 def test_stage_dedup_raises_on_duplicate_key() -> None:
     batch = BucketUploadBatch()
-    batch.stage(_req(b"hello"), digest="d1")
+    batch.stage(_req(b"hello"), digest="d1", expire_at=EXPIRE_AT)
     with pytest.raises(ValueError, match="called twice"):
-        batch.stage(_req(b"hello"), digest="d1")
+        batch.stage(_req(b"hello"), digest="d1", expire_at=EXPIRE_AT)
 
 
 def test_stage_rejects_when_total_exceeds_max_bytes() -> None:
     """One oversized payload trips the guard immediately."""
     batch = BucketUploadBatch(max_bytes=1024)
     with pytest.raises(RequestTooLarge, match="max_bytes=1024"):
-        batch.stage(_req(b"x" * 2048), digest="d1")
+        batch.stage(_req(b"x" * 2048), digest="d1", expire_at=EXPIRE_AT)
     # Nothing was staged after the rejection.
     assert not batch
     assert not batch.has("entity/project", "d1")
@@ -42,10 +45,10 @@ def test_stage_rejects_when_total_exceeds_max_bytes() -> None:
 def test_stage_rejects_when_cumulative_exceeds_max_bytes() -> None:
     """The guard accumulates across items, not just per-item."""
     batch = BucketUploadBatch(max_bytes=1024)
-    batch.stage(_req(b"x" * 600), digest="d1")
-    batch.stage(_req(b"y" * 400), digest="d2")
+    batch.stage(_req(b"x" * 600), digest="d1", expire_at=EXPIRE_AT)
+    batch.stage(_req(b"y" * 400), digest="d2", expire_at=EXPIRE_AT)
     with pytest.raises(RequestTooLarge):
-        batch.stage(_req(b"z" * 100), digest="d3")
+        batch.stage(_req(b"z" * 100), digest="d3", expire_at=EXPIRE_AT)
     # First two items remain staged; the rejected third is not.
     assert batch.has("entity/project", "d1")
     assert batch.has("entity/project", "d2")
@@ -55,18 +58,18 @@ def test_stage_rejects_when_cumulative_exceeds_max_bytes() -> None:
 def test_duplicate_stage_does_not_consume_budget() -> None:
     """Dedup hits raise ValueError before incrementing the byte counter."""
     batch = BucketUploadBatch(max_bytes=1024)
-    batch.stage(_req(b"x" * 600), digest="d1")
+    batch.stage(_req(b"x" * 600), digest="d1", expire_at=EXPIRE_AT)
     with pytest.raises(ValueError, match="called twice"):
-        batch.stage(_req(b"x" * 600), digest="d1")
+        batch.stage(_req(b"x" * 600), digest="d1", expire_at=EXPIRE_AT)
     # Budget should still allow another 400 bytes.
-    batch.stage(_req(b"y" * 400), digest="d2")
+    batch.stage(_req(b"y" * 400), digest="d2", expire_at=EXPIRE_AT)
 
 
 def test_flush_resets_byte_counter(monkeypatch: pytest.MonkeyPatch) -> None:
     """After flush(), staged bytes drop to zero so the next batch starts fresh."""
     monkeypatch.setattr(pbu, "_upload_one", lambda p, client: [])
     batch = BucketUploadBatch(max_bytes=1024)
-    batch.stage(_req(b"x" * 900), digest="d1")
+    batch.stage(_req(b"x" * 900), digest="d1", expire_at=EXPIRE_AT)
     batch.flush(client=cast(FileStorageClient, object()))
-    batch.stage(_req(b"y" * 900), digest="d2")
+    batch.stage(_req(b"y" * 900), digest="d2", expire_at=EXPIRE_AT)
     assert batch.has("entity/project", "d2")

--- a/tests/trace_server/test_ttl_insert_paths.py
+++ b/tests/trace_server/test_ttl_insert_paths.py
@@ -782,3 +782,78 @@ def test_ttl_table_query_skips_ttl_cleared_rows(internal_server):
     returned = {row.digest: row.val for row in result.rows}
     assert expired_digest not in returned
     assert returned == {created.row_digests[1]: {"b": 2}}
+
+
+def _read_file_expire_at(
+    server: ClickHouseTraceServer, internal_project_id: str, digest: str
+) -> list[datetime.datetime]:
+    """Raw-read expire_at for every chunk of a file, ordered by chunk_index."""
+    result = server.ch_client.query(
+        "SELECT expire_at FROM files "
+        "WHERE project_id = {project_id:String} AND digest = {digest:String} "
+        "ORDER BY chunk_index",
+        parameters={"project_id": internal_project_id, "digest": digest},
+    )
+    return [row[0] for row in result.result_rows]
+
+
+@pytest.mark.parametrize(("retention_days", "expected_delta"), RETENTION_CASES)
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: raw expire_at table reads"
+)
+def test_ttl_file_create_sets_expire_at(
+    internal_server, retention_days, expected_delta
+):
+    """A multi-chunk file stamps one identical expire_at on every chunk."""
+    server = internal_server
+    _, pid = _make_project("files")
+    _set_retention_days(server, pid, retention_days)
+
+    # 250KB > 2x FILE_CHUNK_SIZE (100KB) so the inline path writes 3 chunks.
+    content = b"x" * 250_000
+    before = datetime.datetime.now(datetime.timezone.utc)
+    res = server.file_create(
+        tsi.FileCreateReq(project_id=pid, name="f.bin", content=content)
+    )
+    after = datetime.datetime.now(datetime.timezone.utc)
+
+    values = _read_file_expire_at(server, pid, res.digest)
+    assert len(values) == 3
+    # No chunk of a file expires before another.
+    assert len({_as_utc(v) for v in values}) == 1
+    for value in values:
+        _assert_expire_at_in_window(value, before, after, expected_delta)
+
+
+@pytest.mark.skipif(NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: row TTL deletion")
+def test_ttl_file_expired_row_is_deleted_and_reads_404(internal_server):
+    """An expired file row is dropped by the row TTL; the read is a clean 404."""
+    server = internal_server
+    _, pid = _make_project("file_exp")
+    digest = "deadbeef"
+    past = datetime.datetime(2000, 1, 1, tzinfo=datetime.timezone.utc)
+    server.ch_client.insert(
+        "files",
+        [[pid, digest, 0, 1, "f.bin", b"hello", 5, past]],
+        column_names=[
+            "project_id",
+            "digest",
+            "chunk_index",
+            "n_chunks",
+            "name",
+            "val_bytes",
+            "bytes_stored",
+            "expire_at",
+        ],
+    )
+
+    server.ch_client.command("OPTIMIZE TABLE files FINAL")
+    remaining = server.ch_client.query(
+        "SELECT count() FROM files "
+        "WHERE project_id = {project_id:String} AND digest = {digest:String}",
+        parameters={"project_id": pid, "digest": digest},
+    ).result_rows[0][0]
+    assert remaining == 0
+
+    with pytest.raises(NotFoundError):
+        server.file_content_read(tsi.FileContentReadReq(project_id=pid, digest=digest))

--- a/weave/trace_server/clickhouse_schema.py
+++ b/weave/trace_server/clickhouse_schema.py
@@ -269,6 +269,7 @@ class FileChunkCreateCHInsertable(BaseModel):
     val_bytes: bytes
     bytes_stored: int
     file_storage_uri: str | None
+    expire_at: datetime.datetime | None = None
 
 
 ALL_FILE_CHUNK_INSERT_COLUMNS = sorted(FileChunkCreateCHInsertable.model_fields.keys())

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6129,27 +6129,40 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if self._bucket_uploads.has(req.project_id, digest):
             return tsi.FileCreateRes(digest=digest)
 
+        # Files share the plain per-project retention (co-created with their
+        # call); the identical expire_at is stamped on every chunk row.
+        expire_at = compute_expire_at_for_insert(
+            get_project_retention_days(req.project_id, self.ch_client),
+            datetime.datetime.now(datetime.timezone.utc),
+        )
+
         use_file_storage = self._should_use_file_storage_for_writes(req.project_id)
         client = self.file_storage_client
 
         if client is not None and use_file_storage:
             try:
-                self._file_create_bucket(req, digest, client)
+                self._file_create_bucket(req, digest, client, expire_at)
             except FileStorageWriteError:
-                self._file_create_clickhouse(req, digest)
+                self._file_create_clickhouse(req, digest, expire_at)
         else:
-            self._file_create_clickhouse(req, digest)
+            self._file_create_clickhouse(req, digest, expire_at)
         set_root_span_dd_tags({"write_bytes": len(req.content)})
         return tsi.FileCreateRes(digest=digest)
 
     @traced(name="clickhouse_trace_server_batched._file_create_clickhouse")
-    def _file_create_clickhouse(self, req: tsi.FileCreateReq, digest: str) -> None:
+    def _file_create_clickhouse(
+        self, req: tsi.FileCreateReq, digest: str, expire_at: datetime.datetime
+    ) -> None:
         set_root_span_dd_tags({"storage_provider": "clickhouse"})
-        self._insert_file_chunks(file_chunks_for(req, digest))
+        self._insert_file_chunks(file_chunks_for(req, digest, expire_at))
 
     @traced(name="clickhouse_trace_server_batched._file_create_bucket")
     def _file_create_bucket(
-        self, req: tsi.FileCreateReq, digest: str, client: FileStorageClient
+        self,
+        req: tsi.FileCreateReq,
+        digest: str,
+        client: FileStorageClient,
+        expire_at: datetime.datetime,
     ) -> None:
         if not self._flush_immediately:
             # Inside call_batch(): stage for the parallel flush at the end so
@@ -6158,7 +6171,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             # handled inside _upload_one, not by the caller's except arm; root-
             # span attribution is deferred to bucket_upload_batch.flush so the
             # tag matches where the bytes actually land.
-            self._bucket_uploads.stage(req, digest)
+            self._bucket_uploads.stage(req, digest, expire_at)
             return
         set_root_span_dd_tags({"storage_provider": "bucket"})
         target_file_storage_uri = store_in_bucket(
@@ -6175,6 +6188,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     val_bytes=b"",
                     bytes_stored=len(req.content),
                     file_storage_uri=target_file_storage_uri.to_uri_str(),
+                    expire_at=expire_at,
                 )
             ]
         )
@@ -6200,7 +6214,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             chunk_dump = chunk.model_dump()
             row = []
             for col in ALL_FILE_CHUNK_INSERT_COLUMNS:
-                row.append(chunk_dump.get(col, None))
+                # Sentinel-convert so a None expire_at (no TTL) inserts the
+                # far-future value instead of failing the non-null column.
+                row.append(
+                    ch_sentinel_values.to_ch_value(col, chunk_dump.get(col, None))
+                )
             data.append(row)
 
         if data:

--- a/weave/trace_server/parallel_bucket_uploads.py
+++ b/weave/trace_server/parallel_bucket_uploads.py
@@ -10,7 +10,7 @@ This module owns the deferred-upload buffer and the fan-out step:
 
     bucket_uploads = BucketUploadBatch()
     ...
-    bucket_uploads.stage(req, digest)        # cheap, in-memory only
+    bucket_uploads.stage(req, digest, expire_at)  # cheap, in-memory only
     ...
     rows = bucket_uploads.flush(client)      # parallel upload -> CH rows
     self._file_batch.extend(rows)
@@ -40,6 +40,7 @@ content-addressable and consistent.
 
 from __future__ import annotations
 
+import datetime
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -75,6 +76,7 @@ MAX_BUCKET_UPLOAD_BATCH_BYTES = 256 * 1024 * 1024
 class _Pending:
     req: tsi.FileCreateReq
     digest: str
+    expire_at: datetime.datetime
 
 
 class BucketUploadBatch:
@@ -91,7 +93,9 @@ class BucketUploadBatch:
         self._seen: set[tuple[str, str]] = set()
         self._total_bytes = 0
 
-    def stage(self, req: tsi.FileCreateReq, digest: str) -> None:
+    def stage(
+        self, req: tsi.FileCreateReq, digest: str, expire_at: datetime.datetime
+    ) -> None:
         """Defer a bucket upload until `flush()`.
 
         Caller computes the digest, validates `expected_digest`, and dedups
@@ -117,7 +121,7 @@ class BucketUploadBatch:
                 f"BucketUploadBatch would exceed max_bytes={self._max_bytes}: "
                 f"staged={self._total_bytes}, new={size}"
             )
-        self._pending.append(_Pending(req=req, digest=digest))
+        self._pending.append(_Pending(req=req, digest=digest, expire_at=expire_at))
         self._seen.add(key)
         self._total_bytes += size
 
@@ -199,7 +203,7 @@ def _upload_one(
             client, key_for_project_digest(p.req.project_id, p.digest), p.req.content
         )
     except FileStorageWriteError:
-        return file_chunks_for(p.req, p.digest)
+        return file_chunks_for(p.req, p.digest, p.expire_at)
     return [
         FileChunkCreateCHInsertable(
             project_id=p.req.project_id,
@@ -210,17 +214,19 @@ def _upload_one(
             val_bytes=b"",
             bytes_stored=len(p.req.content),
             file_storage_uri=uri.to_uri_str(),
+            expire_at=p.expire_at,
         )
     ]
 
 
 def file_chunks_for(
-    req: tsi.FileCreateReq, digest: str
+    req: tsi.FileCreateReq, digest: str, expire_at: datetime.datetime
 ) -> list[FileChunkCreateCHInsertable]:
     """Split a file_create payload into inline ClickHouse chunk rows.
 
     Shared between the synchronous file_create path and the bucket-upload
     `FileStorageWriteError` fallback so the chunking shape stays in one place.
+    Every chunk of a file carries the same expire_at so it never partially expires.
     """
     pieces = [
         req.content[i : i + ch_settings.FILE_CHUNK_SIZE]
@@ -236,6 +242,7 @@ def file_chunks_for(
             val_bytes=chunk,
             bytes_stored=len(chunk),
             file_storage_uri=None,
+            expire_at=expire_at,
         )
         for i, chunk in enumerate(pieces)
     ]


### PR DESCRIPTION
## Summary
- Stamp `expire_at` on files write paths (file_create, chunked inline + parallel bucket upload).
- Row-TTL drops expired file rows; the read is a clean 404. Files use plain per-project retention (no object multiplier).

## Testing
functional: multi-chunk stamp, expired-row deletion + 404.
