### PR TITLE
feat(weave_ts): Add `SubAgent.record()`

### DIFF
--- a/sdks/node/src/__tests__/genai/subagent.test.ts
+++ b/sdks/node/src/__tests__/genai/subagent.test.ts
@@ -106,6 +106,89 @@ describe('SubAgent', () => {
     warnSpy.mockRestore();
   });
 
+  it('record() updates fields, which are emitted at end()', () => {
+    const turn = Turn.create({});
+    const sub = turn.startSubagent({name: 'researcher'});
+    sub.record({
+      agentId: 'agent-9',
+      agentDescription: 'A research bot',
+      agentVersion: 'v4',
+      systemInstructions: ['Find authoritative sources'],
+    });
+    sub.end();
+    turn.end();
+
+    const span = findSub(getExporter().getFinishedSpans());
+    expect(spanSnapshot(span)).toMatchInlineSnapshot(`
+      {
+        "attributes": {
+          "gen_ai.agent.description": "A research bot",
+          "gen_ai.agent.id": "agent-9",
+          "gen_ai.agent.name": "researcher",
+          "gen_ai.agent.version": "v4",
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.system_instructions": "[{"type":"text","content":"Find authoritative sources"}]",
+        },
+        "endTime": "<timestamp>",
+        "startTime": "<timestamp>",
+      }
+    `);
+  });
+
+  it('record() preserves untouched values', () => {
+    const turn = Turn.create({});
+    const sub = turn.startSubagent({
+      name: 'researcher',
+      agentId: 'preset',
+      agentVersion: 'v1',
+      systemInstructions: ['initial'],
+    });
+    sub.record({agentVersion: 'v2'});
+    sub.end();
+    turn.end();
+
+    const span = findSub(getExporter().getFinishedSpans());
+    expect(spanSnapshot(span)).toMatchInlineSnapshot(`
+      {
+        "attributes": {
+          "gen_ai.agent.id": "preset",
+          "gen_ai.agent.name": "researcher",
+          "gen_ai.agent.version": "v2",
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.system_instructions": "[{"type":"text","content":"initial"}]",
+        },
+        "endTime": "<timestamp>",
+        "startTime": "<timestamp>",
+      }
+    `);
+  });
+
+  it('record() is chainable', () => {
+    const turn = Turn.create({});
+    const sub = turn.startSubagent({name: 'researcher'});
+    expect(sub.record({agentId: 'x'}).record({agentDescription: 'foo'})).toBe(
+      sub
+    );
+    sub.end();
+    turn.end();
+  });
+
+  it('record() warns and is a no-op after end()', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const turn = Turn.create({});
+    const sub = turn.startSubagent({name: 'researcher'});
+    sub.end();
+    sub.record({agentId: 'after-end'});
+    turn.end();
+
+    const subSpan = findSub(getExporter().getFinishedSpans());
+    expect(subSpan.attributes['gen_ai.agent.id']).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('SubAgent.record() called after end()')
+    );
+    warnSpy.mockRestore();
+  });
+
   it('startTime/endTime backdate the invoke_agent span window', () => {
     const startedAt = new Date('2026-01-01T00:00:00Z');
     const endedAt = new Date('2026-01-01T00:00:05Z');

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -5,7 +5,10 @@ import {getGenaiState} from './context';
 import {getWeaveTracer} from './provider';
 import {SpanBase, type SpanEndOptions, type SpanInitBase} from './spanBase';
 import {
+  ATTR_GEN_AI_AGENT_DESCRIPTION,
+  ATTR_GEN_AI_AGENT_ID,
   ATTR_GEN_AI_AGENT_NAME,
+  ATTR_GEN_AI_AGENT_VERSION,
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_REQUEST_MODEL,
@@ -17,6 +20,9 @@ export interface SubAgentInit extends SpanInitBase {
   name: string;
   model?: string;
   systemInstructions?: string[];
+  agentId?: string;
+  agentDescription?: string;
+  agentVersion?: string;
 }
 
 /**
@@ -51,51 +57,127 @@ export interface SubAgentInit extends SpanInitBase {
  *   sub.end();
  * }
  */
+type Opts = {
+  span: Span;
+  conversationId: string;
+} & Required<Omit<SubAgentInit, 'startTime'>>;
+
 export class SubAgent extends SpanBase {
-  private constructor(
-    span: Span,
-    public readonly name: string,
-    public readonly model: string
-  ) {
-    super(span);
+  private _conversationId: string;
+  private _name: string;
+  private _model: string;
+  private _systemInstructions: string[];
+  private _agentId: string;
+  private _agentDescription: string;
+  private _agentVersion: string;
+
+  public get name() {
+    return this._name;
+  }
+
+  public get model() {
+    return this._model;
+  }
+
+  private constructor(opts: Opts) {
+    super(opts.span);
+    this._conversationId = opts.conversationId;
+    this._name = opts.name;
+    this._model = opts.model;
+    this._systemInstructions = opts.systemInstructions;
+    this._agentId = opts.agentId;
+    this._agentDescription = opts.agentDescription;
+    this._agentVersion = opts.agentVersion;
   }
 
   static create(opts: SubAgentInit & ChildSpanContext): SubAgent {
     const state = getGenaiState();
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
-    const attributes: Attributes = {
-      ...(state.conversation?.attributes ?? {}),
-      [ATTR_GEN_AI_OPERATION_NAME]: 'invoke_agent',
-      [ATTR_GEN_AI_AGENT_NAME]: opts.name,
-    };
-    if (opts.model) {
-      attributes[ATTR_GEN_AI_REQUEST_MODEL] = opts.model;
-    }
-    if (opts.conversationId) {
-      attributes[ATTR_GEN_AI_CONVERSATION_ID] = opts.conversationId;
-    }
-    if (opts.systemInstructions && opts.systemInstructions.length > 0) {
-      attributes[ATTR_GEN_AI_SYSTEM_INSTRUCTIONS] = JSON.stringify(
-        opts.systemInstructions.map(content => ({type: 'text', content}))
-      );
-    }
+    const attributes: Attributes = {...(state.conversation?.attributes ?? {})};
     const span = tracer.startSpan(
       'invoke_agent',
       {kind: SpanKind.CLIENT, attributes, startTime: opts.startTime},
       opts.parentContext
     );
-    return new SubAgent(span, opts.name, opts.model ?? '');
+    return new SubAgent({
+      span,
+      name: opts.name,
+      model: opts.model ?? '',
+      conversationId: opts.conversationId ?? '',
+      systemInstructions: opts.systemInstructions ?? [],
+      agentId: opts.agentId ?? '',
+      agentDescription: opts.agentDescription ?? '',
+      agentVersion: opts.agentVersion ?? '',
+    });
   }
 
   /**
-   * Close the SubAgent span. Idempotent. Pass `error` to mark it as failed;
-   * pass `endTime` to backdate the close.
+   * Bulk-set any fields. Replaces (does not merge).
+   */
+  record(opts: Partial<Omit<SubAgentInit, keyof SpanInitBase>>): this {
+    if (this._warnIfEnded('record')) return this;
+
+    if (opts.name !== undefined) {
+      this._name = opts.name;
+    }
+    if (opts.model !== undefined) {
+      this._model = opts.model;
+    }
+    if (opts.systemInstructions !== undefined) {
+      this._systemInstructions = opts.systemInstructions;
+    }
+    if (opts.agentId !== undefined) {
+      this._agentId = opts.agentId;
+    }
+    if (opts.agentDescription !== undefined) {
+      this._agentDescription = opts.agentDescription;
+    }
+    if (opts.agentVersion !== undefined) {
+      this._agentVersion = opts.agentVersion;
+    }
+    return this;
+  }
+
+  /**
+   * Read current field values (to reflect mutations made via `record()`
+   * since `start`) and close the span. Idempotent. Pass `error` to mark
+   * it as failed; pass `endTime` to backdate the close.
    */
   end(opts?: SpanEndOptions): void {
     if (this._ended) {
       return;
     }
     this._ended = true;
+
+    this.span.setAttribute(ATTR_GEN_AI_OPERATION_NAME, 'invoke_agent');
+    this.span.setAttribute(ATTR_GEN_AI_AGENT_NAME, this._name);
+    if (this._model) {
+      this.span.setAttribute(ATTR_GEN_AI_REQUEST_MODEL, this._model);
+    }
+    if (this._conversationId) {
+      this.span.setAttribute(ATTR_GEN_AI_CONVERSATION_ID, this._conversationId);
+    }
+    if (this._agentId) {
+      this.span.setAttribute(ATTR_GEN_AI_AGENT_ID, this._agentId);
+    }
+    if (this._agentDescription) {
+      this.span.setAttribute(
+        ATTR_GEN_AI_AGENT_DESCRIPTION,
+        this._agentDescription
+      );
+    }
+    if (this._agentVersion) {
+      this.span.setAttribute(ATTR_GEN_AI_AGENT_VERSION, this._agentVersion);
+    }
+    if (this._systemInstructions.length > 0) {
+      this.span.setAttribute(
+        ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
+        JSON.stringify(
+          this._systemInstructions.map(content => ({type: 'text', content}))
+        )
+      );
+    }
+
     this._closeSpan(opts);
   }
 }


### PR DESCRIPTION
## Description

* Python has a `SubAgent.record()` function:

```py
    def record(
        self,
        *,
        name: str | None = None,
        model: str | None = None,
        system_instructions: list[str] | None = None,
        agent_id: str | None = None,
        agent_description: str | None = None,
        agent_version: str | None = None,
    ) -> SubAgent:
```

* `SubAgent.record()` is not yet supported by TS. This change adds it.