### PR TITLE
perf(weave): two-pass filter CTE for calls_complete heavy reads

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -2399,11 +2399,9 @@ def test_total_storage_size(with_filter: bool):
 
 @pytest.mark.parametrize("with_filter", [False, True])
 def test_total_storage_size_calls_complete(with_filter: bool):
-    """calls_complete scopes the total-storage rollup by id (the stats PK).
-
-    Without scoping, the rollup aggregates the entire project's
-    calls_complete_stats. The storage_scope_ids CTE narrows it to the matched
-    calls' traces so the (project_id, id) primary key prunes the scan.
+    """calls_complete scopes the total-storage rollup to the matched calls' traces
+    so the (project_id, id) primary key prunes calls_complete_stats. A filtered/paged
+    read narrows via the two-pass filtered_calls CTE; a bare read uses storage_scope_ids.
     """
     cq = CallsQuery(
         project_id="test/project",
@@ -2421,26 +2419,18 @@ def test_total_storage_size_calls_complete(with_filter: bool):
         assert_sql(
             cq,
             """
-            WITH storage_scope_ids AS (
+            WITH filtered_calls AS (
                 SELECT calls_complete.id AS id
                 FROM calls_complete
                 PREWHERE calls_complete.project_id = {pb_2:String}
                 WHERE calls_complete.op_name IN {pb_1:Array(String)}
                     AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
                 LIMIT 50
-            ),
-            filtered_calls AS (
-                SELECT calls_complete.id AS id
-                FROM calls_complete
-                PREWHERE calls_complete.project_id = {pb_2:String}
-                WHERE calls_complete.op_name IN {pb_4:Array(String)}
-                    AND (calls_complete.deleted_at = {pb_3:DateTime64(3)})
-                LIMIT 50
             )
             SELECT
                 calls_complete.id AS id,
                 CASE
-                    WHEN calls_complete.parent_id = {pb_5:String}
+                    WHEN calls_complete.parent_id = {pb_3:String}
                     THEN rolled_up_cms.total_storage_size_bytes
                     ELSE NULL
                 END AS total_storage_size_bytes
@@ -2465,66 +2455,54 @@ def test_total_storage_size_calls_complete(with_filter: bool):
                 "pb_0": SENTINEL_EPOCH,
                 "pb_1": ["a", "b"],
                 "pb_2": "test/project",
-                "pb_3": SENTINEL_EPOCH,
-                "pb_4": ["a", "b"],
-                "pb_5": "",
+                "pb_3": "",
             },
         )
     else:
-        cq.add_field("trace_id")
-        cq.add_condition(
-            tsi_query.EqOperation.model_validate(
-                {"$eq": [{"$getField": "id"}, {"$literal": "my_id"}]}
-            )
-        )
         assert_sql(
             cq,
             """
             WITH storage_scope_ids AS (
                 SELECT calls_complete.id AS id
                 FROM calls_complete
-                PREWHERE calls_complete.project_id = {pb_2:String}
+                PREWHERE calls_complete.project_id = {pb_1:String}
                 WHERE 1
-                    AND (((calls_complete.id = {pb_0:String}))
-                        AND ((calls_complete.deleted_at = {pb_1:DateTime64(3)})))),
-            filtered_calls AS (
-                SELECT calls_complete.id AS id
-                FROM calls_complete
-                PREWHERE calls_complete.project_id = {pb_2:String}
-                WHERE 1
-                    AND (((calls_complete.id = {pb_0:String}))
-                        AND ((calls_complete.deleted_at = {pb_3:DateTime64(3)}))))
+                    AND (calls_complete.deleted_at = {pb_0:DateTime64(3)}))
             SELECT
                 calls_complete.id AS id,
                 CASE
-                    WHEN calls_complete.parent_id = {pb_4:String}
+                    WHEN calls_complete.parent_id = {pb_2:String}
                     THEN rolled_up_cms.total_storage_size_bytes
                     ELSE NULL
-                END AS total_storage_size_bytes,
-                calls_complete.trace_id AS trace_id
+                END AS total_storage_size_bytes
             FROM calls_complete
             LEFT JOIN (SELECT
                 trace_id,
                 sum(COALESCE(attributes_size_bytes,0) + COALESCE(inputs_size_bytes,0) + COALESCE(output_size_bytes,0) + COALESCE(summary_size_bytes,0) + COALESCE(otel_size_bytes,0)) AS total_storage_size_bytes
             FROM calls_complete_stats
-            WHERE project_id = {pb_2:String}
-            AND trace_id IN (
-                SELECT trace_id
+            WHERE project_id = {pb_1:String}
+            AND id IN (
+                SELECT id
                 FROM calls_complete
-                WHERE project_id = {pb_2:String}
-                AND id IN filtered_calls
+                WHERE project_id = {pb_1:String}
+                AND trace_id IN (
+                    SELECT trace_id
+                    FROM calls_complete
+                    WHERE project_id = {pb_1:String}
+                    AND id IN storage_scope_ids
+                )
             )
             GROUP BY trace_id) AS rolled_up_cms
             ON calls_complete.trace_id = rolled_up_cms.trace_id
-            PREWHERE calls_complete.project_id = {pb_2:String}
-            WHERE (calls_complete.id IN filtered_calls)
+            PREWHERE calls_complete.project_id = {pb_1:String}
+            WHERE 1
+                AND (calls_complete.deleted_at = {pb_3:DateTime64(3)})
             """,
             {
-                "pb_0": "my_id",
-                "pb_1": SENTINEL_EPOCH,
-                "pb_2": "test/project",
+                "pb_0": SENTINEL_EPOCH,
+                "pb_1": "test/project",
+                "pb_2": "",
                 "pb_3": SENTINEL_EPOCH,
-                "pb_4": "",
             },
         )
 

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -2428,11 +2428,19 @@ def test_total_storage_size_calls_complete(with_filter: bool):
                 WHERE calls_complete.op_name IN {pb_1:Array(String)}
                     AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
                 LIMIT 50
