### PR TITLE
feat(weave): add predict-only cost total to eval results summary

### DIFF
--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -20,6 +20,7 @@ from weave.trace_server.trace_server_interface import (
     CallsDeleteReq,
     CallsQueryReq,
     CallStartReq,
+    CostCreateReq,
     EndedCallSchemaForInsert,
     EvalResultsFilter,
     EvalResultsQueryReq,
@@ -1053,6 +1054,273 @@ def test_eval_results_summary_predict_total_tokens_counts_zero(client):
     )
     assert res.summary is not None
     assert res.summary.evaluations[0].predict_total_tokens == 0
+
+
+# Known prices for the cost tests below. Custom (project-level) prices keep the
+# expected dollar amounts deterministic regardless of the default cost table.
+_PREDICT_PRICE = {"prompt_token_cost": 0.001, "completion_token_cost": 0.002}
+_JUDGE_PRICE = {"prompt_token_cost": 0.01, "completion_token_cost": 0.02}
+# 100 prompt + 50 completion tokens at the predict price -> a per-trial cost.
+_PREDICT_USAGE = {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150}
+_JUDGE_USAGE = {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150}
+_PREDICT_COST_PER_TRIAL = 100 * 0.001 + 50 * 0.002  # = 0.2
+
+
+def _create_eval_run_with_cost_trials(client, trials, *, eval_name):
+    """Create an eval run whose trials carry predict/scorer usage.
+
+    `trials` is a list of (predict_usage, scorer_usage) pairs keyed by model id,
+    e.g. ({"predict-llm": _PREDICT_USAGE}, {"judge-llm": _JUDGE_USAGE}). A None
+    usage means that child call is omitted. Mirrors the predict_total_tokens
+    setup but with prompt/completion tokens so a cost can be computed.
+    """
+    project_id = client.project_id
+    model_ref = f"model://{eval_name}"
+    run = client.server.evaluation_run_create(
+        EvaluationRunCreateReq(
+            project_id=project_id,
+            evaluation=f"eval://{eval_name}",
+            model=model_ref,
+        )
+    )
+    for i, (predict_usage, scorer_usage) in enumerate(trials):
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        pas_id = generate_id()
+        client.server.call_start(
+            CallStartReq(
+                start=StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=pas_id,
+                    trace_id=run.evaluation_run_id,
+                    parent_id=run.evaluation_run_id,
+                    op_name="Evaluation.predict_and_score",
+                    started_at=now,
+                    attributes={},
+                    inputs={"example": {"idx": i}, "model": model_ref},
+                )
+            )
+        )
+        predict_id = generate_id()
+        client.server.call_start(
+            CallStartReq(
+                start=StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=predict_id,
+                    trace_id=run.evaluation_run_id,
+                    parent_id=pas_id,
+                    op_name="Model.predict",
+                    started_at=now,
+                    attributes={},
+                    inputs={"self": model_ref, "example": {"idx": i}},
+                )
+            )
+        )
+        client.server.call_end(
+            CallEndReq(
+                end=EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=predict_id,
+                    ended_at=now + datetime.timedelta(seconds=1),
+                    output=f"answer_{i}",
+                    summary={"usage": predict_usage} if predict_usage else {},
+                )
+            )
+        )
+        if scorer_usage:
+            scorer_id = generate_id()
+            client.server.call_start(
+                CallStartReq(
+                    start=StartedCallSchemaForInsert(
+                        project_id=project_id,
+                        id=scorer_id,
+                        trace_id=run.evaluation_run_id,
+                        parent_id=pas_id,
+                        op_name="my_scorer.score",
+                        started_at=now + datetime.timedelta(seconds=1),
+                        attributes={},
+                        inputs={"output": f"answer_{i}"},
+                    )
+                )
+            )
+            client.server.call_end(
+                CallEndReq(
+                    end=EndedCallSchemaForInsert(
+                        project_id=project_id,
+                        id=scorer_id,
+                        ended_at=now + datetime.timedelta(seconds=2),
+                        output={"score": 1},
+                        summary={"usage": scorer_usage},
+                    )
+                )
+            )
+        client.server.call_end(
+            CallEndReq(
+                end=EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=pas_id,
+                    ended_at=now + datetime.timedelta(seconds=3),
+                    output={"output": f"answer_{i}", "scores": {}},
+                    summary={},
+                )
+            )
+        )
+    return run.evaluation_run_id
+
+
+def test_eval_results_summary_predict_total_cost(client):
+    """Summary predict_total_cost sums per-trial predict cost, excluding scorer cost."""
+    project_id = client.project_id
+    client.server.cost_create(
+        CostCreateReq(
+            project_id=project_id,
+            costs={"predict-llm": _PREDICT_PRICE, "judge-llm": _JUDGE_PRICE},
+            wb_user_id="VXNlcjo0NTI1NDQ=",
+        )
+    )
+    # Two trials, each with a priced predict child and a (more expensive) priced
+    # judge child. A third trial's predict has no usage: it reports no cost and
+    # is skipped, not counted as 0.
+    eval_id = _create_eval_run_with_cost_trials(
+        client,
+        [
+            ({"predict-llm": _PREDICT_USAGE}, {"judge-llm": _JUDGE_USAGE}),
+            ({"predict-llm": _PREDICT_USAGE}, {"judge-llm": _JUDGE_USAGE}),
+            (None, {"judge-llm": _JUDGE_USAGE}),
+        ],
+        eval_name="predict-cost",
+    )
+    res = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=project_id,
+            evaluation_call_ids=[eval_id],
+            include_rows=False,
+            include_summary=True,
+            include_predict_and_score_children=True,
+            include_costs=True,
+        )
+    )
+    assert res.summary is not None
+    # 2 priced predict trials; the judge cost and the usage-less trial are excluded.
+    assert res.summary.evaluations[0].predict_total_cost == pytest.approx(
+        2 * _PREDICT_COST_PER_TRIAL
+    )
+
+
+def test_eval_results_summary_predict_total_cost_requires_include_costs(client):
+    """Without include_costs the predict_total_cost is None (cost is opt-in)."""
+    project_id = client.project_id
+    client.server.cost_create(
+        CostCreateReq(
+            project_id=project_id,
+            costs={"predict-llm": _PREDICT_PRICE},
+            wb_user_id="VXNlcjo0NTI1NDQ=",
+        )
+    )
+    eval_id = _create_eval_run_with_cost_trials(
+        client,
+        [({"predict-llm": _PREDICT_USAGE}, None)],
+        eval_name="cost-opt-in",
+    )
+    res = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=project_id,
+            evaluation_call_ids=[eval_id],
+            include_rows=False,
+            include_summary=True,
+            include_predict_and_score_children=True,
+            # include_costs omitted -> defaults to False
+        )
+    )
+    assert res.summary is not None
+    assert res.summary.evaluations[0].predict_total_cost is None
+
+
+def test_eval_results_summary_predict_total_cost_none_when_absent(client):
+    """predict_total_cost is None when no trial reports cost (e.g. unpriced models)."""
+    eval_id, _ = _create_eval_with_scores(
+        client, [{"accuracy": 0.5}], eval_name="no-cost"
+    )
+    res = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=client.project_id,
+            evaluation_call_ids=[eval_id],
+            include_rows=False,
+            include_summary=True,
+            include_costs=True,
+        )
+    )
+    assert res.summary is not None
+    assert res.summary.evaluations[0].predict_total_cost is None
+
+
+def test_eval_results_summary_predict_total_cost_counts_zero(client):
+    """A predict model priced at $0 reports 0.0, not None (mirrors the token zero case)."""
+    project_id = client.project_id
+    client.server.cost_create(
+        CostCreateReq(
+            project_id=project_id,
+            costs={
+                "free-llm": {"prompt_token_cost": 0.0, "completion_token_cost": 0.0}
+            },
+            wb_user_id="VXNlcjo0NTI1NDQ=",
+        )
+    )
+    eval_id = _create_eval_run_with_cost_trials(
+        client,
+        [({"free-llm": _PREDICT_USAGE}, None)],
+        eval_name="cost-zero",
+    )
+    res = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=project_id,
+            evaluation_call_ids=[eval_id],
+            include_rows=False,
+            include_summary=True,
+            include_predict_and_score_children=True,
+            include_costs=True,
+        )
+    )
+    assert res.summary is not None
+    assert res.summary.evaluations[0].predict_total_cost == 0.0
+
+
+def test_eval_results_summary_predict_total_cost_sums_multiple_models(client):
+    """When a predict call spans multiple priced models, their costs are summed."""
+    project_id = client.project_id
+    client.server.cost_create(
+        CostCreateReq(
+            project_id=project_id,
+            costs={
+                "predict-llm": _PREDICT_PRICE,
+                "predict-llm-b": {
+                    "prompt_token_cost": 0.003,
+                    "completion_token_cost": 0.004,
+                },
+            },
+            wb_user_id="VXNlcjo0NTI1NDQ=",
+        )
+    )
+    eval_id = _create_eval_run_with_cost_trials(
+        client,
+        [({"predict-llm": _PREDICT_USAGE, "predict-llm-b": _PREDICT_USAGE}, None)],
+        eval_name="cost-multimodel",
+    )
+    res = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=project_id,
+            evaluation_call_ids=[eval_id],
+            include_rows=False,
+            include_summary=True,
+            include_predict_and_score_children=True,
+            include_costs=True,
+        )
+    )
+    assert res.summary is not None
+    # model a: 100*0.001 + 50*0.002 = 0.2; model b: 100*0.003 + 50*0.004 = 0.5.
+    cost_b = 100 * 0.003 + 50 * 0.004
+    assert res.summary.evaluations[0].predict_total_cost == pytest.approx(
+        _PREDICT_COST_PER_TRIAL + cost_b
+    )
 
 
 def test_eval_results_resolved_inputs_inline(client):

