### PR TITLE
feat(weave): propagate GenAI conversation attributes through the handle chain

### DIFF
--- a/sdks/node/src/__tests__/genai/attributes.test.ts
+++ b/sdks/node/src/__tests__/genai/attributes.test.ts
@@ -1,0 +1,113 @@
+import {startConversation, startTurn} from '../../genai/api';
+import {runIsolated} from '../../genai/context';
+
+import {setupExporterPerTest, setupGenAITestEnvironment} from './common';
+
+// Custom (non-semconv) attributes a host sets once at the root and expects on
+// every span -- e.g. weave-openclaw's integration identity.
+const CUSTOM = {
+  'weave.integration.name': 'weave-openclaw',
+  'weave.integration.version': '0.1.1',
+};
+
+describe('custom attribute propagation', () => {
+  setupGenAITestEnvironment();
+  const getExporter = setupExporterPerTest();
+
+  it('propagates startConversation attributes to every span when each is opened in its own runIsolated frame', () => {
+    // Mirrors a decoupled-callback host (the OpenClaw plugin): the Conversation
+    // is created once and stored, then each child span is opened later in a
+    // fresh runIsolated frame, so ambient state.conversation is null at every
+    // create(). The attributes must still ride the stored-handle chain.
+    const conversation = runIsolated(() =>
+      startConversation({conversationId: 'c-x', attributes: CUSTOM})
+    );
+    const turn = runIsolated(() =>
+      conversation.startTurn({agentName: 'agent', model: 'm'})
+    );
+    const llm = runIsolated(() => turn.startLLM({model: 'm'}));
+    const toolUnderTurn = runIsolated(() =>
+      turn.startTool({name: 'search', toolCallId: 't1'})
+    );
+    const toolUnderLlm = runIsolated(() =>
+      llm.startTool({name: 'fetch', toolCallId: 't2'})
+    );
+    const sub = runIsolated(() => turn.startSubagent({name: 'critic'}));
+    toolUnderLlm.end();
+    toolUnderTurn.end();
+    sub.end();
+    llm.end();
+    turn.end();
+    conversation.end();
+
+    const spans = getExporter().getFinishedSpans();
+    expect(spans).toHaveLength(5); // turn, llm, 2 tools, subagent
+    for (const s of spans) {
+      expect(s.attributes['weave.integration.name']).toBe('weave-openclaw');
+      expect(s.attributes['weave.integration.version']).toBe('0.1.1');
+    }
+  });
+
+  it('propagates a rootless startTurn({attributes}) to its children (no Conversation)', () => {
+    // The sessionless path: no Conversation, attributes set on the root Turn.
+    const turn = runIsolated(() =>
+      startTurn({agentName: 'agent', model: 'm', attributes: CUSTOM})
+    );
+    const llm = runIsolated(() => turn.startLLM({model: 'm'}));
+    const tool = runIsolated(() =>
+      turn.startTool({name: 'search', toolCallId: 't1'})
+    );
+    tool.end();
+    llm.end();
+    turn.end();
+
+    const spans = getExporter().getFinishedSpans();
+    expect(spans).toHaveLength(3); // turn, llm, tool
+    for (const s of spans) {
+      expect(s.attributes['weave.integration.name']).toBe('weave-openclaw');
+    }
+  });
+
+  it('still propagates attributes in the single-frame usage (one runIsolated)', () => {
+    // Regression guard: the SDK's documented single-frame usage keeps working
+    // via the ambient state read, unchanged by the handle-threading addition.
+    runIsolated(() => {
+      const conversation = startConversation({
+        conversationId: 'c-1',
+        attributes: CUSTOM,
+      });
+      const turn = conversation.startTurn({agentName: 'agent'});
+      const llm = turn.startLLM({model: 'm'});
+      const tool = llm.startTool({name: 'search'});
+      tool.end();
+      llm.end();
+      turn.end();
+      conversation.end();
+    });
+
+    const spans = getExporter().getFinishedSpans();
+    expect(spans).toHaveLength(3);
+    for (const s of spans) {
+      expect(s.attributes['weave.integration.name']).toBe('weave-openclaw');
+    }
+  });
+
+  it('merges per-turn attributes over conversation attributes', () => {
+    const conversation = runIsolated(() =>
+      startConversation({conversationId: 'c-1', attributes: {a: 'conv', b: 'conv'}})
+    );
+    const turn = runIsolated(() =>
+      conversation.startTurn({attributes: {b: 'turn', c: 'turn'}})
+    );
+    const llm = runIsolated(() => turn.startLLM({model: 'm'}));
+    llm.end();
+    turn.end();
+    conversation.end();
+
+    for (const s of getExporter().getFinishedSpans()) {
+      expect(s.attributes['a']).toBe('conv'); // conversation-only
+      expect(s.attributes['b']).toBe('turn'); // per-turn overrides
+      expect(s.attributes['c']).toBe('turn'); // per-turn-only
+    }
+  });
+});