+            ),
+            filtered_calls AS (
+                SELECT calls_complete.id AS id
+                FROM calls_complete
+                PREWHERE calls_complete.project_id = {pb_2:String}
+                WHERE calls_complete.op_name IN {pb_4:Array(String)}
+                    AND (calls_complete.deleted_at = {pb_3:DateTime64(3)})
+                LIMIT 50
             )
             SELECT
                 calls_complete.id AS id,
                 CASE
-                    WHEN calls_complete.parent_id = {pb_3:String}
+                    WHEN calls_complete.parent_id = {pb_5:String}
                     THEN rolled_up_cms.total_storage_size_bytes
                     ELSE NULL
                 END AS total_storage_size_bytes
@@ -2442,31 +2450,24 @@ def test_total_storage_size_calls_complete(with_filter: bool):
                 sum(COALESCE(attributes_size_bytes,0) + COALESCE(inputs_size_bytes,0) + COALESCE(output_size_bytes,0) + COALESCE(summary_size_bytes,0) + COALESCE(otel_size_bytes,0)) AS total_storage_size_bytes
             FROM calls_complete_stats
             WHERE project_id = {pb_2:String}
-            AND id IN (
-                SELECT id
+            AND trace_id IN (
+                SELECT trace_id
                 FROM calls_complete
                 WHERE project_id = {pb_2:String}
-                AND trace_id IN (
-                    SELECT trace_id
-                    FROM calls_complete
-                    WHERE project_id = {pb_2:String}
-                    AND id IN storage_scope_ids
-                )
+                AND id IN filtered_calls
             )
             GROUP BY trace_id) AS rolled_up_cms
             ON calls_complete.trace_id = rolled_up_cms.trace_id
             PREWHERE calls_complete.project_id = {pb_2:String}
