### PR TITLE
perf(weave): bound eval_results calls_merged scan by eval-root start time

### DIFF
--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -50,6 +50,13 @@ def test_cte_chain_calls_merged() -> None:
                     AND calls_merged.id NOT IN {pb_1:Array(String)}
                     AND (multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
                         OR calls_merged.op_name IS NULL)
+                    AND calls_merged.sortable_datetime >= coalesce(
+                        (SELECT min(roots.started_at) - toIntervalSecond(300)
+                            FROM calls_merged AS roots
+                            PREWHERE roots.project_id = {pb_0:String}
+                            WHERE roots.id IN {pb_1:Array(String)}
+                        ),
+                        toDateTime64(0, 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
                     AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
@@ -408,6 +415,13 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                     AND calls_merged.id NOT IN {pb_1:Array(String)}
                     AND (multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
                         OR calls_merged.op_name IS NULL)
+                    AND calls_merged.sortable_datetime >= coalesce(
+                        (SELECT min(roots.started_at) - toIntervalSecond(300)
+                            FROM calls_merged AS roots
+                            PREWHERE roots.project_id = {pb_0:String}
+                            WHERE roots.id IN {pb_1:Array(String)}
+                        ),
+                        toDateTime64(0, 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
                     AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
@@ -506,6 +520,13 @@ def test_full_query_calls_merged() -> None:
                     AND calls_merged.id NOT IN {pb_1:Array(String)}
                     AND (multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
                         OR calls_merged.op_name IS NULL)
+                    AND calls_merged.sortable_datetime >= coalesce(
+                        (SELECT min(roots.started_at) - toIntervalSecond(300)
+                            FROM calls_merged AS roots
+                            PREWHERE roots.project_id = {pb_0:String}
+                            WHERE roots.id IN {pb_1:Array(String)}
+                        ),
+                        toDateTime64(0, 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
                     AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -14,6 +14,9 @@ from functools import partial
 
 from weave.trace_server import constants
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.calls_query_builder.optimization_builder import (
+    DATETIME_BUFFER_TIME_SECONDS,
+)
 from weave.trace_server.calls_query_builder.utils import (
     json_dump_field_as_sql,
     param_slot,
@@ -43,6 +46,26 @@ END"""
 def _or_any_prefix_matches(op_name_expr: str, op_prefix_params: list[str]) -> str:
     """`multiSearchAny(op_name, [prefixes])`: matches if any prefix is a substring (engages idx_op_name ngrambf index)."""
     return f"multiSearchAny({op_name_expr}, [{', '.join(op_prefix_params)}])"
+
+
+def _build_eval_start_lower_bound(
+    project_id_param: str, eval_root_ids_param: str
+) -> str:
+    """sortable_datetime floor for the calls_merged scan, as a scalar subquery.
+
+    Predict-and-score calls start at/after their eval root, so bounding by the
+    roots' earliest start (minus a buffer) engages the sortable_datetime minmax
+    index and prunes granules. Falls back to epoch if the root start is NULL.
+    """
+    return f"""coalesce(
+        (
+            SELECT min(roots.started_at) - toIntervalSecond({DATETIME_BUFFER_TIME_SECONDS})
+            FROM calls_merged AS roots
+            PREWHERE roots.project_id = {project_id_param}
+            WHERE roots.id IN {eval_root_ids_param}
+        ),
+        toDateTime64(0, 3)
+    )"""
 
 
 def _sort_filter_uses_inputs(
@@ -96,6 +119,9 @@ def build_predict_and_score_calls_cte(
     )
 
     if read_table == "calls_merged":
+        eval_start_lower_bound = _build_eval_start_lower_bound(
+            project_id_param, eval_root_ids_param
+        )
         return f"""predict_and_score_calls AS (
     SELECT
         calls_merged.id AS call_id,
@@ -114,6 +140,7 @@ def build_predict_and_score_calls_cte(
         {op_match_where}
         OR calls_merged.op_name IS NULL
     )
+    AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
     GROUP BY (calls_merged.project_id, calls_merged.id)
     HAVING any(calls_merged.parent_id) IN {eval_root_ids_param}
         AND ({op_match_having})


### PR DESCRIPTION
## Summary
- `/eval_results` scans `calls_merged` with no time bound (filters/sort run in `HAVING`, after the scan), so it reads the whole project and hits the 60s timeout (504) on large evals like ([DD trace](https://us5.datadoghq.com/apm/trace/6a3c066500000000bf35910f05d9bf0a)).
- Predict-and-score calls start at/after their eval root, so floor the scan at the roots' earliest `started_at` (minus a 5m buffer), engaging the `sortable_datetime` minmax index. **`calls_complete` is unchanged** (no `OR parent_id IS NULL` over-read), so this only affects `calls_merged` projects.

## Why a subquery
The bound is data, not input: the request only carries `evaluation_call_ids`, and the roots' `started_at` lives in `calls_merged`. An uncorrelated scalar subquery lets CH read it and fold it to a constant before the scan, pruning via the minmax index with **zero extra round-trips**. `coalesce(..., epoch)` is NULL-safety (a NULL `min` would otherwise make `>= NULL` return zero rows); it doesn't defeat pruning.

## Benchmarks (real prod `weave_trace_db`, identical rows verified before/after)
Each cell is `OLD -> NEW (Δ%)`. `rows` = `read_rows` across the query's CTE scans; `mem` = peak memory; `lat` = wall time. Bytes scanned track rows (e.g. 56.6M recent: 3.8 TB -> 1.0 GB).

### Common case: viewing a recent eval (the default load)
| project | rows | mem | latency |
|---|---|---|---|
| 265M-row hot | ~532M -> 692K (**-99.9%**) | n/a -> 0.24 GB | timeout >60s -> 0.9s (**fixed**) |
| 56.6M-row low eval-frac | 141.6M -> 726K (**-99.5%**) | 0.5 -> 0.83 GB | timeout 65s -> 3.5s (**fixed**) |
| 5.5M-row dense 1-day | 37.9M -> 1.39M (**-96%**) | 0.73 -> 0.33 GB (-55%) | 1.15s -> 0.84s (**-27%**) |
| 2.3M-row 543-day span | 3.09M -> 274K (**-91%**) | 0.79 -> 0.86 GB (+9%) | 0.69s -> 0.33s (**-53%**) |

### Regression case: viewing an old eval (floor near project start)
| project | rows | mem | latency |
|---|---|---|---|
| 2.3M-row, oldest eval | 2.83M -> 18.7M (**+560%**) | 0.70 -> 0.80 GB (+14%) | 0.63s -> 1.83s (**+189%**) |
| 56.6M-row, oldest eval | 128.9M -> 140M (**+9%**) | n/a | timeout -> timeout (**none**) |

When the floor is not selective, its presence makes CH prefer the `sortable_datetime` minmax index and drop the `op_name` ngrambf pruning OLD relies on, so it reads the full table. Peak memory is roughly flat (same GROUP BY); rows/bytes scanned are what move.

## Why the regression is acceptable
1. **Bounded.** Worst measured is 0.63s -> 1.83s (sub-2s). It never turns a fast query into a new timeout: the only projects whose full scan exceeds 60s were already at the wall on OLD for those views (the ngrambf does not save them, see the 56.6M-row case), so NEW is no worse there and fixes their common recent-eval views.
2. **Rare path only.** It costs extra only when viewing an old eval; the default load (recent eval) wins in every project measured, including the timeout cases.
3. **Net.** Prevents 504s on the common path (the only eval_results timeouts in prod over 30d were this exact scan) for a sub-2s slowdown on a narrow, infrequent path.

## How many projects are exposed

| eval temporal spread | % of projects | regression exposure |
|---|---|---|
| all evals in a <=1-day burst | 76.6% | none (no old eval exists) |
| 2-30 day span | 15.9% | negligible |
| >30d span, >=3 evals | **7.5%** | old-eval views only |
| of those, large (>500k ps rows) | <0.1% | already time out on OLD; NEW strictly better |

So at most ~7.5% of projects can see any old-eval slowdown, the large ones in that set are already broken on OLD, and recent-eval views (the common load) benefit across the board.

## Testing
unit (full-SQL assert of the bound) + 30 functional eval-api tests green against real CH; before/after identical rows; benchmarked across prod projects spanning 2.3M-265M rows.
