### PR TITLE
feat(weave_ts): Accept `mediaAttachments`, `responseId`, `responseModel`, `finishReasons`, `outputType` in `LLM.record()`

### DIFF
--- a/sdks/node/src/__tests__/genai/genai.test.ts
+++ b/sdks/node/src/__tests__/genai/genai.test.ts
@@ -212,7 +212,7 @@ async function runAgentLoop(
       providerName: 'some-provider',
       systemInstructions: [agent.instructions],
     });
-    llm.inputMessages = [...messages];
+    llm.record({inputMessages: [...messages]});
 
     const resp = await callSomeLLM({
       model: 'some-model',
@@ -238,12 +238,15 @@ async function runAgentLoop(
       });
     }
     const assistantMessage: Message = {role: 'assistant', parts};
-    llm.outputMessages = [assistantMessage];
     llm.record({
+      outputMessages: [assistantMessage],
       usage: {
         inputTokens: resp.usage?.prompt_tokens,
         outputTokens: resp.usage?.completion_tokens,
       },
+      responseId: resp.id,
+      responseModel: resp.model,
+      finishReasons: [choice.finish_reason],
     });
     llm.end();
     messages.push(assistantMessage);
@@ -392,6 +395,11 @@ describe('GenAI', () => {
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"tool_call","toolCallId":"call_t1","toolName":"get_weather","arguments":"{\\"city\\":\\"Tokyo\\"}"}]}]",
             "gen_ai.provider.name": "some-provider",
             "gen_ai.request.model": "some-model",
+            "gen_ai.response.finish_reasons": [
+              "tool_calls",
+            ],
+            "gen_ai.response.id": "chatcmpl-t1-plan",
+            "gen_ai.response.model": "gpt-4o-mini",
             "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "gen_ai.usage.input_tokens": 42,
             "gen_ai.usage.output_tokens": 10,
@@ -423,6 +431,11 @@ describe('GenAI', () => {
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"Tokyo is 28°C and humid."}]}]",
             "gen_ai.provider.name": "some-provider",
             "gen_ai.request.model": "some-model",
+            "gen_ai.response.finish_reasons": [
+              "stop",
+            ],
+            "gen_ai.response.id": "chatcmpl-t1-answer",
+            "gen_ai.response.model": "gpt-4o-mini",
             "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "gen_ai.usage.input_tokens": 70,
             "gen_ai.usage.output_tokens": 9,
@@ -456,6 +469,11 @@ describe('GenAI', () => {
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"tool_call","toolCallId":"call_t2_sf","toolName":"get_weather","arguments":"{\\"city\\":\\"San Francisco\\"}"},{"type":"tool_call","toolCallId":"call_t2_ldn","toolName":"get_weather","arguments":"{\\"city\\":\\"London\\"}"}]}]",
             "gen_ai.provider.name": "some-provider",
             "gen_ai.request.model": "some-model",
+            "gen_ai.response.finish_reasons": [
+              "tool_calls",
+            ],
+            "gen_ai.response.id": "chatcmpl-t2-plan",
+            "gen_ai.response.model": "gpt-4o-mini",
             "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "gen_ai.usage.input_tokens": 90,
             "gen_ai.usage.output_tokens": 16,
@@ -501,6 +519,11 @@ describe('GenAI', () => {
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"San Francisco is 18°C and foggy. London is 12°C and cloudy."}]}]",
             "gen_ai.provider.name": "some-provider",
             "gen_ai.request.model": "some-model",
+            "gen_ai.response.finish_reasons": [
+              "stop",
+            ],
+            "gen_ai.response.id": "chatcmpl-t2-answer",
+            "gen_ai.response.model": "gpt-4o-mini",
             "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "gen_ai.usage.input_tokens": 140,
             "gen_ai.usage.output_tokens": 18,
@@ -534,6 +557,11 @@ describe('GenAI', () => {
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"tool_call","toolCallId":"call_t3","toolName":"calculate","arguments":"{\\"expression\\":\\"28 - 18\\"}"}]}]",
             "gen_ai.provider.name": "some-provider",
             "gen_ai.request.model": "some-model",
