### PR TITLE
chore(weave): hide publish log and print conversation link each turn

### DIFF
--- a/weave/integrations/openai_realtime/otel_state_exporter.py
+++ b/weave/integrations/openai_realtime/otel_state_exporter.py
@@ -201,7 +201,7 @@ class OTelStateExporter(StateExporter):
             content: Content = Content.from_bytes(
                 pcm_to_wav(bytes(pcm_bytes)), mimetype=_AUDIO_MIME_TYPE
             )
-            ref = publish(content)
+            ref = publish(content, disable_logging=True)
             # ``ref.uri`` may be a str subclass that OTel attr validation rejects.
             return str(getattr(ref, "uri", ref))
         except Exception:
@@ -340,8 +340,7 @@ class OTelStateExporter(StateExporter):
             self._session_root_spans[group_key] = root
             if created_at:
                 self._session_last_activity[group_key] = created_at
-        # Log outside the lock; this runs once, when the root is first created.
-        self._log_conversation_link(conversation_id)
+            self._log_conversation_link(conversation_id)
         return root
 
     def _log_conversation_link(self, conversation_id: str) -> None:

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -190,6 +190,7 @@ def publish(
     name: str | None = None,
     tags: list[str] | None = None,
     aliases: list[str] | None = None,
+    disable_logging: bool = False
 ) -> ObjectRef:
     """Save and version a Python object.
 
@@ -254,16 +255,17 @@ def publish(
                 ref.digest,
             )
         # Ensure logger level is up to date before logging
-        update_logger_level()
-        msg = f"{TRACE_OBJECT_EMOJI} Published to {url}"
-        if tags or aliases:
-            extras = []
-            if tags:
-                extras.append(f"tags: {', '.join(tags)}")
-            if aliases:
-                extras.append(f"aliases: {', '.join(aliases)}")
-            msg += f" ({'; '.join(extras)})"
-        logger.info(msg)
+        if disable_logging:
+            update_logger_level()
+            msg = f"{TRACE_OBJECT_EMOJI} Published to {url}"
+            if tags or aliases:
+                extras = []
+                if tags:
+                    extras.append(f"tags: {', '.join(tags)}")
+                if aliases:
+                    extras.append(f"aliases: {', '.join(aliases)}")
+                msg += f" ({'; '.join(extras)})"
+            logger.info(msg)
     return ref
 
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-36572
- Fixes WB-36573

- Logs conversation link after each turn submission to mirror non-OTel behavior.
- Hides noisy log messages for object publication
