### PR TITLE
perf(weave): parallelize attachment uploads on all writes

### DIFF
--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -25,13 +25,19 @@ from weave.shared.digest import compute_file_digest
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import clickhouse_trace_server_settings, file_storage
 from weave.trace_server.trace_server_interface import (
+    CallEndReq,
     CallEndV2Req,
+    CallStartReq,
+    CallStartRes,
     CallStartV2Req,
+    CallStartV2Res,
+    EndedCallSchemaForInsert,
     EndedCallSchemaForInsertWithStartedAt,
     FileContentReadReq,
     FileCreateReq,
     StartedCallSchemaForInsert,
 )
+from weave.trace_server_bindings.client_interface import TraceServerClientInterface
 
 # Test Data Constants
 TEST_CONTENT = b"Hello, world!"
@@ -763,13 +769,14 @@ def _data_uri(mimetype: str, size: int) -> str:
 @pytest.mark.skipif(
     NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
 )
-def test_call_start_v2_offloads_attachments_to_bucket_in_parallel(
-    client: WeaveClient, gcs
+@pytest.mark.parametrize("version", ["v1", "v2"])
+def test_call_start_offloads_attachments_to_bucket_in_parallel(
+    client: WeaveClient, gcs, version: str
 ):
-    """Eager call_start_v2 with many inline data-URI inputs fans the
-    auto-extracted attachment uploads out across the bucket pool instead of
-    one serial PUT each. The barrier of 2 makes the parallel floor
-    deterministic; the pre-fix serial path only ever had one upload in flight.
+    """Eager call/start (v1 and v2) with many inline data-URI inputs fans the
+    auto-extracted attachment uploads across the bucket pool instead of one
+    serial PUT each. The barrier of 2 makes the parallel floor deterministic;
+    the pre-fix serial path only ever had one upload in flight.
     """
     gcs.state.expected_concurrency = 2
     # Distinct mimetype+size keeps every content and metadata digest unique, so
@@ -779,18 +786,18 @@ def test_call_start_v2_offloads_attachments_to_bucket_in_parallel(
         "jpeg": _data_uri("image/jpeg", 30_000),
         "bin": _data_uri("application/octet-stream", 40_000),
     }
-    res = client.server.call_start_v2(
-        CallStartV2Req(
-            start=StartedCallSchemaForInsert(
-                project_id=client.project_id,
-                id=str(uuid.uuid4()),
-                trace_id=str(uuid.uuid4()),
-                op_name="test_op",
-                started_at=datetime.datetime.now(datetime.timezone.utc),
-                attributes={},
-                inputs=inputs,
-            )
-        )
+    res = _start_call(
+        client.server,
+        version,
+        StartedCallSchemaForInsert(
+            project_id=client.project_id,
+            id=str(uuid.uuid4()),
+            trace_id=str(uuid.uuid4()),
+            op_name="test_op",
+            started_at=datetime.datetime.now(datetime.timezone.utc),
+            attributes={},
+            inputs=inputs,
+        ),
     )
 
     assert res.id
@@ -809,28 +816,29 @@ def test_call_start_v2_offloads_attachments_to_bucket_in_parallel(
 @pytest.mark.skipif(
     NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
 )
-def test_call_end_v2_offloads_attachments_to_bucket_in_parallel(
-    client: WeaveClient, gcs
+@pytest.mark.parametrize("version", ["v1", "v2"])
+def test_call_end_offloads_attachments_to_bucket_in_parallel(
+    client: WeaveClient, gcs, version: str
 ):
-    """Eager call_end_v2 fans its output-attachment uploads across the bucket
-    pool too (and, for calls_complete projects, finishes them before the end
-    UPDATE references them). Barrier of 2 pins the parallel floor; the pre-fix
-    serial path peaked at 1.
+    """Eager call/end (v1 and v2) fans its output-attachment uploads across the
+    bucket pool too (and, for calls_complete projects, finishes them before the
+    end UPDATE references them). Barrier of 2 pins the parallel floor; the
+    pre-fix serial path peaked at 1.
     """
     call_id = str(uuid.uuid4())
     started_at = datetime.datetime.now(datetime.timezone.utc)
-    client.server.call_start_v2(
-        CallStartV2Req(
-            start=StartedCallSchemaForInsert(
-                project_id=client.project_id,
-                id=call_id,
-                trace_id=str(uuid.uuid4()),
-                op_name="test_op",
-                started_at=started_at,
-                attributes={},
-                inputs={},
-            )
-        )
+    _start_call(
+        client.server,
+        version,
+        StartedCallSchemaForInsert(
+            project_id=client.project_id,
+            id=call_id,
+            trace_id=str(uuid.uuid4()),
+            op_name="test_op",
+            started_at=started_at,
+            attributes={},
+            inputs={},
+        ),
     )
 
     # Set the barrier only now so it gates the end's uploads, not the empty start.
@@ -840,17 +848,14 @@ def test_call_end_v2_offloads_attachments_to_bucket_in_parallel(
         "jpeg": _data_uri("image/jpeg", 30_000),
         "bin": _data_uri("application/octet-stream", 40_000),
     }
-    client.server.call_end_v2(
-        CallEndV2Req(
-            end=EndedCallSchemaForInsertWithStartedAt(
-                project_id=client.project_id,
-                id=call_id,
-                started_at=started_at,
-                ended_at=started_at + datetime.timedelta(seconds=1),
-                output=output,
-                summary={},
-            )
-        )
+    _end_call(
+        client.server,
+        version,
+        project_id=client.project_id,
+        call_id=call_id,
+        started_at=started_at,
+        ended_at=started_at + datetime.timedelta(seconds=1),
+        output=output,
     )
 
     assert gcs.state.concurrent_peak >= 2, (
@@ -860,3 +865,56 @@ def test_call_end_v2_offloads_attachments_to_bucket_in_parallel(
     expected_prefix = f"weave/projects/{project_b64}/files/"
     assert gcs.state.blob_data
     assert all(k.startswith(expected_prefix) for k in gcs.state.blob_data)
+
+
+def _start_call(
+    server: TraceServerClientInterface,
+    version: str,
+    start: StartedCallSchemaForInsert,
+) -> CallStartRes | CallStartV2Res:
+    """Dispatch a single eager call/start to the v1 or v2 write path."""
+    if version == "v1":
+        return server.call_start(CallStartReq(start=start))
+    if version == "v2":
+        return server.call_start_v2(CallStartV2Req(start=start))
+    raise ValueError(f"unknown call version: {version}")
+
+
+def _end_call(
+    server: TraceServerClientInterface,
+    version: str,
+    *,
+    project_id: str,
+    call_id: str,
+    started_at: datetime.datetime,
+    ended_at: datetime.datetime,
+    output: dict[str, str],
+) -> None:
+    """Dispatch a single eager call/end to the v1 or v2 write path."""
+    if version == "v1":
+        server.call_end(
+            CallEndReq(
+                end=EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=call_id,
+                    ended_at=ended_at,
+                    output=output,
+                    summary={},
+                )
+            )
+        )
+    elif version == "v2":
+        server.call_end_v2(
+            CallEndV2Req(
+                end=EndedCallSchemaForInsertWithStartedAt(
+                    project_id=project_id,
+                    id=call_id,
+                    started_at=started_at,
+                    ended_at=ended_at,
+                    output=output,
+                    summary={},
+                )
+            )
+        )
+    else:
+        raise ValueError(f"unknown call version: {version}")

--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -6,8 +6,10 @@ specific setup requirements.
 """
 
 import base64
+import datetime
 import os
 import socket
+import uuid
 from unittest import mock
 
 import boto3
@@ -22,7 +24,14 @@ from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from weave.shared.digest import compute_file_digest
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import clickhouse_trace_server_settings, file_storage
-from weave.trace_server.trace_server_interface import FileContentReadReq, FileCreateReq
+from weave.trace_server.trace_server_interface import (
+    CallEndV2Req,
+    CallStartV2Req,
+    EndedCallSchemaForInsertWithStartedAt,
+    FileContentReadReq,
+    FileCreateReq,
+    StartedCallSchemaForInsert,
+)
 
 # Test Data Constants
 TEST_CONTENT = b"Hello, world!"
@@ -741,3 +750,113 @@ def test_call_batch_falls_back_to_clickhouse_on_per_file_bucket_failure(
         FileContentReadReq(project_id=client.project_id, digest=fail_digest)
     )
     assert fallback_read.content == fail_payload
+
+
+def _data_uri(mimetype: str, size: int) -> str:
+    """Build a distinct data URI whose decoded body exceeds AUTO_CONVERSION_MIN_SIZE."""
+    raw = (mimetype + "_" + "x" * size).encode()
+    return f"data:{mimetype};base64," + base64.b64encode(raw).decode()
+
+
+@pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials")
+@pytest.mark.disable_logging_error_check
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+)
+def test_call_start_v2_offloads_attachments_to_bucket_in_parallel(
+    client: WeaveClient, gcs
+):
+    """Eager call_start_v2 with many inline data-URI inputs fans the
+    auto-extracted attachment uploads out across the bucket pool instead of
+    one serial PUT each. The barrier of 2 makes the parallel floor
+    deterministic; the pre-fix serial path only ever had one upload in flight.
+    """
+    gcs.state.expected_concurrency = 2
+    # Distinct mimetype+size keeps every content and metadata digest unique, so
+    # dedup can't collapse the upload set below the barrier width.
+    inputs = {
+        "png": _data_uri("image/png", 20_000),
+        "jpeg": _data_uri("image/jpeg", 30_000),
+        "bin": _data_uri("application/octet-stream", 40_000),
+    }
+    res = client.server.call_start_v2(
+        CallStartV2Req(
+            start=StartedCallSchemaForInsert(
+                project_id=client.project_id,
+                id=str(uuid.uuid4()),
+                trace_id=str(uuid.uuid4()),
+                op_name="test_op",
+                started_at=datetime.datetime.now(datetime.timezone.utc),
+                attributes={},
+                inputs=inputs,
+            )
+        )
+    )
+
+    assert res.id
+    assert res.trace_id
+    assert gcs.state.concurrent_peak >= 2, (
+        f"expected parallel attachment uploads, peak={gcs.state.concurrent_peak}"
+    )
+    project_b64 = base64.b64encode(client.project_id.encode()).decode()
+    expected_prefix = f"weave/projects/{project_b64}/files/"
+    assert gcs.state.blob_data
+    assert all(k.startswith(expected_prefix) for k in gcs.state.blob_data)
+
+
+@pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials")
+@pytest.mark.disable_logging_error_check
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+)
+def test_call_end_v2_offloads_attachments_to_bucket_in_parallel(
+    client: WeaveClient, gcs
+):
+    """Eager call_end_v2 fans its output-attachment uploads across the bucket
+    pool too (and, for calls_complete projects, finishes them before the end
+    UPDATE references them). Barrier of 2 pins the parallel floor; the pre-fix
+    serial path peaked at 1.
+    """
+    call_id = str(uuid.uuid4())
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+    client.server.call_start_v2(
+        CallStartV2Req(
+            start=StartedCallSchemaForInsert(
+                project_id=client.project_id,
+                id=call_id,
+                trace_id=str(uuid.uuid4()),
+                op_name="test_op",
+                started_at=started_at,
+                attributes={},
+                inputs={},
+            )
+        )
+    )
+
+    # Set the barrier only now so it gates the end's uploads, not the empty start.
+    gcs.state.expected_concurrency = 2
+    output = {
+        "png": _data_uri("image/png", 20_000),
+        "jpeg": _data_uri("image/jpeg", 30_000),
+        "bin": _data_uri("application/octet-stream", 40_000),
+    }
+    client.server.call_end_v2(
+        CallEndV2Req(
+            end=EndedCallSchemaForInsertWithStartedAt(
+                project_id=client.project_id,
+                id=call_id,
+                started_at=started_at,
+                ended_at=started_at + datetime.timedelta(seconds=1),
+                output=output,
+                summary={},
+            )
+        )
+    )
+
+    assert gcs.state.concurrent_peak >= 2, (
+        f"expected parallel attachment uploads, peak={gcs.state.concurrent_peak}"
+    )
+    project_b64 = base64.b64encode(client.project_id.encode()).decode()
+    expected_prefix = f"weave/projects/{project_b64}/files/"
+    assert gcs.state.blob_data
+    assert all(k.startswith(expected_prefix) for k in gcs.state.blob_data)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -333,6 +333,9 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 T = TypeVar("T")
+_CallReqT = TypeVar(
+    "_CallReqT", bound=tsi.CallStartReq | tsi.CallEndReq | tsi.CallEndV2Req
+)
 
 # ClickHouse connection pool settings
 CH_POOL_MAX_CONNECTIONS = 50
@@ -885,6 +888,29 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
            is already in the database, we don't want the client to retry.
            TODO: consider kafka retry logic.
         """
+        self._flush_file_batches()
+
+        # Raises on fail
+        try:
+            self._flush_calls()
+            self._flush_calls_complete()
+        except Exception:
+            logger.exception("Failed to flush calls")
+            raise
+
+        # Catch and continue on fail
+        try:
+            self._flush_kafka_producer()
+        except Exception:
+            logger.exception("Failed to flush kafka producer")
+
+    def _flush_file_batches(self) -> None:
+        """Fan out staged bucket uploads in parallel, then insert their chunk rows.
+
+        Shared by the per-request content offload and the call_batch flush. The
+        bucket-upload rows join _file_batch before the chunk insert so URIs land
+        alongside any inline-CH fallback chunks. Requires _flush_immediately=True.
+        """
         # Raises on fail
         try:
             self._file_batch.extend(
@@ -901,19 +927,27 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             logger.exception("Failed to flush file chunks")
             raise
 
-        # Raises on fail
-        try:
-            self._flush_calls()
-            self._flush_calls_complete()
-        except Exception:
-            logger.exception("Failed to flush calls")
-            raise
+    def _offload_call_content(self, req: _CallReqT) -> _CallReqT:
+        """Replace inline base64 content with file refs, uploading in parallel.
 
-        # Catch and continue on fail
+        Each extracted attachment becomes a file_create; staging them and
+        fanning the bucket uploads across the pool turns N serial GCS PUTs into
+        one parallel batch. Files persist before this returns, so the caller's
+        call insert/UPDATE can reference them. Deferral is a no-op when already
+        inside call_batch(), which owns the flush.
+        """
+        if not self._flush_immediately:
+            return process_call_req_to_content(req, self)
+        self._flush_immediately = False
         try:
-            self._flush_kafka_producer()
-        except Exception:
-            logger.exception("Failed to flush kafka producer")
+            processed = process_call_req_to_content(req, self)
+            self._flush_immediately = True
+            self._flush_file_batches()
+            return processed
+        finally:
+            self._file_batch = []
+            self._bucket_uploads = BucketUploadBatch()
+            self._flush_immediately = True
 
     @tag_db_insert_path("call_start_batch")
     def call_start_batch(self, req: tsi.CallCreateBatchReq) -> tsi.CallCreateBatchRes:
@@ -936,7 +970,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # as enforcing business rules and defaults
         set_current_span_dd_tags({"weave_trace_server.insert_call_count": 1})
 
-        req = process_call_req_to_content(req, self)
+        req = self._offload_call_content(req)
         retention_days = get_project_retention_days(
             req.start.project_id, self.ch_client
         )
@@ -969,7 +1003,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # Converts the user-provided call details into a clickhouse schema.
         # This does validation and conversion of the input data as well
         # as enforcing business rules and defaults
-        req = process_call_req_to_content(req, self)
+        req = self._offload_call_content(req)
         retention_days = get_project_retention_days(req.end.project_id, self.ch_client)
         ch_call = end_call_for_insert_to_ch_insertable(req.end, retention_days)
 
@@ -1063,7 +1097,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         This is used for eager ops like Evaluation.evaluate that need
         their start to be visible immediately in the UI.
         """
-        start_req = process_call_req_to_content(tsi.CallStartReq(start=req.start), self)
+        start_req = self._offload_call_content(tsi.CallStartReq(start=req.start))
         retention_days = get_project_retention_days(
             start_req.start.project_id, self.ch_client
         )
@@ -1097,7 +1131,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         Returns:
             CallEndV2Res: Empty response on success.
         """
-        req = process_call_req_to_content(req, self)
+        req = self._offload_call_content(req)
 
         write_target = self.table_routing_resolver.resolve_v2_write_target(
             req.end.project_id,


### PR DESCRIPTION
## Summary
- The eager single-call write paths (`call_start`/`call_end` v1, `call_start_v2`/`call_end_v2`) uploaded the attachments that `process_call_req_to_content` auto-extracts from inline base64 serially: one blocking GCS PUT per `Content`, because the parallel `BucketUploadBatch` pool only engaged inside `call_batch()`. A call with many inline attachments did N sequential PUTs -> prod v2 call/start p99 ~24s, max ~44s.
- New `_offload_call_content()` stages a request's `file_create`s and fans the uploads across the existing 8-worker pool, persisting them before the call insert/UPDATE (so `call_end_v2`'s calls_complete UPDATE references already-stored files). It's a no-op inside `call_batch()`; shared flush logic is extracted to `_flush_file_batches()`.
- Jira: [WB-36574](https://coreweave.atlassian.net/browse/WB-36574)

## Performance
QA `call/start_v2`, N distinct inline attachments, server-side span `@duration` (per-upload cost is QA-auth-inflated; the point is flat-vs-linear scaling with N). Each cell links its Datadog trace:

| attachments (~body) | serial (pre-fix) | parallel (this PR) |
|---|---|---|
| 1 (~13KB)   | [6.8s](https://us5.datadoghq.com/apm/trace/6a45d7e6000000000822008d468b5fa2) | [3.8s](https://us5.datadoghq.com/apm/trace/6a45d52e000000002340ca153a6a6477) |
| 16 (~180KB) | [104s](https://us5.datadoghq.com/apm/trace/6a45d8b100000000fb917a6a26f8cef9) | [3.5s](https://us5.datadoghq.com/apm/trace/6a45d3b900000000a77a8889eee18ff2) |

16 uploads drop from ~16x serial to flat (fanned across the 8-worker pool).

## Testing
adds parallel-upload tests for `call_start_v2` and `call_end_v2` (barrier asserts concurrency; the serial path peaks at 1); existing `call_batch` fan-out tests stay green.


[WB-36574]: https://coreweave.atlassian.net/browse/WB-36574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