-            WHERE calls_complete.op_name IN {pb_5:Array(String)}
-                AND (calls_complete.deleted_at = {pb_4:DateTime64(3)})
-            LIMIT 50
+            WHERE (calls_complete.id IN filtered_calls)
             """,
             {
                 "pb_0": SENTINEL_EPOCH,
                 "pb_1": ["a", "b"],
                 "pb_2": "test/project",
-                "pb_3": "",
-                "pb_4": SENTINEL_EPOCH,
-                "pb_5": ["a", "b"],
+                "pb_3": SENTINEL_EPOCH,
+                "pb_4": ["a", "b"],
+                "pb_5": "",
             },
         )
     else:
@@ -2485,11 +2486,18 @@ def test_total_storage_size_calls_complete(with_filter: bool):
                 PREWHERE calls_complete.project_id = {pb_2:String}
                 WHERE 1
                     AND (((calls_complete.id = {pb_0:String}))
-                        AND ((calls_complete.deleted_at = {pb_1:DateTime64(3)}))))
+                        AND ((calls_complete.deleted_at = {pb_1:DateTime64(3)})))),
+            filtered_calls AS (
+                SELECT calls_complete.id AS id
+                FROM calls_complete
+                PREWHERE calls_complete.project_id = {pb_2:String}
+                WHERE 1
+                    AND (((calls_complete.id = {pb_0:String}))
+                        AND ((calls_complete.deleted_at = {pb_3:DateTime64(3)}))))
             SELECT
                 calls_complete.id AS id,
                 CASE
-                    WHEN calls_complete.parent_id = {pb_3:String}
+                    WHEN calls_complete.parent_id = {pb_4:String}
                     THEN rolled_up_cms.total_storage_size_bytes
                     ELSE NULL
                 END AS total_storage_size_bytes,
@@ -2500,30 +2508,23 @@ def test_total_storage_size_calls_complete(with_filter: bool):
                 sum(COALESCE(attributes_size_bytes,0) + COALESCE(inputs_size_bytes,0) + COALESCE(output_size_bytes,0) + COALESCE(summary_size_bytes,0) + COALESCE(otel_size_bytes,0)) AS total_storage_size_bytes
             FROM calls_complete_stats
             WHERE project_id = {pb_2:String}
-            AND id IN (
-                SELECT id
+            AND trace_id IN (
+                SELECT trace_id
                 FROM calls_complete
                 WHERE project_id = {pb_2:String}
-                AND trace_id IN (
-                    SELECT trace_id
-                    FROM calls_complete
-                    WHERE project_id = {pb_2:String}
-                    AND id IN storage_scope_ids
-                )
+                AND id IN filtered_calls
             )
             GROUP BY trace_id) AS rolled_up_cms
             ON calls_complete.trace_id = rolled_up_cms.trace_id
             PREWHERE calls_complete.project_id = {pb_2:String}
-            WHERE 1
-                AND (((calls_complete.id = {pb_0:String}))
-                    AND ((calls_complete.deleted_at = {pb_4:DateTime64(3)})))
+            WHERE (calls_complete.id IN filtered_calls)
             """,
             {
                 "pb_0": "my_id",
                 "pb_1": SENTINEL_EPOCH,
                 "pb_2": "test/project",
-                "pb_3": "",
-                "pb_4": SENTINEL_EPOCH,
+                "pb_3": SENTINEL_EPOCH,
+                "pb_4": "",
             },
         )
 
@@ -3884,10 +3885,9 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
 ):
     """Test calls_complete table with hardcoded filter, JSON condition, and summary field ordering.
 
-    This test demonstrates that for calls_complete, even when there is a hardcoded filter
-    (op_names, trace_ids) plus a JSON condition on summary, we use a single query pass
-    instead of the two-step CTE pattern. calls_complete has one row per call (no GROUP BY),
-    so a single query is both simpler and significantly faster.
+    Heavy select fields plus a usable hardcoded filter trigger the two-pass
+    filtered_calls CTE: pass 1 resolves the page's ids on light columns with the
+    order + limit, pass 2 loads the columns for those ids and re-sorts.
     Additionally, it tests ordering by summary.weave.status which uses direct column
     access without any() aggregation functions (unlike calls_merged).
     """
