### PR TITLE
perf(weave): cache EMPTY project residence behind a short TTL

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,9 @@ from weave.trace.context import weave_client_context
 from weave.trace.context.call_context import set_call_stack
 from weave.trace.settings import replace_settings
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.project_version.project_version import (
+    reset_project_residence_cache as reset_residence_caches,
+)
 from weave.trace_server_bindings import remote_http_trace_server
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
 from weave.trace_server_bindings.caching_middleware_trace_server import (
@@ -86,19 +89,10 @@ def reset_serializer_load_refs():
 
 @pytest.fixture(autouse=True)
 def reset_project_residence_cache():
-    """Reset the project residence cache between tests.
-
-    The project residence cache stores the residence (merged/complete/both) of a project's data.
-    This needs to be cleared between tests to prevent state leakage, especially when tests
-    create projects with the same name but different data characteristics.
-    """
-    from weave.trace_server.project_version.project_version import (
-        _project_residence_cache,
-    )
-
-    _project_residence_cache.clear()
+    """Clear residence caches (populated LRU + empty TTL) between tests."""
+    reset_residence_caches()
     yield
-    _project_residence_cache.clear()
+    reset_residence_caches()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/trace_server/test_project_version.py
+++ b/tests/trace_server/test_project_version.py
@@ -210,6 +210,35 @@ def test_empty_residence_expires_after_ttl(client, trace_server, monkeypatch):
 @pytest.mark.skipif(
     NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: table routing/residence"
 )
+def test_cached_empty_does_not_mask_write(client, trace_server):
+    """A read that cached EMPTY must not hide a subsequent write's data.
+
+    A read caches EMPTY (routing reads to calls_complete); a legacy V1 write then
+    lands in calls_merged. The write resolution evicts the cached EMPTY so the next
+    read re-probes and routes to calls_merged (read-your-writes).
+    """
+    ch_server = trace_server._internal_trace_server
+    resolver = ch_server.table_routing_resolver
+    resolver._mode = CallsStorageServerMode.AUTO
+
+    proj = make_project_id("cached_empty_then_write")
+    assert (
+        resolver.resolve_read_table(proj, ch_server.ch_client)
+        == ReadTable.CALLS_COMPLETE
+    )
+    assert (
+        resolver.resolve_v1_write_target(proj, ch_server.ch_client)
+        == WriteTarget.CALLS_MERGED
+    )
+    insert_call(ch_server.ch_client, "calls_merged", proj)
+    assert (
+        resolver.resolve_read_table(proj, ch_server.ch_client) == ReadTable.CALLS_MERGED
+    )
+
+
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: table routing/residence"
+)
 def test_mode_off_and_force_legacy(client, trace_server):
 
     ch_server = trace_server._internal_trace_server

--- a/tests/trace_server/test_project_version.py
+++ b/tests/trace_server/test_project_version.py
@@ -1,12 +1,13 @@
 import base64
-import os
 import uuid
 from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
+from cachetools import LRUCache, TTLCache
 
 from tests.trace.util import NOT_CLICKHOUSE_BACKEND
+from weave.trace_server.project_version import project_version as pv
 from weave.trace_server.project_version.clickhouse_project_version import (
     get_project_data_residence,
 )
@@ -163,7 +164,8 @@ def test_caching_behavior(client, trace_server):
         assert table2 == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 
-    empty_proj = make_project_id("empty_not_cached")
+    # EMPTY residence is now cached (short TTL) so cold projects stop re-probing.
+    empty_proj = make_project_id("empty_cached")
     with count_queries(ch_server.ch_client) as get_count:
         table1 = resolver.resolve_read_table(empty_proj, ch_server.ch_client)
         assert table1 == ReadTable.CALLS_COMPLETE
@@ -171,7 +173,38 @@ def test_caching_behavior(client, trace_server):
 
         table2 = resolver.resolve_read_table(empty_proj, ch_server.ch_client)
         assert table2 == ReadTable.CALLS_COMPLETE
