### PR TITLE
feat(weave): stamp eval metadata on agent spans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -679,7 +679,6 @@ ignore_imports = [
   "weave.evaluation.eval -> weave.trace_server.constants",
   "weave.evaluation.eval -> weave.trace_server.trace_server_interface",
   "weave.evaluation.otel_eval_linker -> weave.trace_server.constants",
-  "weave.evaluation.otel_eval_linker -> weave.trace_server.trace_server_interface",
   "weave.flow.annotation_spec -> weave.trace_server.interface.builtin_object_classes.annotation_spec",
   "weave.flow.leaderboard -> weave.trace_server.interface.builtin_object_classes.leaderboard",
   "weave.flow.leaderboard -> weave.trace_server.trace_server_interface",

--- a/tests/trace/test_eval_otel_linking.py
+++ b/tests/trace/test_eval_otel_linking.py
@@ -1,4 +1,4 @@
-"""Tests for automatic GenAI span -> eval prediction linking via EvalLinkSpanProcessor."""
+"""Tests for eval metadata stamping via EvalLinkSpanProcessor."""
 
 import pytest
 from opentelemetry import trace as otel_trace
@@ -8,7 +8,9 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 import weave
 from weave import Evaluation
+from weave.conversation import start_conversation
 from weave.evaluation.otel_eval_linker import EvalLinkSpanProcessor
+from weave.shared.digest import compute_row_digest
 from weave.trace_server import constants
 from weave.trace_server import trace_server_interface as tsi
 
@@ -43,10 +45,18 @@ def _emit_genai_span(model: str = "gpt-4o") -> None:
     span.end()
 
 
+def _emit_weave_operation_span(operation: str = "invoke_agent") -> None:
+    """Create and end a Weave-semconv OTel span."""
+    tracer = otel_trace.get_tracer("test")
+    span = tracer.start_span(operation)
+    span.set_attribute("weave.operation.name", operation)
+    span.end()
+
+
 @pytest.mark.asyncio
-async def test_genai_span_ref_attached_to_eval_call(client, otel_setup):
-    """A GenAI OTel span emitted during a prediction should produce a
-    GenAISpanRef on the predict_and_score call summary.
+async def test_genai_span_ref_not_written_for_eval_spans(client, otel_setup):
+    """A GenAI OTel span emitted during a prediction should be queryable via
+    stamped eval attributes, not by mutating the eval call summary.
     """
     exporter = otel_setup
 
@@ -66,8 +76,12 @@ async def test_genai_span_ref_attached_to_eval_call(client, otel_setup):
     spans = exporter.get_finished_spans()
     genai_spans = [s for s in spans if s.attributes.get("gen_ai.operation.name")]
     assert len(genai_spans) == 1
+    span_attrs = dict(genai_spans[0].attributes)
+    assert constants.EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR in span_attrs
+    assert constants.EVAL_RUN_ID_SPAN_ATTR in span_attrs
 
-    # Verify the GenAISpanRef was attached to the eval results
+    # New SDK behavior does not write genai_span_ref. The UI should find agent
+    # eval traces by querying spans with the stamped eval columns.
     evaluate_call = next(iter(evaluation.evaluate.calls()))
     res = client.server.eval_results_query(
         tsi.EvalResultsQueryReq(
@@ -78,21 +92,12 @@ async def test_genai_span_ref_attached_to_eval_call(client, otel_setup):
     )
 
     trial = res.rows[0].evaluations[0].trials[0]
-    assert trial.genai_span_ref is not None
-    assert len(trial.genai_span_ref) == 1
-    # OTel stores trace/span IDs as integers; W3C Trace Context represents them
-    # as zero-padded hex: 32 hex chars for 128-bit trace IDs, 16 for 64-bit span IDs.
-    assert trial.genai_span_ref[0].trace_id == format(
-        genai_spans[0].context.trace_id, "032x"
-    )
-    assert trial.genai_span_ref[0].span_id == format(
-        genai_spans[0].context.span_id, "016x"
-    )
+    assert trial.genai_span_ref is None
 
 
 @pytest.mark.asyncio
-async def test_multiple_genai_span_refs_attached_to_eval_call(client, otel_setup):
-    """All GenAI OTel spans emitted during a prediction should be linked."""
+async def test_multiple_genai_spans_get_eval_metadata_without_refs(client, otel_setup):
+    """All GenAI OTel spans emitted during a prediction should be stamped."""
     exporter = otel_setup
 
     @weave.op
@@ -114,6 +119,10 @@ async def test_multiple_genai_span_refs_attached_to_eval_call(client, otel_setup
         if s.attributes.get("gen_ai.operation.name")
     ]
     assert len(genai_spans) == 2
+    for span in genai_spans:
+        attrs = dict(span.attributes)
+        assert constants.EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR in attrs
+        assert constants.EVAL_RUN_ID_SPAN_ATTR in attrs
 
     evaluate_call = next(iter(evaluation.evaluate.calls()))
     res = client.server.eval_results_query(
@@ -125,11 +134,7 @@ async def test_multiple_genai_span_refs_attached_to_eval_call(client, otel_setup
     )
 
     trial = res.rows[0].evaluations[0].trials[0]
-    assert trial.genai_span_ref is not None
-    assert {(r.trace_id, r.span_id) for r in trial.genai_span_ref} == {
-        (format(s.context.trace_id, "032x"), format(s.context.span_id, "016x"))
-        for s in genai_spans
-    }
+    assert trial.genai_span_ref is None
 
 
 @pytest.mark.asyncio
@@ -155,14 +160,14 @@ async def test_eval_metadata_injected_onto_spans(client, otel_setup):
 
     span_attrs = dict(spans[0].attributes)
     assert constants.EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR in span_attrs
+    assert constants.EVAL_RUN_ID_SPAN_ATTR in span_attrs
     assert constants.EVAL_PROJECT_ID_SPAN_ATTR in span_attrs
+    assert span_attrs[constants.EVAL_KIND_SPAN_ATTR] == "standard"
 
 
 @pytest.mark.asyncio
 async def test_non_genai_span_gets_eval_metadata_but_no_span_ref(client, otel_setup):
-    """Non-GenAI spans during eval get eval metadata (on_start) but no
-    GenAISpanRef (on_end only links spans with gen_ai.operation.name).
-    """
+    """Non-GenAI spans during eval get eval metadata and no GenAISpanRef."""
     exporter = otel_setup
 
     @weave.op
@@ -185,7 +190,7 @@ async def test_non_genai_span_gets_eval_metadata_but_no_span_ref(client, otel_se
     span_attrs = dict(spans[0].attributes)
     assert constants.EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR in span_attrs
 
-    # But the eval results should NOT have a GenAISpanRef
+    # Eval results should NOT have a GenAISpanRef.
     evaluate_call = next(iter(evaluation.evaluate.calls()))
     res = client.server.eval_results_query(
         tsi.EvalResultsQueryReq(
@@ -209,3 +214,160 @@ async def test_genai_span_outside_eval_does_not_crash(otel_setup):
     assert constants.EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR not in dict(
         spans[0].attributes
     )
+
+
+def test_imperative_eval_logger_stamps_explicit_eval_metadata(
+    client,
+    otel_setup,
+):
+    """EvaluationLogger should stamp explicit row/trial metadata on OTel spans."""
+    exporter = otel_setup
+
+    ev = weave.EvaluationLogger(name="agent-eval")
+    with ev.log_prediction(
+        {"prompt": "hello"},
+        row_digest="row-explicit",
+        example_id="example-1",
+        trial_index=3,
+        eval_kind="agent",
+    ) as pred:
+        _emit_genai_span()
+        pred.output = "hi"
+    ev.finish()
+
+    spans = exporter.get_finished_spans()
+    genai_span = next(s for s in spans if s.attributes.get("gen_ai.operation.name"))
+    span_attrs = dict(genai_span.attributes)
+
+    assert span_attrs[constants.EVAL_RUN_ID_SPAN_ATTR] == ev._evaluate_call.id
+    assert (
+        span_attrs[constants.EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR]
+        == pred.predict_and_score_call.id
+    )
+    assert span_attrs[constants.EVAL_KIND_SPAN_ATTR] == "agent"
+    assert span_attrs[constants.EVAL_ROW_DIGEST_SPAN_ATTR] == "row-explicit"
+    assert span_attrs[constants.EVAL_EXAMPLE_ID_SPAN_ATTR] == "example-1"
+    assert span_attrs[constants.EVAL_TRIAL_INDEX_SPAN_ATTR] == 3
+    assert span_attrs[constants.EVAL_EVALUATION_NAME_SPAN_ATTR] == "agent-eval"
+
+    client.flush()
+    res = client.server.eval_results_query(
+        tsi.EvalResultsQueryReq(
+            project_id=client.project_id,
+            evaluation_call_ids=[ev._evaluate_call.id],
+            include_predict_and_score_children=False,
+        )
+    )
+    trial = res.rows[0].evaluations[0].trials[0]
+    assert trial.genai_span_ref is None
+
+
+def test_imperative_eval_logger_derives_row_digest_and_trial_index(client, otel_setup):
+    """Default row digest and zero-based trial indexes are deterministic."""
+    exporter = otel_setup
+    inputs = {"prompt": "same"}
+
+    ev = weave.EvaluationLogger(name="agent-eval-trials")
+    with ev.log_prediction(inputs) as pred:
+        _emit_genai_span("gpt-4o")
+        pred.output = "first"
+    with ev.log_prediction(inputs) as pred:
+        _emit_genai_span("gpt-4o-mini")
+        pred.output = "second"
+    ev.finish()
+    client.flush()
+
+    spans_by_model = {
+        s.attributes["gen_ai.request.model"]: dict(s.attributes)
+        for s in exporter.get_finished_spans()
+        if s.attributes.get("gen_ai.operation.name")
+    }
+
+    assert spans_by_model["gpt-4o"][constants.EVAL_ROW_DIGEST_SPAN_ATTR] == (
+        compute_row_digest(inputs)
+    )
+    assert spans_by_model["gpt-4o-mini"][constants.EVAL_ROW_DIGEST_SPAN_ATTR] == (
+        compute_row_digest(inputs)
+    )
+    assert spans_by_model["gpt-4o"][constants.EVAL_TRIAL_INDEX_SPAN_ATTR] == 0
+    assert spans_by_model["gpt-4o-mini"][constants.EVAL_TRIAL_INDEX_SPAN_ATTR] == 1
+
+
+def test_imperative_eval_logger_stamps_conversation_sdk_spans(
+    client,
+    otel_setup,
+):
+    """Conversation SDK agent spans should be stamped with eval metadata."""
+    exporter = otel_setup
+
+    ev = weave.EvaluationLogger(name="conversation-agent-eval")
+    with ev.log_prediction(
+        {"prompt": "weather"},
+        row_digest="row-conversation",
+        example_id="conversation-example",
+    ) as pred:
+        with start_conversation(
+            agent_name="weather-bot",
+            conversation_id="conversation-eval",
+        ) as conversation:
+            with conversation.start_turn() as turn:
+                with turn.llm(model="gpt-4o") as llm:
+                    llm.output("Sunny")
+        pred.output = "Sunny"
+    ev.finish()
+    client.flush()
+
+    genai_spans = [
+        s
+        for s in exporter.get_finished_spans()
+        if s.attributes.get("gen_ai.operation.name")
+    ]
+    assert {s.name for s in genai_spans} == {
+        "invoke_agent weather-bot",
+        "chat gpt-4o",
+    }
+    for span in genai_spans:
+        attrs = dict(span.attributes)
+        assert attrs[constants.EVAL_RUN_ID_SPAN_ATTR] == ev._evaluate_call.id
+        assert attrs[constants.EVAL_KIND_SPAN_ATTR] == "agent"
+        assert attrs[constants.EVAL_ROW_DIGEST_SPAN_ATTR] == "row-conversation"
+        assert attrs[constants.EVAL_EXAMPLE_ID_SPAN_ATTR] == "conversation-example"
+        assert attrs[constants.EVAL_TRIAL_INDEX_SPAN_ATTR] == 0
+
+    res = client.server.eval_results_query(
+        tsi.EvalResultsQueryReq(
+            project_id=client.project_id,
+            evaluation_call_ids=[ev._evaluate_call.id],
+            include_predict_and_score_children=False,
+        )
+    )
+    trial = res.rows[0].evaluations[0].trials[0]
+    assert trial.genai_span_ref is None
+
+
+def test_imperative_eval_logger_stamps_weave_operation_spans(client, otel_setup):
+    """Non-GenAI OTel integrations get eval metadata on Weave operation spans."""
+    exporter = otel_setup
+
+    ev = weave.EvaluationLogger(name="weave-operation-eval")
+    with ev.log_prediction({"prompt": "hello"}) as pred:
+        _emit_weave_operation_span()
+        pred.output = "hi"
+    ev.finish()
+    client.flush()
+
+    operation_span = next(
+        s for s in exporter.get_finished_spans() if s.name == "invoke_agent"
+    )
+    attrs = dict(operation_span.attributes)
+    assert attrs[constants.EVAL_KIND_SPAN_ATTR] == "agent"
+
+    res = client.server.eval_results_query(
+        tsi.EvalResultsQueryReq(
+            project_id=client.project_id,
+            evaluation_call_ids=[ev._evaluate_call.id],
+            include_predict_and_score_children=False,
+        )
+    )
+    trial = res.rows[0].evaluations[0].trials[0]
+    assert trial.genai_span_ref is None

--- a/weave/evaluation/eval.py
+++ b/weave/evaluation/eval.py
@@ -5,6 +5,7 @@ import traceback
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 from datetime import datetime
 from itertools import chain, repeat
 from typing import Any, Literal
@@ -43,7 +44,6 @@ from weave.trace.table import Table
 from weave.trace.vals import WeaveObject
 from weave.trace.weave_client import get_ref
 from weave.trace_server import constants
-from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.trace_server_interface import CallsFilter
 from weave.utils.project_id import from_project_id
 
@@ -65,49 +65,49 @@ _current_eval_predict_and_score_call: ContextVar[Call | None] = ContextVar(
 )
 
 
+@dataclass(frozen=True, slots=True)
+class EvalSpanContext:
+    """Eval metadata available to OTel span processors during predictions."""
+
+    predict_and_score_call: Call
+    evaluate_call: Call | None = None
+    eval_kind: str | None = None
+    row_digest: str | None = None
+    example_id: str | None = None
+    trial_index: int | None = None
+    evaluation_name: str | None = None
+
+
+_current_eval_span_context: ContextVar[EvalSpanContext | None] = ContextVar(
+    "current_eval_span_context", default=None
+)
+
+
 @contextmanager
-def _active_eval_prediction_context(call: Call | None) -> Iterator[None]:
-    """Set _current_eval_predict_and_score_call for the duration of a block.
+def _active_eval_prediction_context(
+    call: Call | None,
+    span_context: EvalSpanContext | None = None,
+) -> Iterator[None]:
+    """Set active eval prediction metadata for the duration of a block.
 
     This needs to be explicitly set in the imperative path because the EvaluationLogger
     creates synthetic ops, so there is no call stack to walk to find the actual
-    predict_and_score call.
+    predict_and_score call. ``span_context`` carries the richer eval metadata
+    needed by OTel span processors.
     """
     if call is None:
         yield
         return
 
-    token = _current_eval_predict_and_score_call.set(call)
+    call_token = _current_eval_predict_and_score_call.set(call)
+    span_context_token = _current_eval_span_context.set(
+        span_context or EvalSpanContext(predict_and_score_call=call)
+    )
     try:
         yield
     finally:
-        _current_eval_predict_and_score_call.reset(token)
-
-
-def _attach_genai_span_ref_to_call_summary(
-    call: Call,
-    genai_span_ref: tsi.GenAISpanRef,
-) -> None:
-    """Append a GenAISpanRef into call.summary so eval results can find it.
-
-    Our EvalLinkSpanProcessor calls this to attach GenAISpanRef to an Eval
-    call. The trace server can then extract span refs from call summaries
-    by looking for the presence of the GenAISpanRef attribute key.
-    """
-    if call.summary is None:
-        call.summary = {}
-
-    if constants.WEAVE_ATTRIBUTES_NAMESPACE not in call.summary:
-        call.summary[constants.WEAVE_ATTRIBUTES_NAMESPACE] = {}
-
-    weave_summary = call.summary[constants.WEAVE_ATTRIBUTES_NAMESPACE]
-
-    new_ref = genai_span_ref.model_dump()
-    existing = weave_summary.get(constants.GENAI_SPAN_REF_ATTR_KEY)
-    if isinstance(existing, list):
-        existing.append(new_ref)
-    else:
-        weave_summary[constants.GENAI_SPAN_REF_ATTR_KEY] = [new_ref]
+        _current_eval_span_context.reset(span_context_token)
+        _current_eval_predict_and_score_call.reset(call_token)
 
 
 def _find_call_on_stack(op_names: str | tuple[str, ...]) -> Call | None:

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -14,12 +14,13 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from threading import Lock
 from types import MethodType
-from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
+from typing import Any, TypeVar, cast, overload
 
 from typing_extensions import Self
 
 from weave.dataset.dataset import Dataset
 from weave.evaluation.eval import (
+    EvalSpanContext,
     Evaluation,
     _active_eval_prediction_context,
     default_evaluation_display_name,
@@ -30,6 +31,7 @@ from weave.flow.scorer import Scorer
 from weave.flow.scorer import auto_summarize as auto_summarize_fn
 from weave.flow.util import make_memorable_name
 from weave.object.obj import Object
+from weave.shared.digest import compute_row_digest
 from weave.trace.api import attributes
 from weave.trace.call import Call
 from weave.trace.context import call_context
@@ -40,9 +42,6 @@ from weave.trace.util import Thread
 from weave.trace.view_utils import set_call_view
 from weave.type_wrappers.Content.content import Content
 from weave.utils.sentinel import NOT_SET, _NotSetType
-
-if TYPE_CHECKING:
-    from weave.trace.call import Call
 
 DEFAULT_SCORER_CACHE_SIZE = 1000
 
@@ -91,6 +90,13 @@ IMPERATIVE_SCORE_META_MARKER = {"imperative": True, "score": True}
 
 def _as_call_attributes(eval_meta: dict[str, Any]) -> dict[str, Any]:
     return {EVAL_META_KEY: eval_meta}
+
+
+def _compute_default_row_digest(inputs: dict[str, Any]) -> str | None:
+    try:
+        return compute_row_digest(inputs)
+    except (TypeError, ValueError):
+        return None
 
 
 @contextmanager
@@ -268,7 +274,7 @@ class _LogScoreContext:
 
     @property
     def value(self) -> ScoreType | None:
-        """Get the current score value."""
+        """Current score value."""
         return self._score_value
 
     @value.setter
@@ -363,11 +369,13 @@ class ScoreLogger:
         evaluate_call: Call,
         predict_call: Call,
         predefined_scorers: list[str] | None = None,
+        eval_span_context: EvalSpanContext | None = None,
     ) -> None:
         self.predict_and_score_call = predict_and_score_call
         self.evaluate_call = evaluate_call
         self.predict_call = predict_call
         self.predefined_scorers = predefined_scorers
+        self._eval_span_context = eval_span_context
         self._score_meta = IMPERATIVE_SCORE_META_MARKER
 
         self._captured_scores: dict[str, ScoreType] = {}
@@ -603,7 +611,7 @@ class ScoreLogger:
 
     @property
     def output(self) -> Any:
-        """Get the current output value."""
+        """Current output value."""
         return self._predict_output
 
     @output.setter
@@ -614,7 +622,8 @@ class ScoreLogger:
     def __enter__(self) -> Self:
         """Enter context manager and set call stack to predict_call."""
         self._eval_prediction_context = _active_eval_prediction_context(
-            self.predict_and_score_call
+            self.predict_and_score_call,
+            self._eval_span_context,
         )
         self._eval_prediction_context.__enter__()
         self._call_stack_context = call_context.set_call_stack([self.predict_call])
@@ -711,6 +720,7 @@ class EvaluationLogger:
         # Private state
         self._is_finalized: bool = False
         self._accumulated_predictions: list[ScoreLogger] = []
+        self._trial_counts_by_row_digest: dict[str, int] = {}
 
         # Register this instance in the global registry for atexit cleanup
         _active_evaluation_loggers.append(self)
@@ -841,6 +851,30 @@ class EvaluationLogger:
     def attributes(self) -> dict[str, Any]:
         return self.eval_attributes | _as_call_attributes(self._eval_meta)
 
+    def _resolve_eval_row_metadata(
+        self,
+        inputs: dict[str, Any],
+        row_digest: str | None,
+        trial_index: int | None,
+    ) -> tuple[str | None, int | None]:
+        resolved_row_digest = (
+            row_digest
+            if row_digest is not None
+            else _compute_default_row_digest(inputs)
+        )
+        if resolved_row_digest is None:
+            return None, trial_index
+
+        next_trial_index = self._trial_counts_by_row_digest.get(resolved_row_digest, 0)
+        resolved_trial_index = (
+            trial_index if trial_index is not None else next_trial_index
+        )
+        self._trial_counts_by_row_digest[resolved_row_digest] = max(
+            next_trial_index,
+            resolved_trial_index + 1,
+        )
+        return resolved_row_digest, resolved_trial_index
+
     def _cleanup_predictions(self) -> None:
         if self._is_finalized:
             return
@@ -874,7 +908,16 @@ class EvaluationLogger:
 
         self._is_finalized = True
 
-    def log_prediction(self, inputs: dict[str, Any], output: Any = None) -> ScoreLogger:
+    def log_prediction(
+        self,
+        inputs: dict[str, Any],
+        output: Any = None,
+        *,
+        example_id: str | None = None,
+        row_digest: str | None = None,
+        trial_index: int | None = None,
+        eval_kind: str | None = "agent",
+    ) -> ScoreLogger:
         """Log a prediction to the Evaluation.
 
         Returns a ScoreLogger that can be used directly or as a context manager.
@@ -882,6 +925,10 @@ class EvaluationLogger:
         Args:
             inputs: The input data for the prediction
             output: The output value. Defaults to None. Can be set later using pred.output.
+            example_id: Optional caller-provided example identifier for OTel spans.
+            row_digest: Optional stable row identity. Defaults to a digest of inputs.
+            trial_index: Optional zero-based trial index for this row digest.
+            eval_kind: Optional eval kind for OTel spans. Defaults to "agent".
 
         Returns:
             ScoreLogger for logging scores and optionally finishing the prediction.
@@ -934,11 +981,32 @@ class EvaluationLogger:
         # Set the output on the predict_call now so it's available for apply_scorer
         predict_call.output = output
 
+        resolved_row_digest, resolved_trial_index = self._resolve_eval_row_metadata(
+            inputs,
+            row_digest,
+            trial_index,
+        )
+        evaluation_name = (
+            self._evaluate_call.display_name
+            if isinstance(self._evaluate_call.display_name, str)
+            else self.name
+        )
+        eval_span_context = EvalSpanContext(
+            predict_and_score_call=predict_and_score_call,
+            evaluate_call=self._evaluate_call,
+            eval_kind=eval_kind,
+            row_digest=resolved_row_digest,
+            example_id=example_id,
+            trial_index=resolved_trial_index,
+            evaluation_name=evaluation_name,
+        )
+
         pred = ScoreLogger(
             predict_and_score_call=predict_and_score_call,
             evaluate_call=self._evaluate_call,
             predict_call=predict_call,
             predefined_scorers=self.scorers,
+            eval_span_context=eval_span_context,
         )
         pred._apply_eval_meta(self._eval_meta)
         # Store the output so we can use it when finishing the predict_call

--- a/weave/evaluation/otel_eval_linker.py
+++ b/weave/evaluation/otel_eval_linker.py
@@ -1,12 +1,9 @@
-"""Auto-link GenAI OTel spans to eval predictions.
+"""Stamp eval metadata onto OTel spans created during eval predictions.
 
-When a GenAI OTel span ends during an active ``Evaluation.predict_and_score``
-call, the :class:`EvalLinkSpanProcessor` automatically populates a
-:class:`GenAISpanRef` on the predict_and_score call summary — no user code
-required.
-
-It also injects eval metadata (call ID, evaluation name, project) onto the
-span so the agent traces UI can deep-link and filter by eval run.
+When an OTel span starts during an active ``Evaluation.predict_and_score`` call,
+the :class:`EvalLinkSpanProcessor` injects eval metadata (call IDs, evaluation
+name, project, row identity, trial index, and kind) onto the span so the agent
+traces UI can find eval traces by querying promoted span columns.
 
 Register this processor alongside the ``BatchSpanProcessor`` during
 ``_setup_conversation_tracing`` in ``weave_init.py``.
@@ -14,38 +11,27 @@ Register this processor alongside the ``BatchSpanProcessor`` during
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 
 from weave.evaluation.eval import (
-    _attach_genai_span_ref_to_call_summary,
+    EvalSpanContext,
     _current_eval_predict_and_score_call,
+    _current_eval_span_context,
     _find_current_evaluate_call,
     _find_current_predict_and_score_call,
 )
 from weave.trace_server import constants
-from weave.trace_server import trace_server_interface as tsi
 
 if TYPE_CHECKING:
     from opentelemetry.context import Context
 
     from weave.trace.call import Call
 
-logger = logging.getLogger(__name__)
 
-# GenAI semantic convention attribute that identifies a span as a GenAI operation.
-# It is available as GEN_AI_OPERATION_NAME in opentelemetry.semconv._incubating, but
-# given it's a private module and subject to change, I don't want to depend on it for
-# now.
-# TODO: Use the official semconv when this standard moves out of _incubating
-_GENAI_OPERATION_NAME_ATTR = "gen_ai.operation.name"
-
-
-def _get_evaluation_name() -> str | None:
+def _get_evaluation_name(call: Call | None) -> str | None:
     """Find the parent evaluate call and return the eval display name."""
-    call = _find_current_evaluate_call()
     if call is None:
         return None
     name = call.display_name
@@ -53,15 +39,11 @@ def _get_evaluation_name() -> str | None:
 
 
 class EvalLinkSpanProcessor(SpanProcessor):
-    """OTel SpanProcessor that auto-links GenAI spans to eval predictions.
+    """OTel SpanProcessor that stamps eval metadata onto prediction spans.
 
     When ``on_start`` the processor injects eval context attributes (call ID,
     evaluation name, project) onto the span for reverse lookup and filtering
     in the agent traces UI.
-
-    When ``on_end`` fires, it attaches a ``GenAISpanRef`` (trace_id + span_id)
-    to the predict_and_score call summary so eval results can navigate to the
-    underlying GenAI span.
     """
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
@@ -73,36 +55,54 @@ class EvalLinkSpanProcessor(SpanProcessor):
         not available at start time.  The query side can intersect with gen_ai.operation.name
         to narrow to GenAI spans.
         """
-        call = self._find_predict_and_score_call()
-        if call is None:
+        eval_context = self._find_eval_span_context()
+        if eval_context is None:
             return
 
-        span.set_attribute(constants.EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR, call.id)
-        span.set_attribute(constants.EVAL_PROJECT_ID_SPAN_ATTR, call.project_id)
+        predict_and_score_call = eval_context.predict_and_score_call
+        if predict_and_score_call.id is not None:
+            span.set_attribute(
+                constants.EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR,
+                predict_and_score_call.id,
+            )
+        span.set_attribute(
+            constants.EVAL_PROJECT_ID_SPAN_ATTR, predict_and_score_call.project_id
+        )
 
-        eval_name = _get_evaluation_name()
+        if (
+            eval_context.evaluate_call is not None
+            and eval_context.evaluate_call.id is not None
+        ):
+            span.set_attribute(
+                constants.EVAL_RUN_ID_SPAN_ATTR,
+                eval_context.evaluate_call.id,
+            )
+        if eval_context.eval_kind is not None:
+            span.set_attribute(constants.EVAL_KIND_SPAN_ATTR, eval_context.eval_kind)
+        if eval_context.row_digest is not None:
+            span.set_attribute(
+                constants.EVAL_ROW_DIGEST_SPAN_ATTR,
+                eval_context.row_digest,
+            )
+        if eval_context.example_id is not None:
+            span.set_attribute(
+                constants.EVAL_EXAMPLE_ID_SPAN_ATTR,
+                eval_context.example_id,
+            )
+        if eval_context.trial_index is not None:
+            span.set_attribute(
+                constants.EVAL_TRIAL_INDEX_SPAN_ATTR,
+                eval_context.trial_index,
+            )
+
+        eval_name = eval_context.evaluation_name or _get_evaluation_name(
+            eval_context.evaluate_call
+        )
         if eval_name:
             span.set_attribute(constants.EVAL_EVALUATION_NAME_SPAN_ATTR, eval_name)
 
     def on_end(self, span: ReadableSpan) -> None:
-        """Auto-populate GenAISpanRef when a GenAI span ends during an eval."""
-        attrs = span.attributes or {}
-        if _GENAI_OPERATION_NAME_ATTR not in attrs:
-            return
-
-        call = self._find_predict_and_score_call()
-        if call is None:
-            return
-
-        ctx = span.context
-        if ctx is None or not ctx.is_valid:
-            return
-
-        trace_id = format(ctx.trace_id, "032x")
-        span_id = format(ctx.span_id, "016x")
-
-        ref = tsi.GenAISpanRef(trace_id=trace_id, span_id=span_id)
-        _attach_genai_span_ref_to_call_summary(call, ref)
+        return None
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         return True
@@ -124,4 +124,22 @@ class EvalLinkSpanProcessor(SpanProcessor):
         return (
             _current_eval_predict_and_score_call.get()
             or _find_current_predict_and_score_call()
+        )
+
+    @staticmethod
+    def _find_eval_span_context() -> EvalSpanContext | None:
+        """Find structured eval span context, with legacy stack fallback."""
+        if (eval_context := _current_eval_span_context.get()) is not None:
+            return eval_context
+
+        predict_and_score_call = EvalLinkSpanProcessor._find_predict_and_score_call()
+        if predict_and_score_call is None:
+            return None
+
+        evaluate_call = _find_current_evaluate_call()
+        return EvalSpanContext(
+            predict_and_score_call=predict_and_score_call,
+            evaluate_call=evaluate_call,
+            eval_kind="standard" if evaluate_call is not None else None,
+            evaluation_name=_get_evaluation_name(evaluate_call),
         )

--- a/weave/trace_server/constants.py
+++ b/weave/trace_server/constants.py
@@ -48,6 +48,11 @@ SCORE_EVALUATION_RUN_ID_ATTR_KEY = "evaluation_run_id"
 WEAVE_ATTRIBUTES_NAMESPACE = "weave"
 
 # OTel span attribute keys for eval context
+EVAL_RUN_ID_SPAN_ATTR = "weave.eval.run_id"
 EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR = "weave.eval.predict_and_score_call_id"
 EVAL_PROJECT_ID_SPAN_ATTR = "weave.eval.project_id"
+EVAL_KIND_SPAN_ATTR = "weave.eval.kind"
+EVAL_ROW_DIGEST_SPAN_ATTR = "weave.eval.row_digest"
+EVAL_EXAMPLE_ID_SPAN_ATTR = "weave.eval.example_id"
+EVAL_TRIAL_INDEX_SPAN_ATTR = "weave.eval.trial_index"
 EVAL_EVALUATION_NAME_SPAN_ATTR = "weave.eval.evaluation_name"


### PR DESCRIPTION
## Description

Second PR in the agent evals bridge stack, built on #7469.

This wires the Weave SDK eval path to OTel agent tracing. When an imperative eval prediction runs inside a `ScoreLogger` context, the SDK carries a structured eval context and stamps OTel spans created inside that context with the `weave.eval.*` metadata promoted by #7469.

This PR intentionally stops creating new `summary.weave.genai_span_ref` links. Those refs remain readable for historical data, but new agent eval correlation should happen by querying promoted agent span columns like `eval_run_id` and `eval_predict_and_score_call_id`.

What this PR changes:

- Adds a structured `EvalSpanContext` for active eval predictions.
- Extends `EvaluationLogger.log_prediction(...)` with optional metadata:
  - `example_id`
  - `row_digest`
  - `trial_index`
  - `eval_kind` (defaults to `"agent"`)
- Derives deterministic row digests from inputs when `row_digest` is omitted.
- Counts default `trial_index` values per row digest when callers do not provide one.
- Stamps active OTel spans with:
  - `weave.eval.run_id`
  - `weave.eval.predict_and_score_call_id`
  - `weave.eval.kind`
  - `weave.eval.row_digest`
  - `weave.eval.example_id`
  - `weave.eval.trial_index`
  - `weave.eval.evaluation_name`
- Removes the SDK path that appended new `genai_span_ref` entries to eval trial summaries.

What this is for:

- Makes imperative eval logging work for OTel-instrumented agents.
- Supports both generic OTel instrumentation and spans emitted by the Weave Conversation SDK.
- Preserves the separation between eval calls/scores and agent span storage: evals remain evals, agents remain OTel spans, and the bridge is eval metadata on spans.

## How to use it

For spans to be stamped, run the instrumented agent inside the `log_prediction(...)` context:

```python
import weave
from opentelemetry import trace

weave.init("entity/project")
tracer = trace.get_tracer("support-agent")

ev = weave.EvaluationLogger(name="support-agent-eval", scorers=["passed"])

with ev.log_prediction(
    inputs={"question": "How should I debug missing traces?"},
    example_id="missing-traces-001",
    # row_digest is optional; omitted values are derived from inputs.
    trial_index=0,
    eval_kind="agent",
) as pred:
    with tracer.start_as_current_span("support_agent.invoke") as span:
        span.set_attribute("gen_ai.operation.name", "invoke_agent")
        span.set_attribute("gen_ai.agent.name", "SupportAgent")
        span.set_attribute("gen_ai.agent.version", "v1")
        answer = "Check WF_TRACE_SERVER_URL, entity/project, and write access."

    pred.output = {"answer": answer}
    pred.log_score("passed", True)

ev.log_summary({"accuracy": 1.0})
```

The same pattern works with the Conversation SDK:

```python
import weave
from weave.conversation import Message, Usage, start_conversation, start_llm

weave.init("entity/project")
ev = weave.EvaluationLogger(name="conversation-agent-eval", scorers=["passed"])

with ev.log_prediction(
    inputs={"question": "Can admins rotate API keys?"},
    example_id="api-key-rotation",
    eval_kind="agent",
) as pred:
    with start_conversation(
        agent_name="SupportAgent",
        model="demo-policy-agent",
        conversation_id="eval-api-key-rotation-trial-0",
    ) as conversation:
        with conversation.start_turn(
            user_message="Can admins rotate API keys?",
            agent_name="SupportAgent",
            model="demo-policy-agent",
        ):
            with start_llm(model="demo-policy-agent", provider_name="demo") as llm:
                answer = "Admins can rotate keys after confirming owner and scope."
                llm.record(
                    input_messages=[Message.user("Can admins rotate API keys?")],
                    output_messages=[Message.assistant(answer)],
                    usage=Usage(input_tokens=32, output_tokens=12),
                    finish_reasons=["stop"],
                    output_type="text",
                )

    pred.output = {"answer": answer}
    pred.log_score("passed", True)

ev.log_summary({"accuracy": 1.0})
```

Every OTel span created inside the prediction context gets the active eval metadata. The UI can then find the agent trace by filtering agent spans on `eval_run_id` or `eval_predict_and_score_call_id`.

## Testing

Added/updated coverage in:

- `tests/trace/test_eval_otel_linking.py`

Focused validation:

- `uvx ruff check --fix weave/evaluation/otel_eval_linker.py weave/evaluation/eval.py tests/trace/test_eval_otel_linking.py AGENTS.md`
- `uv run --group test python -m pytest tests/trace/test_eval_otel_linking.py -q`

Full-stack smoke after applying the stack:

- Seeded an imperative agent eval run using `EvaluationLogger` plus the Conversation SDK.
- Verified `agent_spans_query` returned linked agent spans with `eval_kind=agent`, distinct row digests, and distinct predict-and-score trial calls.