@@ -3920,6 +3920,29 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
     assert_sql(
         cq,
         """
+        WITH filtered_calls AS (
+            SELECT calls_complete.id AS id
+            FROM calls_complete
+            PREWHERE calls_complete.project_id = {pb_12:String}
+            WHERE calls_complete.op_name IN {pb_3:Array(String)}
+                AND (calls_complete.trace_id = {pb_4:String})
+            AND (
+                ((toInt64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.summary_dump, {pb_0:String}), 'null'), '')) > {pb_1:Int64}))
+                AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)}))
+            )
+            ORDER BY CASE
+                WHEN calls_complete.exception != {pb_10:String} THEN {pb_6:String}
+                WHEN IFNULL(
+                    toInt64OrNull(
+                        coalesce(nullIf(JSON_VALUE(calls_complete.summary_dump, {pb_5:String}), 'null'), '')
+                    ),
+                    0
+                ) > 0 THEN {pb_9:String}
+                WHEN calls_complete.ended_at = {pb_11:DateTime64(6)} THEN {pb_7:String}
+                ELSE {pb_8:String}
+                END ASC
+            LIMIT 100
+        )
         SELECT
             calls_complete.id AS id,
             calls_complete.started_at AS started_at,
@@ -3927,24 +3950,18 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
             calls_complete.ended_at AS ended_at
         FROM calls_complete
         PREWHERE calls_complete.project_id = {pb_12:String}
-        WHERE calls_complete.op_name IN {pb_3:Array(String)}
-            AND (calls_complete.trace_id = {pb_4:String})
-        AND (
-            ((toInt64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.summary_dump, {pb_0:String}), 'null'), '')) > {pb_1:Int64}))
-            AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)}))
-        )
+        WHERE (calls_complete.id IN filtered_calls)
         ORDER BY CASE
-            WHEN calls_complete.exception != {pb_10:String} THEN {pb_6:String}
+            WHEN calls_complete.exception != {pb_13:String} THEN {pb_6:String}
             WHEN IFNULL(
                 toInt64OrNull(
                     coalesce(nullIf(JSON_VALUE(calls_complete.summary_dump, {pb_5:String}), 'null'), '')
                 ),
                 0
             ) > 0 THEN {pb_9:String}
-            WHEN calls_complete.ended_at = {pb_11:DateTime64(6)} THEN {pb_7:String}
+            WHEN calls_complete.ended_at = {pb_14:DateTime64(6)} THEN {pb_7:String}
             ELSE {pb_8:String}
             END ASC
-        LIMIT 100
         """,
         {
             "pb_0": '$."latency"',
@@ -3960,6 +3977,8 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
             "pb_10": "",
             "pb_11": SENTINEL_EPOCH,
             "pb_12": "project",
+            "pb_13": "",
+            "pb_14": SENTINEL_EPOCH,
         },
     )
 

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -3942,7 +3942,7 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
                 ) > 0 THEN {pb_9:String}
                 WHEN calls_complete.ended_at = {pb_11:DateTime64(6)} THEN {pb_7:String}
                 ELSE {pb_8:String}
-                END ASC
+                END ASC, calls_complete.id ASC
             LIMIT 100
         )
         SELECT

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -3886,8 +3886,9 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
     """Test calls_complete table with hardcoded filter, JSON condition, and summary field ordering.
 
     Heavy select fields plus a usable hardcoded filter trigger the two-pass
-    filtered_calls CTE: pass 1 resolves the page's ids on light columns with the
-    order + limit, pass 2 loads the columns for those ids and re-sorts.
+    filtered_calls CTE: pass 1 resolves the page's ids (and started_at) on light
+    columns with the order + limit, pass 2 loads the columns for those ids and
+    re-sorts, bounded on the page's started_at range so it PK-prunes.
     Additionally, it tests ordering by summary.weave.status which uses direct column
     access without any() aggregation functions (unlike calls_merged).
     """
