### PR TITLE
feat(weave): stamp bucket blobs for native lifecycle expiry

### DIFF
--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -6,6 +6,7 @@ specific setup requirements.
 """
 
 import base64
+import datetime
 import os
 import socket
 from unittest import mock
@@ -317,7 +318,13 @@ class _CountingStorageClient(file_storage.FileStorageClient):
         super().__init__(base_uri)
         self.store_calls = 0
 
-    def store(self, uri: file_storage.FileStorageURI, data: bytes) -> None:
+    def store(
+        self,
+        uri: file_storage.FileStorageURI,
+        data: bytes,
+        retention_days: int = file_storage.RETENTION_DAYS_NO_TTL,
+        expire_at: datetime.datetime | None = None,
+    ) -> None:
         self.store_calls += 1
 
     def read(self, uri: file_storage.FileStorageURI) -> bytes:
@@ -741,3 +748,77 @@ def test_call_batch_falls_back_to_clickhouse_on_per_file_bucket_failure(
         FileContentReadReq(project_id=client.project_id, digest=fail_digest)
     )
     assert fallback_read.content == fail_payload
+
+
+# --- Blob retention stamping (migration 036 / TTL) -------------------------
+
+S3_TEST_CREDS = {
+    "access_key_id": "test-key",
+    "secret_access_key": "test-secret",
+    "session_token": None,
+    "region": "us-east-1",
+}
+
+
+def test_s3_store_tags_retention_bucket_and_skips_when_no_ttl():
+    """S3 store tags the retention bucket for lifecycle; no-TTL stamps nothing."""
+    base = file_storage.FileStorageURI.parse_uri_str(f"s3://{TEST_BUCKET}")
+    with mock_aws():
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id="test-key",
+            aws_secret_access_key="test-secret",
+            region_name="us-east-1",
+        )
+        s3.create_bucket(Bucket=TEST_BUCKET)
+        client = file_storage.S3StorageClient(base, S3_TEST_CREDS)
+
+        client.store(base.with_path("ttl"), b"data", retention_days=30)
+        ttl_tags = s3.get_object_tagging(Bucket=TEST_BUCKET, Key="ttl")["TagSet"]
+        assert ttl_tags == [{"Key": file_storage.RETENTION_TAG_KEY, "Value": "30"}]
+
+        client.store(base.with_path("none"), b"data", retention_days=0)
+        none_tags = s3.get_object_tagging(Bucket=TEST_BUCKET, Key="none")["TagSet"]
+        assert none_tags == []
+
+
+def test_gcs_store_sets_custom_time_and_skips_when_no_ttl():
+    """GCS store sets custom_time for lifecycle; no-TTL leaves it unset."""
+    base = file_storage.FileStorageURI.parse_uri_str("gs://test-bucket")
+    mock_client = mock.MagicMock()
+    with mock.patch.object(
+        file_storage, "_build_keepalive_gcs_client", return_value=mock_client
+    ):
+        client = file_storage.GCSStorageClient(base)
+
+    expire_at = datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc)
+    ttl_blob = mock.MagicMock()
+    mock_client.bucket.return_value.blob.return_value = ttl_blob
+    client.store(base.with_path("ttl"), b"data", retention_days=30, expire_at=expire_at)
+    assert ttl_blob.custom_time == expire_at
+
+    none_blob = mock.MagicMock()
+    mock_client.bucket.return_value.blob.return_value = none_blob
+    client.store(base.with_path("none"), b"data", retention_days=0)
+    assert not isinstance(none_blob.custom_time, datetime.datetime)
+
+
+def test_azure_store_tags_retention_bucket_and_skips_when_no_ttl():
+    """Azure store sets the retention index tag; no-TTL passes tags=None."""
+    base = file_storage.FileStorageURI.parse_uri_str("az://acct/container")
+    client = file_storage.AzureStorageClient(base, {"connection_string": "x"})
+
+    captured: list[dict] = []
+    blob_client = mock.MagicMock()
+    blob_client.upload_blob.side_effect = lambda data, overwrite=False, **kw: (
+        captured.append(kw)
+    )
+    service = mock.MagicMock()
+    service.get_container_client.return_value.get_blob_client.return_value = blob_client
+
+    with mock.patch.object(client, "_get_client", return_value=service):
+        client.store(base.with_path("ttl"), b"data", retention_days=14)
+        client.store(base.with_path("none"), b"data", retention_days=0)
+
+    assert captured[0]["tags"] == {file_storage.RETENTION_TAG_KEY: "14"}
+    assert captured[1]["tags"] is None

--- a/tests/trace_server/test_parallel_bucket_uploads.py
+++ b/tests/trace_server/test_parallel_bucket_uploads.py
@@ -27,16 +27,18 @@ def _req(content: bytes, name: str = "f.bin") -> FileCreateReq:
 
 def test_stage_dedup_raises_on_duplicate_key() -> None:
     batch = BucketUploadBatch()
-    batch.stage(_req(b"hello"), digest="d1", expire_at=EXPIRE_AT)
+    batch.stage(_req(b"hello"), digest="d1", expire_at=EXPIRE_AT, retention_days=0)
     with pytest.raises(ValueError, match="called twice"):
-        batch.stage(_req(b"hello"), digest="d1", expire_at=EXPIRE_AT)
+        batch.stage(_req(b"hello"), digest="d1", expire_at=EXPIRE_AT, retention_days=0)
 
 
 def test_stage_rejects_when_total_exceeds_max_bytes() -> None:
     """One oversized payload trips the guard immediately."""
     batch = BucketUploadBatch(max_bytes=1024)
     with pytest.raises(RequestTooLarge, match="max_bytes=1024"):
-        batch.stage(_req(b"x" * 2048), digest="d1", expire_at=EXPIRE_AT)
+        batch.stage(
+            _req(b"x" * 2048), digest="d1", expire_at=EXPIRE_AT, retention_days=0
+        )
     # Nothing was staged after the rejection.
     assert not batch
     assert not batch.has("entity/project", "d1")
@@ -45,10 +47,12 @@ def test_stage_rejects_when_total_exceeds_max_bytes() -> None:
 def test_stage_rejects_when_cumulative_exceeds_max_bytes() -> None:
     """The guard accumulates across items, not just per-item."""
     batch = BucketUploadBatch(max_bytes=1024)
-    batch.stage(_req(b"x" * 600), digest="d1", expire_at=EXPIRE_AT)
-    batch.stage(_req(b"y" * 400), digest="d2", expire_at=EXPIRE_AT)
+    batch.stage(_req(b"x" * 600), digest="d1", expire_at=EXPIRE_AT, retention_days=0)
+    batch.stage(_req(b"y" * 400), digest="d2", expire_at=EXPIRE_AT, retention_days=0)
     with pytest.raises(RequestTooLarge):
-        batch.stage(_req(b"z" * 100), digest="d3", expire_at=EXPIRE_AT)
+        batch.stage(
+            _req(b"z" * 100), digest="d3", expire_at=EXPIRE_AT, retention_days=0
+        )
     # First two items remain staged; the rejected third is not.
     assert batch.has("entity/project", "d1")
     assert batch.has("entity/project", "d2")
@@ -58,18 +62,20 @@ def test_stage_rejects_when_cumulative_exceeds_max_bytes() -> None:
 def test_duplicate_stage_does_not_consume_budget() -> None:
     """Dedup hits raise ValueError before incrementing the byte counter."""
     batch = BucketUploadBatch(max_bytes=1024)
-    batch.stage(_req(b"x" * 600), digest="d1", expire_at=EXPIRE_AT)
+    batch.stage(_req(b"x" * 600), digest="d1", expire_at=EXPIRE_AT, retention_days=0)
     with pytest.raises(ValueError, match="called twice"):
-        batch.stage(_req(b"x" * 600), digest="d1", expire_at=EXPIRE_AT)
+        batch.stage(
+            _req(b"x" * 600), digest="d1", expire_at=EXPIRE_AT, retention_days=0
+        )
     # Budget should still allow another 400 bytes.
-    batch.stage(_req(b"y" * 400), digest="d2", expire_at=EXPIRE_AT)
+    batch.stage(_req(b"y" * 400), digest="d2", expire_at=EXPIRE_AT, retention_days=0)
 
 
 def test_flush_resets_byte_counter(monkeypatch: pytest.MonkeyPatch) -> None:
     """After flush(), staged bytes drop to zero so the next batch starts fresh."""
     monkeypatch.setattr(pbu, "_upload_one", lambda p, client: [])
     batch = BucketUploadBatch(max_bytes=1024)
-    batch.stage(_req(b"x" * 900), digest="d1", expire_at=EXPIRE_AT)
+    batch.stage(_req(b"x" * 900), digest="d1", expire_at=EXPIRE_AT, retention_days=0)
     batch.flush(client=cast(FileStorageClient, object()))
-    batch.stage(_req(b"y" * 900), digest="d2", expire_at=EXPIRE_AT)
+    batch.stage(_req(b"y" * 900), digest="d2", expire_at=EXPIRE_AT, retention_days=0)
     assert batch.has("entity/project", "d2")

--- a/tests/trace_server/test_ttl_insert_paths.py
+++ b/tests/trace_server/test_ttl_insert_paths.py
@@ -20,6 +20,7 @@ import pytest
 from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server import ttl_settings
 from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.errors import InvalidRequest, NotFoundError
@@ -857,3 +858,32 @@ def test_ttl_file_expired_row_is_deleted_and_reads_404(internal_server):
 
     with pytest.raises(NotFoundError):
         server.file_content_read(tsi.FileContentReadReq(project_id=pid, digest=digest))
+
+
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: D1 retention multiplier split"
+)
+def test_object_retention_multiplier_splits_objects_from_files(
+    internal_server, monkeypatch
+):
+    """D1: objects scale retention by OBJECT_RETENTION_MULTIPLIER; files use it raw."""
+    monkeypatch.setattr(ttl_settings, "OBJECT_RETENTION_MULTIPLIER", 3)
+    server = internal_server
+    _, pid = _make_project("d1_split")
+    _set_retention_days(server, pid, 10)
+
+    before = datetime.datetime.now(datetime.timezone.utc)
+    obj = server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(project_id=pid, object_id="o", val={"v": 1})
+        )
+    )
+    file = server.file_create(
+        tsi.FileCreateReq(project_id=pid, name="f.bin", content=b"x")
+    )
+    after = datetime.datetime.now(datetime.timezone.utc)
+
+    [obj_expire] = _read_object_expire_at(server, pid, "o")
+    _assert_expire_at_in_window(obj_expire, before, after, datetime.timedelta(days=30))
+    for value in _read_file_expire_at(server, pid, file.digest):
+        _assert_expire_at_in_window(value, before, after, datetime.timedelta(days=10))

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6130,10 +6130,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             return tsi.FileCreateRes(digest=digest)
 
         # Files share the plain per-project retention (co-created with their
-        # call); the identical expire_at is stamped on every chunk row.
+        # call); the identical expire_at is stamped on every chunk row, and
+        # retention_days tags the bucket blob for native lifecycle expiry.
+        retention_days = get_project_retention_days(req.project_id, self.ch_client)
         expire_at = compute_expire_at_for_insert(
-            get_project_retention_days(req.project_id, self.ch_client),
-            datetime.datetime.now(datetime.timezone.utc),
+            retention_days, datetime.datetime.now(datetime.timezone.utc)
         )
 
         use_file_storage = self._should_use_file_storage_for_writes(req.project_id)
@@ -6141,7 +6142,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         if client is not None and use_file_storage:
             try:
-                self._file_create_bucket(req, digest, client, expire_at)
+                self._file_create_bucket(req, digest, client, expire_at, retention_days)
             except FileStorageWriteError:
                 self._file_create_clickhouse(req, digest, expire_at)
         else:
@@ -6163,6 +6164,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         digest: str,
         client: FileStorageClient,
         expire_at: datetime.datetime,
+        retention_days: int,
     ) -> None:
         if not self._flush_immediately:
             # Inside call_batch(): stage for the parallel flush at the end so
@@ -6171,11 +6173,15 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             # handled inside _upload_one, not by the caller's except arm; root-
             # span attribution is deferred to bucket_upload_batch.flush so the
             # tag matches where the bytes actually land.
-            self._bucket_uploads.stage(req, digest, expire_at)
+            self._bucket_uploads.stage(req, digest, expire_at, retention_days)
             return
         set_root_span_dd_tags({"storage_provider": "bucket"})
         target_file_storage_uri = store_in_bucket(
-            client, key_for_project_digest(req.project_id, digest), req.content
+            client,
+            key_for_project_digest(req.project_id, digest),
+            req.content,
+            retention_days=retention_days,
+            expire_at=expire_at,
         )
         self._insert_file_chunks(
             [

--- a/weave/trace_server/file_storage.py
+++ b/weave/trace_server/file_storage.py
@@ -40,6 +40,7 @@ There are two ways to authenticate with Azure Blob Storage:
     - `WF_FILE_STORAGE_AZURE_ACCOUNT_URL`: (optional) the account url for the azure account - defaults to `https://<account>.blob.core.windows.net/`
 """
 