+            "gen_ai.response.finish_reasons": [
+              "tool_calls",
+            ],
+            "gen_ai.response.id": "chatcmpl-t3-plan",
+            "gen_ai.response.model": "gpt-4o-mini",
             "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "gen_ai.usage.input_tokens": 170,
             "gen_ai.usage.output_tokens": 12,
@@ -564,6 +592,11 @@ describe('GenAI', () => {
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"Tokyo is 10°C warmer than San Francisco."}]}]",
             "gen_ai.provider.name": "some-provider",
             "gen_ai.request.model": "some-model",
+            "gen_ai.response.finish_reasons": [
+              "stop",
+            ],
+            "gen_ai.response.id": "chatcmpl-t3-answer",
+            "gen_ai.response.model": "gpt-4o-mini",
             "gen_ai.system_instructions": "[{"type":"text","content":"You are a research assistant. Use the available tools when appropriate to answer questions accurately."}]",
             "gen_ai.usage.input_tokens": 200,
             "gen_ai.usage.output_tokens": 12,
@@ -655,7 +688,7 @@ describe('GenAI', () => {
             providerName: 'some-provider',
             startTime: toDate(resp),
           });
-          llm.inputMessages = [...messages];
+          llm.record({inputMessages: [...messages]});
 
           const choice = resp.choices[0];
           const toolCalls = (choice.message.tool_calls ?? []).filter(
@@ -675,8 +708,8 @@ describe('GenAI', () => {
             });
           }
           const assistantMessage: Message = {role: 'assistant', parts};