@@ -3921,7 +3922,8 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
         cq,
         """
         WITH filtered_calls AS (
-            SELECT calls_complete.id AS id
+            SELECT calls_complete.id AS id,
+                calls_complete.started_at AS started_at
             FROM calls_complete
             PREWHERE calls_complete.project_id = {pb_12:String}
             WHERE calls_complete.op_name IN {pb_3:Array(String)}
@@ -3950,7 +3952,9 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
             calls_complete.ended_at AS ended_at
         FROM calls_complete
         PREWHERE calls_complete.project_id = {pb_12:String}
-        WHERE (calls_complete.id IN filtered_calls)
+        WHERE (calls_complete.id IN (SELECT id FROM filtered_calls))
+            AND (calls_complete.started_at >= (SELECT min(started_at) FROM filtered_calls))
+            AND (calls_complete.started_at <= (SELECT max(started_at) FROM filtered_calls))
         ORDER BY CASE
             WHEN calls_complete.exception != {pb_13:String} THEN {pb_6:String}
             WHEN IFNULL(

--- a/tests/trace_server/query_builder/test_object_ref_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_object_ref_calls_query_builder.py
@@ -1095,22 +1095,27 @@ def test_object_ref_filter_calls_complete_mixed_conditions() -> None:
            WHERE project_id = {pb_0:String}
              AND JSON_VALUE(val_dump, {pb_1:String}) = {pb_2:String}
            GROUP BY project_id,
-                    digest)
+                    digest),
+             filtered_calls AS
+          (SELECT calls_complete.id AS id
+           FROM calls_complete PREWHERE calls_complete.project_id = {pb_0:String}
+           WHERE (calls_complete.parent_id = {pb_7:String})
+             AND (length(calls_complete.input_refs) > 0)
+             AND (((((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_3:String}), 'null'), '') GLOBAL IN
+                        (SELECT ref
+                         FROM obj_filter_0)
+                      OR regexpExtract(coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
+                        (SELECT ref
+                         FROM obj_filter_0)))
+                    OR ((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_4:String}), 'null'), '') = {pb_5:String}))))
+                  AND ((calls_complete.deleted_at = {pb_6:DateTime64(3)})))
+           ORDER BY calls_complete.started_at DESC
+           LIMIT 10)
         SELECT calls_complete.id AS id,
                calls_complete.inputs_dump AS inputs_dump
         FROM calls_complete PREWHERE calls_complete.project_id = {pb_0:String}
-        WHERE (calls_complete.parent_id = {pb_7:String})
-          AND (length(calls_complete.input_refs) > 0)
-          AND (((((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_3:String}), 'null'), '') GLOBAL IN
-                     (SELECT ref
-                      FROM obj_filter_0)
-                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
-                     (SELECT ref
-                      FROM obj_filter_0)))
-                OR ((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_4:String}), 'null'), '') = {pb_5:String}))))
-              AND ((calls_complete.deleted_at = {pb_6:DateTime64(3)})))
+        WHERE (calls_complete.id IN filtered_calls)
         ORDER BY calls_complete.started_at DESC
-        LIMIT 10
         """,
         {
             "pb_0": "project",

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1151,8 +1151,6 @@ class CallsQuery(BaseModel):
             raise ValueError("Missing select columns")
 
         # Determine if we should use the two-step filtered_calls CTE pattern.
-        # Only relevant for calls_merged (where GROUP BY makes the two-pass
-        # approach worthwhile). For calls_complete, we always use single-pass.
         should_use_filter_cte = self._should_use_filter_cte()
 
         # Important: Always inject deleted_at into the query.
@@ -1224,16 +1222,29 @@ class CallsQuery(BaseModel):
             ctes.add_cte(CTE_FILTER_CANDIDATE_IDS, candidate_cte_sql)
             candidate_cte_name = CTE_FILTER_CANDIDATE_IDS
 
+        # Two-pass filtered_calls CTE: pass 1 narrows ids on light columns, pass 2
+        # loads heavy *_dump columns only for the page. For calls_complete this reads
+        # the page's payloads instead of every scanned row's (prod: 28 GiB -> 1.7 GiB
+        # on a fat-payload list read). calls_merged additionally uses it for costs /
+        # object-ref pushdown ahead of its GROUP BY.
+        use_filter_cte = should_use_filter_cte or (
+            self.read_table != ReadTable.CALLS_COMPLETE
+            and (self.include_costs or bool(object_ref_conditions))
+        )
+
         # On calls_complete the total-storage rollup otherwise aggregates the
         # whole project's stats. Scope it to the matched calls' traces so the
-        # stats primary key (project_id, id) prunes the scan.
+        # stats primary key (project_id, id) prunes the scan. Only the single-pass
+        # paths reference it; two-pass scopes the rollup via filtered_calls, so
+        # emitting it there is dead SQL.
         storage_scope_cte_name: str | None = None
-        scope_cte_sql = self._build_storage_scope_ids_cte_sql(
-            pb, table_alias_resolved, field_to_object_join_alias_map
-        )
-        if scope_cte_sql is not None:
-            ctes.add_cte(CTE_STORAGE_SCOPE_IDS, scope_cte_sql)
-            storage_scope_cte_name = CTE_STORAGE_SCOPE_IDS
+        if not use_filter_cte:
+            scope_cte_sql = self._build_storage_scope_ids_cte_sql(
+                pb, table_alias_resolved, field_to_object_join_alias_map
+            )
+            if scope_cte_sql is not None:
+                ctes.add_cte(CTE_STORAGE_SCOPE_IDS, scope_cte_sql)
+                storage_scope_cte_name = CTE_STORAGE_SCOPE_IDS
 
         if (
             not should_use_filter_cte
@@ -1249,16 +1260,6 @@ class CallsQuery(BaseModel):
             if ctes.has_ctes():
                 return safely_format_sql(ctes.to_sql() + "\n" + base_sql, logger)
             return base_sql
-
-        # Two-pass filtered_calls CTE: pass 1 narrows ids on light columns, pass 2
-        # loads heavy *_dump columns only for the page. For calls_complete this reads
-        # the page's payloads instead of every scanned row's (prod: 28 GiB -> 1.7 GiB
-        # on a fat-payload list read). calls_merged additionally uses it for costs /
-        # object-ref pushdown ahead of its GROUP BY.
-        use_filter_cte = should_use_filter_cte or (
-            self.read_table != ReadTable.CALLS_COMPLETE
-            and (self.include_costs or bool(object_ref_conditions))
-        )
 
         if use_filter_cte:
             # Build two queries: a filter CTE that narrows rows by light

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1294,7 +1294,15 @@ class CallsQuery(BaseModel):
                 filter_query.query_conditions.append(condition)
 
             filter_query.hardcoded_filter = self.hardcoded_filter
-            filter_query.order_fields = self.order_fields
+            # Total-order pass 1 with an id tiebreaker so the min/max started_at
+            # bound and the id set derive from the identical LIMIT cut.
+            if page_started_at_bound:
+                filter_query.order_fields = [
+                    *self.order_fields,
+                    OrderField(field=get_field_by_name("id"), direction="ASC"),
+                ]
+            else:
+                filter_query.order_fields = self.order_fields
             filter_query.limit = self.limit
             filter_query.offset = self.offset
             # SUPER IMPORTANT: still need to re-sort the final query

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1274,7 +1274,19 @@ class CallsQuery(BaseModel):
                 read_table=self.read_table,
             )
 
+            # Plain calls_complete two-pass: carry started_at through pass 1 so pass 2
+            # can bound on the page's time range and PK-prune (see _build_where_clause_optimizations).
+            page_started_at_bound = (
+                self.read_table == ReadTable.CALLS_COMPLETE
+                and not self.include_costs
+                and not object_ref_conditions
+                and not self.include_storage_size
+                and not self.include_total_storage_size
+            )
+
             filter_query.add_field("id")
+            if page_started_at_bound:
+                filter_query.add_field("started_at")
             for field in self.select_fields:
                 select_query.select_fields.append(field)
 
@@ -1309,6 +1321,7 @@ class CallsQuery(BaseModel):
                 id_subquery_name=CTE_FILTERED_CALLS,
                 field_to_object_join_alias_map=field_to_object_join_alias_map,
                 expand_columns=self.expand_columns,
+                page_started_at_bound=page_started_at_bound,
             )
         else:
             # Single-pass: the full query (with all filters, ordering, and