--- a/sdks/node/src/genai/common.ts
+++ b/sdks/node/src/genai/common.ts
@@ -1,11 +1,16 @@
-import type {Context} from '@opentelemetry/api';
+import type {Attributes, Context} from '@opentelemetry/api';
 
 /**
  * Internal options threaded from a parent emitter into a child class's
  * `create()` factory. Carries the OTel parent Context (which already has
- * the parent span attached) and the propagating conversation id.
+ * the parent span attached), the propagating conversation id, and the
+ * propagating custom attributes.
  */
 export interface ChildSpanContext {
   parentContext: Context;
   conversationId?: string;
+  /** Custom attributes carried down from the parent span. Lets conversation /
+   *  turn-level attributes ride the handle chain even when the ambient GenAI
+   *  state does not span the parent's and child's async frames. */
+  attributes?: Attributes;
 }

--- a/sdks/node/src/genai/conversation.ts
+++ b/sdks/node/src/genai/conversation.ts
@@ -65,6 +65,10 @@ export class Conversation {
       agentName: opts.agentName ?? this.agentName,
       model: opts.model ?? this.model,
       conversationId: this.conversationId,
+      // Forward the conversation's attributes so they ride the handle chain to
+      // the turn and every child, even across runIsolated frames. Per-turn opts
+      // override on key collision.
+      attributes: {...this.attributes, ...(opts.attributes ?? {})},
     });
   }
 

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -94,6 +94,7 @@ export class LLM extends SpanBase {
     span: Span,
     private readonly context: Context,
     private readonly conversationId: string,
+    private readonly attributes: Attributes,
     public readonly model: string,
     public readonly providerName: string
   ) {
@@ -108,8 +109,12 @@ export class LLM extends SpanBase {
       );
     }
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
-    const attributes: Attributes = {
+    const propagated: Attributes = {
       ...(state.conversation?.attributes ?? {}),
+      ...(opts.attributes ?? {}),
+    };
+    const attributes: Attributes = {
+      ...propagated,
       [ATTR_GEN_AI_OPERATION_NAME]: 'chat',
       [ATTR_GEN_AI_REQUEST_MODEL]: opts.model,
     };
@@ -128,6 +133,7 @@ export class LLM extends SpanBase {
       span,
       trace.setSpan(opts.parentContext, span),
       opts.conversationId ?? '',
+      propagated,
       opts.model,
       opts.providerName ?? ''
     );
@@ -225,6 +231,7 @@ export class LLM extends SpanBase {
       ...opts,
       parentContext: this.context,
       conversationId: this.conversationId,
+      attributes: this.attributes,
     });
   }
 