+import datetime
 import logging
 import socket
 import threading
@@ -87,9 +88,14 @@ from weave.trace_server.file_storage_uris import (
     GCSFileStorageURI,
     S3FileStorageURI,
 )
+from weave.trace_server.ttl_settings import RETENTION_DAYS_NO_TTL
 
 # Configure logger
 logger = logging.getLogger(__name__)
+
+# Blob object tag (S3/Azure) keying native lifecycle rules to a retention bucket;
+# GCS instead uses the blob's custom_time. One source of truth for the rules.
+RETENTION_TAG_KEY = "weave-retention-days"
 
 # Default timeout values (in seconds)
 DEFAULT_CONNECT_TIMEOUT = 10
@@ -150,8 +156,19 @@ class FileStorageClient:
         self.base_uri = base_uri
 
     @abstractmethod
-    def store(self, uri: FileStorageURI, data: bytes) -> None:
-        """Store data at the specified URI location in cloud storage."""
+    def store(
+        self,
+        uri: FileStorageURI,
+        data: bytes,
+        retention_days: int = RETENTION_DAYS_NO_TTL,
+        expire_at: datetime.datetime | None = None,
+    ) -> None:
+        """Store data at the specified URI location in cloud storage.
+
+        retention_days/expire_at stamp the blob for native object-store lifecycle
+        expiry (GCS custom_time, S3/Azure retention-days tag). RETENTION_DAYS_NO_TTL
+        stamps nothing so the blob is never matched by a lifecycle rule.
+        """
         pass
 
     @abstractmethod