@@ -1365,6 +1378,7 @@ class CallsQuery(BaseModel):
         table_alias: str,
         expand_columns: list[str] | None,
         id_subquery_name: str | None = None,
+        page_started_at_bound: bool = False,
     ) -> WhereFilters:
         """Build all WHERE clause optimization filters.
 
@@ -1436,7 +1450,16 @@ class CallsQuery(BaseModel):
 
         id_subquery = ""
         if id_subquery_name is not None:
-            id_subquery = f"AND ({table_alias}.id IN {id_subquery_name})"
+            if page_started_at_bound:
+                # Bound pass-2 on the page's started_at range so it prunes on the
+                # (project_id, started_at) PK prefix, not just idx_id (which fails for non-time-ordered ids).
+                id_subquery = (
+                    f"AND ({table_alias}.id IN (SELECT id FROM {id_subquery_name}))\n"
+                    f"        AND ({table_alias}.started_at >= (SELECT min(started_at) FROM {id_subquery_name}))\n"
+                    f"        AND ({table_alias}.started_at <= (SELECT max(started_at) FROM {id_subquery_name}))"
+                )
+            else:
+                id_subquery = f"AND ({table_alias}.id IN {id_subquery_name})"
 
         # call_ids is handled exclusively here (not in process_calls_filter_to_conditions)
         # to avoid duplicate id IN filters in the generated SQL.
@@ -1740,6 +1763,7 @@ class CallsQuery(BaseModel):
         field_to_object_join_alias_map: dict[str, str] | None = None,
         expand_columns: list[str] | None = None,
         storage_scope_id_cte: str | None = None,
+        page_started_at_bound: bool = False,
     ) -> QueryBodyResult:
         """Build the SQL query body: everything from FROM through OFFSET.
 