-          llm.outputMessages = [assistantMessage];
           llm.record({
+            outputMessages: [assistantMessage],
             usage: {
               inputTokens: resp.usage?.prompt_tokens,
               outputTokens: resp.usage?.completion_tokens,
@@ -1022,7 +1055,7 @@ describe('GenAI', () => {
             providerName: 'some-provider',
             startTime: toDate(resp),
           });
-          llm.inputMessages = [...messages];
+          llm.record({inputMessages: [...messages]});
 
           const choice = resp.choices[0];
           const toolCalls = (choice.message.tool_calls ?? []).filter(
@@ -1042,8 +1075,8 @@ describe('GenAI', () => {
             });
           }
           const assistantMessage: Message = {role: 'assistant', parts};
-          llm.outputMessages = [assistantMessage];
           llm.record({
+            outputMessages: [assistantMessage],
             usage: {
               inputTokens: resp.usage?.prompt_tokens,
               outputTokens: resp.usage?.completion_tokens,

--- a/sdks/node/src/__tests__/genai/llm.test.ts
+++ b/sdks/node/src/__tests__/genai/llm.test.ts
@@ -255,7 +255,7 @@ describe('LLM (via Turn.startLLM)', () => {
       ]);
     });
 
-    it('record(opts) replaces the data fields', () => {
+    it('record() updates fields, which are emitted at end()', () => {
       const turn = Turn.create({});
       const llm = turn.startLLM({model: 'gpt-4o'});
       llm.inputMessages = [{role: 'user', content: 'will be replaced'}];
@@ -264,6 +264,13 @@ describe('LLM (via Turn.startLLM)', () => {
         outputMessages: [{role: 'assistant', content: 'hello'}],
         usage: {inputTokens: 7, outputTokens: 3},
         reasoning: {content: 'thinking'},
+        outputType: 'text',
+        responseId: 'resp-abc',
+        responseModel: 'gpt-4o-2024-08-06',
+        mediaAttachments: [
+          {uri: 'https://example.com/a.png', modality: 'image'},
+        ],
+        finishReasons: ['stop'],
       });
       expect(llm.inputMessages).toEqual([{role: 'user', content: 'hi'}]);
       expect(llm.outputMessages).toEqual([
@@ -273,6 +280,28 @@ describe('LLM (via Turn.startLLM)', () => {
       expect(llm.reasoning).toEqual({content: 'thinking'});
       llm.end();
       turn.end();
+
+      const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
+      expect(spanSnapshot(llmSpan)).toMatchInlineSnapshot(`
+        {
+          "attributes": {
+            "gen_ai.input.messages": "[{"role":"user","parts":[{"type":"text","content":"hi"},{"type":"uri","uri":"https://example.com/a.png","modality":"image"}]}]",
+            "gen_ai.operation.name": "chat",
+            "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"hello"},{"type":"reasoning","content":"thinking"}]}]",
+            "gen_ai.output.type": "text",
+            "gen_ai.request.model": "gpt-4o",
+            "gen_ai.response.finish_reasons": [
+              "stop",
+            ],
+            "gen_ai.response.id": "resp-abc",
+            "gen_ai.response.model": "gpt-4o-2024-08-06",
+            "gen_ai.usage.input_tokens": 7,
+            "gen_ai.usage.output_tokens": 3,
+          },
+          "endTime": "<timestamp>",
+          "startTime": "<timestamp>",
+        }
+      `);
     });
 
     it('chains: output / think / attachMedia / record all return `this`', () => {

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -15,8 +15,12 @@ import {
   ATTR_GEN_AI_INPUT_MESSAGES,
   ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_OUTPUT_MESSAGES,
+  ATTR_GEN_AI_OUTPUT_TYPE,
   ATTR_GEN_AI_PROVIDER_NAME,
   ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
+  ATTR_GEN_AI_RESPONSE_ID,
+  ATTR_GEN_AI_RESPONSE_MODEL,
   ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
   ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
@@ -100,12 +104,19 @@ export class LLM extends SpanBase {
    */
   reasoning?: Reasoning;
 
+  private _mediaAttachments: AttachMediaOpts[] = [];
+  private _responseId?: string;
+  private _responseModel?: string;
+  private _finishReasons: string[] = [];
+  private _outputType?: string;
+
   private constructor(
     span: Span,
     private readonly context: Context,
     private readonly conversationId: string,
     public readonly model: string,
-    public readonly providerName: string
+    public readonly providerName: string,
+    private readonly systemInstructions: string[]
   ) {
     super(span);
   }
@@ -118,22 +129,7 @@ export class LLM extends SpanBase {
       );
     }
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
-    const attributes: Attributes = {
-      ...(state.conversation?.attributes ?? {}),
-      [ATTR_GEN_AI_OPERATION_NAME]: 'chat',
-      [ATTR_GEN_AI_REQUEST_MODEL]: opts.model,
-    };
-    if (opts.providerName) {
-      attributes[ATTR_GEN_AI_PROVIDER_NAME] = opts.providerName;
-    }
-    if (opts.conversationId) {
-      attributes[ATTR_GEN_AI_CONVERSATION_ID] = opts.conversationId;
-    }
-    if (opts.systemInstructions && opts.systemInstructions.length > 0) {
-      attributes[ATTR_GEN_AI_SYSTEM_INSTRUCTIONS] = JSON.stringify(
-        opts.systemInstructions.map(content => ({type: 'text', content}))
-      );
-    }
+    const attributes: Attributes = {...(state.conversation?.attributes ?? {})};
     const span = tracer.startSpan(
       'chat',
       {kind: SpanKind.CLIENT, attributes, startTime: opts.startTime},
@@ -144,7 +140,8 @@ export class LLM extends SpanBase {
       trace.setSpan(opts.parentContext, span),
       opts.conversationId ?? '',
       opts.model,
-      opts.providerName ?? ''
+      opts.providerName ?? '',
+      opts.systemInstructions ?? []
     );
     state.llm = llm;
     return llm;
@@ -179,23 +176,15 @@ export class LLM extends SpanBase {
     return this;
   }
 
-  /** Attach a media part to the last input message. Pick exactly one of
+  /** Stage a media attachment for the LLM call. Pick exactly one of
    *  `content` (inline base64 bytes), `uri` (URI reference), or `fileId`
-   *  (pre-uploaded file id). */
+   *  (pre-uploaded file id). The attachment is glued onto the last user
+   *  message in `inputMessages` on `end()`. */
   attachMedia(opts: AttachMediaOpts): this {
     if (this._warnIfEnded('attachMedia')) {
       return this;
     }
-    const parts = this._ensureLastInputParts();
-    let part: MessagePart;
-    if ('content' in opts) {
-      part = {type: 'blob', ...opts};
-    } else if ('uri' in opts) {
-      part = {type: 'uri', ...opts};
-    } else {
-      part = {type: 'file', ...opts};
-    }
-    parts.push(part);
+    this._mediaAttachments.push(opts);
     return this;
   }
 
@@ -216,6 +205,11 @@ export class LLM extends SpanBase {
     outputMessages?: Message[];
     usage?: Usage;
     reasoning?: Reasoning;
+    responseId?: string;
+    responseModel?: string;
+    finishReasons?: string[];
+    outputType?: string;
+    mediaAttachments?: AttachMediaOpts[];
   }): this {
     if (this._warnIfEnded('record')) {
       return this;
@@ -231,6 +225,21 @@ export class LLM extends SpanBase {
     }
     if (opts.reasoning !== undefined) {
       this.reasoning = opts.reasoning;
+    }
+    if (opts.responseId !== undefined) {
+      this._responseId = opts.responseId;
+    }
+    if (opts.responseModel !== undefined) {
+      this._responseModel = opts.responseModel;
+    }
+    if (opts.finishReasons !== undefined) {
+      this._finishReasons = opts.finishReasons;
+    }
+    if (opts.outputType !== undefined) {
+      this._outputType = opts.outputType;
+    }
+    if (opts.mediaAttachments !== undefined) {
+      this._mediaAttachments = opts.mediaAttachments;
     }
     return this;
   }
@@ -268,12 +277,47 @@ export class LLM extends SpanBase {
     }
     this._ended = true;
 
+    this.span.setAttribute(ATTR_GEN_AI_OPERATION_NAME, 'chat');
+    if (this.model) {
+      this.span.setAttribute(ATTR_GEN_AI_REQUEST_MODEL, this.model);
+    }
+    if (this.providerName) {
+      this.span.setAttribute(ATTR_GEN_AI_PROVIDER_NAME, this.providerName);
+    }
+    if (this.conversationId) {
+      this.span.setAttribute(ATTR_GEN_AI_CONVERSATION_ID, this.conversationId);
+    }
+    if (this.systemInstructions.length > 0) {
+      this.span.setAttribute(
+        ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
+        JSON.stringify(
+          this.systemInstructions.map(content => ({type: 'text', content}))
+        )
+      );
+    }
+
     // Fold reasoning into the last assistant message as a ReasoningPart so
     // the wire format matches the Python SDK (which serializes reasoning
     // inside gen_ai.output.messages, not as a separate attribute).
     if (this.reasoning?.content) {
       const parts = this._ensureLastAssistantParts();
       parts.push({type: 'reasoning', content: this.reasoning.content});
+    }
+
+    // Throw staged media attachments onto the last user message in `inputMessages`.
+    if (this._mediaAttachments.length > 0) {
+      const parts = this._ensureLastInputParts();
+      for (const m of this._mediaAttachments) {
+        let part: MessagePart;
+        if ('content' in m) {
+          part = {type: 'blob', ...m};
+        } else if ('uri' in m) {
+          part = {type: 'uri', ...m};
+        } else {
+          part = {type: 'file', ...m};
+        }
+        parts.push(part);
+      }
     }
 
     if (this.inputMessages.length > 0) {
@@ -313,6 +357,22 @@ export class LLM extends SpanBase {
         ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
         u.cacheReadInputTokens
       );
+    }
+
+    if (this._responseId) {
+      this.span.setAttribute(ATTR_GEN_AI_RESPONSE_ID, this._responseId);
+    }
+    if (this._responseModel) {
+      this.span.setAttribute(ATTR_GEN_AI_RESPONSE_MODEL, this._responseModel);
+    }
+    if (this._finishReasons.length > 0) {
+      this.span.setAttribute(
+        ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
+        this._finishReasons
+      );
+    }
+    if (this._outputType) {
+      this.span.setAttribute(ATTR_GEN_AI_OUTPUT_TYPE, this._outputType);
     }
 
     this._closeSpan(opts);


### PR DESCRIPTION
## Description

* Python supports the following arguments to `LLM.record()`:

```py
    def record(
        self,
        *,
        input_messages: list[Message] | None = None,
        output_messages: list[Message] | None = None,
        media_attachments: list[MediaAttachment] | None = None,
        usage: Usage | None = None,
        reasoning: Reasoning | str | None = None,
        response_id: str | None = None,
        response_model: str | None = None,
        finish_reasons: list[str] | None = None,
        output_type: str | None = None,
    ) -> LLM:
```

* `LLM.record()` does not yet support `mediaAttachments`, `responseId`, `responseModel`, `finishReasons`, or `outputType`. This change adds them.