--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -1167,27 +1167,72 @@ def _create_eval_run_with_cost_trials(client, trials, *, eval_name):
     return run.evaluation_run_id
 
 
-def test_eval_results_summary_predict_total_cost(client):
-    """Summary predict_total_cost sums per-trial predict cost, excluding scorer cost."""
+# One table of (prices, trials, include_costs, expected) instead of five
+# near-identical functions. `expected is None` asserts the None contract;
+# otherwise an exact ($0) or approx dollar amount.
+@pytest.mark.parametrize(
+    ("prices", "trials", "include_costs", "expected"),
+    [
+        # Sums per-trial predict cost and excludes the judge; a usage-less trial
+        # reports no cost and is skipped, not counted as 0.
+        pytest.param(
+            {"predict-llm": _PREDICT_PRICE, "judge-llm": _JUDGE_PRICE},
+            [
+                ({"predict-llm": _PREDICT_USAGE}, {"judge-llm": _JUDGE_USAGE}),
+                ({"predict-llm": _PREDICT_USAGE}, {"judge-llm": _JUDGE_USAGE}),
+                (None, {"judge-llm": _JUDGE_USAGE}),
+            ],
+            True,
+            pytest.approx(2 * _PREDICT_COST_PER_TRIAL),
+            id="sums_predict_excludes_judge",
+        ),
+        # Cost is opt-in: without include_costs the total is None even when priced.
+        pytest.param(
+            {"predict-llm": _PREDICT_PRICE},
+            [({"predict-llm": _PREDICT_USAGE}, None)],
+            False,
+            None,
+            id="requires_include_costs",
+        ),
+        # A predict model priced at $0 reports 0.0, not None (mirrors token zero).
+        pytest.param(
+            {"free-llm": {"prompt_token_cost": 0.0, "completion_token_cost": 0.0}},
+            [({"free-llm": _PREDICT_USAGE}, None)],
+            True,
+            0.0,
+            id="counts_zero",
+        ),
+        # Multiple priced models on one predict call: their costs sum.
+        pytest.param(
+            {
+                "predict-llm": _PREDICT_PRICE,
+                "predict-llm-b": {
+                    "prompt_token_cost": 0.003,
+                    "completion_token_cost": 0.004,
+                },
+            },
+            [({"predict-llm": _PREDICT_USAGE, "predict-llm-b": _PREDICT_USAGE}, None)],
+            True,
+            pytest.approx(_PREDICT_COST_PER_TRIAL + 100 * 0.003 + 50 * 0.004),
+            id="sums_multiple_models",
+        ),
+    ],
+)
+def test_eval_results_summary_predict_total_cost(
+    client, prices, trials, include_costs, expected
+):
+    """Summary predict_total_cost: predict-only, opt-in, $0-vs-None, multi-model."""
     project_id = client.project_id