@@ -1763,7 +1787,7 @@ class CallsQuery(BaseModel):
             pb, table_alias, expand_columns, field_to_object_join_alias_map
         )
         where_filters = self._build_where_clause_optimizations(
-            pb, table_alias, expand_columns, id_subquery_name
+            pb, table_alias, expand_columns, id_subquery_name, page_started_at_bound
         )
         order_result = self._build_order_limit_offset(
             pb, table_alias, expand_columns, field_to_object_join_alias_map
@@ -1895,6 +1919,7 @@ class CallsQuery(BaseModel):
         field_to_object_join_alias_map: dict[str, str] | None = None,
         expand_columns: list[str] | None = None,
         storage_scope_id_cte: str | None = None,
+        page_started_at_bound: bool = False,
     ) -> str:
         """Build the base SQL query format.
 
@@ -1926,6 +1951,7 @@ class CallsQuery(BaseModel):
             field_to_object_join_alias_map,
             expand_columns,
             storage_scope_id_cte,
+            page_started_at_bound,
         )
         # On calls_complete, feedback LEFT JOIN can multiply rows, so use DISTINCT to de-dup.
         distinct = ""

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1250,12 +1250,14 @@ class CallsQuery(BaseModel):
                 return safely_format_sql(ctes.to_sql() + "\n" + base_sql, logger)
             return base_sql
 
-        # Use the filtered_calls CTE (two-pass) pattern only for calls_merged
-        # where it reduces rows before expensive GROUP BY aggregation.
-        # For calls_complete (one row per call, no GROUP BY), always use a
-        # single-pass query — it's both simpler and significantly faster.
-        use_filter_cte = self.read_table != ReadTable.CALLS_COMPLETE and (
-            should_use_filter_cte or self.include_costs or bool(object_ref_conditions)
+        # Two-pass filtered_calls CTE: pass 1 narrows ids on light columns, pass 2
+        # loads heavy *_dump columns only for the page. For calls_complete this reads
+        # the page's payloads instead of every scanned row's (prod: 28 GiB -> 1.7 GiB
+        # on a fat-payload list read). calls_merged additionally uses it for costs /
+        # object-ref pushdown ahead of its GROUP BY.
+        use_filter_cte = should_use_filter_cte or (
+            self.read_table != ReadTable.CALLS_COMPLETE
+            and (self.include_costs or bool(object_ref_conditions))
         )
 
         if use_filter_cte:


### PR DESCRIPTION
## Summary
- Enable the two-pass filter CTE for calls_complete heavy-column reads (was calls_merged-only): pass 1 resolves the page's ids + started_at on light columns, pass 2 loads `*_dump` payloads for only those ids, bounded on the page's `[min,max]` started_at so it prunes on the `(project_id, started_at)` PK prefix. Same rows returned.
- The started_at bound keeps pass 2 fast for non-time-ordered ids (e.g. OTel span ids); without it `id IN (page ids)` can't use `idx_id` and rescans the project (one 7.8M-row project read 27 GiB / 847 ms vs 24 MiB / 57 ms).

## Performance
Prod read-only, full-row list, `ORDER BY started_at DESC LIMIT 100`, interleaved warm, master -> branch:

| project (rows, avg row) | p50 ↓ | bytes read ↓ |
|---|---|---|
| 9.9k, 4 MB/row | 81% (2.18s -> 0.42s) | 94% (30.9 GB -> 1.84 GB) |
| 1.4M, 182 KB | 35% (95 -> 62 ms) | 98% (892 MB -> 18 MB) |
| 7.8M, 5 KB, OTel-style ids | -54% (37 -> 57 ms) | 93% (369 MB -> 24 MB) |

p50 win tracks payload size: heavy reads get much faster, thin-payload projects add about 20 ms of CTE-rescan overhead (pass-1 re-inlined 3x, fixable) while still cutting bytes ~15x.

## Testing
prod benchmark above; updated calls_query_builder snapshots.
