### PR TITLE
fix(weave): restore unix-domain-socket support for dogstatsd db_inserts

### DIFF
--- a/tests/trace_server/test_datadog.py
+++ b/tests/trace_server/test_datadog.py
@@ -8,6 +8,9 @@ can't silently drift them.
 
 from __future__ import annotations
 
+import socket
+from pathlib import Path
+
 import pytest
 
 from weave.trace_server import datadog
@@ -47,55 +50,68 @@ def test_format_packet_wire_format(
 
 
 # ---------------------------------------------------------------------------
-# Address resolution — env-var fallback chain
+# Target resolution — family + address from the env-var fallback chain
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_addr_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """No env vars set → `localhost:8125`."""
-    monkeypatch.delenv("DD_DOGSTATSD_URL", raising=False)
-    monkeypatch.delenv("DD_AGENT_HOST", raising=False)
-    monkeypatch.delenv("DD_DOGSTATSD_PORT", raising=False)
-    assert datadog._resolve_dogstatsd_addr() == ("localhost", 8125)
-
-
-def test_resolve_addr_url_with_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`DD_DOGSTATSD_URL=udp://host:port` is the documented prod form."""
-    monkeypatch.setenv("DD_DOGSTATSD_URL", "udp://datadog.datadog:8125")
-    assert datadog._resolve_dogstatsd_addr() == ("datadog.datadog", 8125)
-
-
-def test_resolve_addr_url_without_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Bare `host:port` (no `udp://`) is also accepted."""
-    monkeypatch.setenv("DD_DOGSTATSD_URL", "my-agent:9125")
-    assert datadog._resolve_dogstatsd_addr() == ("my-agent", 9125)
-
-
-def test_resolve_addr_url_no_port_defaults_to_8125(
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        # No env vars → localhost UDP default.
+        ({}, (socket.AF_INET, ("localhost", 8125))),
+        # `udp://host:port` is the documented single-tenant prod form.
+        (
+            {"DD_DOGSTATSD_URL": "udp://datadog.datadog:8125"},
+            (socket.AF_INET, ("datadog.datadog", 8125)),
+        ),
+        # Bare `host:port` (no scheme) is accepted as UDP.
+        ({"DD_DOGSTATSD_URL": "my-agent:9125"}, (socket.AF_INET, ("my-agent", 9125))),
+        # UDP URL without a port defaults to 8125.
+        (
+            {"DD_DOGSTATSD_URL": "udp://datadog.datadog"},
+            (socket.AF_INET, ("datadog.datadog", 8125)),
+        ),
+        # Garbage URL must NOT raise; falls back to localhost.
+        (
+            {"DD_DOGSTATSD_URL": "://this-is-broken::"},
+            (socket.AF_INET, ("localhost", 8125)),
+        ),
+        # No URL → DD_AGENT_HOST + DD_DOGSTATSD_PORT.
+        (
+            {"DD_AGENT_HOST": "agent.example.com", "DD_DOGSTATSD_PORT": "9999"},
+            (socket.AF_INET, ("agent.example.com", 9999)),
+        ),
+        # Non-numeric port must NOT crash import; falls back to the default.
+        (
+            {"DD_AGENT_HOST": "agent.example.com", "DD_DOGSTATSD_PORT": "abc"},
+            (socket.AF_INET, ("agent.example.com", 8125)),
+        ),
+        # UDS schemes → AF_UNIX with the socket path. This is the SaaS-prod
+        # Agent form that PR #7268 regressed (its UDP-only client dropped it).
+        (
+            {"DD_DOGSTATSD_URL": "unix:///var/run/datadog/dsd.socket"},
+            (socket.AF_UNIX, "/var/run/datadog/dsd.socket"),
+        ),
+        (
+            {"DD_DOGSTATSD_URL": "unixgram:///var/run/datadog/dsd.socket"},
+            (socket.AF_UNIX, "/var/run/datadog/dsd.socket"),
+        ),
+        (
+            {"DD_DOGSTATSD_URL": "uds:///var/run/datadog/dsd.socket"},
+            (socket.AF_UNIX, "/var/run/datadog/dsd.socket"),
+        ),
+    ],
+)
+def test_resolve_dogstatsd_target(
+    env: dict[str, str],
+    expected: tuple[int, str | tuple[str, int]],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("DD_DOGSTATSD_URL", "udp://datadog.datadog")
-    assert datadog._resolve_dogstatsd_addr() == ("datadog.datadog", 8125)
-
-
-def test_resolve_addr_url_malformed_falls_back(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A garbage URL must NOT raise; fall back to localhost."""
-    monkeypatch.setenv("DD_DOGSTATSD_URL", "://this-is-broken::")
-    monkeypatch.delenv("DD_AGENT_HOST", raising=False)
-    monkeypatch.delenv("DD_DOGSTATSD_PORT", raising=False)
-    assert datadog._resolve_dogstatsd_addr() == ("localhost", 8125)
-
-
-def test_resolve_addr_falls_back_to_host_and_port_env(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """No URL set → `DD_AGENT_HOST` + `DD_DOGSTATSD_PORT`."""
-    monkeypatch.delenv("DD_DOGSTATSD_URL", raising=False)
-    monkeypatch.setenv("DD_AGENT_HOST", "agent.example.com")
-    monkeypatch.setenv("DD_DOGSTATSD_PORT", "9999")
-    assert datadog._resolve_dogstatsd_addr() == ("agent.example.com", 9999)
+    for var in ("DD_DOGSTATSD_URL", "DD_AGENT_HOST", "DD_DOGSTATSD_PORT"):
+        monkeypatch.delenv(var, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    assert datadog._resolve_dogstatsd_target() == expected
 
 
 # ---------------------------------------------------------------------------
@@ -121,14 +137,29 @@ def test_parse_port_non_numeric_falls_back(
     assert datadog._parse_port("not-a-port") == 8125
 
 
-def test_parse_port_non_numeric_does_not_raise_at_import(
-    monkeypatch: pytest.MonkeyPatch,
+# ---------------------------------------------------------------------------
+# Unix-domain-socket emit — the path PR #7268 regressed in SaaS prod
+# ---------------------------------------------------------------------------
+
+
+def test_statsd_client_emits_over_unix_socket(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The whole resolution path stays safe even with a bad port env var."""
-    monkeypatch.delenv("DD_DOGSTATSD_URL", raising=False)
-    monkeypatch.setenv("DD_AGENT_HOST", "agent.example.com")
-    monkeypatch.setenv("DD_DOGSTATSD_PORT", "abc")
-    # Must not raise.
-    host, port = datadog._resolve_dogstatsd_addr()
-    assert host == "agent.example.com"
-    assert port == 8125  # fell back to default
+    """A real AF_UNIX datagram server receives the exact wire bytes.
+
+    Uses a relative socket name under a chdir'd tmp dir to stay well under
+    the platform's AF_UNIX path-length limit.
+    """
+    monkeypatch.chdir(tmp_path)
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    server.bind("dsd.socket")
+    server.settimeout(2.0)
+    try:
+        client = datadog._StatsDClient(socket.AF_UNIX, "dsd.socket")
+        client.emit("weave_trace_server.db_inserts", 3, ["table:calls", "path:otel"])
+        assert (
+            server.recv(4096)
+            == b"weave_trace_server.db_inserts:3|c|#table:calls,path:otel"
+        )
+    finally:
+        server.close()

--- a/weave/trace_server/datadog.py
+++ b/weave/trace_server/datadog.py
@@ -1,7 +1,7 @@
 """DogStatsD counter emission + DD-flavored OTel span-tag helpers.
 
-Emits a single counter (`weave_trace_server.db_inserts`) over a UDP socket.
-Wire format: `metric.name:value|c|#tag1:val1,tag2:val2`.
+Emits a single counter (`weave_trace_server.db_inserts`) over UDP or a Unix
+domain socket. Wire format: `metric.name:value|c|#tag1:val1,tag2:val2`.
 """
 
 from __future__ import annotations
@@ -29,6 +29,9 @@ DB_INSERT_PATH_UNKNOWN = "unknown"
 
 _DEFAULT_HOST = "localhost"
 _DEFAULT_PORT = 8125
+# DD_DOGSTATSD_URL schemes that denote a Unix domain socket (the SaaS-prod
+# Agent form); anything else is treated as UDP host:port.
+_UDS_SCHEMES = frozenset({"unix", "unixgram", "uds"})
 
 _db_insert_path: ContextVar[str] = ContextVar(
     "_db_insert_path", default=DB_INSERT_PATH_UNKNOWN
@@ -51,26 +54,30 @@ def _parse_port(raw: str | None, *, default: int = _DEFAULT_PORT) -> int:
         return default
 
 
-def _resolve_dogstatsd_addr() -> tuple[str, int]:
-    """Honor `DD_DOGSTATSD_URL` (`udp://host:port`), then
-    `DD_AGENT_HOST` + `DD_DOGSTATSD_PORT`, then `localhost:8125`.
+def _resolve_dogstatsd_target() -> tuple[int, str | tuple[str, int]]:
+    """Resolve the DogStatsD socket family + address.
+
+    Honors `DD_DOGSTATSD_URL` (`unix://`/`unixgram://`/`uds://` path for a
+    Unix domain socket, else `udp://host:port`), then `DD_AGENT_HOST` +
+    `DD_DOGSTATSD_PORT`, then `localhost:8125`. SaaS-prod Agents expose
+    DogStatsD over a Unix socket, so UDS support is load-bearing.
     """
     url = os.environ.get("DD_DOGSTATSD_URL")
     if url:
         try:
             parsed = urlparse(url if "://" in url else f"udp://{url}")
+            if parsed.scheme in _UDS_SCHEMES and parsed.path:
+                return socket.AF_UNIX, parsed.path
             if parsed.hostname:
-                return parsed.hostname, parsed.port or _DEFAULT_PORT
+                return socket.AF_INET, (parsed.hostname, parsed.port or _DEFAULT_PORT)
         except ValueError:
             logger.warning(
-                "Could not parse DD_DOGSTATSD_URL=%r; falling back to %s:%d",
+                "Could not parse DD_DOGSTATSD_URL=%r; falling back to host/port env",
                 url,
-                _DEFAULT_HOST,
-                _DEFAULT_PORT,
             )
     host = os.environ.get("DD_AGENT_HOST", _DEFAULT_HOST)
     port = _parse_port(os.environ.get("DD_DOGSTATSD_PORT"))
-    return host, port
+    return socket.AF_INET, (host, port)
 
 
 def format_packet(metric: str, value: int, tags: list[str]) -> bytes:
@@ -80,16 +87,17 @@ def format_packet(metric: str, value: int, tags: list[str]) -> bytes:
 
 
 class _StatsDClient:
-    """Best-effort, fire-and-forget DogStatsD UDP client.
+    """Best-effort, fire-and-forget DogStatsD client over UDP or a Unix socket.
 
-    Resolves the address once and connects the socket, so each `emit`
-    is a single non-blocking `send()` — no per-call DNS, no per-call
-    address lookup. A failed `connect()` (e.g. DNS resolution failure
-    at startup) disables the client; subsequent emits are no-ops.
+    Resolves the target once and connects the socket, so each `emit` is a
+    single non-blocking `send()` — no per-call DNS or address lookup. A
+    failed `connect()` (bad host, missing socket file) disables the client;
+    subsequent emits are no-ops.
     """
 
-    def __init__(self, host: str, port: int) -> None:
-        self._addr = (host, port)
+    def __init__(self, family: int, addr: str | tuple[str, int]) -> None:
+        self._family = family
+        self._addr = addr
         self._sock: socket.socket | None = None
         self._init_failed = False
         self._lock = threading.Lock()
@@ -107,18 +115,17 @@ class _StatsDClient:
             if self._init_failed:
                 return None
             try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                sock = socket.socket(self._family, socket.SOCK_DGRAM)
                 sock.setblocking(False)
-                # `connect()` resolves the hostname once and binds the
-                # UDP socket's default destination — eliminates per-call
-                # DNS on `sendto` (which `setblocking(False)` does NOT
-                # make non-blocking).
+                # `connect()` binds the datagram socket's default
+                # destination once (resolving the host for UDP), so each
+                # `emit` is a bare non-blocking `send()` with no per-call
+                # lookup.
                 sock.connect(self._addr)
             except OSError as exc:
                 logger.warning(
-                    "DogStatsD init failed for %s:%d (%s); metrics disabled",
-                    self._addr[0],
-                    self._addr[1],
+                    "DogStatsD init failed for %r (%s); metrics disabled",
+                    self._addr,
                     exc,
                 )
                 self._init_failed = True
@@ -138,7 +145,7 @@ class _StatsDClient:
             pass
 
 
-_client = _StatsDClient(*_resolve_dogstatsd_addr())
+_client = _StatsDClient(*_resolve_dogstatsd_target())
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Summary
- #7268's inlined DogStatsD client is UDP-only; it dropped the unix-socket support ddtrace had. SaaS prod runs the Agent over a Unix socket (`DD_DOGSTATSD_URL=unix://...`), so `weave_trace_server.db_inserts` silently went to zero on deploy. Single-tenant (`udp://`) was unaffected.
- Resolve the URL scheme to `AF_UNIX` vs `AF_INET` and connect the matching datagram socket.

## Testing
unit tests: UDS/UDP/host-port resolution cases + a real AF_UNIX server receiving the emitted packet.