-    client.server.cost_create(
-        CostCreateReq(
-            project_id=project_id,
-            costs={"predict-llm": _PREDICT_PRICE, "judge-llm": _JUDGE_PRICE},
-            wb_user_id="VXNlcjo0NTI1NDQ=",
+    if prices:
+        client.server.cost_create(
+            CostCreateReq(
+                project_id=project_id,
+                costs=prices,
+                wb_user_id="VXNlcjo0NTI1NDQ=",
+            )
         )
-    )
-    # Two trials, each with a priced predict child and a (more expensive) priced
-    # judge child. A third trial's predict has no usage: it reports no cost and
-    # is skipped, not counted as 0.
     eval_id = _create_eval_run_with_cost_trials(
-        client,
-        [
-            ({"predict-llm": _PREDICT_USAGE}, {"judge-llm": _JUDGE_USAGE}),
-            ({"predict-llm": _PREDICT_USAGE}, {"judge-llm": _JUDGE_USAGE}),
-            (None, {"judge-llm": _JUDGE_USAGE}),
-        ],
-        eval_name="predict-cost",
+        client, trials, eval_name="predict-cost"
     )
     res = client.server.eval_results_query(
         EvalResultsQueryReq(
@@ -1196,47 +1241,23 @@ def test_eval_results_summary_predict_total_cost(client):
             include_rows=False,
             include_summary=True,
             include_predict_and_score_children=True,
-            include_costs=True,
+            include_costs=include_costs,
         )
     )
     assert res.summary is not None
-    # 2 priced predict trials; the judge cost and the usage-less trial are excluded.
-    assert res.summary.evaluations[0].predict_total_cost == pytest.approx(
-        2 * _PREDICT_COST_PER_TRIAL
-    )
-
-
-def test_eval_results_summary_predict_total_cost_requires_include_costs(client):
-    """Without include_costs the predict_total_cost is None (cost is opt-in)."""
-    project_id = client.project_id
-    client.server.cost_create(
-        CostCreateReq(
-            project_id=project_id,
-            costs={"predict-llm": _PREDICT_PRICE},
-            wb_user_id="VXNlcjo0NTI1NDQ=",
-        )
-    )
-    eval_id = _create_eval_run_with_cost_trials(
-        client,
-        [({"predict-llm": _PREDICT_USAGE}, None)],
-        eval_name="cost-opt-in",
-    )
-    res = client.server.eval_results_query(
-        EvalResultsQueryReq(
-            project_id=project_id,
-            evaluation_call_ids=[eval_id],
-            include_rows=False,
-            include_summary=True,
-            include_predict_and_score_children=True,
-            # include_costs omitted -> defaults to False
-        )
-    )
-    assert res.summary is not None
-    assert res.summary.evaluations[0].predict_total_cost is None
+    if expected is None:
+        assert res.summary.evaluations[0].predict_total_cost is None
+    else:
+        assert res.summary.evaluations[0].predict_total_cost == expected
 
 
 def test_eval_results_summary_predict_total_cost_none_when_absent(client):
-    """predict_total_cost is None when no trial reports cost (e.g. unpriced models)."""
+    """predict_total_cost is None when no trial reports cost (e.g. unpriced models).
+
+    Kept separate from the parametrized cases above: it drives a normal eval via
+    _create_eval_with_scores (no predict usage at all) rather than the priced
+    cost-trial builder, exercising the None path from a different setup.
+    """
     eval_id, _ = _create_eval_with_scores(
         client, [{"accuracy": 0.5}], eval_name="no-cost"
     )
@@ -1251,76 +1272,6 @@ def test_eval_results_summary_predict_total_cost_none_when_absent(client):
     )
     assert res.summary is not None
     assert res.summary.evaluations[0].predict_total_cost is None
