### PR TITLE
chore(weave_ts): Update type to unblock `typedoc` in `docs/` repo.

### DIFF
--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -129,7 +129,7 @@ function toolResultText(content: ToolResultBlock['content']): string {
   }
   // `content` is an array of content blocks here; keep the text parts.
   const text = content
-    .map(block => (block.type === 'text' ? block.text : ''))
+    .map((block: any) => (block.type === 'text' ? block.text : ''))
     .filter(Boolean)
     .join('\n');
   return text || JSON.stringify(content);


### PR DESCRIPTION
## Description

* `typedoc` currently fails in the `docs/` repo. This is bandaid on that so we can get our reference docs updated. 

```tsx
[info] Loaded plugin typedoc-plugin-markdown
[warning] You are running with an unsupported TypeScript version! If TypeDoc crashes, this is why. TypeDoc supports 4.6, 4.7, 4.8, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4
src/integrations/claude-agent-sdk/otelTracer.ts:132:10 - error TS7006: Parameter 'block' implicitly has an 'any' type.

132     .map(block => (block.type === 'text' ? block.text : ''))
```


* Once we update `typedoc` in that repo, this should no longer be an issue.