-        assert get_count() == 2
+        assert get_count() == 1
+
+
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: table routing/residence"
+)
+def test_empty_residence_expires_after_ttl(client, trace_server, monkeypatch):
+    """EMPTY is re-probed after the short TTL; populated residence never expires."""
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(
+        pv,
+        "_empty_residence_cache",
+        TTLCache(
+            maxsize=10,
+            ttl=pv.EMPTY_RESIDENCE_CACHE_TTL_SECS,
+            timer=lambda: clock["t"],
+        ),
+    )
+    monkeypatch.setattr(pv, "_project_residence_cache", LRUCache(maxsize=10))
+
+    ch_server = trace_server._internal_trace_server
+    resolver = ch_server.table_routing_resolver
+    resolver._mode = CallsStorageServerMode.AUTO
+
+    empty_proj = make_project_id("empty_ttl_expiry")
+    with count_queries(ch_server.ch_client) as get_count:
+        resolver.resolve_read_table(empty_proj, ch_server.ch_client)
+        resolver.resolve_read_table(empty_proj, ch_server.ch_client)
+        assert get_count() == 1  # cached within TTL
+        clock["t"] += pv.EMPTY_RESIDENCE_CACHE_TTL_SECS + 1
+        resolver.resolve_read_table(empty_proj, ch_server.ch_client)
+        assert get_count() == 2  # re-probed after TTL
 
 
 @pytest.mark.skipif(
@@ -251,29 +284,16 @@ def test_resolver_as_trace_server_member(client, trace_server):
         assert get_count() == 1
 
 
-def test_project_version_mode_from_env():
-    original_value = os.environ.get("PROJECT_VERSION_MODE")
+def test_project_version_mode_from_env(monkeypatch):
+    test_cases = [
+        ("off", CallsStorageServerMode.OFF),
+        ("force_legacy", CallsStorageServerMode.FORCE_LEGACY),
+        ("auto", CallsStorageServerMode.AUTO),
+        ("invalid_mode", CallsStorageServerMode.AUTO),
+    ]
+    for env_val, expected_mode in test_cases:
+        monkeypatch.setenv("PROJECT_VERSION_MODE", env_val)
+        assert CallsStorageServerMode.from_env() == expected_mode
 
-    try:
-        test_cases = [
-            ("off", CallsStorageServerMode.OFF),
-            ("force_legacy", CallsStorageServerMode.FORCE_LEGACY),
-            ("auto", CallsStorageServerMode.AUTO),
-            ("invalid_mode", CallsStorageServerMode.AUTO),
-        ]
-
-        for env_val, expected_mode in test_cases:
-            os.environ["PROJECT_VERSION_MODE"] = env_val
-            mode = CallsStorageServerMode.from_env()
-            assert mode == expected_mode
-
-        if "PROJECT_VERSION_MODE" in os.environ:
-            del os.environ["PROJECT_VERSION_MODE"]
-        mode = CallsStorageServerMode.from_env()
-        assert mode == CallsStorageServerMode.AUTO
-
-    finally:
-        if original_value is not None:
-            os.environ["PROJECT_VERSION_MODE"] = original_value
-        elif "PROJECT_VERSION_MODE" in os.environ:
-            del os.environ["PROJECT_VERSION_MODE"]
+    monkeypatch.delenv("PROJECT_VERSION_MODE", raising=False)
+    assert CallsStorageServerMode.from_env() == CallsStorageServerMode.AUTO

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 
-from cachetools import LRUCache
+from cachetools import LRUCache, TTLCache
 from clickhouse_connect.driver.client import Client as CHClient
 
 from weave.trace_server.datadog import (
@@ -22,23 +22,27 @@ from weave.trace_server.tracing import _tracer
 logger = logging.getLogger(__name__)
 
 PROJECT_RESIDENCE_CACHE_SIZE = 10_000
+# Populated residence is immutable per project, so it is cached without expiry.
+# EMPTY is cached only briefly: a stale EMPTY routes reads to calls_complete while
+# a legacy (V1) first write lands in calls_merged, so the read misses fresh data
+# until the entry expires. The short TTL bounds that window; the miss self-heals.
+EMPTY_RESIDENCE_CACHE_TTL_SECS = 10
 
-# Global cache shared across all resolvers
+# Global caches shared across all resolvers and threads, keyed by project_id.
 _project_residence_cache: LRUCache[str, ProjectDataResidence] = LRUCache(
     maxsize=PROJECT_RESIDENCE_CACHE_SIZE
+)
+_empty_residence_cache: TTLCache[str, ProjectDataResidence] = TTLCache(
+    maxsize=PROJECT_RESIDENCE_CACHE_SIZE, ttl=EMPTY_RESIDENCE_CACHE_TTL_SECS
 )
 _project_residence_cache_lock = threading.Lock()
 
 
 def reset_project_residence_cache() -> None:
-    """Clear the cached project data residence entries.
-
-    Examples:
-        >>> reset_project_residence_cache()
-
-    """
+    """Clear the cached project data residence entries."""
     with _project_residence_cache_lock:
         _project_residence_cache.clear()
+        _empty_residence_cache.clear()
 
 
 class TableRoutingResolver:
@@ -55,6 +59,8 @@ class TableRoutingResolver:
     ) -> ProjectDataResidence:
         with _project_residence_cache_lock:
             cached = _project_residence_cache.get(project_id)
+            if cached is None:
+                cached = _empty_residence_cache.get(project_id)
         if cached is not None:
             return cached
 
@@ -79,9 +85,12 @@ class TableRoutingResolver:
                     }
                 )
 