-
-
-def test_eval_results_summary_predict_total_cost_counts_zero(client):
-    """A predict model priced at $0 reports 0.0, not None (mirrors the token zero case)."""
-    project_id = client.project_id
-    client.server.cost_create(
-        CostCreateReq(
-            project_id=project_id,
-            costs={
-                "free-llm": {"prompt_token_cost": 0.0, "completion_token_cost": 0.0}
-            },
-            wb_user_id="VXNlcjo0NTI1NDQ=",
-        )
-    )
-    eval_id = _create_eval_run_with_cost_trials(
-        client,
-        [({"free-llm": _PREDICT_USAGE}, None)],
-        eval_name="cost-zero",
-    )
-    res = client.server.eval_results_query(
-        EvalResultsQueryReq(
-            project_id=project_id,
-            evaluation_call_ids=[eval_id],
-            include_rows=False,
-            include_summary=True,
-            include_predict_and_score_children=True,
-            include_costs=True,
-        )
-    )
-    assert res.summary is not None
-    assert res.summary.evaluations[0].predict_total_cost == 0.0
-
-
-def test_eval_results_summary_predict_total_cost_sums_multiple_models(client):
-    """When a predict call spans multiple priced models, their costs are summed."""
-    project_id = client.project_id
-    client.server.cost_create(
-        CostCreateReq(
-            project_id=project_id,
-            costs={
-                "predict-llm": _PREDICT_PRICE,
-                "predict-llm-b": {
-                    "prompt_token_cost": 0.003,
-                    "completion_token_cost": 0.004,
-                },
-            },
-            wb_user_id="VXNlcjo0NTI1NDQ=",
-        )
-    )
-    eval_id = _create_eval_run_with_cost_trials(
-        client,
-        [({"predict-llm": _PREDICT_USAGE, "predict-llm-b": _PREDICT_USAGE}, None)],
-        eval_name="cost-multimodel",
-    )
-    res = client.server.eval_results_query(
-        EvalResultsQueryReq(
-            project_id=project_id,
-            evaluation_call_ids=[eval_id],
-            include_rows=False,
-            include_summary=True,
-            include_predict_and_score_children=True,
-            include_costs=True,
-        )
-    )
-    assert res.summary is not None
-    # model a: 100*0.001 + 50*0.002 = 0.2; model b: 100*0.003 + 50*0.004 = 0.5.
-    cost_b = 100 * 0.003 + 50 * 0.004
-    assert res.summary.evaluations[0].predict_total_cost == pytest.approx(
-        _PREDICT_COST_PER_TRIAL + cost_b
-    )
 
 
 def test_eval_results_resolved_inputs_inline(client):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5662,6 +5662,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     filter=tsi.CallsFilter(parent_ids=batch),
                     columns=child_columns,
                     sort_by=[tsi.SortBy(field="started_at", direction="asc")],