@@ -161,7 +178,11 @@ class FileStorageClient:
 
 
 def store_in_bucket(
-    client: FileStorageClient, path: str, data: bytes
+    client: FileStorageClient,
+    path: str,
+    data: bytes,
+    retention_days: int = RETENTION_DAYS_NO_TTL,
+    expire_at: datetime.datetime | None = None,
 ) -> FileStorageURI:
     """Store a file in a storage bucket, deduping repeat content-addressed writes."""
     target_file_storage_uri = client.base_uri.with_path(path)
@@ -171,7 +192,12 @@ def store_in_bucket(
     if already_stored:
         return target_file_storage_uri
     try:
-        client.store(target_file_storage_uri, data)
+        client.store(
+            target_file_storage_uri,
+            data,
+            retention_days=retention_days,
+            expire_at=expire_at,
+        )
     except Exception as e:
         logger.exception("Failed to store file at %s", target_file_storage_uri)
         raise FileStorageWriteError(f"Failed to store file at {path}: {e!s}") from e
@@ -306,7 +332,13 @@ class S3StorageClient(FileStorageClient):
         )
 
     @create_retry_decorator("s3_storage")
-    def store(self, uri: FileStorageURI, data: bytes) -> None:
+    def store(
+        self,
+        uri: FileStorageURI,
+        data: bytes,
+        retention_days: int = RETENTION_DAYS_NO_TTL,
+        expire_at: datetime.datetime | None = None,
+    ) -> None:
         """Store data in S3 bucket with automatic retries on failure."""
         assert isinstance(uri, S3FileStorageURI)
         assert uri.to_uri_str().startswith(self.base_uri.to_uri_str())