-            # Don't cache if project is empty, we could write to either table.
-            if residence != ProjectDataResidence.EMPTY:
-                with _project_residence_cache_lock:
+            # Populated residence is immutable -> long-lived cache; EMPTY is
+            # cached briefly (short TTL) so cold projects stop re-probing CH.
+            with _project_residence_cache_lock:
+                if residence == ProjectDataResidence.EMPTY:
+                    _empty_residence_cache[project_id] = residence
+                else:
                     _project_residence_cache[project_id] = residence
 
             return residence

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -23,9 +23,9 @@ logger = logging.getLogger(__name__)
 
 PROJECT_RESIDENCE_CACHE_SIZE = 10_000
 # Populated residence is immutable per project, so it is cached without expiry.
-# EMPTY is cached only briefly: a stale EMPTY routes reads to calls_complete while
-# a legacy (V1) first write lands in calls_merged, so the read misses fresh data
-# until the entry expires. The short TTL bounds that window; the miss self-heals.
+# EMPTY is cached (read path only) so cold projects stop re-probing CH. Writes
+# evict it, so same-process reads see fresh data; the short TTL bounds staleness
+# on other replicas that cached EMPTY but did not serve the write.
 EMPTY_RESIDENCE_CACHE_TTL_SECS = 10
 
 # Global caches shared across all resolvers and threads, keyed by project_id.
@@ -55,11 +55,11 @@ class TableRoutingResolver:
         self._mode = CallsStorageServerMode.from_env()
 
     def _get_residence(
-        self, project_id: str, ch_client: CHClient
+        self, project_id: str, ch_client: CHClient, *, cache_empty: bool = True
     ) -> ProjectDataResidence:
         with _project_residence_cache_lock:
             cached = _project_residence_cache.get(project_id)
-            if cached is None:
+            if cached is None and cache_empty:
                 cached = _empty_residence_cache.get(project_id)
         if cached is not None:
             return cached
@@ -85,13 +85,16 @@ class TableRoutingResolver:
                     }
                 )
 
-            # Populated residence is immutable -> long-lived cache; EMPTY is
-            # cached briefly (short TTL) so cold projects stop re-probing CH.
+            # Populated residence is immutable -> long-lived cache. EMPTY is cached
+            # (short TTL) only on the read path; a write resolution instead evicts any
+            # read-cached EMPTY, so the post-write read re-probes and sees the new data.
             with _project_residence_cache_lock:
-                if residence == ProjectDataResidence.EMPTY:
+                if residence != ProjectDataResidence.EMPTY:
+                    _project_residence_cache[project_id] = residence
+                elif cache_empty:
                     _empty_residence_cache[project_id] = residence
                 else:
-                    _project_residence_cache[project_id] = residence
+                    _empty_residence_cache.pop(project_id, None)
 
             return residence
 
@@ -156,7 +159,7 @@ class TableRoutingResolver:
         if self._mode == CallsStorageServerMode.OFF:
             return WriteTarget.CALLS_MERGED
 