+                    include_costs=req.include_costs,
                 )
                 page_calls.extend(self.calls_query_stream(child_req))
 

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -238,6 +238,47 @@ def extract_total_tokens(
     return total_tokens if found_any else None
 
 
+# The four components of a call's spent cost, summed to the canonical total_cost
+# (see the total_cost definition in trace_server_interface.py). Populated in
+# summary.weave.costs when calls are read with include_costs=True.
+_COST_COMPONENT_KEYS = (
+    "prompt_tokens_total_cost",
+    "completion_tokens_total_cost",
+    "cache_read_input_tokens_total_cost",
+    "cache_creation_input_tokens_total_cost",
+)
+
+
+def extract_total_cost(
+    summary: "dict[str, Any] | tsi.SummaryMap | None",
+) -> float | None:
+    """Return the total cost from summary.weave.costs if present.
+
+    Sums the four spent-cost components across all models. Returns None when no
+    cost data is present (e.g. the model is not in the cost table) so callers
+    can tell "no cost reported" apart from a real $0.
+    """
+    if not isinstance(summary, dict):
+        return None
+    weave_summary = summary.get("weave")
+    if not isinstance(weave_summary, dict):
+        return None
+    costs = weave_summary.get("costs")
+    if not isinstance(costs, dict):
+        return None
+    total_cost = 0.0
+    found_any = False
+    for model_cost in costs.values():
+        if not isinstance(model_cost, dict):
+            continue
+        for key in _COST_COMPONENT_KEYS:
+            value = model_cost.get(key)
+            if isinstance(value, (int, float)):
+                total_cost += float(value)
+                found_any = True
+    return total_cost if found_any else None
+
+
 def best_effort_scorer_call_ids(
     scores: dict[str, Any], child_calls: list[tsi.CallSchema]
 ) -> dict[str, str]:
@@ -361,6 +402,10 @@ def _build_trial(
         total_tokens=extract_total_tokens(
             predict_call.summary if predict_call else predict_and_score_call.summary
         ),
+        # Predict-only: read cost from the predict call alone. Unlike tokens, do
+        # not fall back to the predict_and_score summary, whose cost rollup would
+        # include the LLM-as-a-judge scorer.
+        total_cost=extract_total_cost(predict_call.summary) if predict_call else None,
         scorer_call_ids=best_effort_scorer_call_ids(scores, trial_children),
         genai_span_ref=_combine_genai_span_refs(predict_call, predict_and_score_call),
     )
@@ -788,6 +833,10 @@ def compute_summary_from_rows(
                     eval_summary_map[eval_call_id].predict_total_tokens = (
                         eval_summary_map[eval_call_id].predict_total_tokens or 0
                     ) + trial.total_tokens
+                if trial.total_cost is not None:
+                    eval_summary_map[eval_call_id].predict_total_cost = (
+                        eval_summary_map[eval_call_id].predict_total_cost or 0.0
+                    ) + trial.total_cost
                 for scorer_key, scorer_val in trial.scores.items():
                     _process_scorer_output(
                         scorer_val,

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -2461,6 +2461,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
         project_id: str,
         eval_root_ids: list[str],
         include_children: bool = True,
+        include_costs: bool = False,
     ) -> Iterator[tsi.CallSchema]:
         columns = [
             "id",
@@ -2493,6 +2494,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                         filter=tsi.CallsFilter(parent_ids=eval_root_children_ids),
                         columns=columns,
                         sort_by=[tsi.SortBy(field="started_at", direction="asc")],
+                        include_costs=include_costs,
                     )
                 )
 
@@ -6811,6 +6813,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                 req.project_id,
                 eval_root_ids,
                 include_children=req.include_predict_and_score_children,
+                include_costs=req.include_costs,
             )
         )
         if req.resolve_row_refs:

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3292,6 +3292,14 @@ class EvalResultsQueryBody(BaseModelStrict):
             "scorer_call_ids will be null/empty)."
         ),
     )
