### PR TITLE
feat(weave_ts): Accept `userMessage` and `systemInstructions` when creating `Turn`s

### DIFF
--- a/sdks/node/src/__tests__/genai/conversation.test.ts
+++ b/sdks/node/src/__tests__/genai/conversation.test.ts
@@ -4,7 +4,12 @@ import {
 } from '../../genai/semconv';
 import {Conversation, Session} from '../../genai/conversation';
 
-import {setupExporterPerTest, setupGenAITestEnvironment} from './common';
+import {
+  findSpan,
+  setupExporterPerTest,
+  setupGenAITestEnvironment,
+  spanSnapshot,
+} from './common';
 
 describe('Conversation', () => {
   setupGenAITestEnvironment();
@@ -54,5 +59,62 @@ describe('Conversation', () => {
     });
     expect(conversation.conversationId).toBe('new');
     conversation.end();
+  });
+
+  it('startTurn emits given data on `invoke_agent` span', () => {
+    const conversation = Conversation.create({
+      agentName: 'dispatcher',
+      model: 'some-model',
+      conversationId: 'c-2',
+    });
+    const turn = conversation.startTurn({
+      agentName: 'weather-bot',
+      model: 'gpt-4o',
+      userMessage: "What's the weather?",
+      systemInstructions: ['Be helpful', 'Be concise'],
+    });
+    turn.end();
+    conversation.end();
+
+    const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
+    expect(spanSnapshot(span)).toMatchInlineSnapshot(`
+      {
+        "attributes": {
+          "gen_ai.agent.name": "weather-bot",
+          "gen_ai.conversation.id": "<uuid>",
+          "gen_ai.input.messages": "[{"role":"user","parts":[{"type":"text","content":"What's the weather?"}]}]",
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.request.model": "gpt-4o",
+          "gen_ai.system_instructions": "[{"type":"text","content":"Be helpful"},{"type":"text","content":"Be concise"}]",
+        },
+        "endTime": "<timestamp>",
+        "startTime": "<timestamp>",
+      }
+    `);
+  });
+
+  it('startTurn falls back to conversation data when not given', () => {
+    const conversation = Conversation.create({
+      agentName: 'dispatcher',
+      model: 'some-model',
+      conversationId: 'c-3',
+    });
+    const turn = conversation.startTurn();
+    turn.end();
+    conversation.end();
+
+    const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
+    expect(spanSnapshot(span)).toMatchInlineSnapshot(`
+      {
+        "attributes": {
+          "gen_ai.agent.name": "dispatcher",
+          "gen_ai.conversation.id": "<uuid>",
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.request.model": "some-model",
+        },
+        "endTime": "<timestamp>",
+        "startTime": "<timestamp>",
+      }
+    `);
   });
 });

