### PR TITLE
feat(weave_ts): Accept `agent_id`, `agent_description`, `agent_version` when creating `Turn`s

### DIFF
--- a/sdks/node/src/__tests__/genai/genai.test.ts
+++ b/sdks/node/src/__tests__/genai/genai.test.ts
@@ -35,7 +35,10 @@ async function callSomeLLM(_args: unknown): Promise<ChatCompletion> {
 }
 
 type Agent = {
+  id: string;
   name: string;
+  description: string;
+  version: string;
   instructions: string;
   tools: Tool[];
 };
@@ -91,9 +94,13 @@ const calculateTool: Tool = {
 };
 
 const agent: Agent = {
+  id: '62e4a66c-c22f-4ef2-8fce-b573e499a182',
   name: 'Reasearch Assistant',
   instructions:
     'You are a research assistant. Use the available tools when appropriate to answer questions accurately.',
+  description:
+    'Research assistant that is so advanced it has a typo in its name',
+  version: '1.14.3',
   tools: [calculateTool, getWeatherTool],
 };
 
@@ -310,7 +317,10 @@ async function run(agent: Agent, prompts: string[]): Promise<string[]> {
     for (const prompt of prompts) {
       messages.push({role: 'user', content: prompt});
       const turn = conversation.startTurn({
+        agentId: agent.id,
         agentName: agent.name,
+        agentDescription: agent.description,
+        agentVersion: agent.version,
         userMessage: prompt,
         systemInstructions: [agent.instructions],
       });
@@ -424,7 +434,10 @@ describe('GenAI', () => {
         },
         {
           "attributes": {
+            "gen_ai.agent.description": "Research assistant that is so advanced it has a typo in its name",
+            "gen_ai.agent.id": "62e4a66c-c22f-4ef2-8fce-b573e499a182",
             "gen_ai.agent.name": "Reasearch Assistant",
+            "gen_ai.agent.version": "1.14.3",
             "gen_ai.conversation.id": "<uuid>",
             "gen_ai.input.messages": "[{"role":"user","parts":[{"type":"text","content":"How warm is Tokyo?"}]}]",
             "gen_ai.operation.name": "invoke_agent",
@@ -499,7 +512,10 @@ describe('GenAI', () => {
         },
         {
           "attributes": {
+            "gen_ai.agent.description": "Research assistant that is so advanced it has a typo in its name",
+            "gen_ai.agent.id": "62e4a66c-c22f-4ef2-8fce-b573e499a182",
             "gen_ai.agent.name": "Reasearch Assistant",
+            "gen_ai.agent.version": "1.14.3",
             "gen_ai.conversation.id": "<uuid>",
             "gen_ai.input.messages": "[{"role":"user","parts":[{"type":"text","content":"What about San Francisco and London?"}]}]",
             "gen_ai.operation.name": "invoke_agent",
@@ -559,7 +575,10 @@ describe('GenAI', () => {
         },
         {
           "attributes": {
+            "gen_ai.agent.description": "Research assistant that is so advanced it has a typo in its name",
+            "gen_ai.agent.id": "62e4a66c-c22f-4ef2-8fce-b573e499a182",
             "gen_ai.agent.name": "Reasearch Assistant",
+            "gen_ai.agent.version": "1.14.3",
             "gen_ai.conversation.id": "<uuid>",
             "gen_ai.input.messages": "[{"role":"user","parts":[{"type":"text","content":"How much warmer is Tokyo than San Francisco?"}]}]",
             "gen_ai.operation.name": "invoke_agent",

--- a/sdks/node/src/__tests__/genai/turn.test.ts
+++ b/sdks/node/src/__tests__/genai/turn.test.ts
@@ -15,8 +15,11 @@ describe('Turn', () => {
 
   it('emits an invoke_agent span with GenAI agent / model attributes', () => {
     const turn = Turn.create({
-      agentName: 'weather-bot',
       model: 'gpt-4o',
+      agentId: '12345',
+      agentName: 'weather-bot',
+      agentDescription: 'Finds the most accurate weather',
+      agentVersion: '1.2.3',
       conversationId: 'conv-1',
       userMessage: "What's the weather?",
       systemInstructions: ['Be helpful', 'Be concise'],
@@ -27,7 +30,10 @@ describe('Turn', () => {
     expect(spanSnapshot(span)).toMatchInlineSnapshot(`
       {
         "attributes": {
+          "gen_ai.agent.description": "Finds the most accurate weather",
+          "gen_ai.agent.id": "12345",
           "gen_ai.agent.name": "weather-bot",
+          "gen_ai.agent.version": "1.2.3",
           "gen_ai.conversation.id": "<uuid>",
           "gen_ai.input.messages": "[{"role":"user","parts":[{"type":"text","content":"What's the weather?"}]}]",
           "gen_ai.operation.name": "invoke_agent",

--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -41,7 +41,10 @@ export const startSession = startConversation;
  *
  * @example
  * weave.startTurn({
+ *   agentId: 'research-bot-prod',
  *   agentName: 'research-bot',
+ *   agentDescription: 'Looks up facts on Wikipedia.',
+ *   agentVersion: '1.4.2',
  *   model: 'gpt-4o',
  *   userMessage: 'What is the weather in Tokyo?',
  *   systemInstructions: ['You are a helpful weather bot.'],

--- a/sdks/node/src/genai/conversation.ts
+++ b/sdks/node/src/genai/conversation.ts
@@ -71,6 +71,9 @@ export class Conversation {
    * const turn = conversation.startTurn({
    *   model: 'gpt-4o',
    *   agentName: 'research-bot',
+   *   agentId: 'research-bot-prod',
+   *   agentDescription: 'Looks up facts on Wikipedia.',
+   *   agentVersion: '1.4.2',
    *   userMessage: 'What is the weather in Tokyo?',
    *   systemInstructions: ['You are a helpful weather bot.'],
    *   startTime: new Date('2026-05-29T10:00:00.000Z'),

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -13,7 +13,10 @@ import {LLM, type LLMInit} from './llm';
 import {getWeaveTracer} from './provider';
 import {SpanBase, type SpanEndOptions, type SpanInitBase} from './spanBase';
 import {
+  ATTR_GEN_AI_AGENT_DESCRIPTION,
+  ATTR_GEN_AI_AGENT_ID,
   ATTR_GEN_AI_AGENT_NAME,
+  ATTR_GEN_AI_AGENT_VERSION,
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_INPUT_MESSAGES,
   ATTR_GEN_AI_OPERATION_NAME,
@@ -27,9 +30,12 @@ import type {Message} from './types';
 
 export interface TurnInit extends SpanInitBase {
   model?: string;
-  agentName?: string;
   systemInstructions?: string[];
   userMessage?: string;
+  agentId?: string;
+  agentName?: string;
+  agentDescription?: string;
+  agentVersion?: string;
 }
 
 /**
@@ -59,6 +65,9 @@ export interface TurnInit extends SpanInitBase {
  * const turn = weave.startTurn({
  *   model: 'gpt-4o',
  *   agentName: 'research-bot',
+ *   agentId: 'research-bot-prod',
+ *   agentDescription: 'Looks up facts on Wikipedia.',
+ *   agentVersion: '1.4.2',
  *   userMessage: 'What is the weather in Tokyo?',
  *   systemInstructions: ['You are a helpful weather bot.'],
  *   startTime: new Date('2026-05-29T10:00:00.000Z'),
@@ -83,7 +92,10 @@ type Opts = {
 export class Turn extends SpanBase {
   private _context: Context;
   private _conversationId: string;
+  private _agentId: string;
   private _agentName: string;
+  private _agentDescription: string;
+  private _agentVersion: string;
   private _model: string;
   private _messages: Message[];
   private _systemInstructions: string[];
@@ -100,7 +112,10 @@ export class Turn extends SpanBase {
     super(opts.span);
     this._context = opts.context;
     this._conversationId = opts.conversationId;
+    this._agentId = opts.agentId;
     this._agentName = opts.agentName;
+    this._agentDescription = opts.agentDescription;
+    this._agentVersion = opts.agentVersion;
     this._messages = opts.messages;
     this._model = opts.model;
     this._systemInstructions = opts.systemInstructions;
@@ -126,6 +141,15 @@ export class Turn extends SpanBase {
     }
     if (opts.conversationId) {
       attributes[ATTR_GEN_AI_CONVERSATION_ID] = opts.conversationId;
+    }
+    if (opts.agentId) {
+      attributes[ATTR_GEN_AI_AGENT_ID] = opts.agentId;
+    }
+    if (opts.agentDescription) {
+      attributes[ATTR_GEN_AI_AGENT_DESCRIPTION] = opts.agentDescription;
+    }
+    if (opts.agentVersion) {
+      attributes[ATTR_GEN_AI_AGENT_VERSION] = opts.agentVersion;
     }
     const messages: Message[] = opts.userMessage
       ? [{role: 'user', parts: [{type: 'text', content: opts.userMessage}]}]
@@ -154,6 +178,9 @@ export class Turn extends SpanBase {
       agentName: opts.agentName ?? '',
       messages,
       systemInstructions: opts.systemInstructions ?? [],
+      agentId: opts.agentId ?? '',
+      agentDescription: opts.agentDescription ?? '',
+      agentVersion: opts.agentVersion ?? '',
     });
     state.turn = turn;
     return turn;


### PR DESCRIPTION
## Description

* Python interfaces for creating turns accept these named arguments:

```py
    def start_turn(
        self,
        *,
        user_message: str = "",
        model: str = "",
        agent_name: str = "",
        agent_id: str = "",
        agent_description: str = "",
        agent_version: str = "",
        system_instructions: list[str] | None = None,
    ) -> Turn:
```

* `agentId`, `agentDescription` and `agentVersion` are not yet supported by TS. This change adds them to `weave.startTurn` and `conversation.startTurn`.

* Note: will eventually support these use when creating `Conversation`s as well.