@@ -317,6 +349,10 @@ class S3StorageClient(FileStorageClient):
         if self.kms_key:
             put_object_params["ServerSideEncryption"] = "aws:kms"
             put_object_params["SSEKMSKeyId"] = self.kms_key
+
+        # Tag the retention bucket so a per-N lifecycle rule expires the blob.
+        if retention_days != RETENTION_DAYS_NO_TTL:
+            put_object_params["Tagging"] = f"{RETENTION_TAG_KEY}={retention_days}"
 
         self.client.put_object(**put_object_params)
 
@@ -341,7 +377,13 @@ class GCSStorageClient(FileStorageClient):
         self.client = _build_keepalive_gcs_client(credentials)
 
     @create_retry_decorator("gcs_storage")
-    def store(self, uri: FileStorageURI, data: bytes) -> None:
+    def store(
+        self,
+        uri: FileStorageURI,
+        data: bytes,
+        retention_days: int = RETENTION_DAYS_NO_TTL,
+        expire_at: datetime.datetime | None = None,
+    ) -> None:
         """Store data in GCS bucket with automatic retries on failure.
 
         Use if_generation_match=0 to skip writing if the object already exists.
@@ -350,6 +392,12 @@ class GCSStorageClient(FileStorageClient):
         assert uri.to_uri_str().startswith(self.base_uri.to_uri_str())
         bucket = self.client.bucket(uri.bucket)
         blob = bucket.blob(uri.path)
+        # custom_time drives the `daysSinceCustomTime: 0` lifecycle rule.
+        if retention_days != RETENTION_DAYS_NO_TTL:
+            assert expire_at is not None, (
+                "expire_at required when retention_days is set"
+            )
+            blob.custom_time = expire_at
         try:
             # if_generation_match=0 means "only write if object doesn't exist"
             # This prevents rate limiting from multiple pods writing the same object
@@ -411,7 +459,13 @@ class AzureStorageClient(FileStorageClient):
             )
 
     @create_retry_decorator("azure_storage")
-    def store(self, uri: FileStorageURI, data: bytes) -> None:
+    def store(
+        self,
+        uri: FileStorageURI,
+        data: bytes,
+        retention_days: int = RETENTION_DAYS_NO_TTL,
+        expire_at: datetime.datetime | None = None,
+    ) -> None:
         """Store data in Azure container with automatic retries on failure.
 
         Uses `overwrite=False` so content-addressable blobs are write-once:
