### PR TITLE
perf(weave): opt-in limit+1 has_more for calls_complete pagination

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4640,6 +4640,70 @@ def test_stats_query_calls_complete_with_feedback_filter_uses_count_distinct() -
     )
 
 
+def test_stats_query_calls_complete_include_exact_count_toggle() -> None:
+    """include_exact_count picks exact filtered count() vs a limit+1 has_more probe.
+
+    Both share identical filter SQL/params; only the SELECT and limit differ.
+    The probe scans up to limit+1 ids instead of decompressing the whole
+    heavy *_dump column for an exact count.
+    """
+    heavy_filter_query = tsi.Query.model_validate(
+        {
+            "$expr": {
+                "$contains": {
+                    "input": {"$getField": "inputs.foo"},
+                    "substr": {"$literal": "bar"},
+                }
+            }
+        }
+    )
+    exact_req = tsi.CallsQueryStatsReq(
+        project_id="project",
+        query=heavy_filter_query,
+        limit=100,
+        include_exact_count=True,
+    )
+    expected_params = {
+        "pb_0": '$."foo"',
+        "pb_1": "bar",
+        "pb_2": SENTINEL_EPOCH,
+        "pb_3": '%"%bar%"%',
+        "pb_4": "project",
+    }
+    assert_stats_sql(
+        exact_req,
+        """
+        SELECT count() AS count, toUInt8(0) AS has_more
+        FROM calls_complete
+        PREWHERE calls_complete.project_id = {pb_4:String}
+        WHERE (calls_complete.inputs_dump LIKE {pb_3:String})
+          AND ((position(coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_0:String}), 'null'), ''), {pb_1:String}) > 0)
+               AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
+        LIMIT 100
+        """,
+        expected_params,
+        read_table=ReadTable.CALLS_COMPLETE,
+    )
+
+    probe_req = exact_req.model_copy(update={"include_exact_count": False})
+    assert_stats_sql(
+        probe_req,
+        """
+        SELECT count() AS count, toUInt8(count() > 100) AS has_more
+        FROM (
+          SELECT calls_complete.id
+          FROM calls_complete
+          PREWHERE calls_complete.project_id = {pb_4:String}
+          WHERE (calls_complete.inputs_dump LIKE {pb_3:String})
+            AND ((position(coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_0:String}), 'null'), ''), {pb_1:String}) > 0)
+                 AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
+          LIMIT 101)
+        """,
+        expected_params,
+        read_table=ReadTable.CALLS_COMPLETE,
+    )
+
+
 def test_stats_query_calls_merged_unfiltered_limit_1_stays_with_pattern_1() -> None:
     """limit=1 with no filter is the project-existence check (Pattern 1),
     which uses `LIMIT 1` and is strictly cheaper than starting a uniqUpTo

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -3022,6 +3022,14 @@ def build_calls_stats_query(
     #   Fast:  SELECT count() FROM calls_complete WHERE ...
     #   Slow:  SELECT count() FROM (SELECT id FROM calls_complete WHERE ...)
     if read_table == ReadTable.CALLS_COMPLETE:
+        if (
+            req.limit is not None
+            and not req.include_exact_count
+            and not req.include_total_storage_size
+        ):
+            probe_query = _build_calls_complete_has_more_probe_query(req, param_builder)
+            if probe_query is not None:
+                return (probe_query, aggregated_columns.keys(), settings)
         query = _build_calls_complete_stats_query(
             req, param_builder, aggregated_columns
         )
@@ -3131,6 +3139,52 @@ def _build_calls_complete_stats_query(
     raw_sql = f"""
     SELECT {stats_select}
     {body_result.sql}
+    """
+    return safely_format_sql(raw_sql, logger)
+
+
+def _build_calls_complete_has_more_probe_query(
+    req: tsi.CallsQueryStatsReq,
+    param_builder: ParamBuilder,
+) -> str | None:
+    """Build a limit+1 probe answering has_more without an exact filtered count.
+
+    Scans only up to limit+1 matching ids instead of counting the whole
+    project, which on a heavy *_dump filter avoids decompressing the full
+    column. Returns None to fall back to the exact count when a feedback JOIN
+    is present (it can duplicate rows and break the simple count).
+    """
+    if req.limit is None:
+        return None
+    limit = req.limit
+    table_name = get_calls_table_name(ReadTable.CALLS_COMPLETE)
+    cq = _build_stats_calls_query(req, ReadTable.CALLS_COMPLETE)
+
+    # See _build_calls_complete_stats_query: inject the deleted_at sentinel that
+    # as_sql() would otherwise add, using None so process_operation types it.
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {"$getField": "deleted_at"},
+                    {"$literal": None},
+                ]
+            }
+        )
+    )
+
+    # The body already emits LIMIT {req.limit}; clear it so we append limit+1.
+    cq.limit = None
+    body_result = cq._build_query_body(param_builder, table_name)
+    if body_result.needs_feedback_join:
+        return None
+
+    inner_sql = f"""SELECT {table_name}.id
+    {body_result.sql}
+    LIMIT {limit + 1}"""
+    raw_sql = f"""
+    SELECT count() AS count, toUInt8(count() > {limit}) AS has_more
+    FROM ({inner_sql})
     """
     return safely_format_sql(raw_sql, logger)
 

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -684,6 +684,8 @@ class CallsQueryStatsReq(BaseModelStrict):
     query: Query | None = None
     limit: int | None = None
     include_total_storage_size: bool | None = False
+    # When False, has_more is computed via a limit+1 probe instead of an exact count.
+    include_exact_count: bool = True
     # List of columns that include refs to objects or table rows that require
     # expansion during filtering or ordering. Required when filtering
     # on reffed fields.


### PR DESCRIPTION
## Summary
- Add opt-in `include_exact_count` (default true) to calls stats. When false, calls_complete `has_more` is computed via a `limit+1` probe instead of an exact filtered `count()`, so a heavy-field-filtered page stops scanning after limit+1 matches.
- Default preserves today's exact-count behavior; frontend list views opt in separately.

## Performance
Prod read-only, heavy `inputs_dump` filter, 33,638 matches, limit=100:

| | bytes_read | elapsed |
|---|--:|--:|
| exact count | 7.28 GiB | 1.71s |
| limit+1 probe | 0.02 GiB | 0.03s |

## Testing
adds calls_query_builder snapshot coverage for both the exact and limit+1 stats SQL.