@@ -234,6 +241,7 @@ export class LLM extends SpanBase {
       ...opts,
       parentContext: this.context,
       conversationId: this.conversationId,
+      attributes: this.attributes,
     });
   }
 

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -48,6 +48,7 @@ export class SubAgent extends SpanBase {
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
     const attributes: Attributes = {
       ...(state.conversation?.attributes ?? {}),
+      ...(opts.attributes ?? {}),
       [ATTR_GEN_AI_OPERATION_NAME]: 'invoke_agent',
       [ATTR_GEN_AI_AGENT_NAME]: opts.name,
     };

--- a/sdks/node/src/genai/tool.ts
+++ b/sdks/node/src/genai/tool.ts
@@ -60,6 +60,7 @@ export class Tool extends SpanBase {
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
     const attributes: Attributes = {
       ...(state.conversation?.attributes ?? {}),
+      ...(opts.attributes ?? {}),
       [ATTR_GEN_AI_OPERATION_NAME]: 'execute_tool',
       [ATTR_GEN_AI_TOOL_NAME]: opts.name,
     };

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -25,6 +25,10 @@ import {Tool, type ToolInit} from './tool';
 export interface TurnInit extends SpanInitBase {
   agentName?: string;
   model?: string;
+  /** Custom attributes stamped on this turn and propagated to every child span
+   *  (chat, tool, subagent). Use for a rootless turn with no Conversation; a
+   *  Conversation forwards its own `attributes` here automatically. */
+  attributes?: Attributes;
 }
 
 /**
@@ -54,6 +58,7 @@ export class Turn extends SpanBase {
     span: Span,
     private readonly context: Context,
     private readonly conversationId: string,
+    private readonly attributes: Attributes,
     public readonly agentName: string,
     public readonly model: string
   ) {
@@ -68,8 +73,15 @@ export class Turn extends SpanBase {
       );
     }
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
-    const attributes: Attributes = {
+    // The propagating set: conversation attributes (when the conversation is
+    // ambient) merged with any threaded/explicit turn attributes. Stored on the
+    // turn so its children inherit it via the handle chain.
+    const propagated: Attributes = {
       ...(state.conversation?.attributes ?? {}),
+      ...(opts.attributes ?? {}),
+    };
+    const attributes: Attributes = {
+      ...propagated,
       [ATTR_GEN_AI_OPERATION_NAME]: 'invoke_agent',
     };
     if (opts.agentName) {
@@ -93,6 +105,7 @@ export class Turn extends SpanBase {
       span,
       trace.setSpan(ROOT_CONTEXT, span),
       opts.conversationId ?? '',
+      propagated,
       opts.agentName ?? '',
       opts.model ?? ''
     );
@@ -106,6 +119,7 @@ export class Turn extends SpanBase {
       ...opts,
       parentContext: this.context,
       conversationId: this.conversationId,
+      attributes: this.attributes,
     });
   }
 
@@ -115,6 +129,7 @@ export class Turn extends SpanBase {
       ...opts,
       parentContext: this.context,
       conversationId: this.conversationId,
+      attributes: this.attributes,
     });
   }
 
@@ -124,6 +139,7 @@ export class Turn extends SpanBase {
       ...opts,
       parentContext: this.context,
       conversationId: this.conversationId,
+      attributes: this.attributes,
     });
   }
 


### PR DESCRIPTION
## What

`ConversationInit.attributes` is documented as "custom attributes stamped on every
span the conversation emits," but today they only land on spans created in the
**same async frame** as the Conversation. Each span's `create()` reads them from the
ambient `state.conversation`, and `runIsolated()` installs a fresh state per frame.
Hosts that open spans across decoupled callbacks (each span in its own
`runIsolated()` frame, correlated by id rather than a shared async chain) get none
of them.

This threads the custom attribute set through the handle chain, the same way
`conversationId` already propagates, so it survives across frames.

## How

- `ChildSpanContext` carries `attributes` (alongside `parentContext`, `conversationId`).
- `Turn` and `LLM` compute the propagating set (`{...ambient, ...threaded}`), store it,
  and pass it to every child factory (`startLLM` / `startTool` / `startSubagent`).
- `Tool` / `SubAgent` merge `opts.attributes` onto their span.
- `Conversation.startTurn` forwards `this.attributes` (per-turn opts override on collision).
- New `TurnInit.attributes`, so a rootless `startTurn({attributes})` (no Conversation)
  carries them to its children too.

Backward compatible: the ambient read is kept and merged first, so single-frame usage
is unchanged.

## Test

`src/__tests__/genai/attributes.test.ts`:
- **cross-frame**: `startConversation({attributes})` with each span opened in its own
  `runIsolated` frame via stored handles -> turn / chat / 2 tools / subagent all carry
  the attrs (this is the case that fails before the change).
- **rootless** `startTurn({attributes})` -> children inherit.
- **single-frame regression** -> unchanged.
- **per-turn override** -> per-turn attributes win over conversation attributes.

Full genai suite green (77 tests).

## Follow-ups

- Mirror in the Python SDK for parity.
- Motivating consumer: the `weave-openclaw` OpenClaw plugin stamps integration identity
  per-span today because of this gap; it can switch to a single
  `startConversation({ attributes })` once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