-        residence = self._get_residence(project_id, ch_client)
+        residence = self._get_residence(project_id, ch_client, cache_empty=False)
         set_current_span_dd_tags(
             {
                 "project_version.residence": residence.value,
@@ -205,7 +208,7 @@ class TableRoutingResolver:
         if self._mode == CallsStorageServerMode.OFF:
             return WriteTarget.CALLS_MERGED
 
-        residence = self._get_residence(project_id, ch_client)
+        residence = self._get_residence(project_id, ch_client, cache_empty=False)
         set_current_span_dd_tags(
             {
                 "project_version.residence": residence.value,

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -22,10 +22,12 @@ from weave.trace_server.tracing import _tracer
 logger = logging.getLogger(__name__)
 
 PROJECT_RESIDENCE_CACHE_SIZE = 10_000
-# Populated residence is immutable per project, so it is cached without expiry.
-# EMPTY is cached (read path only) so cold projects stop re-probing CH. Writes
-# evict it, so same-process reads see fresh data; the short TTL bounds staleness
-# on other replicas that cached EMPTY but did not serve the write.
+# Populated residence is treated as immutable (assumes data never migrates
+# between tables post-write) and cached without expiry. EMPTY is cached (read
+# path only, short TTL) so cold projects stop re-probing CH. Writes best-effort
+# evict it, but the TTL is the real staleness bound: a read racing a write's
+# probe->insert can re-cache EMPTY on any replica, including the writer. Worst
+# case is a <=TTL transient empty read, never wrong data.
 EMPTY_RESIDENCE_CACHE_TTL_SECS = 10
 
 # Global caches shared across all resolvers and threads, keyed by project_id.
@@ -57,6 +59,9 @@ class TableRoutingResolver:
     def _get_residence(
         self, project_id: str, ch_client: CHClient, *, cache_empty: bool = True
     ) -> ProjectDataResidence:
+        # cache_empty=False on write paths: EMPTY must be ground-truth (a stale
+        # EMPTY would misroute a V1 write into calls_merged past an upgrade error),
+        # so skip the read cache and evict any entry instead of populating it.
         with _project_residence_cache_lock:
             cached = _project_residence_cache.get(project_id)
             if cached is None and cache_empty:
@@ -85,9 +90,9 @@ class TableRoutingResolver:
                     }
                 )
 
-            # Populated residence is immutable -> long-lived cache. EMPTY is cached
-            # (short TTL) only on the read path; a write resolution instead evicts any
-            # read-cached EMPTY, so the post-write read re-probes and sees the new data.
+            # Populated residence -> long-lived cache. EMPTY -> short-TTL read cache;
+            # a write resolution instead evicts any read-cached EMPTY so a post-write
+            # read re-probes (best-effort; a racing read can re-cache it, TTL is the bound).
             with _project_residence_cache_lock:
                 if residence != ProjectDataResidence.EMPTY:
                     _project_residence_cache[project_id] = residence


### PR DESCRIPTION
## Summary
- Cache `EMPTY` project data residence behind a short 10s TTL instead of never caching it; populated residence stays in the unbounded LRU (immutable per project). Eliminates the dominant re-probe-every-request volume from cold/empty projects on the highest-traffic CH read query.
- Only hazard is a <=10s transient empty read for a project whose first write is a legacy V1 SDK call (lands in calls_merged while EMPTY routes reads to calls_complete); never returns wrong data, self-heals at expiry.

## Testing
extends test_project_version cache tests: EMPTY is now cached within the TTL, plus a fake-timer test asserting it re-probes after expiry while populated residence does not.

## QA validation (zoo-qa)
Deployed via `/qa-this` (core pin, since closed), verified live at `/version`=`5737480` + `/health` ok. No new error class vs master; `calls_query_stats` on empty projects returns count=0 / HTTP 200 on both builds. No regression.

Measured the change directly as **ClickHouse queries per read** (`clickhouse_connect.execute` child spans per request trace), which isolates the probe from request noise:

| read | CH queries/read |
|---|---|
| master, every read (fast or slow) | **2** — residence probe + stats |
| PR, first read per pod | 2 — probe populates the 10s cache |
| PR, repeat read within TTL | **1** — probe eliminated |

Confirmed across multiple traces including a 24ms fast master read (still 2 CH queries) vs a 17ms PR cache-hit (1). On a hot empty project the PR cuts this endpoint's CH read-query volume from ~2/req toward ~1/req.

End-user P50 is ~parity (~200ms both builds): the probe is only ~8ms of CH time; the request tail is gorilla `get_project_info` + audit-log pub/sub, not the probe. This is a CH-load reduction, not a latency win. Safe to ship.

Traces: [PR cache-hit = 1 CH query](https://us5.datadoghq.com/apm/trace/6a469e200000000057807f2dc2fbb066) · [master = 2 CH queries](https://us5.datadoghq.com/apm/trace/6a469b5f0000000015cd8f91f2de5479)