@@ -423,8 +477,14 @@ class AzureStorageClient(FileStorageClient):
         client = self._get_client(uri.account)
         container_client = client.get_container_client(uri.container)
         blob_client = container_client.get_blob_client(uri.path)
+        # Index tag keys a per-N lifecycle rule to expire the blob.
+        tags = (
+            {RETENTION_TAG_KEY: str(retention_days)}
+            if retention_days != RETENTION_DAYS_NO_TTL
+            else None
+        )
         try:
-            blob_client.upload_blob(data, overwrite=False)
+            blob_client.upload_blob(data, overwrite=False, tags=tags)
         except ResourceExistsError:
             logger.debug("Object already exists at %s, skipping write", uri)
 

--- a/weave/trace_server/parallel_bucket_uploads.py
+++ b/weave/trace_server/parallel_bucket_uploads.py
@@ -10,7 +10,7 @@ This module owns the deferred-upload buffer and the fan-out step:
 
     bucket_uploads = BucketUploadBatch()
     ...
-    bucket_uploads.stage(req, digest, expire_at)  # cheap, in-memory only
+    bucket_uploads.stage(req, digest, expire_at, retention_days)  # in-memory only
     ...
     rows = bucket_uploads.flush(client)      # parallel upload -> CH rows
     self._file_batch.extend(rows)
@@ -77,6 +77,7 @@ class _Pending:
     req: tsi.FileCreateReq
     digest: str
     expire_at: datetime.datetime
+    retention_days: int
 
 
 class BucketUploadBatch:
@@ -94,7 +95,11 @@ class BucketUploadBatch:
         self._total_bytes = 0
 
     def stage(
-        self, req: tsi.FileCreateReq, digest: str, expire_at: datetime.datetime
+        self,
+        req: tsi.FileCreateReq,
+        digest: str,
+        expire_at: datetime.datetime,
+        retention_days: int,
     ) -> None:
         """Defer a bucket upload until `flush()`.
 
@@ -121,7 +126,14 @@ class BucketUploadBatch:
                 f"BucketUploadBatch would exceed max_bytes={self._max_bytes}: "
                 f"staged={self._total_bytes}, new={size}"
             )
-        self._pending.append(_Pending(req=req, digest=digest, expire_at=expire_at))
+        self._pending.append(
+            _Pending(
+                req=req,
+                digest=digest,
+                expire_at=expire_at,
+                retention_days=retention_days,
+            )
+        )
         self._seen.add(key)
         self._total_bytes += size
 
@@ -200,7 +212,11 @@ def _upload_one(
 ) -> list[FileChunkCreateCHInsertable]:
     try:
         uri = store_in_bucket(
-            client, key_for_project_digest(p.req.project_id, p.digest), p.req.content
+            client,
+            key_for_project_digest(p.req.project_id, p.digest),
+            p.req.content,
+            retention_days=p.retention_days,
+            expire_at=p.expire_at,
         )
     except FileStorageWriteError:
         return file_chunks_for(p.req, p.digest, p.expire_at)


### PR DESCRIPTION
## Summary
- Stamp bucket blobs so the object store expires them natively: GCS `custom_time`, S3/Azure `weave-retention-days` tag (one shared `RETENTION_TAG_KEY`).
- D2=no-SLA: the lifecycle rules that act on these (Task G, terraform) are a required deploy follow-up; without them blobs persist past the ClickHouse row TTL.

## Testing
functional store tests per backend + D1 multiplier split (objects scale, files do not).