+    include_costs: bool = Field(
+        default=False,
+        description=(
+            "When true, enrich the predict-and-score child calls with cost so "
+            "the summary can report predict-only `predict_total_cost`. Opt-in: "
+            "other callers skip the cost computation."
+        ),
+    )
     sort_by: list[EvalResultsSortBy] | None = Field(
         default=None,
         description=(
@@ -3344,6 +3352,7 @@ class EvalResultsTrial(BaseModel):
     scores: dict[str, Any] = Field(default_factory=dict)
     model_latency_seconds: float | None = None
     total_tokens: int | None = None
+    total_cost: float | None = None
     scorer_call_ids: dict[str, str] = Field(default_factory=dict)
     genai_span_ref: list[GenAISpanRef] | None = None
 
@@ -3403,6 +3412,14 @@ class EvalResultsEvaluationSummary(BaseModel):
             "Sum of per-trial predict-only token usage for this evaluation "
             "(the model's predict() tokens only, excluding LLM-as-a-judge "
             "scorer usage); None when no trial reports usage."
+        ),
+    )
+    predict_total_cost: float | None = Field(
+        default=None,
+        description=(
+            "Sum of per-trial predict-only cost for this evaluation (the "
+            "model's predict() cost only, excluding LLM-as-a-judge scorer "
+            "cost); None when no trial reports cost."
         ),
     )
     evaluation_ref: str | None = None


### PR DESCRIPTION
## JIRA Issue(s)
https://coreweave.atlassian.net/browse/WB-33374

## Description
The eval-results summary already returns a predict-only token total (#7364). This adds the matching cost.

The summary now also returns `predict_total_cost` — the model's `predict()` cost summed across trials, without the LLM judge's cost. It follows the same path as tokens: a small `extract_total_cost` helper next to `extract_total_tokens`, a per-trial `total_cost`, and the total on the summary.

It's opt-in. The request has a new `include_costs` flag, and only when it's set do we fetch the cost on the predict call (on both the ClickHouse and in-memory backends), so callers that don't ask for cost pay nothing extra. If no trial has a price (for example the model isn't in the cost table), `predict_total_cost` is `None`, so the client can tell "no cost" apart from a real `$0`.

## Testing
Server tests on both backends: two priced predict trials plus a priced judge check that the total is predict-only and leaves the judge out; a trial with no usage is skipped instead of counted as zero; and the value is `None` when nothing has a price or when `include_costs` isn't set.

## Merge order
1. wandb/weave#7487 (server, this PR)
2. wandb/core#47134 (frontend)
