### PR TITLE
feat(weave_ts): Accept `systemInstructions` when creating `LLM`s

### DIFF
--- a/sdks/node/src/__tests__/genai/genai.test.ts
+++ b/sdks/node/src/__tests__/genai/genai.test.ts
@@ -203,6 +203,7 @@ async function runAgentLoop(
     const llm = turn.startLLM({
       model: 'some-model',
       providerName: 'some-provider',
+      systemInstructions: [agent.instructions],
     });
     llm.inputMessages = [...messages];
 
@@ -381,6 +382,7 @@ describe('GenAI', () => {
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"tool_call","toolCallId":"call_t1","toolName":"get_weather","arguments":"{\\"city\\":\\"Tokyo\\"}"}]}]",
             "gen_ai.provider.name": "some-provider",
             "gen_ai.request.model": "some-model",
+            "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "gen_ai.usage.input_tokens": 42,
             "gen_ai.usage.output_tokens": 10,
             "myagent.region": "ORD",
@@ -411,6 +413,7 @@ describe('GenAI', () => {
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"Tokyo is 28°C and humid."}]}]",
             "gen_ai.provider.name": "some-provider",
             "gen_ai.request.model": "some-model",
+            "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "gen_ai.usage.input_tokens": 70,
             "gen_ai.usage.output_tokens": 9,
             "myagent.region": "ORD",
@@ -440,6 +443,7 @@ describe('GenAI', () => {
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"tool_call","toolCallId":"call_t2_sf","toolName":"get_weather","arguments":"{\\"city\\":\\"San Francisco\\"}"},{"type":"tool_call","toolCallId":"call_t2_ldn","toolName":"get_weather","arguments":"{\\"city\\":\\"London\\"}"}]}]",
             "gen_ai.provider.name": "some-provider",
             "gen_ai.request.model": "some-model",
+            "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "gen_ai.usage.input_tokens": 90,
             "gen_ai.usage.output_tokens": 16,
             "myagent.region": "ORD",
@@ -484,6 +488,7 @@ describe('GenAI', () => {
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"San Francisco is 18°C and foggy. London is 12°C and cloudy."}]}]",
             "gen_ai.provider.name": "some-provider",
             "gen_ai.request.model": "some-model",
+            "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "gen_ai.usage.input_tokens": 140,
             "gen_ai.usage.output_tokens": 18,
             "myagent.region": "ORD",
@@ -513,6 +518,7 @@ describe('GenAI', () => {
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"tool_call","toolCallId":"call_t3","toolName":"calculate","arguments":"{\\"expression\\":\\"28 - 18\\"}"}]}]",
             "gen_ai.provider.name": "some-provider",
             "gen_ai.request.model": "some-model",
+            "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "gen_ai.usage.input_tokens": 170,
             "gen_ai.usage.output_tokens": 12,
             "myagent.region": "ORD",
@@ -542,6 +548,7 @@ describe('GenAI', () => {
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"Tokyo is 10°C warmer than San Francisco."}]}]",
             "gen_ai.provider.name": "some-provider",
             "gen_ai.request.model": "some-model",
+            "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "gen_ai.usage.input_tokens": 200,
             "gen_ai.usage.output_tokens": 12,
             "myagent.region": "ORD",