--- a/sdks/node/src/__tests__/genai/genai.test.ts
+++ b/sdks/node/src/__tests__/genai/genai.test.ts
@@ -285,7 +285,11 @@ async function run(agent: Agent, prompts: string[]): Promise<string[]> {
     const answers: string[] = [];
     for (const prompt of prompts) {
       messages.push({role: 'user', content: prompt});
-      const turn = conversation.startTurn({agentName: agent.name});
+      const turn = conversation.startTurn({
+        agentName: agent.name,
+        userMessage: prompt,
+        systemInstructions: [agent.instructions],
+      });
       try {
         answers.push(await runAgentLoop(agent, messages, turn));
       } finally {
@@ -396,7 +400,9 @@ describe('GenAI', () => {
           "attributes": {
             "gen_ai.agent.name": "Reasearch Assistant",
             "gen_ai.conversation.id": "<uuid>",
+            "gen_ai.input.messages": "[{"role":"user","parts":[{"type":"text","content":"How warm is Tokyo?"}]}]",
             "gen_ai.operation.name": "invoke_agent",
+            "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "myagent.region": "ORD",
             "myagent.version": "4.21",
           },
@@ -467,7 +473,9 @@ describe('GenAI', () => {
           "attributes": {
             "gen_ai.agent.name": "Reasearch Assistant",
             "gen_ai.conversation.id": "<uuid>",
+            "gen_ai.input.messages": "[{"role":"user","parts":[{"type":"text","content":"What about San Francisco and London?"}]}]",
             "gen_ai.operation.name": "invoke_agent",
+            "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "myagent.region": "ORD",
             "myagent.version": "4.21",
           },
@@ -524,7 +532,9 @@ describe('GenAI', () => {
           "attributes": {
             "gen_ai.agent.name": "Reasearch Assistant",
             "gen_ai.conversation.id": "<uuid>",
+            "gen_ai.input.messages": "[{"role":"user","parts":[{"type":"text","content":"How much warmer is Tokyo than San Francisco?"}]}]",
             "gen_ai.operation.name": "invoke_agent",
+            "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "myagent.region": "ORD",
             "myagent.version": "4.21",
           },

--- a/sdks/node/src/__tests__/genai/turn.test.ts
+++ b/sdks/node/src/__tests__/genai/turn.test.ts
@@ -1,11 +1,4 @@
-import {SpanKind, SpanStatusCode} from '@opentelemetry/api';
-
-import {
-  ATTR_GEN_AI_AGENT_NAME,
-  ATTR_GEN_AI_CONVERSATION_ID,
-  ATTR_GEN_AI_OPERATION_NAME,
-  ATTR_GEN_AI_REQUEST_MODEL,
-} from '../../genai/semconv';
+import {SpanStatusCode} from '@opentelemetry/api';
 import {Turn} from '../../genai/turn';
 
 import {
@@ -13,6 +6,7 @@ import {
   findSpan,
   setupExporterPerTest,
   setupGenAITestEnvironment,
+  spanSnapshot,
 } from './common';
 
 describe('Turn', () => {
@@ -24,16 +18,26 @@ describe('Turn', () => {
       agentName: 'weather-bot',
       model: 'gpt-4o',
       conversationId: 'conv-1',
+      userMessage: "What's the weather?",
+      systemInstructions: ['Be helpful', 'Be concise'],
     });
     turn.end();
 
     const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
-    expect(span.kind).toBe(SpanKind.CLIENT);
-    expect(span.attributes[ATTR_GEN_AI_OPERATION_NAME]).toBe('invoke_agent');
-    expect(span.attributes[ATTR_GEN_AI_AGENT_NAME]).toBe('weather-bot');
-    expect(span.attributes[ATTR_GEN_AI_REQUEST_MODEL]).toBe('gpt-4o');
-    expect(span.attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('conv-1');
-    expect(span.parentSpanId).toBeUndefined();
+    expect(spanSnapshot(span)).toMatchInlineSnapshot(`
+      {
+        "attributes": {
+          "gen_ai.agent.name": "weather-bot",
+          "gen_ai.conversation.id": "<uuid>",
+          "gen_ai.input.messages": "[{"role":"user","parts":[{"type":"text","content":"What's the weather?"}]}]",
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.request.model": "gpt-4o",
+          "gen_ai.system_instructions": "[{"type":"text","content":"Be helpful"},{"type":"text","content":"Be concise"}]",
+        },
+        "endTime": "<timestamp>",
+        "startTime": "<timestamp>",
+      }
+    `);
   });
 
   it('end() is idempotent', () => {

--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -37,11 +37,14 @@ export const startSession = startConversation;
  * `conversationId`; otherwise the turn has no conversation id.
  *
  * @example
- * weave.startTurn({agentName: 'research-bot'});
+ * weave.startTurn();
  *
  * @example
  * weave.startTurn({
  *   agentName: 'research-bot',
+ *   model: 'gpt-4o',
+ *   userMessage: 'What is the weather in Tokyo?',
+ *   systemInstructions: ['You are a helpful weather bot.'],
  *   startTime: new Date('2026-05-29T10:00:00.000Z'),
  * });
  */

--- a/sdks/node/src/genai/conversation.ts
+++ b/sdks/node/src/genai/conversation.ts
@@ -59,6 +59,23 @@ export class Conversation {
     return conversation;
   }
 
+  /**
+   * Start a new `Turn` under this `Conversation`. The turn inherits the
+   * conversation's `conversationId`; `agentName` and `model` fall back to
+   * the conversation's values when not provided on `opts`.
+   *
+   * @example
+   * const turn = conversation.startTurn();
+   *
+   * @example
+   * const turn = conversation.startTurn({
+   *   model: 'gpt-4o',
+   *   agentName: 'research-bot',
+   *   userMessage: 'What is the weather in Tokyo?',
+   *   systemInstructions: ['You are a helpful weather bot.'],
+   *   startTime: new Date('2026-05-29T10:00:00.000Z'),
+   * });
+   */
   startTurn(opts: TurnInit = {}): Turn {
     return Turn.create({
       ...opts,

--- a/sdks/node/src/genai/semconv.ts
+++ b/sdks/node/src/genai/semconv.ts
@@ -24,6 +24,7 @@
 export const ATTR_GEN_AI_AGENT_DESCRIPTION = 'gen_ai.agent.description';
 export const ATTR_GEN_AI_AGENT_ID = 'gen_ai.agent.id';
 export const ATTR_GEN_AI_AGENT_NAME = 'gen_ai.agent.name';
+export const ATTR_GEN_AI_AGENT_VERSION = 'gen_ai.agent.version';
 export const ATTR_GEN_AI_CONVERSATION_ID = 'gen_ai.conversation.id';
 export const ATTR_GEN_AI_INPUT_MESSAGES = 'gen_ai.input.messages';
 export const ATTR_GEN_AI_OPERATION_NAME = 'gen_ai.operation.name';

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -15,16 +15,21 @@ import {SpanBase, type SpanEndOptions, type SpanInitBase} from './spanBase';
 import {
   ATTR_GEN_AI_AGENT_NAME,
   ATTR_GEN_AI_CONVERSATION_ID,
+  ATTR_GEN_AI_INPUT_MESSAGES,
   ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   WEAVE_GENAI_TRACER_NAME,
 } from './semconv';
 import {SubAgent, type SubAgentInit} from './subagent';
 import {Tool, type ToolInit} from './tool';
+import type {Message} from './types';
 
 export interface TurnInit extends SpanInitBase {
-  agentName?: string;
   model?: string;
+  agentName?: string;
+  systemInstructions?: string[];
+  userMessage?: string;
 }
 
 /**
@@ -40,24 +45,65 @@ export interface TurnInit extends SpanInitBase {
  * `startSubagent` methods.
  *
  * @example
- * const turn = weave.startTurn({agentName: 'research-bot', model: MODEL});
+ * const turn = weave.startTurn();
+ *
  * try {
- *   const llm = turn.startLLM({model: MODEL, providerName: 'openai'});
+ *   const llm = turn.startLLM({model: 'gpt-4o', providerName: 'openai'});
+ *   // ...
+ *   llm.end();
+ * } finally {
+ *   turn.end();
+ * }
+ *
+ * @example
+ * const turn = weave.startTurn({
+ *   model: 'gpt-4o',
+ *   agentName: 'research-bot',
+ *   userMessage: 'What is the weather in Tokyo?',
+ *   systemInstructions: ['You are a helpful weather bot.'],
+ *   startTime: new Date('2026-05-29T10:00:00.000Z'),
+ * });
+ *
+ * try {
+ *   const llm = turn.startLLM({model: 'gpt-4o', providerName: 'openai'});
  *   // ...
  *   llm.end();
  * } finally {
  *   turn.end();
  * }
  */
+
+type Opts = {
+  conversationId: string;
+  messages: Message[];
+  span: Span;
+  context: Context;
+} & Required<Omit<TurnInit, 'userMessage' | 'startTime'>>;
+
 export class Turn extends SpanBase {
-  private constructor(
-    span: Span,
-    private readonly context: Context,
-    private readonly conversationId: string,
-    public readonly agentName: string,
-    public readonly model: string
-  ) {
-    super(span);
+  private _context: Context;
+  private _conversationId: string;
+  private _agentName: string;
+  private _model: string;
+  private _messages: Message[];
+  private _systemInstructions: string[];
+
+  public get agentName() {
+    return this._agentName;
+  }
+
+  public get model() {
+    return this._model;
+  }
+
+  private constructor(opts: Opts) {
+    super(opts.span);
+    this._context = opts.context;
+    this._conversationId = opts.conversationId;
+    this._agentName = opts.agentName;
+    this._messages = opts.messages;
+    this._model = opts.model;
+    this._systemInstructions = opts.systemInstructions;
   }
 
   static create(opts: TurnInit & {conversationId?: string} = {}): Turn {
@@ -81,6 +127,17 @@ export class Turn extends SpanBase {
     if (opts.conversationId) {
       attributes[ATTR_GEN_AI_CONVERSATION_ID] = opts.conversationId;
     }
+    const messages: Message[] = opts.userMessage
+      ? [{role: 'user', parts: [{type: 'text', content: opts.userMessage}]}]
+      : [];
+    if (messages.length > 0) {
+      attributes[ATTR_GEN_AI_INPUT_MESSAGES] = JSON.stringify(messages);
+    }
+    if (opts.systemInstructions && opts.systemInstructions.length > 0) {
+      attributes[ATTR_GEN_AI_SYSTEM_INSTRUCTIONS] = JSON.stringify(
+        opts.systemInstructions.map(content => ({type: 'text', content}))
+      );
+    }
     // Pass ROOT_CONTEXT explicitly so Turn is always a root span — never
     // accidentally inherits a parent from some other OTel-instrumented
     // library's active context.
@@ -89,13 +146,15 @@ export class Turn extends SpanBase {
       {kind: SpanKind.CLIENT, attributes, startTime: opts.startTime},
       ROOT_CONTEXT
     );
-    const turn = new Turn(
+    const turn = new Turn({
       span,
-      trace.setSpan(ROOT_CONTEXT, span),
-      opts.conversationId ?? '',
-      opts.agentName ?? '',
-      opts.model ?? ''
-    );
+      context: trace.setSpan(ROOT_CONTEXT, span),
+      conversationId: opts.conversationId ?? '',
+      model: opts.model ?? '',
+      agentName: opts.agentName ?? '',
+      messages,
+      systemInstructions: opts.systemInstructions ?? [],
+    });
     state.turn = turn;
     return turn;
   }
@@ -104,8 +163,8 @@ export class Turn extends SpanBase {
   startLLM(opts: LLMInit): LLM {
     return LLM.create({
       ...opts,
-      parentContext: this.context,
-      conversationId: this.conversationId,
+      parentContext: this._context,
+      conversationId: this._conversationId,
     });
   }
 
@@ -113,8 +172,8 @@ export class Turn extends SpanBase {
   startTool(opts: ToolInit): Tool {
     return Tool.create({
       ...opts,
-      parentContext: this.context,
-      conversationId: this.conversationId,
+      parentContext: this._context,
+      conversationId: this._conversationId,
     });
   }
 
@@ -122,8 +181,8 @@ export class Turn extends SpanBase {
   startSubagent(opts: SubAgentInit): SubAgent {
     return SubAgent.create({
       ...opts,
-      parentContext: this.context,
-      conversationId: this.conversationId,
+      parentContext: this._context,
+      conversationId: this._conversationId,
     });
   }
 


### PR DESCRIPTION
## Description

* Python interfaces for creating turns accept these named arguments:

```py
def start_turn(
    *,
    user_message: str = "",
    model: str = "",
    agent_name: str = "",
    system_instructions: list[str] | None = None,
) -> Turn:
```

* `userMessage` and `systemInstructions` are not yet added to TS. This change adds them to `weave.startTurn` and `conversation.startTurn`.
