### PR TITLE
feat(weave_ts): Accept `systemInstructions` when creating `Subagents`.

### DIFF
--- a/sdks/node/src/__tests__/genai/genai.test.ts
+++ b/sdks/node/src/__tests__/genai/genai.test.ts
@@ -249,6 +249,29 @@ async function runAgentLoop(
       if (!toolDef) {
         throw new Error(`unknown tool: ${tc.function.name}`);
       }
+      if (tc.function.name === 'calculate') {
+        const sub = turn.startSubagent({
+          name: 'calculator-bot',
+          model: 'gpt-4o-mini',
+          systemInstructions: ['Evaluate arithmetic expressions.'],
+        });
+        try {
+          const result = await toolDef.execute(
+            JSON.parse(tc.function.arguments)
+          );
+          sub.end();
+          messages.push({
+            role: 'tool',
+            toolCallId: tc.id,
+            content: JSON.stringify(result),
+          });
+        } catch (err) {
+          sub.end({error: err as Error});
+          throw err;
+        }
+        continue;
+      }
+
       const tool = turn.startTool({
         name: tc.function.name,
         args: tc.function.arguments,
@@ -500,12 +523,11 @@ describe('GenAI', () => {
         },
         {
           "attributes": {
+            "gen_ai.agent.name": "calculator-bot",
             "gen_ai.conversation.id": "<uuid>",
-            "gen_ai.operation.name": "execute_tool",
-            "gen_ai.tool.call.arguments": "{"expression":"28 - 18"}",
-            "gen_ai.tool.call.id": "call_t3",
-            "gen_ai.tool.call.result": ""28 - 18 = 10"",
-            "gen_ai.tool.name": "calculate",
+            "gen_ai.operation.name": "invoke_agent",
+            "gen_ai.request.model": "gpt-4o-mini",
+            "gen_ai.system_instructions": "[{"type":"text","content":"Evaluate arithmetic expressions."}]",
             "myagent.region": "ORD",
             "myagent.version": "4.21",
           },

--- a/sdks/node/src/__tests__/genai/subagent.test.ts
+++ b/sdks/node/src/__tests__/genai/subagent.test.ts
@@ -1,15 +1,13 @@
 import type {ReadableSpan} from '@opentelemetry/sdk-trace-base';
 
-import {
-  ATTR_GEN_AI_AGENT_NAME,
-  ATTR_GEN_AI_REQUEST_MODEL,
-} from '../../genai/semconv';
+import {ATTR_GEN_AI_AGENT_NAME} from '../../genai/semconv';
 import {Turn} from '../../genai/turn';
 
 import {
   expectSpanTimesToMatch,
   setupExporterPerTest,
   setupGenAITestEnvironment,
+  spanSnapshot,
 } from './common';
 
 describe('SubAgent', () => {
@@ -18,7 +16,11 @@ describe('SubAgent', () => {
 
   it('emits a nested invoke_agent span as a child of the turn', () => {
     const turn = Turn.create({agentName: 'parent'});
-    const sub = turn.startSubagent({name: 'child-bot', model: 'gpt-4o'});
+    const sub = turn.startSubagent({
+      name: 'child-bot',
+      model: 'gpt-4o',
+      systemInstructions: ['Be helpful', 'Be concise'],
+    });
     sub.end();
     turn.end();
 
@@ -37,7 +39,19 @@ describe('SubAgent', () => {
     expect(subSpan).toBeDefined();
     expect(parentTurnSpan).toBeDefined();
     expect(subSpan!.parentSpanId).toBe(parentTurnSpan!.spanContext().spanId);
-    expect(subSpan!.attributes[ATTR_GEN_AI_REQUEST_MODEL]).toBe('gpt-4o');
+
+    expect(spanSnapshot(subSpan!)).toMatchInlineSnapshot(`
+      {
+        "attributes": {
+          "gen_ai.agent.name": "child-bot",
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.request.model": "gpt-4o",
+          "gen_ai.system_instructions": "[{"type":"text","content":"Be helpful"},{"type":"text","content":"Be concise"}]",
+        },
+        "endTime": "<timestamp>",
+        "startTime": "<timestamp>",
+      }
+    `);
   });
 
   const findSub = (spans: ReadableSpan[]) => {

--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -120,12 +120,13 @@ export function startTool(opts: ToolInit): Tool {
  * Start a SubAgent span. Same parent-resolution rules as `startTool`.
  *
  * @example
- * weave.startSubagent({name: 'critic', model: 'gpt-4o'});
+ * weave.startSubagent({name: 'critic'});
  *
  * @example
  * weave.startSubagent({
  *   name: 'critic',
  *   model: 'gpt-4o',
+ *   systemInstructions: ['Critique the proposed plan.'],
  *   startTime: new Date('2026-05-29T10:00:00.000Z'),
  * });
  */

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -9,12 +9,14 @@ import {
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   WEAVE_GENAI_TRACER_NAME,
 } from './semconv';
 
 export interface SubAgentInit extends SpanInitBase {
   name: string;
   model?: string;
+  systemInstructions?: string[];
 }
 
 /**
@@ -23,11 +25,26 @@ export interface SubAgentInit extends SpanInitBase {
  * `invoke_agent` span tagged with the sub-agent's name and (optionally)
  * its model.
  *
- * Created by `weave.startSubagent()` (or `turn.startAgent()`, or
- * `llm.startAgent()`) and terminated with `end()`.
+ * Created by `weave.startSubagent()` (or `turn.startSubagent()`, or
+ * `llm.startSubagent()`) and terminated with `end()`.
  *
  * @example
- * const sub = weave.startSubagent({name: 'researcher', model: 'gpt-4o'});
+ * const sub = weave.startSubagent({name: 'researcher'});
+ *
+ * try {
+ *   // ... orchestrate the sub-agent's LLM/Tool calls ...
+ * } finally {
+ *   sub.end();
+ * }
+ *
+ * @example
+ * const sub = weave.startSubagent({
+ *   name: 'researcher',
+ *   model: 'gpt-4o',
+ *   systemInstructions: ['Find authoritative sources before answering.'],
+ *   startTime: new Date('2026-05-29T10:00:00.000Z'),
+ * });
+ *
  * try {
  *   // ... orchestrate the sub-agent's LLM/Tool calls ...
  * } finally {
@@ -56,6 +73,11 @@ export class SubAgent extends SpanBase {
     }
     if (opts.conversationId) {
       attributes[ATTR_GEN_AI_CONVERSATION_ID] = opts.conversationId;
+    }
+    if (opts.systemInstructions && opts.systemInstructions.length > 0) {
+      attributes[ATTR_GEN_AI_SYSTEM_INSTRUCTIONS] = JSON.stringify(
+        opts.systemInstructions.map(content => ({type: 'text', content}))
+      );
     }
     const span = tracer.startSpan(
       'invoke_agent',


### PR DESCRIPTION
## Description

* Python interfaces for creating subagents accept these named arguments:

```py
def start_subagent(
    *, name: str, model: str = "", system_instructions: list[str] | None = None
) -> SubAgent:
```

* `systemInstructions` is not yet supported in TS. This change adds it to `weave.startSubagent`, `turn.startSubagent` and `llm.startSubagent`