--- a/sdks/node/src/__tests__/genai/llm.test.ts
+++ b/sdks/node/src/__tests__/genai/llm.test.ts
@@ -7,6 +7,7 @@ import {
   ATTR_GEN_AI_OUTPUT_MESSAGES,
   ATTR_GEN_AI_PROVIDER_NAME,
   ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
   ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
   ATTR_GEN_AI_USAGE_INPUT_TOKENS,
@@ -20,6 +21,7 @@ import {
   findSpan,
   setupExporterPerTest,
   setupGenAITestEnvironment,
+  spanSnapshot,
 } from './common';
 
 describe('LLM (via Turn.startLLM)', () => {
@@ -28,7 +30,11 @@ describe('LLM (via Turn.startLLM)', () => {
 
   it("emits a 'chat' span as a child of the turn's invoke_agent span", () => {
     const turn = Turn.create({agentName: 'a', conversationId: 'conv-1'});
-    const llm = turn.startLLM({model: 'gpt-4o', providerName: 'openai'});
+    const llm = turn.startLLM({
+      model: 'gpt-4o',
+      providerName: 'openai',
+      systemInstructions: ['Be helpful', 'Be concise'],
+    });
     llm.end();
     turn.end();
 
@@ -37,12 +43,22 @@ describe('LLM (via Turn.startLLM)', () => {
     const turnSpan = findSpan(spans, 'invoke_agent');
 
     expect(llmSpan.kind).toBe(SpanKind.CLIENT);
-    expect(llmSpan.attributes[ATTR_GEN_AI_OPERATION_NAME]).toBe('chat');
-    expect(llmSpan.attributes[ATTR_GEN_AI_REQUEST_MODEL]).toBe('gpt-4o');
-    expect(llmSpan.attributes[ATTR_GEN_AI_PROVIDER_NAME]).toBe('openai');
-    expect(llmSpan.attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('conv-1');
     expect(llmSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
     expect(llmSpan.spanContext().traceId).toBe(turnSpan.spanContext().traceId);
+
+    expect(spanSnapshot(llmSpan)).toMatchInlineSnapshot(`
+      {
+        "attributes": {
+          "gen_ai.conversation.id": "<uuid>",
+          "gen_ai.operation.name": "chat",
+          "gen_ai.provider.name": "openai",
+          "gen_ai.request.model": "gpt-4o",
+          "gen_ai.system_instructions": "[{"type":"text","content":"Be helpful"},{"type":"text","content":"Be concise"}]",
+        },
+        "endTime": "<timestamp>",
+        "startTime": "<timestamp>",
+      }
+    `);
   });
 
   it('serializes input/output messages and usage at end()', () => {

--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -67,6 +67,7 @@ export function startTurn(opts: TurnInit = {}): Turn {
  * weave.startLLM({
  *   model: 'gpt-4o-mini',
  *   providerName: 'openai',
+ *   systemInstructions: ['You are a helpful weather bot.'],
  *   startTime: new Date('2026-05-29T10:00:00.000Z'),
  * });
  */

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -17,6 +17,7 @@ import {
   ATTR_GEN_AI_OUTPUT_MESSAGES,
   ATTR_GEN_AI_PROVIDER_NAME,
   ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
   ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
   ATTR_GEN_AI_USAGE_INPUT_TOKENS,
@@ -31,6 +32,7 @@ import type {Message, MessagePart, Modality, Reasoning, Usage} from './types';
 export interface LLMInit extends SpanInitBase {
   model: string;
   providerName?: string;
+  systemInstructions?: string[];
 }
 
 /** Discriminated union for `LLM.attachMedia`: pick one of content / uri / fileId. */
@@ -60,11 +62,26 @@ export interface LLMRecordOpts {
  *
  * @example
  * const llm = weave.startLLM({model: 'gpt-4o-mini', providerName: 'openai'});
+ *
  * try {
  *   llm.inputMessages = [{role: 'user', content: prompt}];
  *   const resp = await openai.chat.completions.create({...});
  *   llm.output(resp.choices[0].message.content ?? '');
  *   llm.record({usage: {inputTokens: resp.usage?.prompt_tokens}});
+ * } finally {
+ *   llm.end();
+ * }
+ *
+ * @example
+ * const llm = weave.startLLM({
+ *   model: 'gpt-4o-mini',
+ *   providerName: 'openai',
+ *   systemInstructions: ['You are a helpful weather bot.'],
+ *   startTime: new Date('2026-05-29T10:00:00.000Z'),
+ * });
+ *
+ * try {
+ *   // ... call the LLM, populate llm.outputMessages / usage ...
  * } finally {
  *   llm.end();
  * }
@@ -118,6 +135,11 @@ export class LLM extends SpanBase {
     }
     if (opts.conversationId) {
       attributes[ATTR_GEN_AI_CONVERSATION_ID] = opts.conversationId;
+    }
+    if (opts.systemInstructions && opts.systemInstructions.length > 0) {
+      attributes[ATTR_GEN_AI_SYSTEM_INSTRUCTIONS] = JSON.stringify(
+        opts.systemInstructions.map(content => ({type: 'text', content}))
+      );
     }
     const span = tracer.startSpan(
       'chat',


### PR DESCRIPTION
## Description

* Python interfaces for creating turns accept these named arguments:

```py
def start_llm(
    *,
    model: str = "",
    provider_name: str = "",
    system_instructions: list[str] | None = None,
) -> LLM:
```

* `systemInstructions` is not yet supported by TS. This change adds is to `weave.startLLM` and `turn.startLLM`.
