### PR TITLE
feat(weave): Base64 and Data URL content ref conversion

### DIFF
--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -188,6 +188,33 @@ class TestBase64Replacement:
         assert result[1] == b64_data
         _assert_content_ref(result[2]["nested"], "test_project")
 
+    def test_wb_user_id_reaches_obj_create(self):
+        """The ``wb_user_id`` passed to ``replace_base64_with_content_objects``
+        is forwarded onto the ``ObjSchemaForInsert`` that publishes the Content
+        object, so server-side (in-process) conversions are user-attributed.
+        """
+        trace_server = MagicMock()
+        trace_server.file_create = MagicMock(
+            side_effect=[
+                FileCreateRes(digest="content_digest"),
+                FileCreateRes(digest="metadata_digest"),
+            ]
+        )
+        _mock_obj_create(trace_server)
+
+        test_data = b"a" * LARGE_TEST_DATA_SIZE
+        b64_data = base64.b64encode(test_data).decode("ascii")
+        input_data = {"image": f"data:image/png;base64,{b64_data}"}
+
+        result = replace_base64_with_content_objects(
+            input_data, "proj", trace_server, wb_user_id="user-123"
+        )
+
+        _assert_content_ref(result["image"], "proj")
+        assert trace_server.obj_create.call_count == 1
+        obj_create_req = trace_server.obj_create.call_args.args[0]
+        assert obj_create_req.obj.wb_user_id == "user-123"
+
     def test_process_call_req_to_content_start_and_end(self):
         """Test the main entry point for processing CallStartReq and CallEndReq."""
         # Mock trace server

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -38,9 +38,7 @@ def _mock_obj_create(trace_server: MagicMock) -> None:
     ``replace_base64_with_content_objects`` publishes each converted blob as a
     weave object and embeds its ref, so any test that converts must stub this.
     """
-    trace_server.obj_create = MagicMock(
-        return_value=ObjCreateRes(digest=_OBJ_DIGEST)
-    )
+    trace_server.obj_create = MagicMock(return_value=ObjCreateRes(digest=_OBJ_DIGEST))
 
 
 def _assert_content_ref(value: object, project_id: str) -> None:
@@ -582,7 +580,9 @@ class TestReplaceBase64InRawMessages:
     def test_structured_list_messages_converted(self):
         """An already-parsed list is walked directly (no JSON string)."""
         trace_server = self._trace_server()
-        messages = [{"role": "user", "parts": [{"type": "image", "url": self._data_uri()}]}]
+        messages = [
+            {"role": "user", "parts": [{"type": "image", "url": self._data_uri()}]}
+        ]
 
         result = replace_base64_in_raw_messages(messages, "proj", trace_server)
 

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -11,6 +11,7 @@ from weave.trace_server.base64_content_conversion import (
     is_base64,
     is_data_uri,
     process_call_req_to_content,
+    replace_base64_in_raw_messages,
     replace_base64_with_content_objects,
     store_content_object,
 )
@@ -513,6 +514,97 @@ class TestThresholdAndStructuralIdentity:
         # by value rather than identity here — content must round-trip
         # unchanged regardless of the SDK copy.
         assert processed.start.inputs == inputs_before
+        assert trace_server.file_create.call_count == 0
+
+
+class TestReplaceBase64InRawMessages:
+    """Test the OTel raw-message wrapper that mirrors the non-OTel calls path.
+
+    GenAI OTel spans usually carry their message payload as a JSON-encoded
+    string, so ``replace_base64_in_raw_messages`` must parse it into structured
+    form before the shared walker can find inline base64 leaves.
+    """
+
+    @staticmethod
+    def _trace_server() -> MagicMock:
+        trace_server = MagicMock()
+        trace_server.file_create = MagicMock(
+            side_effect=lambda req: FileCreateRes(digest=f"digest_{req.name}")
+        )
+        return trace_server
+
+    @staticmethod
+    def _data_uri() -> str:
+        b64 = base64.b64encode(b"a" * LARGE_TEST_DATA_SIZE).decode("ascii")
+        return f"data:image/png;base64,{b64}"
+
+    def test_json_string_messages_data_uri_converted(self):
+        """A JSON-string payload is parsed and inline data-URIs are converted."""
+        trace_server = self._trace_server()
+        data_uri = self._data_uri()
+        messages = json.dumps(
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"type": "text", "content": "describe this"},
+                        {"type": "image", "url": data_uri},
+                    ],
+                }
+            ]
+        )
+
+        result = replace_base64_in_raw_messages(messages, "proj", trace_server)
+
+        # Parsed into structured form (mirrors what _normalize_raw_messages sees).
+        assert isinstance(result, list)
+        parts = result[0]["parts"]
+        assert parts[0] == {"type": "text", "content": "describe this"}
+        # The data-URI field value (not the whole part) becomes the Content ref.
+        assert parts[1]["type"] == "image"
+        assert parts[1]["url"]["_type"] == "CustomWeaveType"
+        assert set(parts[1]["url"]["files"].keys()) == {"content", "metadata.json"}
+        assert trace_server.file_create.call_count == 2
+
+    def test_structured_list_messages_converted(self):
+        """An already-parsed list is walked directly (no JSON string)."""
+        trace_server = self._trace_server()
+        messages = [{"role": "user", "parts": [{"type": "image", "url": self._data_uri()}]}]
+
+        result = replace_base64_in_raw_messages(messages, "proj", trace_server)
+
+        assert result[0]["parts"][0]["url"]["_type"] == "CustomWeaveType"
+        assert trace_server.file_create.call_count == 2
+
+    def test_no_base64_is_noop(self):
+        """A payload without base64 triggers no file storage."""
+        trace_server = self._trace_server()
+        messages = json.dumps(
+            [{"role": "user", "parts": [{"type": "text", "content": "hello"}]}]
+        )
+
+        result = replace_base64_in_raw_messages(messages, "proj", trace_server)
+
+        assert result == [
+            {"role": "user", "parts": [{"type": "text", "content": "hello"}]}
+        ]
+        assert trace_server.file_create.call_count == 0
+
+    def test_non_json_string_returned_unchanged(self):
+        """A plain (non-JSON) string is returned as-is, not stored."""
+        trace_server = self._trace_server()
+
+        result = replace_base64_in_raw_messages("just some text", "proj", trace_server)
+
+        assert result == "just some text"
+        assert trace_server.file_create.call_count == 0
+
+    def test_none_and_non_container_returned_unchanged(self):
+        """None and non-container inputs are passed through untouched."""
+        trace_server = self._trace_server()
+
+        assert replace_base64_in_raw_messages(None, "proj", trace_server) is None
+        assert replace_base64_in_raw_messages(42, "proj", trace_server) == 42
         assert trace_server.file_create.call_count == 0
 
 

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -20,12 +20,34 @@ from weave.trace_server.trace_server_interface import (
     CallStartReq,
     EndedCallSchemaForInsert,
     FileCreateRes,
+    ObjCreateRes,
     StartedCallSchemaForInsert,
 )
 from weave.type_wrappers.Content.content import Content
 
 # Test data size larger than AUTO_CONVERSION_MIN_SIZE to trigger conversion
 LARGE_TEST_DATA_SIZE = AUTO_CONVERSION_MIN_SIZE + 10
+
+# Object digest returned by the mocked ``obj_create`` when content is published.
+_OBJ_DIGEST = "obj_digest"
+
+
+def _mock_obj_create(trace_server: MagicMock) -> None:
+    """Mock ``obj_create`` so auto-conversion can publish a Content object.
+
+    ``replace_base64_with_content_objects`` publishes each converted blob as a
+    weave object and embeds its ref, so any test that converts must stub this.
+    """
+    trace_server.obj_create = MagicMock(
+        return_value=ObjCreateRes(digest=_OBJ_DIGEST)
+    )
+
+
+def _assert_content_ref(value: object, project_id: str) -> None:
+    """Assert *value* is an internal weave object ref to a published Content."""
+    assert isinstance(value, str)
+    assert value.startswith(f"weave-trace-internal:///{project_id}/object/")
+    assert value.endswith(f":{_OBJ_DIGEST}")
 
 
 class TestBase64AndDataURIDetection:
@@ -110,6 +132,7 @@ class TestBase64Replacement:
                 FileCreateRes(digest="metadata_digest2"),
             ]
         )
+        _mock_obj_create(trace_server)
 
         test_data = b"a" * LARGE_TEST_DATA_SIZE
         b64_data = base64.b64encode(test_data).decode("ascii")
@@ -130,13 +153,8 @@ class TestBase64Replacement:
         # Check standalone base64 is NOT replaced
         assert result["field2"] == b64_data
 
-        # Check data URI was replaced
-        assert isinstance(result["nested"]["field3"], dict)
-        assert result["nested"]["field3"]["_type"] == "CustomWeaveType"
-        assert set(result["nested"]["field3"]["files"].keys()) == {
-            "content",
-            "metadata.json",
-        }
+        # Check data URI was replaced with a published-object ref
+        _assert_content_ref(result["nested"]["field3"], "test_project")
 
     def test_replace_data_uri_in_list_only(self):
         """Only base64 data URIs are replaced in lists; raw base64 is left untouched."""
@@ -150,6 +168,7 @@ class TestBase64Replacement:
                 FileCreateRes(digest="metadata_digest2"),
             ]
         )
+        _mock_obj_create(trace_server)
 
         test_data = b"a" * LARGE_TEST_DATA_SIZE
         b64_data = base64.b64encode(test_data).decode("ascii")
@@ -169,8 +188,7 @@ class TestBase64Replacement:
         assert result[0] == "normal string"
         # Raw base64 remains a string
         assert result[1] == b64_data
-        assert isinstance(result[2]["nested"], dict)
-        assert result[2]["nested"]["_type"] == "CustomWeaveType"
+        _assert_content_ref(result[2]["nested"], "test_project")
 
     def test_process_call_req_to_content_start_and_end(self):
         """Test the main entry point for processing CallStartReq and CallEndReq."""
@@ -185,6 +203,7 @@ class TestBase64Replacement:
                 FileCreateRes(digest="metadata_digest_end"),
             ]
         )
+        _mock_obj_create(trace_server)
 
         test_data = b"x" * LARGE_TEST_DATA_SIZE
         b64_data = base64.b64encode(test_data).decode("ascii")
@@ -205,8 +224,7 @@ class TestBase64Replacement:
 
         processed_start = process_call_req_to_content(start_req, trace_server)
         assert processed_start.start.inputs["text"] == "Some normal text"
-        assert isinstance(processed_start.start.inputs["image"], dict)
-        assert processed_start.start.inputs["image"]["_type"] == "CustomWeaveType"
+        _assert_content_ref(processed_start.start.inputs["image"], "proj")
 
         long_bytes = b"y" * LARGE_TEST_DATA_SIZE
         long_b64 = base64.b64encode(long_bytes).decode("ascii")
@@ -282,6 +300,7 @@ class TestStandaloneBase64Detection:
                 FileCreateRes(digest="metadata_digest"),
             ]
         )
+        _mock_obj_create(trace_server)
 
         # Create a minimal valid WAV file (larger than AUTO_CONVERSION_MIN_SIZE)
         # WAV format: RIFF header + fmt chunk + data chunk
@@ -331,16 +350,8 @@ class TestStandaloneBase64Detection:
             input_data, "test_project", trace_server
         )
 
-        # The WAV file should be converted to Content object
-        assert isinstance(result["audio_field"], dict)
-        assert result["audio_field"]["_type"] == "CustomWeaveType"
-        assert (
-            result["audio_field"]["weave_type"]["type"]
-            == "weave.type_wrappers.Content.content.Content"
-        )
-        assert "files" in result["audio_field"]
-        assert "content" in result["audio_field"]["files"]
-        assert "metadata.json" in result["audio_field"]["files"]
+        # The WAV file should be converted to a published-object ref
+        _assert_content_ref(result["audio_field"], "test_project")
 
         # Normal string should be unchanged
         assert result["other_field"] == "normal string"
@@ -419,6 +430,7 @@ class TestThresholdAndStructuralIdentity:
                 FileCreateRes(digest="metadata_digest"),
             ]
         )
+        _mock_obj_create(trace_server)
         png_data_uri = "data:image/png;base64," + base64.b64encode(
             b"\x89PNG\r\n\x1a\n" + b"\x00" * 12000
         ).decode("ascii")
@@ -460,6 +472,7 @@ class TestThresholdAndStructuralIdentity:
                 FileCreateRes(digest="metadata_digest"),
             ]
         )
+        _mock_obj_create(trace_server)
         png_data_uri = "data:image/png;base64," + base64.b64encode(
             b"\x89PNG\r\n\x1a\n" + b"\x00" * 12000
         ).decode("ascii")
@@ -531,6 +544,7 @@ class TestReplaceBase64InRawMessages:
         trace_server.file_create = MagicMock(
             side_effect=lambda req: FileCreateRes(digest=f"digest_{req.name}")
         )
+        _mock_obj_create(trace_server)
         return trace_server
 
     @staticmethod
@@ -560,10 +574,9 @@ class TestReplaceBase64InRawMessages:
         assert isinstance(result, list)
         parts = result[0]["parts"]
         assert parts[0] == {"type": "text", "content": "describe this"}
-        # The data-URI field value (not the whole part) becomes the Content ref.
+        # The data-URI field value (not the whole part) becomes a Content ref.
         assert parts[1]["type"] == "image"
-        assert parts[1]["url"]["_type"] == "CustomWeaveType"
-        assert set(parts[1]["url"]["files"].keys()) == {"content", "metadata.json"}
+        _assert_content_ref(parts[1]["url"], "proj")
         assert trace_server.file_create.call_count == 2
 
     def test_structured_list_messages_converted(self):
@@ -573,7 +586,7 @@ class TestReplaceBase64InRawMessages:
 
         result = replace_base64_in_raw_messages(messages, "proj", trace_server)
 
-        assert result[0]["parts"][0]["url"]["_type"] == "CustomWeaveType"
+        _assert_content_ref(result[0]["parts"][0]["url"], "proj")
         assert trace_server.file_create.call_count == 2
 
     def test_no_base64_is_noop(self):

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -605,7 +605,7 @@ def test_calls_complete_routing_both_residence_state(
 def test_calls_complete_converts_data_uri_inputs_and_outputs(
     trace_server, clickhouse_trace_server
 ):
-    """Verify data URIs in inputs/outputs are converted to CustomWeaveType."""
+    """Verify data URIs in inputs/outputs are converted to a published weave ref."""
     project_id = f"{TEST_ENTITY}/calls_complete_base64"
     internal_project_id = b64(project_id)
     raw_bytes = b"a" * (AUTO_CONVERSION_MIN_SIZE + 10)
@@ -633,15 +633,24 @@ def test_calls_complete_converts_data_uri_inputs_and_outputs(
         internal_project_id,
         call_id,
     )
-    assert inputs_dump["image"]["_type"] == "CustomWeaveType"
-    assert output_dump["image"]["_type"] == "CustomWeaveType"
+    # Stored value is a compact internal object ref, not an inline object.
+    assert isinstance(inputs_dump["image"], str)
+    assert inputs_dump["image"].startswith(
+        f"weave-trace-internal:///{internal_project_id}/object/"
+    )
+    assert isinstance(output_dump["image"], str)
+    assert output_dump["image"].startswith(
+        f"weave-trace-internal:///{internal_project_id}/object/"
+    )
 
-    # Verify read-side also returns the converted type
+    # Read-side converts the internal ref to the external form.
     calls = _fetch_calls_stream(trace_server, project_id)
     assert len(calls) == 1
     fetched_call = calls[0]
-    assert fetched_call.inputs["image"]["_type"] == "CustomWeaveType"
-    assert fetched_call.output["image"]["_type"] == "CustomWeaveType"
+    assert isinstance(fetched_call.inputs["image"], str)
+    assert fetched_call.inputs["image"].startswith(f"weave:///{project_id}/object/")
+    assert isinstance(fetched_call.output["image"], str)
+    assert fetched_call.output["image"].startswith(f"weave:///{project_id}/object/")
 
 
 def test_call_start_end_v2_updates_calls_complete(

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -4,10 +4,15 @@ Runs against the ClickHouse backend (the only supported backend).
 Migration 030 creates the genai tables automatically.
 """
 
+import base64
 import datetime
+import json
 import uuid
 
 import pytest
+from opentelemetry.proto.common.v1.common_pb2 import InstrumentationScope, KeyValue
+from opentelemetry.proto.resource.v1.resource_pb2 import Resource
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans, Span
 
 from tests.trace_server.helpers import make_project_id as _make_project_id
 from weave.shared import refs_internal as ri
@@ -35,12 +40,16 @@ from weave.trace_server.agents.types import (
     AgentSpanStatsReq,
     AgentSpanValueRef,
     AgentsQueryReq,
+    AgentTraceChatReq,
+    GenAIOTelExportReq,
 )
+from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
 from weave.trace_server.interface.feedback_types import (
     AGENT_MONITOR_FEEDBACK_TYPE,
     AGENT_USER_FEEDBACK_TYPE,
 )
 from weave.trace_server.interface.query import Query
+from weave.trace_server.opentelemetry.python_spans import StatusCode
 
 
 def _make_span(project_id: str, **overrides: object) -> AgentSpanCHInsertable:
@@ -2707,3 +2716,202 @@ def test_query_dsl_typed_custom_attr_comparison(ch_server):
     )
     assert res.total_count == 1
     assert len(res.spans) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: end-to-end base64 -> Content-ref conversion on the GenAI OTel agents
+# ingest path (mirrors test_calls_complete's data-URI conversion test, but for
+# the agents endpoint).
+# ---------------------------------------------------------------------------
+
+
+def _ref_safe_project_id(prefix: str) -> str:
+    """A unique internal project id whose base64 form carries no '/'.
+
+    Inline-blob conversion embeds ``project_id`` in a
+    ``weave-trace-internal:///<project_id>/object/...`` ref, and
+    ``InternalObjectRef`` rejects a project_id containing '/'. Standard base64
+    (what ``make_project_id`` and the id converter emit) can produce '/', so
+    regenerate until it can't.
+    """
+    while True:
+        pid = _make_project_id(prefix)
+        if "/" not in pid:
+            return pid
+
+
+def _build_genai_chat_processed_span(
+    trace_id: bytes,
+    span_id: bytes,
+    input_messages_json: str,
+) -> tsi.ProcessedResourceSpans:
+    """Build a real OTel proto ``chat`` span carrying JSON-encoded input messages.
+
+    The messages arrive under ``gen_ai.input.messages`` as a JSON *string* — the
+    shape that exercises the ``_strip_message_attr`` -> ``replace_base64_in_raw_messages``
+    message-payload pass on ingest.
+    """
+    span = Span()
+    span.name = "chat gemini-2.0-flash"
+    span.trace_id = trace_id
+    span.span_id = span_id
+    now_ns = int(datetime.datetime.now().timestamp() * 1_000_000_000)
+    span.start_time_unix_nano = now_ns
+    span.end_time_unix_nano = now_ns + 1_000_000_000
+    span.kind = 1  # CLIENT
+
+    op_kv = KeyValue()
+    op_kv.key = "gen_ai.operation.name"
+    op_kv.value.string_value = "chat"
+    span.attributes.append(op_kv)
+
+    model_kv = KeyValue()
+    model_kv.key = "gen_ai.request.model"
+    model_kv.value.string_value = "gemini-2.0-flash"
+    span.attributes.append(model_kv)
+
+    msgs_kv = KeyValue()
+    msgs_kv.key = "gen_ai.input.messages"
+    msgs_kv.value.string_value = input_messages_json
+    span.attributes.append(msgs_kv)
+
+    span.status.code = StatusCode.OK.value  # type: ignore[assignment]
+
+    scope = InstrumentationScope()
+    scope.name = "test_instrumentation"
+    scope.version = "1.0.0"
+    scope_spans = ScopeSpans()
+    scope_spans.scope.CopyFrom(scope)
+    scope_spans.spans.append(span)
+
+    resource_spans = ResourceSpans()
+    resource_spans.resource.CopyFrom(Resource())
+    resource_spans.scope_spans.append(scope_spans)
+
+    return tsi.ProcessedResourceSpans(
+        entity="test-entity",
+        project="test-project",
+        run_id=None,
+        resource_spans=resource_spans,
+    )
+
+
+# flaky: CI ClickHouse occasionally doesn't surface the just-inserted spans to
+# the immediate read.
+@pytest.mark.flaky(reruns=3)
+def test_genai_otel_export_strips_base64_to_content_ref(ch_server, trace_server):
+    """End-to-end: a data-URI in a Gemini-style ``chat`` span's input messages is
+    converted to a published Content ref during ``genai_otel_export`` ingest.
+
+    Drives the real GenAI OTel agents endpoint against ClickHouse, then reads
+    the span back and asserts the base64 is stored as a compact internal object
+    ref (never inline), the converted media surfaces in the agent chat view
+    (internal ref on the raw internal server; external ``weave://`` ref through
+    the external adapter's read path), and the created Content object is
+    attributed to the caller's ``wb_user_id``.
+    """
+    internal_project_id = _ref_safe_project_id("genai_otel_base64")
+    external_project_id = base64.b64decode(internal_project_id).decode("ascii")
+    # The internal server publishes the converted Content object via obj_create,
+    # which requires wb_user_id to be a canonical (internal-form) base64 id.
+    wb_user_id = base64.b64encode(
+        f"user-{uuid.uuid4().hex[:12]}".encode()
+    ).decode("ascii")
+
+    raw_bytes = b"a" * (AUTO_CONVERSION_MIN_SIZE + 10)
+    b64_data = base64.b64encode(raw_bytes).decode("ascii")
+    data_uri = f"data:image/png;base64,{b64_data}"
+
+    trace_id = uuid.uuid4().bytes
+    span_id = uuid.uuid4().bytes[:8]
+    input_messages_json = json.dumps(
+        [
+            {
+                "role": "user",
+                "parts": [
+                    {"type": "text", "content": "describe"},
+                    {"type": "image", "url": data_uri},
+                ],
+            }
+        ]
+    )
+    processed = _build_genai_chat_processed_span(
+        trace_id, span_id, input_messages_json
+    )
+
+    res = ch_server.genai_otel_export(
+        GenAIOTelExportReq(
+            processed_spans=[processed],
+            project_id=internal_project_id,
+            wb_user_id=wb_user_id,
+        )
+    )
+    assert res.accepted_spans == 1
+    assert res.rejected_spans == 0
+    assert res.error_message == ""
+
+    # --- Stored form: internal ref, base64 gone (raw internal server) ---
+    stored = ch_server.agent_spans_query(
+        AgentSpansQueryReq(project_id=internal_project_id, include_details=True)
+    )
+    assert len(stored.spans) == 1
+    stored_span = stored.spans[0]
+    assert stored_span.operation_name == "chat"
+    assert len(stored_span.input_messages) == 1
+
+    stored_content = stored_span.input_messages[0].content
+    # The big base64 blob is nowhere in the stored message payload.
+    assert b64_data not in stored_content
+
+    parts = json.loads(stored_content)
+    # Text part survives verbatim; the image url is now a compact internal ref.
+    assert parts[0] == {"type": "text", "content": "describe"}
+    image_ref = parts[1]["url"]
+    assert parts[1] == {"type": "image", "url": image_ref}
+
+    parsed_ref = ri.parse_internal_uri(image_ref)
+    assert isinstance(parsed_ref, ri.InternalObjectRef)
+    assert parsed_ref.project_id == internal_project_id
+    assert (
+        image_ref
+        == f"weave-trace-internal:///{internal_project_id}/object/"
+        f"{parsed_ref.name}:{parsed_ref.version}"
+    )
+
+    trace_id_hex = stored_span.trace_id
+
+    # --- Chat view (raw internal server): media surfaces as the internal ref ---
+    internal_chat = ch_server.agent_traces_chat(
+        AgentTraceChatReq(project_id=internal_project_id, trace_id=trace_id_hex)
+    )
+    internal_user_messages = [
+        m for m in internal_chat.messages if m.type == "user_message"
+    ]
+    assert len(internal_user_messages) == 1
+    assert internal_user_messages[0].user_message.content_refs == [image_ref]
+
+    # --- Chat view (external adapter read path): int ref -> external weave:// ---
+    external_chat = trace_server.agent_traces_chat(
+        AgentTraceChatReq(project_id=external_project_id, trace_id=trace_id_hex)
+    )
+    external_user_messages = [
+        m for m in external_chat.messages if m.type == "user_message"
+    ]
+    assert len(external_user_messages) == 1
+    expected_external_ref = (
+        f"weave:///{external_project_id}/object/"
+        f"{parsed_ref.name}:{parsed_ref.version}"
+    )
+    assert external_user_messages[0].user_message.content_refs == [
+        expected_external_ref
+    ]
+
+    # --- The converted Content object is attributed to the caller ---
+    obj = ch_server.obj_read(
+        tsi.ObjReadReq(
+            project_id=internal_project_id,
+            object_id=parsed_ref.name,
+            digest=parsed_ref.version,
+        )
+    )
+    assert obj.obj.wb_user_id == wb_user_id

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -2826,9 +2826,9 @@ def test_genai_otel_export_ref_boundary_internal_in_db_external_out(
     Content object is attributed to the caller's ``wb_user_id``.
     """
     external_project_id = _ref_safe_external_project_id("genai_otel_boundary")
-    internal_project_id = base64.b64encode(
-        external_project_id.encode("ascii")
-    ).decode("ascii")
+    internal_project_id = base64.b64encode(external_project_id.encode("ascii")).decode(
+        "ascii"
+    )
     # The client sends an external user id; the adapter converts it to the
     # internal (base64) form the internal server persists on the Content object.
     external_user_id = "user-42"
@@ -2860,9 +2860,7 @@ def test_genai_otel_export_ref_boundary_internal_in_db_external_out(
             }
         ]
     )
-    processed = _build_genai_chat_processed_span(
-        trace_id, span_id, input_messages_json
-    )
+    processed = _build_genai_chat_processed_span(trace_id, span_id, input_messages_json)
 
     # Submit through the EXTERNAL adapter, exactly as a real client would: no
     # internal ids or internal refs cross this boundary.
@@ -2902,8 +2900,7 @@ def test_genai_otel_export_ref_boundary_internal_in_db_external_out(
     assert isinstance(parsed_image_ref, ri.InternalObjectRef)
     assert parsed_image_ref.project_id == internal_project_id
     assert (
-        internal_image_ref
-        == f"weave-trace-internal:///{internal_project_id}/object/"
+        internal_image_ref == f"weave-trace-internal:///{internal_project_id}/object/"
         f"{parsed_image_ref.name}:{parsed_image_ref.version}"
     )
 

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -2725,19 +2725,20 @@ def test_query_dsl_typed_custom_attr_comparison(ch_server):
 # ---------------------------------------------------------------------------
 
 
-def _ref_safe_project_id(prefix: str) -> str:
-    """A unique internal project id whose base64 form carries no '/'.
+def _ref_safe_external_project_id(prefix: str) -> str:
+    """A unique EXTERNAL ``entity/project`` id whose internal form carries no '/'.
 
-    Inline-blob conversion embeds ``project_id`` in a
-    ``weave-trace-internal:///<project_id>/object/...`` ref, and
-    ``InternalObjectRef`` rejects a project_id containing '/'. Standard base64
-    (what ``make_project_id`` and the id converter emit) can produce '/', so
-    regenerate until it can't.
+    A real client submits an external ``entity/project`` id; the adapter maps it
+    to the internal id via ``base64(entity/project)`` and embeds that internal id
+    in ``weave-trace-internal:///<internal>/object/...`` refs. ``InternalObjectRef``
+    rejects a project_id containing '/', and standard base64 can emit '/', so
+    regenerate the external id until its base64 form is clean.
     """
     while True:
-        pid = _make_project_id(prefix)
-        if "/" not in pid:
-            return pid
+        external = f"test/{prefix}_{uuid.uuid4().hex[:8]}"
+        internal = base64.b64encode(external.encode("ascii")).decode("ascii")
+        if "/" not in internal:
+            return external
 
 
 def _build_genai_chat_processed_span(
@@ -2799,28 +2800,51 @@ def _build_genai_chat_processed_span(
 # flaky: CI ClickHouse occasionally doesn't surface the just-inserted spans to
 # the immediate read.
 @pytest.mark.flaky(reruns=3)
-def test_genai_otel_export_strips_base64_to_content_ref(ch_server, trace_server):
-    """End-to-end: a data-URI in a Gemini-style ``chat`` span's input messages is
-    converted to a published Content ref during ``genai_otel_export`` ingest.
+def test_genai_otel_export_ref_boundary_internal_in_db_external_out(
+    ch_server, trace_server
+):
+    """End-to-end ref-boundary check for the GenAI OTel agents ingest/read path.
 
-    Drives the real GenAI OTel agents endpoint against ClickHouse, then reads
-    the span back and asserts the base64 is stored as a compact internal object
-    ref (never inline), the converted media surfaces in the agent chat view
-    (internal ref on the raw internal server; external ``weave://`` ref through
-    the external adapter's read path), and the created Content object is
-    attributed to the caller's ``wb_user_id``.
+    A real client submits ONE Gemini-style ``chat`` span through the EXTERNAL
+    adapter (external ``entity/project`` id, external user id, external refs).
+    Its ``gen_ai.input.messages`` JSON carries three parts: a text part, an image
+    part with an inline base64 data-URI (the server converts it to a stored
+    Content ref), and a ``resource`` part embedding an EXTERNAL weave ref (an
+    MCP-fetched dataset). The invariant is then asserted in BOTH directions:
+
+      * DB truth (raw internal server): the stored message content holds ONLY
+        internal refs — the base64 became an internal Content ref, and the
+        external dataset ref was converted to internal on ingest; no external
+        scheme and no base64 blob survive.
+      * External read (through the adapter): the same content holds ONLY
+        external refs — ``weave-trace-internal://`` never leaks (the leak the
+        boundary converter closes), and the dataset ref round-trips
+        ext -> int -> ext unchanged.
+
+    Also checks the chat view surfaces the media consistently (internal refs on
+    the raw server, external refs through the adapter) and that the converted
+    Content object is attributed to the caller's ``wb_user_id``.
     """
-    internal_project_id = _ref_safe_project_id("genai_otel_base64")
-    external_project_id = base64.b64decode(internal_project_id).decode("ascii")
-    # The internal server publishes the converted Content object via obj_create,
-    # which requires wb_user_id to be a canonical (internal-form) base64 id.
-    wb_user_id = base64.b64encode(
-        f"user-{uuid.uuid4().hex[:12]}".encode()
+    external_project_id = _ref_safe_external_project_id("genai_otel_boundary")
+    internal_project_id = base64.b64encode(
+        external_project_id.encode("ascii")
     ).decode("ascii")
+    # The client sends an external user id; the adapter converts it to the
+    # internal (base64) form the internal server persists on the Content object.
+    external_user_id = "user-42"
+    internal_user_id = base64.b64encode(external_user_id.encode("ascii")).decode(
+        "ascii"
+    )
 
     raw_bytes = b"a" * (AUTO_CONVERSION_MIN_SIZE + 10)
     b64_data = base64.b64encode(raw_bytes).decode("ascii")
     data_uri = f"data:image/png;base64,{b64_data}"
+    # An MCP-fetched dataset ref, in the same external project as the span so it
+    # maps back cleanly on read.
+    external_dataset_ref = f"weave:///{external_project_id}/object/mcp_dataset:v1"
+    internal_dataset_ref = (
+        f"weave-trace-internal:///{internal_project_id}/object/mcp_dataset:v1"
+    )
 
     trace_id = uuid.uuid4().bytes
     span_id = uuid.uuid4().bytes[:8]
@@ -2831,6 +2855,7 @@ def test_genai_otel_export_strips_base64_to_content_ref(ch_server, trace_server)
                 "parts": [
                     {"type": "text", "content": "describe"},
                     {"type": "image", "url": data_uri},
+                    {"type": "resource", "ref": external_dataset_ref},
                 ],
             }
         ]
@@ -2839,18 +2864,20 @@ def test_genai_otel_export_strips_base64_to_content_ref(ch_server, trace_server)
         trace_id, span_id, input_messages_json
     )
 
-    res = ch_server.genai_otel_export(
+    # Submit through the EXTERNAL adapter, exactly as a real client would: no
+    # internal ids or internal refs cross this boundary.
+    res = trace_server.genai_otel_export(
         GenAIOTelExportReq(
             processed_spans=[processed],
-            project_id=internal_project_id,
-            wb_user_id=wb_user_id,
+            project_id=external_project_id,
+            wb_user_id=external_user_id,
         )
     )
     assert res.accepted_spans == 1
     assert res.rejected_spans == 0
     assert res.error_message == ""
 
-    # --- Stored form: internal ref, base64 gone (raw internal server) ---
+    # --- DB TRUTH (raw internal server): only internal refs, no base64 ---
     stored = ch_server.agent_spans_query(
         AgentSpansQueryReq(project_id=internal_project_id, include_details=True)
     )
@@ -2860,27 +2887,57 @@ def test_genai_otel_export_strips_base64_to_content_ref(ch_server, trace_server)
     assert len(stored_span.input_messages) == 1
 
     stored_content = stored_span.input_messages[0].content
-    # The big base64 blob is nowhere in the stored message payload.
-    assert b64_data not in stored_content
+    stored_parts = json.loads(stored_content)
 
-    parts = json.loads(stored_content)
-    # Text part survives verbatim; the image url is now a compact internal ref.
-    assert parts[0] == {"type": "text", "content": "describe"}
-    image_ref = parts[1]["url"]
-    assert parts[1] == {"type": "image", "url": image_ref}
+    # Text part verbatim; the base64 image url is now a compact internal Content
+    # ref; the external dataset ref was rewritten to internal on ingest.
+    internal_image_ref = stored_parts[1]["url"]
+    assert stored_parts == [
+        {"type": "text", "content": "describe"},
+        {"type": "image", "url": internal_image_ref},
+        {"type": "resource", "ref": internal_dataset_ref},
+    ]
 
-    parsed_ref = ri.parse_internal_uri(image_ref)
-    assert isinstance(parsed_ref, ri.InternalObjectRef)
-    assert parsed_ref.project_id == internal_project_id
+    parsed_image_ref = ri.parse_internal_uri(internal_image_ref)
+    assert isinstance(parsed_image_ref, ri.InternalObjectRef)
+    assert parsed_image_ref.project_id == internal_project_id
     assert (
-        image_ref
+        internal_image_ref
         == f"weave-trace-internal:///{internal_project_id}/object/"
-        f"{parsed_ref.name}:{parsed_ref.version}"
+        f"{parsed_image_ref.name}:{parsed_image_ref.version}"
     )
+
+    # No base64 blob and no external scheme survive anywhere in the stored content.
+    assert b64_data not in stored_content
+    assert "weave:///" not in stored_content
+
+    # --- EXTERNAL READ (through the adapter): only external refs, no leak ---
+    external = trace_server.agent_spans_query(
+        AgentSpansQueryReq(project_id=external_project_id, include_details=True)
+    )
+    assert len(external.spans) == 1
+    external_span = external.spans[0]
+    assert external_span.project_id == external_project_id
+    external_content = external_span.input_messages[0].content
+    external_parts = json.loads(external_content)
+
+    expected_external_image_ref = (
+        f"weave:///{external_project_id}/object/"
+        f"{parsed_image_ref.name}:{parsed_image_ref.version}"
+    )
+    assert external_parts == [
+        {"type": "text", "content": "describe"},
+        {"type": "image", "url": expected_external_image_ref},
+        {"type": "resource", "ref": external_dataset_ref},
+    ]
+    # KEY leak assertion: the internal scheme must never reach the client.
+    assert "weave-trace-internal:///" not in external_content
+    # The embedded dataset ref round-trips ext -> int -> ext unchanged.
+    assert external_parts[2]["ref"] == external_dataset_ref
 
     trace_id_hex = stored_span.trace_id
 
-    # --- Chat view (raw internal server): media surfaces as the internal ref ---
+    # --- Chat view (raw internal server): media surfaces as internal refs ---
     internal_chat = ch_server.agent_traces_chat(
         AgentTraceChatReq(project_id=internal_project_id, trace_id=trace_id_hex)
     )
@@ -2888,9 +2945,12 @@ def test_genai_otel_export_strips_base64_to_content_ref(ch_server, trace_server)
         m for m in internal_chat.messages if m.type == "user_message"
     ]
     assert len(internal_user_messages) == 1
-    assert internal_user_messages[0].user_message.content_refs == [image_ref]
+    assert internal_user_messages[0].user_message.content_refs == [
+        internal_image_ref,
+        internal_dataset_ref,
+    ]
 
-    # --- Chat view (external adapter read path): int ref -> external weave:// ---
+    # --- Chat view (external adapter read path): int refs -> external weave:// ---
     external_chat = trace_server.agent_traces_chat(
         AgentTraceChatReq(project_id=external_project_id, trace_id=trace_id_hex)
     )
@@ -2898,20 +2958,17 @@ def test_genai_otel_export_strips_base64_to_content_ref(ch_server, trace_server)
         m for m in external_chat.messages if m.type == "user_message"
     ]
     assert len(external_user_messages) == 1
-    expected_external_ref = (
-        f"weave:///{external_project_id}/object/"
-        f"{parsed_ref.name}:{parsed_ref.version}"
-    )
     assert external_user_messages[0].user_message.content_refs == [
-        expected_external_ref
+        expected_external_image_ref,
+        external_dataset_ref,
     ]
 
     # --- The converted Content object is attributed to the caller ---
     obj = ch_server.obj_read(
         tsi.ObjReadReq(
             project_id=internal_project_id,
-            object_id=parsed_ref.name,
-            digest=parsed_ref.version,
+            object_id=parsed_image_ref.name,
+            digest=parsed_image_ref.version,
         )
     )
-    assert obj.obj.wb_user_id == wb_user_id
+    assert obj.obj.wb_user_id == internal_user_id

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -1043,6 +1043,58 @@ def test_inline_internal_ref_surfaces_without_span_content_refs() -> None:
     assert _assistant_payload(assistant).content_refs == []
 
 
+@pytest.mark.xfail(
+    reason=(
+        "Known limitation (PR #7489 discussion): the inline-ref sweep "
+        "(_iter_internal_refs) surfaces ANY internal weave ref, not only "
+        "Content/media refs. A message that legitimately carries a ref to a "
+        "non-media object (prompt/model/dataset) in a structured field leaks "
+        "into content_refs and renders as broken media. A media ref is "
+        "indistinguishable from a prompt ref at the string level and the part "
+        "shapes are not normalized, so scoping the sweep is deferred to a "
+        "follow-up (e.g. record converted media refs authoritatively at "
+        "ingest, or scope the sweep to media part positions)."
+    ),
+    strict=False,
+)
+def test_inline_sweep_excludes_non_media_internal_refs() -> None:
+    """The inline-ref sweep must surface only Content/media refs. A message that
+    legitimately carries a ref to a non-media object (a prompt, model, dataset)
+    in a structured field must NOT land in ``content_refs``, or the UI renders
+    it as broken media. Content objects are stored under a sanitized-filename
+    object_id, so a media ref is indistinguishable at the string level from a
+    prompt ref — the walker needs to scope the match.
+    """
+    image_ref = "weave-trace-internal:///PID/object/gift_basket_png:IMGDIGEST"
+    prompt_ref = "weave-trace-internal:///PID/object/describe_image_prompt:PROMPTDIGEST"
+    spans = [
+        _span(
+            span_id="chat",
+            operation_name="chat",
+            input_messages=[
+                {
+                    "role": "user",
+                    "content": _parts(
+                        _text_part("What is in this image?"),
+                        {"type": "image_url", "image_url": {"url": image_ref}},
+                        # Agent quoting the prompt object it ran under — not media.
+                        {"type": "tool_use", "input": {"prompt_ref": prompt_ref}},
+                    ),
+                }
+            ],
+            output_messages=[
+                {"role": "assistant", "content": _parts(_text_part("A gift basket."))}
+            ],
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+    user = next(m for m in messages if m.type == "user_message")
+
+    # Only the media ref should render; the prompt ref is a false positive today.
+    assert _user_payload(user).content_refs == [image_ref]
+
+
 def test_output_media_attaches_to_assistant_message() -> None:
     """Model-generated media is a part on the output message and renders on
     the assistant bubble (mirror image of the input case).

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -993,6 +993,53 @@ def test_input_media_attaches_to_user_message_not_assistant() -> None:
     assert _assistant_payload(assistant).content_refs == []
 
 
+def test_inline_internal_ref_surfaces_without_span_content_refs() -> None:
+    """Server-side content conversion embeds an internal weave ref directly in
+    the message part (e.g. an OpenAI ``image_url``) with no span-level
+    ``content_refs``. The recursive inline-ref sweep surfaces it so the image
+    still renders on the user bubble.
+    """
+    image_internal = "weave-trace-internal:///PID/object/image-abcd.png:IMGDIGEST"
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="image-describer",
+            input_messages=[
+                {
+                    "role": "user",
+                    "content": _parts(_text_part("What is in this image?")),
+                }
+            ],
+        ),
+        _span(
+            span_id="chat",
+            parent_span_id="agent",
+            operation_name="chat",
+            input_messages=[
+                {
+                    "role": "user",
+                    "content": _parts(
+                        _text_part("What is in this image?"),
+                        {"type": "image_url", "image_url": {"url": image_internal}},
+                    ),
+                }
+            ],
+            output_messages=[
+                {"role": "assistant", "content": _parts(_text_part("A gift basket."))}
+            ],
+            # No span-level content_refs — the ref lives only inline in the part.
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+    user = next(m for m in messages if m.type == "user_message")
+    assistant = next(m for m in messages if m.type == "assistant_message")
+
+    assert _user_payload(user).content_refs == [image_internal]
+    assert _assistant_payload(assistant).content_refs == []
+
+
 def test_output_media_attaches_to_assistant_message() -> None:
     """Model-generated media is a part on the output message and renders on
     the assistant bubble (mirror image of the input case).

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -6,10 +6,13 @@ end-to-end against ClickHouse; these tests pin the pure projection rules.
 
 import datetime
 import json
+import sys
 
 import pytest
 
 from weave.trace_server.agents.chat_view import (
+    _MAX_REF_SEARCH_DEPTH,
+    _iter_internal_refs,
     build_chat_messages,
     build_span_tree,
     build_trace_chat,
@@ -1388,3 +1391,54 @@ def test_build_span_tree_sorts_equal_starts_by_latest_end_first() -> None:
     ]
     roots = build_span_tree(spans)
     assert [r.span.span_id for r in roots] == ["z-long", "a-short", "b-short"]
+
+
+def _nest_in_lists(value: object, levels: int) -> object:
+    """Wrap ``value`` in ``levels`` nested single-element lists.
+
+    Each list level costs one ``_iter_internal_refs`` recursive descent, so the
+    ref sits exactly ``levels`` deep — a deterministic knob for the depth cap.
+    """
+    nested = value
+    for _ in range(levels):
+        nested = [nested]
+    return nested
+
+
+def test_iter_internal_refs_finds_refs_at_normal_depth() -> None:
+    """A realistically nested inline part (message dict -> content JSON ->
+    parts list -> image_url dict -> url string) is well within the cap, so the
+    internal ref is still surfaced exactly as before.
+    """
+    image_internal = "weave-trace-internal:///PID/object/image-abcd.png:IMGDIGEST"
+    message = {
+        "role": "user",
+        "content": _parts(
+            _text_part("What is in this image?"),
+            {"type": "image_url", "image_url": {"url": image_internal}},
+        ),
+        "finish_reason": "",
+    }
+    assert list(_iter_internal_refs(message)) == [image_internal]
+
+
+def test_iter_internal_refs_caps_recursion_on_deeply_nested_payload() -> None:
+    """A pathologically deep payload terminates without ``RecursionError``.
+
+    The recursion limit is dwarfed by the nesting depth, so an uncapped walk
+    would blow the interpreter stack. With the cap in place the walk returns
+    cleanly; refs at the cap boundary are surfaced and deeper refs are dropped.
+    """
+    ref = "weave-trace-internal:///PID/object/deep:DIGEST"
+
+    # A ref sitting exactly at the cap is still found; one level deeper is not.
+    assert list(_iter_internal_refs(_nest_in_lists(ref, _MAX_REF_SEARCH_DEPTH))) == [
+        ref
+    ]
+    assert (
+        list(_iter_internal_refs(_nest_in_lists(ref, _MAX_REF_SEARCH_DEPTH + 1))) == []
+    )
+
+    # Far beyond sys.getrecursionlimit(): must not raise, must yield nothing.
+    pathological = _nest_in_lists(ref, sys.getrecursionlimit() * 2)
+    assert list(_iter_internal_refs(pathological)) == []

--- a/tests/trace_server/test_genai_extraction.py
+++ b/tests/trace_server/test_genai_extraction.py
@@ -7,9 +7,11 @@ success-path test that exercises every extractor plus one error-status
 test since that's a separate code path (Status object vs attributes).
 """
 
+import base64
 import datetime
 import json
 from typing import Any
+from unittest.mock import MagicMock
 
 from weave.trace_server.agents import semconv
 from weave.trace_server.opentelemetry.genai_extraction import extract_genai_span
@@ -20,6 +22,7 @@ from weave.trace_server.opentelemetry.python_spans import (
     Status,
     StatusCode,
 )
+from weave.trace_server.trace_server_interface import FileCreateRes
 
 
 def _make_span(
@@ -415,3 +418,60 @@ def test_extract_custom_attrs_skips_non_finite_floats() -> None:
         assert key not in result.custom_attrs_float
         assert key not in result.custom_attrs_string
         assert key not in result.custom_attrs_int
+
+
+def _mock_trace_server() -> MagicMock:
+    trace_server = MagicMock()
+    trace_server.file_create = MagicMock(
+        side_effect=lambda req: FileCreateRes(digest=f"digest_{req.name}")
+    )
+    return trace_server
+
+
+def test_extract_genai_span_strips_base64_when_trace_server_given() -> None:
+    """With a trace_server, inline base64 in messages is stripped to Content refs.
+
+    Mirrors the non-OTel calls path. The image field value becomes a
+    CustomWeaveType ref inside the JSON-serialized NormalizedMessage content.
+    """
+    b64 = base64.b64encode(b"a" * 12000).decode("ascii")
+    data_uri = f"data:image/png;base64,{b64}"
+    attrs = {
+        "gen_ai.input.messages": json.dumps(
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"type": "text", "content": "describe this"},
+                        {"type": "image", "url": data_uri},
+                    ],
+                }
+            ]
+        )
+    }
+    trace_server = _mock_trace_server()
+
+    result = extract_genai_span(
+        _make_span(attrs=attrs), project_id="p1", trace_server=trace_server
+    )
+
+    content = json.loads(result.input_messages[0].content)
+    assert content[0] == {"type": "text", "content": "describe this"}
+    assert content[1]["url"]["_type"] == "CustomWeaveType"
+    assert b64 not in result.input_messages[0].content
+    assert trace_server.file_create.call_count == 2
+
+
+def test_extract_genai_span_leaves_base64_when_no_trace_server() -> None:
+    """Without a trace_server (the default), base64 is left inline untouched."""
+    b64 = base64.b64encode(b"a" * 12000).decode("ascii")
+    data_uri = f"data:image/png;base64,{b64}"
+    attrs = {
+        "gen_ai.input.messages": json.dumps(
+            [{"role": "user", "parts": [{"type": "image", "url": data_uri}]}]
+        )
+    }
+
+    result = extract_genai_span(_make_span(attrs=attrs), project_id="p1")
+
+    assert data_uri in result.input_messages[0].content

--- a/tests/trace_server/test_genai_extraction.py
+++ b/tests/trace_server/test_genai_extraction.py
@@ -14,6 +14,9 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from weave.trace_server.agents import semconv
+from weave.trace_server.base64_content_conversion import (
+    replace_base64_with_content_objects,
+)
 from weave.trace_server.opentelemetry.genai_extraction import extract_genai_span
 from weave.trace_server.opentelemetry.python_spans import (
     Resource,
@@ -22,7 +25,7 @@ from weave.trace_server.opentelemetry.python_spans import (
     Status,
     StatusCode,
 )
-from weave.trace_server.trace_server_interface import FileCreateRes
+from weave.trace_server.trace_server_interface import FileCreateRes, ObjCreateRes
 
 
 def _make_span(
@@ -425,14 +428,17 @@ def _mock_trace_server() -> MagicMock:
     trace_server.file_create = MagicMock(
         side_effect=lambda req: FileCreateRes(digest=f"digest_{req.name}")
     )
+    # Auto-conversion publishes each converted blob as a weave object and embeds
+    # its ref, so obj_create must be stubbed with a deterministic digest.
+    trace_server.obj_create = MagicMock(return_value=ObjCreateRes(digest="obj_digest"))
     return trace_server
 
 
 def test_extract_genai_span_strips_base64_when_trace_server_given() -> None:
-    """With a trace_server, inline base64 in messages is stripped to Content refs.
+    """With a trace_server, inline base64 in messages is stripped to a ref.
 
-    Mirrors the non-OTel calls path. The image field value becomes a
-    CustomWeaveType ref inside the JSON-serialized NormalizedMessage content.
+    Mirrors the non-OTel calls path. The image field value becomes a compact
+    weave object ref inside the JSON-serialized NormalizedMessage content.
     """
     b64 = base64.b64encode(b"a" * 12000).decode("ascii")
     data_uri = f"data:image/png;base64,{b64}"
@@ -457,7 +463,8 @@ def test_extract_genai_span_strips_base64_when_trace_server_given() -> None:
 
     content = json.loads(result.input_messages[0].content)
     assert content[0] == {"type": "text", "content": "describe this"}
-    assert content[1]["url"]["_type"] == "CustomWeaveType"
+    assert content[1]["url"].startswith("weave-trace-internal:///p1/object/")
+    assert content[1]["url"].endswith(":obj_digest")
     assert b64 not in result.input_messages[0].content
     assert trace_server.file_create.call_count == 2
 
@@ -475,3 +482,95 @@ def test_extract_genai_span_leaves_base64_when_no_trace_server() -> None:
     result = extract_genai_span(_make_span(attrs=attrs), project_id="p1")
 
     assert data_uri in result.input_messages[0].content
+
+
+def test_extract_genai_span_preserves_multimodal_content_parts() -> None:
+    """OpenAI-style list ``content`` (text + image) is preserved as a JSON parts
+    array; non-text parts must not be dropped during normalization.
+    """
+    attrs = {
+        "gen_ai.input.messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is in this image?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/x.png"},
+                    },
+                ],
+            }
+        ]
+    }
+
+    result = extract_genai_span(_make_span(attrs=attrs), project_id="p1")
+
+    parts = json.loads(result.input_messages[0].content)
+    assert parts == [
+        {"type": "text", "text": "What is in this image?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+    ]
+
+
+def test_extract_genai_span_normalizes_indexed_prompt_dict() -> None:
+    """Legacy ``gen_ai.prompt.{i}`` / ``gen_ai.completion.{i}`` unflatten to a
+    numeric-keyed dict; it must be converted to a message list (as the
+    non-agents path does) so input/output messages are populated.
+    """
+    attrs = {
+        "gen_ai": {
+            "prompt": {
+                "0": {"role": "user", "content": "hello"},
+                "1": {"role": "assistant", "content": "hi there"},
+            },
+            "completion": {"0": {"role": "assistant", "content": "done"}},
+        }
+    }
+
+    result = extract_genai_span(_make_span(attrs=attrs), project_id="p1")
+
+    assert [m.role for m in result.input_messages] == ["user", "assistant"]
+    assert result.input_messages[0].content == "hello"
+    assert result.input_messages[1].content == "hi there"
+    assert [m.role for m in result.output_messages] == ["assistant"]
+    assert result.output_messages[0].content == "done"
+
+
+def test_ingest_flow_strips_base64_from_span_attribute_dumps() -> None:
+    """Replicates AgentWriteHandler.insert_otel_spans: converting span.attributes
+    before extraction strips base64 from the lossless attributes_dump /
+    raw_span_dump columns (the OpenLLMetry ``gen_ai.prompt.{i}`` shape unflattens
+    to a numeric-keyed dict with a structured content array).
+    """
+    b64 = base64.b64encode(b"a" * 15000).decode("ascii")
+    attrs = {
+        "gen_ai": {
+            "prompt": {
+                "0": {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What is in this image?"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/png;base64,{b64}"},
+                        },
+                    ],
+                }
+            }
+        }
+    }
+    trace_server = _mock_trace_server()
+    span = _make_span(attrs=attrs)
+
+    # AgentWriteHandler converts span.attributes in place before extraction.
+    span.attributes = replace_base64_with_content_objects(
+        span.attributes, "p1", trace_server
+    )
+    result = extract_genai_span(span, project_id="p1", trace_server=trace_server)
+
+    assert b64 not in result.attributes_dump
+    assert b64 not in result.raw_span_dump
+    # Base64 is replaced by a compact weave object ref, not an inline object.
+    assert "weave-trace-internal:///p1/object/" in result.attributes_dump
+    assert "CustomWeaveType" not in result.attributes_dump
+    assert trace_server.file_create.call_count == 2

--- a/tests/trace_server/test_genai_extraction.py
+++ b/tests/trace_server/test_genai_extraction.py
@@ -572,3 +572,29 @@ def test_ingest_flow_strips_base64_from_span_attribute_dumps() -> None:
     assert "weave-trace-internal:///p1/object/" in result.attributes_dump
     assert "CustomWeaveType" not in result.attributes_dump
     assert trace_server.file_create.call_count == 2
+
+
+def test_strip_inline_blobs_attributes_obj_create_to_wb_user_id() -> None:
+    """The OTel agents path attributes converted Content objects to the caller.
+
+    ``strip_inline_blobs_from_span``'s ``wb_user_id`` must reach the
+    ``ObjSchemaForInsert`` used to publish each Content object via ``obj_create``.
+    Here the base64 is buried inside a JSON-encoded ``gen_ai.input.messages``
+    string, so the conversion happens on the message-payload pass
+    (``_strip_message_attr`` -> ``replace_base64_in_raw_messages``).
+    """
+    b64 = base64.b64encode(b"a" * 12000).decode("ascii")
+    data_uri = f"data:image/png;base64,{b64}"
+    attrs = {
+        "gen_ai.input.messages": json.dumps(
+            [{"role": "user", "parts": [{"type": "image", "url": data_uri}]}]
+        )
+    }
+    trace_server = _mock_trace_server()
+    span = _make_span(attrs=attrs)
+
+    strip_inline_blobs_from_span(span, "p1", trace_server, wb_user_id="u-9")
+
+    assert trace_server.obj_create.call_count == 1
+    obj_create_req = trace_server.obj_create.call_args.args[0]
+    assert obj_create_req.obj.wb_user_id == "u-9"

--- a/tests/trace_server/test_genai_extraction.py
+++ b/tests/trace_server/test_genai_extraction.py
@@ -14,10 +14,10 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from weave.trace_server.agents import semconv
-from weave.trace_server.base64_content_conversion import (
-    replace_base64_with_content_objects,
+from weave.trace_server.opentelemetry.genai_extraction import (
+    extract_genai_span,
+    strip_inline_blobs_from_span,
 )
-from weave.trace_server.opentelemetry.genai_extraction import extract_genai_span
 from weave.trace_server.opentelemetry.python_spans import (
     Resource,
     Span,
@@ -434,8 +434,8 @@ def _mock_trace_server() -> MagicMock:
     return trace_server
 
 
-def test_extract_genai_span_strips_base64_when_trace_server_given() -> None:
-    """With a trace_server, inline base64 in messages is stripped to a ref.
+def test_strip_inline_blobs_then_extract_strips_base64() -> None:
+    """After ``strip_inline_blobs_from_span``, inline base64 in messages is a ref.
 
     Mirrors the non-OTel calls path. The image field value becomes a compact
     weave object ref inside the JSON-serialized NormalizedMessage content.
@@ -456,10 +456,10 @@ def test_extract_genai_span_strips_base64_when_trace_server_given() -> None:
         )
     }
     trace_server = _mock_trace_server()
+    span = _make_span(attrs=attrs)
 
-    result = extract_genai_span(
-        _make_span(attrs=attrs), project_id="p1", trace_server=trace_server
-    )
+    strip_inline_blobs_from_span(span, "p1", trace_server)
+    result = extract_genai_span(span, project_id="p1")
 
     content = json.loads(result.input_messages[0].content)
     assert content[0] == {"type": "text", "content": "describe this"}
@@ -469,8 +469,8 @@ def test_extract_genai_span_strips_base64_when_trace_server_given() -> None:
     assert trace_server.file_create.call_count == 2
 
 
-def test_extract_genai_span_leaves_base64_when_no_trace_server() -> None:
-    """Without a trace_server (the default), base64 is left inline untouched."""
+def test_extract_genai_span_leaves_base64_without_strip_step() -> None:
+    """Without the strip step, ``extract_genai_span`` leaves base64 inline."""
     b64 = base64.b64encode(b"a" * 12000).decode("ascii")
     data_uri = f"data:image/png;base64,{b64}"
     attrs = {
@@ -562,11 +562,9 @@ def test_ingest_flow_strips_base64_from_span_attribute_dumps() -> None:
     trace_server = _mock_trace_server()
     span = _make_span(attrs=attrs)
 
-    # AgentWriteHandler converts span.attributes in place before extraction.
-    span.attributes = replace_base64_with_content_objects(
-        span.attributes, "p1", trace_server
-    )
-    result = extract_genai_span(span, project_id="p1", trace_server=trace_server)
+    # AgentWriteHandler strips inline blobs in place before extraction.
+    strip_inline_blobs_from_span(span, "p1", trace_server)
+    result = extract_genai_span(span, project_id="p1")
 
     assert b64 not in result.attributes_dump
     assert b64 not in result.raw_span_dump

--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -271,3 +271,260 @@ def test_universal_int_to_ext_ref_converter_tolerate_external_refs(caplog):
     }
     assert "Returning stored external ref unchanged" in caplog.text
     assert external_ref in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Embedded refs inside JSON-serialized string leaves
+#
+# Agent message payloads store content as a JSON string (e.g.
+# NormalizedMessage.content, tool_call_arguments, raw_span_dump). Refs buried
+# inside those strings must convert with the SAME semantics as top-level ref
+# leaves, or internal refs leak to external consumers on read and external refs
+# leak into the DB on write.
+# ---------------------------------------------------------------------------
+
+
+def test_universal_int_to_ext_converts_ref_embedded_in_json_string():
+    """A ref inside a JSON-string content field converts int->ext and the
+    surrounding non-ref JSON is preserved.
+    """
+    internal_project_id = "internal-project"
+    internal_ref = f"weave-trace-internal:///{internal_project_id}/object/img:abc"
+    external_ref = "weave:///entity/project/object/img:abc"
+
+    def int_to_ext(project_id: str) -> str | None:
+        return "entity/project" if project_id == internal_project_id else None
+
+    content = json.dumps(
+        [
+            {"type": "image", "url": internal_ref},
+            {"type": "text", "text": "hello world"},
+        ]
+    )
+    converted = universal_int_to_ext_ref_converter({"content": content}, int_to_ext)
+
+    assert json.loads(converted["content"]) == [
+        {"type": "image", "url": external_ref},
+        {"type": "text", "text": "hello world"},
+    ]
+
+
+def test_universal_ext_to_int_converts_ref_embedded_in_json_string():
+    """A ref inside a JSON-string content field converts ext->int and the
+    surrounding non-ref JSON is preserved.
+    """
+    project_id = "entity/project"
+    internal_project_id = "internal-project"
+    external_ref = f"weave:///{project_id}/object/img:abc"
+    internal_ref = f"weave-trace-internal:///{internal_project_id}/object/img:abc"
+
+    content = json.dumps(
+        [
+            {"type": "image", "url": external_ref},
+            {"type": "text", "text": "hello world"},
+        ]
+    )
+    converted = universal_ext_to_int_ref_converter(
+        {"content": content}, lambda project: internal_project_id
+    )
+
+    assert json.loads(converted["content"]) == [
+        {"type": "image", "url": internal_ref},
+        {"type": "text", "text": "hello world"},
+    ]
+
+
+def test_universal_int_to_ext_converts_all_refs_in_nested_json_containers():
+    """Every ref in a nested list/dict inside a JSON string converts."""
+    internal_project_id = "internal-project"
+    ref_a = f"weave-trace-internal:///{internal_project_id}/object/a:1"
+    ref_b = f"weave-trace-internal:///{internal_project_id}/object/b:2"
+    ext_a = "weave:///entity/project/object/a:1"
+    ext_b = "weave:///entity/project/object/b:2"
+
+    def int_to_ext(project_id: str) -> str | None:
+        return "entity/project" if project_id == internal_project_id else None
+
+    content = json.dumps(
+        {
+            "parts": [
+                {"type": "image", "url": ref_a},
+                {"nested": {"deep": ref_b}},
+                {"type": "text", "text": "plain"},
+            ]
+        }
+    )
+    converted = universal_int_to_ext_ref_converter({"content": content}, int_to_ext)
+
+    assert json.loads(converted["content"]) == {
+        "parts": [
+            {"type": "image", "url": ext_a},
+            {"nested": {"deep": ext_b}},
+            {"type": "text", "text": "plain"},
+        ]
+    }
+
+
+def test_universal_int_to_ext_converts_ref_nested_two_json_levels():
+    """A ref buried in a JSON string nested inside another JSON string converts
+    (JSON-in-JSON within the depth cap).
+    """
+    internal_project_id = "internal-project"
+    internal_ref = f"weave-trace-internal:///{internal_project_id}/object/x:d"
+    external_ref = "weave:///entity/project/object/x:d"
+
+    def int_to_ext(project_id: str) -> str | None:
+        return "entity/project" if project_id == internal_project_id else None
+
+    inner = json.dumps({"url": internal_ref})
+    outer = json.dumps({"raw": inner})
+
+    converted = universal_int_to_ext_ref_converter(
+        {"attributes_dump": outer}, int_to_ext
+    )
+
+    result = json.loads(converted["attributes_dump"])
+    assert json.loads(result["raw"]) == {"url": external_ref}
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        "see weave-trace-internal:///internal-project/object/x:d for the image",
+        "see weave:///entity/project/object/x:d for the image",
+    ],
+)
+def test_embedded_path_leaves_non_json_prose_unchanged(prose):
+    """A plain (non-JSON) string that merely contains a ref-like substring does
+    not parse as JSON, so it is passed through unchanged (identity preserved).
+    """
+
+    def int_to_ext(project_id: str) -> str | None:
+        return "entity/project"
+
+    payload = {"note": prose}
+    converted = universal_int_to_ext_ref_converter(payload, int_to_ext)
+
+    assert converted is payload
+    assert converted["note"] is prose
+
+
+def test_json_string_without_refs_is_not_reserialized():
+    """A JSON string with no ref never reaches json.loads (the substring guard
+    fails) and is returned byte-identical (identity preserved, no re-dump).
+    """
+
+    def int_to_ext(project_id: str) -> str | None:
+        return "entity/project"
+
+    blob = '[{"type": "text", "text": "hello"}]'
+    payload = {"content": blob}
+    converted = universal_int_to_ext_ref_converter(payload, int_to_ext)
+
+    assert converted is payload
+    assert converted["content"] is blob
+
+
+@pytest.mark.disable_logging_error_check
+def test_json_string_with_only_tolerated_external_ref_is_returned_unchanged(caplog):
+    """When an embedded ref does not change (already-external + tolerate), the
+    ORIGINAL string is returned with no re-serialization (spacing preserved).
+    """
+    external_ref = "weave:///entity/project/object/x:d"
+
+    def int_to_ext(project_id: str) -> str | None:
+        return "entity/project"
+
+    # Non-canonical spacing (indent) so a gratuitous re-dump would change bytes.
+    blob = json.dumps([{"type": "image", "url": external_ref}], indent=2)
+    payload = {"content": blob}
+
+    with caplog.at_level(logging.ERROR):
+        converted = universal_int_to_ext_ref_converter(
+            payload, int_to_ext, tolerate_external_refs=True
+        )
+
+    assert converted is payload
+    assert converted["content"] is blob
+    assert "Returning stored external ref unchanged" in caplog.text
+
+
+@pytest.mark.disable_logging_error_check
+def test_embedded_external_ref_respects_tolerate_flag_int_to_ext(caplog):
+    """An embedded external ref obeys the same tolerate/raise policy as a
+    top-level external ref on the int->ext path.
+    """
+    external_ref = "weave:///entity/project/object/x:d"
+
+    def int_to_ext(project_id: str) -> str | None:
+        return "entity/project"
+
+    content = json.dumps([{"type": "image", "url": external_ref}])
+    payload = {"content": content}
+
+    # Strict default: embedded external ref raises, same as top-level.
+    with pytest.raises(InvalidInternalRef):
+        universal_int_to_ext_ref_converter(payload, int_to_ext)
+
+    # Tolerant: passed through + logged, embedded JSON preserved unchanged.
+    with caplog.at_level(logging.ERROR):
+        converted = universal_int_to_ext_ref_converter(
+            payload, int_to_ext, tolerate_external_refs=True
+        )
+
+    assert json.loads(converted["content"]) == [
+        {"type": "image", "url": external_ref}
+    ]
+    assert "Returning stored external ref unchanged" in caplog.text
+
+
+def test_embedded_internal_ref_requires_verification_ext_to_int():
+    """An embedded internal ref on the ext->int path goes through the same
+    verify_internal_project_id gate as a top-level internal ref.
+    """
+    internal_project_id = "internal-project"
+    internal_ref = f"weave-trace-internal:///{internal_project_id}/object/x:d"
+    content = json.dumps([{"type": "image", "url": internal_ref}])
+    payload = {"content": content}
+
+    # No verify callback -> embedded internal ref rejected, same as top-level.
+    with pytest.raises(InvalidExternalRef):
+        universal_ext_to_int_ref_converter(
+            payload,
+            lambda project: "should-not-be-called",
+            verify_internal_project_id=None,
+        )
+
+    # verify accepts -> embedded internal ref passed through unchanged.
+    converted = universal_ext_to_int_ref_converter(
+        payload,
+        lambda project: "unused",
+        verify_internal_project_id=lambda pid: pid == internal_project_id,
+    )
+    assert json.loads(converted["content"]) == [
+        {"type": "image", "url": internal_ref}
+    ]
+
+
+def test_deeply_nested_json_in_json_terminates_without_recursion_error():
+    """Deeply nested JSON-in-JSON hits the depth cap and terminates without
+    raising RecursionError (a ref below the cap simply is not descended into).
+    """
+    internal_project_id = "internal-project"
+    ref = f"weave-trace-internal:///{internal_project_id}/object/x:d"
+
+    def int_to_ext(project_id: str) -> str | None:
+        return "entity/project" if project_id == internal_project_id else None
+
+    # Nest well beyond the depth cap. Each json.dumps of a string only escapes
+    # quotes/backslashes, so this stays small while nesting deeply.
+    nested = ref
+    for _ in range(12):
+        nested = json.dumps(nested)
+    payload = {"content": nested}
+
+    converted = universal_int_to_ext_ref_converter(payload, int_to_ext)
+
+    # Termination + no RecursionError is the contract; the buried ref is below
+    # the cap so the string comes back unchanged.
+    assert converted["content"] == nested

--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -472,9 +472,7 @@ def test_embedded_external_ref_respects_tolerate_flag_int_to_ext(caplog):
             payload, int_to_ext, tolerate_external_refs=True
         )
 
-    assert json.loads(converted["content"]) == [
-        {"type": "image", "url": external_ref}
-    ]
+    assert json.loads(converted["content"]) == [{"type": "image", "url": external_ref}]
     assert "Returning stored external ref unchanged" in caplog.text
 
 
@@ -501,9 +499,7 @@ def test_embedded_internal_ref_requires_verification_ext_to_int():
         lambda project: "unused",
         verify_internal_project_id=lambda pid: pid == internal_project_id,
     )
-    assert json.loads(converted["content"]) == [
-        {"type": "image", "url": internal_ref}
-    ]
+    assert json.loads(converted["content"]) == [{"type": "image", "url": internal_ref}]
 
 
 def test_deeply_nested_json_in_json_terminates_without_recursion_error():

--- a/tests/trace_server/test_trace_server_interface_util.py
+++ b/tests/trace_server/test_trace_server_interface_util.py
@@ -488,3 +488,91 @@ def test_genai_otel_export_caches_project_id_lookup_across_batch() -> None:
     # One call for `req.project_id` translation + exactly one more for the
     # rewrite cache (not 6 — one per ref).
     assert converter.ext_to_int_calls == ["ent/proj", "ent/proj"]
+
+
+# --- otel_export (non-agents OTel calls path) mirrors the same span-attribute
+# ref rewriting: its raw protobuf ResourceSpans is equally opaque to the
+# `_ref_apply` walker, so embedded/whole external refs must be converted to
+# internal before reaching the inner server. ---
+
+
+def _otel_export_req_with_string_attr(
+    attr_key: str,
+    attr_value: str,
+    *,
+    project_id: str = "ent/proj",
+) -> tsi.OTelExportReq:
+    """Build a plain (non-agents) `OTelExportReq` with a single string span attr,
+    reusing the GenAI helper's span-building.
+    """
+    genai = _make_otel_export_req_with_string_attr(
+        attr_key, attr_value, project_id=project_id
+    )
+    return tsi.OTelExportReq(
+        processed_spans=genai.processed_spans, project_id=project_id, wb_user_id=None
+    )
+
+
+def _capture_otel_export_req(req: tsi.OTelExportReq) -> tsi.OTelExportReq:
+    """Run an `OTelExportReq` through the adapter and return the req the inner
+    trace server actually received (mirror of `_capture_genai_otel_export_req`).
+    """
+    inner = MagicMock(spec=tsi.FullTraceServerInterface)
+    inner.otel_export.return_value = tsi.OTelExportRes(partial_success=None)
+    adapter = ExternalTraceServer(inner, _EncodingIdConverter())
+    adapter.otel_export(req)
+    assert inner.otel_export.call_count == 1
+    return inner.otel_export.call_args.args[0]
+
+
+def test_otel_export_rewrites_ref_embedded_in_message_json() -> None:
+    """An external ref buried inside a `gen_ai.input.messages` JSON string is
+    rewritten to internal on the non-agents OTel calls path before the request
+    reaches the inner server; the surrounding JSON structure is preserved.
+    """
+    internal_proj = _EncodingIdConverter().ext_to_int_project_id("ent/proj")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "ref": "weave:///ent/proj/object/ds:DIG"},
+                {"type": "text", "text": "no ref here"},
+            ],
+        }
+    ]
+    req = _otel_export_req_with_string_attr(
+        "gen_ai.input.messages", json.dumps(messages)
+    )
+
+    forwarded = _capture_otel_export_req(req)
+
+    forwarded_json = json.loads(_string_attr_value(forwarded, "gen_ai.input.messages"))
+    assert forwarded_json == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "ref": f"weave-trace-internal:///{internal_proj}/object/ds:DIG",
+                },
+                {"type": "text", "text": "no ref here"},
+            ],
+        }
+    ]
+
+
+def test_otel_export_rewrites_whole_ref_string_attr() -> None:
+    """A whole-value external ref string attribute is forwarded as the internal
+    whole ref on the non-agents OTel calls path.
+    """
+    internal_proj = _EncodingIdConverter().ext_to_int_project_id("ent/proj")
+    req = _otel_export_req_with_string_attr(
+        "gen_ai.output.dataset_ref", "weave:///ent/proj/object/ds:DIG"
+    )
+
+    forwarded = _capture_otel_export_req(req)
+
+    assert (
+        _string_attr_value(forwarded, "gen_ai.output.dataset_ref")
+        == f"weave-trace-internal:///{internal_proj}/object/ds:DIG"
+    )

--- a/tests/trace_server/test_trace_server_interface_util.py
+++ b/tests/trace_server/test_trace_server_interface_util.py
@@ -1,4 +1,5 @@
 import base64
+import json
 from collections.abc import Callable
 from typing import Any
 from unittest.mock import MagicMock
@@ -179,9 +180,10 @@ def _make_otel_export_req_with_ref_attrs(
             kv = KeyValue(key=full_key)
             kv.value.CopyFrom(build_array_value(refs))
             span.attributes.append(kv)
-    # Non-ref attributes must survive unchanged.
+    # A string attribute that contains no ref substring must survive
+    # byte-for-byte (the cheap pre-check skips the conversion entirely).
     other = KeyValue(key="weave.raw_span_dump")
-    other.value.string_value = "weave:///should/not/be/rewritten"
+    other.value.string_value = "raw span dump with no refs"
     span.attributes.append(other)
 
     scope_spans = ScopeSpans()
@@ -279,18 +281,24 @@ def test_genai_otel_export_rewrites_nested_kvlist_ref_attrs() -> None:
 
 
 def test_genai_otel_export_leaves_non_ref_attrs_untouched() -> None:
-    """Refs embedded in non-ref attributes (here `weave.raw_span_dump`)
-    must survive byte-for-byte — only the three typed-array ref keys are
-    rewritten.
+    """A string attribute whose value contains no ref substring is left
+    byte-identical (the cheap pre-check short-circuits before any parse),
+    while the typed ref array alongside it is still rewritten.
     """
+    internal_proj = _EncodingIdConverter().ext_to_int_project_id("ent/proj")
     req = _make_otel_export_req_with_ref_attrs(
         {"weave.object_refs": ["weave:///ent/proj/object/a:v1"]}
     )
 
     forwarded = _capture_genai_otel_export_req(req)
+    # Non-ref string attribute is untouched.
     span = forwarded.processed_spans[0].resource_spans.scope_spans[0].spans[0]
     dump_kv = next(kv for kv in span.attributes if kv.key == "weave.raw_span_dump")
-    assert dump_kv.value.string_value == "weave:///should/not/be/rewritten"
+    assert dump_kv.value.string_value == "raw span dump with no refs"
+    # Typed ref array is still converted to internal form.
+    assert _ref_attr_values(forwarded, "weave.object_refs") == [
+        f"weave-trace-internal:///{internal_proj}/object/a:v1"
+    ]
 
 
 def test_genai_otel_export_skips_non_external_refs_in_array() -> None:
@@ -314,6 +322,116 @@ def test_genai_otel_export_skips_non_external_refs_in_array() -> None:
         "weave-trace-internal:///already-internal/object/b:v1",
         "not-a-ref-at-all",
     ]
+
+
+# --- genai_otel_export ext→int rewriting of refs in string attributes ---
+# Refs also reach the server buried in ordinary string attribute values —
+# most importantly the message-content JSON under `gen_ai.input.messages` /
+# `gen_ai.output.messages`. Those escape both `_ref_apply` (the protobuf is
+# opaque to its walker) and the typed-array path, so the adapter now runs
+# every string_value through the embedded-ref-aware converter.
+
+
+def _make_otel_export_req_with_string_attr(
+    attr_key: str,
+    attr_value: str,
+    *,
+    project_id: str = "ent/proj",
+) -> tsi.agent_types.GenAIOTelExportReq:
+    """Build a `GenAIOTelExportReq` with a single string-valued span attr."""
+    from opentelemetry.proto.common.v1.common_pb2 import KeyValue
+    from opentelemetry.proto.resource.v1.resource_pb2 import Resource
+    from opentelemetry.proto.trace.v1.trace_pb2 import (
+        ResourceSpans,
+        ScopeSpans,
+        Span,
+    )
+
+    span = Span()
+    span.name = "test"
+    kv = KeyValue(key=attr_key)
+    kv.value.string_value = attr_value
+    span.attributes.append(kv)
+
+    scope_spans = ScopeSpans()
+    scope_spans.spans.append(span)
+    resource_spans = ResourceSpans()
+    resource_spans.resource.CopyFrom(Resource())
+    resource_spans.scope_spans.append(scope_spans)
+
+    processed = tsi.ProcessedResourceSpans(
+        entity=project_id.split("/", maxsplit=1)[0],
+        project=project_id.split("/")[1],
+        run_id=None,
+        resource_spans=resource_spans,
+    )
+    return tsi.agent_types.GenAIOTelExportReq(
+        processed_spans=[processed], project_id=project_id, wb_user_id=None
+    )
+
+
+def _string_attr_value(
+    req: tsi.agent_types.GenAIOTelExportReq, attr_key: str
+) -> str:
+    """Pull the string_value of a flat string attribute from a request."""
+    span = req.processed_spans[0].resource_spans.scope_spans[0].spans[0]
+    for kv in span.attributes:
+        if kv.key == attr_key and kv.value.HasField("string_value"):
+            return kv.value.string_value
+    raise AssertionError(f"no string_value for {attr_key}")
+
+
+def test_genai_otel_export_rewrites_ref_embedded_in_message_json() -> None:
+    """An external ref buried inside a `gen_ai.input.messages` JSON string
+    is rewritten to internal form before the request reaches the inner
+    server; the surrounding JSON structure is preserved.
+    """
+    internal_proj = _EncodingIdConverter().ext_to_int_project_id("ent/proj")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "ref": "weave:///ent/proj/object/ds:DIG"},
+                {"type": "text", "text": "no ref here"},
+            ],
+        }
+    ]
+    req = _make_otel_export_req_with_string_attr(
+        "gen_ai.input.messages", json.dumps(messages)
+    )
+
+    forwarded = _capture_genai_otel_export_req(req)
+
+    forwarded_json = json.loads(_string_attr_value(forwarded, "gen_ai.input.messages"))
+    assert forwarded_json == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "ref": f"weave-trace-internal:///{internal_proj}/object/ds:DIG",
+                },
+                {"type": "text", "text": "no ref here"},
+            ],
+        }
+    ]
+
+
+def test_genai_otel_export_rewrites_whole_ref_string_attr() -> None:
+    """A string attribute whose whole value is an external ref (not JSON) is
+    forwarded as the internal whole ref.
+    """
+    internal_proj = _EncodingIdConverter().ext_to_int_project_id("ent/proj")
+    req = _make_otel_export_req_with_string_attr(
+        "gen_ai.output.dataset_ref", "weave:///ent/proj/object/ds:DIG"
+    )
+
+    forwarded = _capture_genai_otel_export_req(req)
+
+    assert (
+        _string_attr_value(forwarded, "gen_ai.output.dataset_ref")
+        == f"weave-trace-internal:///{internal_proj}/object/ds:DIG"
+    )
 
 
 def test_genai_otel_export_caches_project_id_lookup_across_batch() -> None:

--- a/tests/trace_server/test_trace_server_interface_util.py
+++ b/tests/trace_server/test_trace_server_interface_util.py
@@ -370,9 +370,7 @@ def _make_otel_export_req_with_string_attr(
     )
 
 
-def _string_attr_value(
-    req: tsi.agent_types.GenAIOTelExportReq, attr_key: str
-) -> str:
+def _string_attr_value(req: tsi.agent_types.GenAIOTelExportReq, attr_key: str) -> str:
     """Pull the string_value of a flat string attribute from a request."""
     span = req.processed_spans[0].resource_spans.scope_spans[0].spans[0]
     for kv in span.attributes:

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -770,8 +770,18 @@ def _directional_content_refs(
 
 _INTERNAL_REF_PREFIX = f"{WEAVE_INTERNAL_SCHEME}:///"
 
+# Cap on how far ``_iter_internal_refs`` will descend. It walks nested
+# dicts/lists AND re-parses JSON-encoded strings (JSON-inside-JSON), so a deeply
+# nested or adversarial span payload could otherwise exceed Python's recursion
+# limit and raise ``RecursionError`` on the OTel ingest path, rejecting an
+# otherwise-valid span. Realistic message-part nesting is only a handful of
+# levels deep (message dict -> content JSON -> parts list -> part dict ->
+# image_url dict -> url string), so 8 leaves ample headroom while staying far
+# below ``sys.getrecursionlimit()`` (1000 by default).
+_MAX_REF_SEARCH_DEPTH = 8
 
-def _iter_internal_refs(value: Any) -> Iterator[str]:
+
+def _iter_internal_refs(value: Any, depth: int = 0) -> Iterator[str]:
     """Yield every internal weave ref found anywhere in ``value``.
 
     Recurses through dicts/lists and attempts ``json.loads`` on strings so refs
@@ -780,7 +790,13 @@ def _iter_internal_refs(value: Any) -> Iterator[str]:
     internal-form refs are yielded: the int->ext adapter converts these and
     rejects bare external refs, and external inline refs are already handled via
     ``_directional_content_refs``.
+
+    ``depth`` bounds recursion at ``_MAX_REF_SEARCH_DEPTH``: once it is exceeded
+    we stop without yielding, trading unreachable deep refs for a guarantee that
+    a pathological payload cannot raise ``RecursionError``.
     """
+    if depth > _MAX_REF_SEARCH_DEPTH:
+        return
     if isinstance(value, str):
         stripped = value.strip()
         if stripped.startswith(_INTERNAL_REF_PREFIX):
@@ -790,13 +806,13 @@ def _iter_internal_refs(value: Any) -> Iterator[str]:
                 parsed = json.loads(stripped)
             except (ValueError, TypeError):
                 return
-            yield from _iter_internal_refs(parsed)
+            yield from _iter_internal_refs(parsed, depth + 1)
     elif isinstance(value, dict):
         for v in value.values():
-            yield from _iter_internal_refs(v)
+            yield from _iter_internal_refs(v, depth + 1)
     elif isinstance(value, list):
         for item in value:
-            yield from _iter_internal_refs(item)
+            yield from _iter_internal_refs(item, depth + 1)
 
 
 def _inline_media_refs(messages: list[NormalizedMessage]) -> list[str]:

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -16,9 +16,12 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Any
 
+from weave.shared.refs_internal import WEAVE_INTERNAL_SCHEME
 from weave.trace_server.agents.constants import (
     MAX_WALK_DEPTH,
     OP_EXECUTE_TOOL,
@@ -488,7 +491,7 @@ class ChatTraversal:
         """
         for message in _trailing_user_messages(span.input_messages):
             text = _display_text(message.content)
-            media = _directional_content_refs(span, _media_part_digests([message]))
+            media = _message_content_refs(span, [message])
             if not text and not media:
                 continue
             sig = (text, tuple(media))
@@ -765,6 +768,71 @@ def _directional_content_refs(
     return [r for r in _content_refs(span) if _ref_digest(r) in part_digests]
 
 
+_INTERNAL_REF_PREFIX = f"{WEAVE_INTERNAL_SCHEME}:///"
+
+
+def _iter_internal_refs(value: Any) -> Iterator[str]:
+    """Yield every internal weave ref found anywhere in ``value``.
+
+    Recurses through dicts/lists and attempts ``json.loads`` on strings so refs
+    buried inside JSON-serialized blobs (e.g. a message ``content`` parts array)
+    are not missed, regardless of which field/part shape carries them. Only
+    internal-form refs are yielded: the int->ext adapter converts these and
+    rejects bare external refs, and external inline refs are already handled via
+    ``_directional_content_refs``.
+    """
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.startswith(_INTERNAL_REF_PREFIX):
+            yield stripped
+        elif stripped[:1] in {"[", "{"}:
+            try:
+                parsed = json.loads(stripped)
+            except (ValueError, TypeError):
+                return
+            yield from _iter_internal_refs(parsed)
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _iter_internal_refs(v)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_internal_refs(item)
+
+
+def _inline_media_refs(messages: list[NormalizedMessage]) -> list[str]:
+    """Internal weave refs embedded inline anywhere in ``messages``.
+
+    Server-side content conversion replaces an inline blob with a weave ref in
+    the message part itself (rather than via the span's ``content_refs``). Walk
+    each message recursively so those refs render, without special-casing any
+    part shape.
+    """
+    refs: list[str] = []
+    seen: set[str] = set()
+    for message in messages:
+        for ref in _iter_internal_refs(message.model_dump()):
+            if ref not in seen:
+                seen.add(ref)
+                refs.append(ref)
+    return refs
+
+
+def _message_content_refs(
+    span: AgentSpanSchema, messages: list[NormalizedMessage]
+) -> list[str]:
+    """Content refs for ``messages``: span.content_refs matched by media-part
+    digest (client-uploaded media) plus internal refs found inline in the
+    messages (server-converted content).
+    """
+    refs = list(_directional_content_refs(span, _media_part_digests(messages)))
+    seen = set(refs)
+    for ref in _inline_media_refs(messages):
+        if ref not in seen:
+            seen.add(ref)
+            refs.append(ref)
+    return refs
+
+
 def _user_messages(messages: list[NormalizedMessage]) -> list[NormalizedMessage]:
     """The user's side of a message list, selected by role.
 
@@ -810,8 +878,7 @@ def _input_content_refs(spans: list[AgentSpanSchema]) -> list[str]:
     refs: list[str] = []
     seen: set[str] = set()
     for span in spans:
-        in_digests = _media_part_digests(_user_messages(span.input_messages))
-        for ref in _directional_content_refs(span, in_digests):
+        for ref in _message_content_refs(span, _user_messages(span.input_messages)):
             if ref not in seen:
                 seen.add(ref)
                 refs.append(ref)
@@ -944,8 +1011,6 @@ def _emit_assistant_message(
             total_cost_usd=totals.total_cost_usd,
             duration_ms=_compute_duration_ms(span.started_at, span.ended_at),
             status=span.status_code,
-            content_refs=_directional_content_refs(
-                span, _media_part_digests(span.output_messages)
-            ),
+            content_refs=_message_content_refs(span, span.output_messages),
         ),
     )

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -589,12 +589,18 @@ def _display_text(content: str) -> str:
         return content
     texts: list[str] = []
     for p in parts:
-        if isinstance(p, dict) and isinstance(p.get("content"), str):
+        if isinstance(p, dict):
             # Reasoning is rendered separately via `reasoning_content`;
             # concatenating it here would duplicate it in the message body.
             if p.get("type") == "reasoning":
                 continue
-            texts.append(p["content"])
+            # Support both the weave parts model (``content``) and the
+            # OpenAI-style multimodal shape (``text``). Non-text parts (e.g.
+            # images) carry neither and are skipped for display.
+            if isinstance(p.get("content"), str):
+                texts.append(p["content"])
+            elif isinstance(p.get("text"), str):
+                texts.append(p["text"])
         elif isinstance(p, str):
             texts.append(p)
     return "\n".join(texts)

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -121,6 +121,7 @@ from weave.trace_server.trace_server_common import (
 from weave.trace_server.trace_server_interface import (
     FeedbackQueryReq,
     FeedbackQueryRes,
+    TraceServerInterface,
 )
 from weave.trace_server.tracing import traced
 
@@ -806,10 +807,13 @@ class AgentWriteHandler:
     """Write-side operations for agent data.
 
     Takes a `ch_client` for `insert` calls, which have no query wrapper.
+    Optionally takes a `trace_server` used for file storage when stripping
+    inline base64 out of GenAI message payloads into Content refs.
     """
 
     _ch_client: CHClient
     _insert_settings: dict[str, Any] | None = None
+    _trace_server: TraceServerInterface | None = None
 
     # ------------------------------------------------------------------
     # OTel ingest
@@ -853,6 +857,7 @@ class AgentWriteHandler:
                             project_id=req.project_id,
                             wb_user_id=req.wb_user_id or "",
                             wb_run_id=processed_span.run_id or "",
+                            trace_server=self._trace_server,
                         )
                     except Exception as e:
                         error_type = type(e).__name__

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -858,7 +858,10 @@ class AgentWriteHandler:
                     # pure extraction transform runs.
                     if self._trace_server is not None:
                         strip_inline_blobs_from_span(
-                            span, req.project_id, self._trace_server
+                            span,
+                            req.project_id,
+                            self._trace_server,
+                            wb_user_id=req.wb_user_id,
                         )
 
                     try:

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -854,10 +854,7 @@ class AgentWriteHandler:
                         errors.append(str(e))
                         continue
 
-                    # Mirror the non-OTel calls path: strip inline base64 /
-                    # base64 data-URIs into Content refs. Converting the span
-                    # attributes in place strips the lossless attributes_dump /
-                    # raw_span_dump as well as the extracted messages.
+                    # strip inline base64/data-URIs into weave refs.
                     if self._trace_server is not None:
                         span.attributes = replace_base64_with_content_objects(
                             span.attributes, req.project_id, self._trace_server

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -81,13 +81,13 @@ from weave.trace_server.agents.types import (
     GenAIOTelExportRes,
     group_by_ref_alias,
 )
-from weave.trace_server.base64_content_conversion import (
-    replace_base64_with_content_objects,
-)
 from weave.trace_server.clickhouse.utilities import insert_with_empty_query_retry
 from weave.trace_server.datadog import record_db_insert, set_root_span_dd_tags
 from weave.trace_server.interface.query import Query
-from weave.trace_server.opentelemetry.genai_extraction import extract_genai_span
+from weave.trace_server.opentelemetry.genai_extraction import (
+    extract_genai_span,
+    strip_inline_blobs_from_span,
+)
 from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
 from weave.trace_server.opentelemetry.python_spans import Resource, Span
 from weave.trace_server.orm import ParamBuilder
@@ -854,10 +854,11 @@ class AgentWriteHandler:
                         errors.append(str(e))
                         continue
 
-                    # strip inline base64/data-URIs into weave refs.
+                    # Strip inline base64/data-URIs into weave refs before the
+                    # pure extraction transform runs.
                     if self._trace_server is not None:
-                        span.attributes = replace_base64_with_content_objects(
-                            span.attributes, req.project_id, self._trace_server
+                        strip_inline_blobs_from_span(
+                            span, req.project_id, self._trace_server
                         )
 
                     try:
@@ -866,7 +867,6 @@ class AgentWriteHandler:
                             project_id=req.project_id,
                             wb_user_id=req.wb_user_id or "",
                             wb_run_id=processed_span.run_id or "",
-                            trace_server=self._trace_server,
                         )
                     except Exception as e:
                         error_type = type(e).__name__

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -81,6 +81,9 @@ from weave.trace_server.agents.types import (
     GenAIOTelExportRes,
     group_by_ref_alias,
 )
+from weave.trace_server.base64_content_conversion import (
+    replace_base64_with_content_objects,
+)
 from weave.trace_server.clickhouse.utilities import insert_with_empty_query_retry
 from weave.trace_server.datadog import record_db_insert, set_root_span_dd_tags
 from weave.trace_server.interface.query import Query
@@ -850,6 +853,15 @@ class AgentWriteHandler:
                         rejected += 1
                         errors.append(str(e))
                         continue
+
+                    # Mirror the non-OTel calls path: strip inline base64 /
+                    # base64 data-URIs into Content refs. Converting the span
+                    # attributes in place strips the lossless attributes_dump /
+                    # raw_span_dump as well as the extracted messages.
+                    if self._trace_server is not None:
+                        span.attributes = replace_base64_with_content_objects(
+                            span.attributes, req.project_id, self._trace_server
+                        )
 
                     try:
                         genai_row = extract_genai_span(

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -139,9 +139,7 @@ def store_content_object_ref(
     # Coerce to a plain ``str``: ``.uri`` is a str subclass (``_CallableStr``)
     # that exact-type checks (JSON/serialization/ref extraction) can reject.
     return str(
-        InternalObjectRef(
-            project_id=project_id, name=object_id, version=res.digest
-        ).uri
+        InternalObjectRef(project_id=project_id, name=object_id, version=res.digest).uri
     )
 
 

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -9,13 +9,17 @@ import logging
 import re
 from typing import Any, TypeVar
 
+from weave.shared.refs_internal import InternalObjectRef
 from weave.trace_server.content.content import Content
+from weave.trace_server.object_creation_utils import make_object_id
 from weave.trace_server.trace_server_interface import (
     CallEndReq,
     CallEndV2Req,
     CallStartReq,
     CompletedCallSchemaForInsert,
     FileCreateReq,
+    ObjCreateReq,
+    ObjSchemaForInsert,
     TraceServerInterface,
 )
 from weave.trace_server.tracing import traced
@@ -109,6 +113,38 @@ def store_content_object(
     }
 
 
+@traced(name="store_content_object_ref")
+def store_content_object_ref(
+    content_obj: Content,
+    project_id: str,
+    trace_server: TraceServerInterface,
+) -> str:
+    """Store a Content object, publish it, and return its internal weave ref.
+
+    ``store_content_object`` returns the inline ``CustomWeaveType`` dict (the
+    object *value*); this publishes that value as a weave object so callers can
+    embed a compact ``weave-trace-internal:///…`` ref in the payload instead of
+    the inline object. The version is the server-computed object digest, so
+    identical content dedupes to the same ref.
+    """
+    obj_val = store_content_object(content_obj, project_id, trace_server)
+    object_id = make_object_id(content_obj.filename, "content")
+    res = trace_server.obj_create(
+        ObjCreateReq(
+            obj=ObjSchemaForInsert(
+                project_id=project_id, object_id=object_id, val=obj_val
+            )
+        )
+    )
+    # Coerce to a plain ``str``: ``.uri`` is a str subclass (``_CallableStr``)
+    # that exact-type checks (JSON/serialization/ref extraction) can reject.
+    return str(
+        InternalObjectRef(
+            project_id=project_id, name=object_id, version=res.digest
+        ).uri
+    )
+
+
 T = TypeVar("T")
 
 
@@ -162,8 +198,8 @@ def replace_base64_with_content_objects(
             # Check for data URI pattern first
             if is_data_uri(val):
                 try:
-                    # Create proper Content object structure
-                    return store_content_object(
+                    # Publish the content and replace the base64 with its ref.
+                    return store_content_object_ref(
                         Content.from_data_url(val),
                         project_id,
                         trace_server,
@@ -186,7 +222,7 @@ def replace_base64_with_content_objects(
                         "text/plain",
                         "application/octet-stream",
                     }:
-                        return store_content_object(
+                        return store_content_object_ref(
                             content,
                             project_id,
                             trace_server,

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -252,3 +252,30 @@ def process_complete_call_to_content(
         complete_call.output, complete_call.project_id, trace_server
     )
     return complete_call
+
+
+def replace_base64_in_raw_messages(
+    raw: Any,
+    project_id: str,
+    trace_server: TraceServerInterface,
+) -> Any:
+    """Strip inline base64 / base64 data-URIs from raw GenAI message payloads.
+
+    Mirrors the non-OTel calls path (``replace_base64_with_content_objects``
+    applied to ``inputs``/``output``) for the OTel *agents* path, where the
+    message payload frequently arrives as a JSON-encoded string. The string is
+    parsed into structured form first so that any inline base64 becomes a leaf
+    value the walker can detect, then the shared conversion runs.
+
+    Returns the (possibly converted) structured messages, or the input
+    unchanged when it is neither a message container nor JSON-decodable.
+    """
+    if not isinstance(raw, (str, list, dict)):
+        return raw
+    parsed = raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return raw
+    return replace_base64_with_content_objects(parsed, project_id, trace_server)

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -118,6 +118,7 @@ def store_content_object_ref(
     content_obj: Content,
     project_id: str,
     trace_server: TraceServerInterface,
+    wb_user_id: str | None = None,
 ) -> str:
     """Store a Content object, publish it, and return its internal weave ref.
 
@@ -132,7 +133,10 @@ def store_content_object_ref(
     res = trace_server.obj_create(
         ObjCreateReq(
             obj=ObjSchemaForInsert(
-                project_id=project_id, object_id=object_id, val=obj_val
+                project_id=project_id,
+                object_id=object_id,
+                val=obj_val,
+                wb_user_id=wb_user_id,
             )
         )
     )
@@ -150,6 +154,7 @@ def replace_base64_with_content_objects(
     vals: T,
     project_id: str,
     trace_server: TraceServerInterface,
+    wb_user_id: str | None = None,
 ) -> T:
     """Recursively replace base64 content with Content objects.
 
@@ -201,6 +206,7 @@ def replace_base64_with_content_objects(
                         Content.from_data_url(val),
                         project_id,
                         trace_server,
+                        wb_user_id,
                     )
                 except Exception as e:
                     logger.warning(
@@ -224,6 +230,7 @@ def replace_base64_with_content_objects(
                             content,
                             project_id,
                             trace_server,
+                            wb_user_id,
                         )
                 except Exception as e:
                     logger.warning(
@@ -256,9 +263,17 @@ def process_call_req_to_content(
     """
     if isinstance(req, CallStartReq):
         req.start.inputs = replace_base64_with_content_objects(
-            req.start.inputs, req.start.project_id, trace_server
+            req.start.inputs,
+            req.start.project_id,
+            trace_server,
+            req.start.wb_user_id,
         )
     elif isinstance(req, (CallEndReq, CallEndV2Req)):
+        # NOTE: EndedCallSchemaForInsert has no ``wb_user_id`` field, so Content
+        # objects created from base64 in a call-end ``output`` cannot be
+        # user-attributed on this path without a schema change. This falls back
+        # to the ``wb_user_id=None`` default (unattributed) — see the report /
+        # PR discussion for the required follow-up.
         req.end.output = replace_base64_with_content_objects(
             req.end.output, req.end.project_id, trace_server
         )
@@ -280,10 +295,16 @@ def process_complete_call_to_content(
         CompletedCallSchemaForInsert with base64 content replaced by Content objects.
     """
     complete_call.inputs = replace_base64_with_content_objects(
-        complete_call.inputs, complete_call.project_id, trace_server
+        complete_call.inputs,
+        complete_call.project_id,
+        trace_server,
+        complete_call.wb_user_id,
     )
     complete_call.output = replace_base64_with_content_objects(
-        complete_call.output, complete_call.project_id, trace_server
+        complete_call.output,
+        complete_call.project_id,
+        trace_server,
+        complete_call.wb_user_id,
     )
     return complete_call
 
@@ -292,6 +313,7 @@ def replace_base64_in_raw_messages(
     raw: Any,
     project_id: str,
     trace_server: TraceServerInterface,
+    wb_user_id: str | None = None,
 ) -> Any:
     """Strip inline base64 / base64 data-URIs from raw GenAI message payloads.
 
@@ -312,4 +334,6 @@ def replace_base64_in_raw_messages(
             parsed = json.loads(raw)
         except (json.JSONDecodeError, TypeError):
             return raw
-    return replace_base64_with_content_objects(parsed, project_id, trace_server)
+    return replace_base64_with_content_objects(
+        parsed, project_id, trace_server, wb_user_id
+    )

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -809,13 +809,21 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                         error_messages.append(f"Rejected span ({span_ident}): {e!s}")
                         continue
 
+                    # Mirror the non-OTel calls path: strip inline base64 /
+                    # base64 data-URIs into Content refs. Converting the span
+                    # attributes in place (before deriving the call) also
+                    # strips the lossless otel_dump the call carries.
+                    span.attributes = replace_base64_with_content_objects(
+                        span.attributes, req.project_id, self
+                    )
                     start_call, end_call = span.to_call(
                         req.project_id,
                         wb_user_id=req.wb_user_id,
                         wb_run_id=wb_run_id,
                     )
-                    # Mirror the non-OTel calls path: strip inline base64 /
-                    # base64 data-URIs from inputs and output into Content refs.
+                    # Also convert the derived inputs/output: base64 nested in a
+                    # JSON-encoded message attribute only surfaces as a leaf
+                    # after to_call parses it.
                     start_call.inputs = replace_base64_with_content_objects(
                         start_call.inputs, req.project_id, self
                     )

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -814,7 +814,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     # attributes in place (before deriving the call) also
                     # strips the lossless otel_dump the call carries.
                     span.attributes = replace_base64_with_content_objects(
-                        span.attributes, req.project_id, self
+                        span.attributes, req.project_id, self, wb_user_id=req.wb_user_id
                     )
                     start_call, end_call = span.to_call(
                         req.project_id,
@@ -825,10 +825,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     # JSON-encoded message attribute only surfaces as a leaf
                     # after to_call parses it.
                     start_call.inputs = replace_base64_with_content_objects(
-                        start_call.inputs, req.project_id, self
+                        start_call.inputs, req.project_id, self, wb_user_id=req.wb_user_id
                     )
                     end_call.output = replace_base64_with_content_objects(
-                        end_call.output, req.project_id, self
+                        end_call.output, req.project_id, self, wb_user_id=req.wb_user_id
                     )
                     calls.append((start_call, end_call))
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -84,6 +84,7 @@ from weave.trace_server.agents.types import (
 from weave.trace_server.base64_content_conversion import (
     process_call_req_to_content,
     process_complete_call_to_content,
+    replace_base64_with_content_objects,
 )
 from weave.trace_server.call_stats_helpers import (
     rows_to_bucket_dicts,
@@ -808,13 +809,20 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                         error_messages.append(f"Rejected span ({span_ident}): {e!s}")
                         continue
 
-                    calls.append(
-                        span.to_call(
-                            req.project_id,
-                            wb_user_id=req.wb_user_id,
-                            wb_run_id=wb_run_id,
-                        )
+                    start_call, end_call = span.to_call(
+                        req.project_id,
+                        wb_user_id=req.wb_user_id,
+                        wb_run_id=wb_run_id,
                     )
+                    # Mirror the non-OTel calls path: strip inline base64 /
+                    # base64 data-URIs from inputs and output into Content refs.
+                    start_call.inputs = replace_base64_with_content_objects(
+                        start_call.inputs, req.project_id, self
+                    )
+                    end_call.output = replace_base64_with_content_objects(
+                        end_call.output, req.project_id, self
+                    )
+                    calls.append((start_call, end_call))
 
         set_current_span_dd_tags({"call_count": len(calls)})
         return calls, rejected_spans, error_messages
@@ -7082,7 +7090,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     @tag_db_insert_path("genai_otel_export")
     def genai_otel_export(self, req: GenAIOTelExportReq) -> GenAIOTelExportRes:
         res, span_rows = AgentWriteHandler(
-            self.ch_client, self._async_insert_settings()
+            self.ch_client, self._async_insert_settings(), self
         ).insert_otel_spans(req)
 
         # Return early without emitting kafka events if online eval or agent scoring are disabled

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -825,7 +825,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     # JSON-encoded message attribute only surfaces as a leaf
                     # after to_call parses it.
                     start_call.inputs = replace_base64_with_content_objects(
-                        start_call.inputs, req.project_id, self, wb_user_id=req.wb_user_id
+                        start_call.inputs,
+                        req.project_id,
+                        self,
+                        wb_user_id=req.wb_user_id,
                     )
                     end_call.output = replace_base64_with_content_objects(
                         end_call.output, req.project_id, self, wb_user_id=req.wb_user_id

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -3,7 +3,7 @@ import asyncio
 from collections.abc import Awaitable, Callable, Iterable, Iterator
 from typing import Any, TypeVar
 
-from opentelemetry.proto.common.v1.common_pb2 import KeyValue
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
 
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.async_clickhouse_trace_server import AsyncClickHouseTraceServer
@@ -11,6 +11,7 @@ from weave.trace_server.trace_server_converter import (
     replace_external_weave_ref,
     universal_ext_to_int_ref_converter,
     universal_int_to_ext_ref_converter,
+    weave_internal_prefix,
     weave_prefix,
 )
 
@@ -30,37 +31,95 @@ _OTEL_REF_ATTR_KEYS = frozenset(
 def _rewrite_otel_ref_attrs_inplace(
     attrs: Iterable[KeyValue],
     ext_to_int_project_id: Callable[[str], str],
-    cache: dict[str, str],
+    verify_internal_project_id: Callable[[str], bool],
     prefix: str = "",
 ) -> None:
-    """Recursively rewrite typed ref attributes from external to internal form.
+    """Recursively rewrite refs in span attributes from external to internal.
 
     OTel encodes attributes either flat (`weave.object_refs`) or nested as
     a `kvlist_value` (top-level key `weave` with a child `object_refs`),
     so we descend through `kvlist_value`s and accumulate dotted prefixes.
-    Only `Array(String)` values under the known ref keys are touched;
-    everything else (including refs embedded in event payloads, message
-    content, `raw_span_dump`, etc.) is left exactly as the client sent it.
-    `cache` is a shared per-request dict that memoizes ext→int project_id
-    lookups across every ref in the batch.
+
+    Two kinds of refs are converted:
+
+      * The typed `Array(String)` ref columns under the known ref keys
+        (`weave.content_refs` / `weave.artifact_refs` / `weave.object_refs`).
+        Only WHOLE external refs are touched here; internal refs and
+        non-refs pass through untouched, because the read path surfaces
+        these as bare strings and must round-trip them exactly.
+      * Every other `string_value` leaf (most importantly the message
+        content JSON under `gen_ai.input.messages` / `gen_ai.output.messages`,
+        but also any other string attribute). These go through the
+        embedded-ref-aware `universal_ext_to_int_ref_converter`, so a whole
+        external ref OR a JSON string that merely embeds refs both convert
+        with the same semantics `_ref_apply` gives every other endpoint.
+
+    `ext_to_int_project_id` is a shared per-request memoized closure so the
+    ext→int project_id lookup runs at most once per distinct entity/project
+    pair across the whole batch (typed arrays AND embedded refs).
+    `verify_internal_project_id` gates embedded internal refs exactly as
+    `_ref_apply` does (accept the request's own project + access-checked
+    cross-project refs).
     """
     for kv in attrs:
         full_key = f"{prefix}{kv.key}" if prefix else kv.key
-        value = kv.value
-        if full_key in _OTEL_REF_ATTR_KEYS and value.HasField("array_value"):
-            for item in value.array_value.values:
-                if item.HasField("string_value") and item.string_value.startswith(
-                    weave_prefix
-                ):
-                    item.string_value = replace_external_weave_ref(
-                        item.string_value, ext_to_int_project_id, cache
-                    )
-        elif value.HasField("kvlist_value"):
-            _rewrite_otel_ref_attrs_inplace(
-                value.kvlist_value.values,
+        _rewrite_otel_value_inplace(
+            kv.value, full_key, ext_to_int_project_id, verify_internal_project_id
+        )
+
+
+def _rewrite_otel_value_inplace(
+    value: AnyValue,
+    full_key: str,
+    ext_to_int_project_id: Callable[[str], str],
+    verify_internal_project_id: Callable[[str], bool],
+) -> None:
+    """Rewrite refs inside a single OTel `AnyValue`, in place.
+
+    Dispatched by value kind; see `_rewrite_otel_ref_attrs_inplace` for the
+    overall contract. Array elements are keyless (`full_key=""`), so they
+    can never match a typed ref key and always fall through to the generic
+    string handling.
+    """
+    # 1. Typed ref-array columns: convert WHOLE external refs only; leave
+    #    internal refs and non-refs exactly as sent so the read path can
+    #    round-trip the bare strings.
+    if full_key in _OTEL_REF_ATTR_KEYS and value.HasField("array_value"):
+        for item in value.array_value.values:
+            if item.HasField("string_value") and item.string_value.startswith(
+                weave_prefix
+            ):
+                item.string_value = replace_external_weave_ref(
+                    item.string_value, ext_to_int_project_id
+                )
+        return
+    # 2. Nested kvlist: descend, accumulating the dotted key so typed ref
+    #    keys emitted as `weave` -> `object_refs` still match.
+    if value.HasField("kvlist_value"):
+        _rewrite_otel_ref_attrs_inplace(
+            value.kvlist_value.values,
+            ext_to_int_project_id,
+            verify_internal_project_id,
+            prefix=f"{full_key}." if full_key else "",
+        )
+        return
+    # 3. Non-typed array: descend into each (keyless) element.
+    if value.HasField("array_value"):
+        for item in value.array_value.values:
+            _rewrite_otel_value_inplace(
+                item, "", ext_to_int_project_id, verify_internal_project_id
+            )
+        return
+    # 4. Plain string leaf: convert whole-ref AND embedded-in-JSON refs via
+    #    the embedded-ref-aware converter. Gated by the cheap substring
+    #    pre-check so ref-free strings never pay for a parse pass.
+    if value.HasField("string_value"):
+        s = value.string_value
+        if weave_prefix in s or weave_internal_prefix in s:
+            value.string_value = universal_ext_to_int_ref_converter(
+                s,
                 ext_to_int_project_id,
-                cache,
-                prefix=f"{full_key}.",
+                verify_internal_project_id=verify_internal_project_id,
             )
 
 
@@ -1313,25 +1372,45 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     def genai_otel_export(
         self, req: tsi.agent_types.GenAIOTelExportReq
     ) -> tsi.agent_types.GenAIOTelExportRes:
+        # Convert `req.project_id` DIRECTLY (not through the memoized wrapper
+        # below): this is the request's own project translation and must
+        # always hit the id converter once.
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         if req.wb_user_id is not None:
             req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
         # `_ref_apply`'s universal walker can't descend into the raw
-        # protobuf `ResourceSpans` payload, so the typed-ref OTel
-        # attribute values (`weave.content_refs`, `weave.artifact_refs`,
-        # `weave.object_refs`) escape the standard ext→int conversion.
-        # Rewrite them in-place here so the inner trace server sees a
-        # request that's already in internal-ref form, matching the
-        # invariant every other resolver relies on. The cache is shared
-        # across every span in the batch so ext→int_project_id runs at
-        # most once per distinct entity/project pair per request.
-        ext_to_int = self._idc.ext_to_int_project_id
+        # protobuf `ResourceSpans` payload, so refs carried in span
+        # attributes escape the standard ext→int conversion. Rewrite them
+        # in-place here so the inner trace server sees a request that's
+        # already in internal-ref form, matching the invariant every other
+        # resolver relies on. This covers both the typed ref-array columns
+        # (`weave.content_refs` / `weave.artifact_refs` / `weave.object_refs`)
+        # AND refs embedded in ordinary string attributes (e.g. a dataset ref
+        # inside the `gen_ai.input.messages` / `gen_ai.output.messages` JSON).
+        #
+        # A SINGLE memoized closure funnels every ext→int project lookup
+        # (array items AND embedded string refs) so `ext_to_int_project_id`
+        # runs at most once per distinct entity/project pair across the whole
+        # batch. `req.project_id` is already internal here, so the verifier
+        # accepts the request's own project plus access-checked cross-project
+        # internal refs — exactly what `_ref_apply` does.
         project_id_cache: dict[str, str] = {}
+
+        def cached_ext_to_int(project_key: str) -> str:
+            if project_key not in project_id_cache:
+                project_id_cache[project_key] = self._idc.ext_to_int_project_id(
+                    project_key
+                )
+            return project_id_cache[project_key]
+
+        verify_internal_project_id = self._make_project_verifier(req.project_id)
         for processed_span in req.processed_spans:
             for scope_spans in processed_span.resource_spans.scope_spans:
                 for span in scope_spans.spans:
                     _rewrite_otel_ref_attrs_inplace(
-                        span.attributes, ext_to_int, project_id_cache
+                        span.attributes,
+                        cached_ext_to_int,
+                        verify_internal_project_id,
                     )
         return self._internal_trace_server.genai_otel_export(req)
 

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -202,6 +202,49 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
 
         return verify
 
+    def _rewrite_processed_spans_refs_inplace(
+        self,
+        processed_spans: Iterable[Any],
+        internal_project_id: str,
+    ) -> None:
+        """Convert external weave refs in OTel span attributes to internal form.
+
+        Both ``otel_export`` and ``genai_otel_export`` receive a raw protobuf
+        ``ResourceSpans`` payload that ``_ref_apply``'s universal walker cannot
+        descend into (it is an ``arbitrary_types_allowed`` field), so refs
+        carried in span attributes — the typed
+        ``weave.{content,artifact,object}_refs`` arrays AND refs embedded in
+        ordinary string attributes such as the ``gen_ai.{input,output}.messages``
+        JSON — escape the standard ext→int conversion. Rewrite them in place so
+        the inner trace server always sees internal-ref form, matching the
+        invariant every other resolver relies on.
+
+        A single memoized closure funnels every ext→int project lookup so
+        ``ext_to_int_project_id`` runs at most once per distinct entity/project
+        pair across the whole batch. ``internal_project_id`` is the request's
+        already-converted project, so the verifier accepts the request's own
+        project plus access-checked cross-project internal refs — exactly what
+        ``_ref_apply`` does.
+        """
+        project_id_cache: dict[str, str] = {}
+
+        def cached_ext_to_int(project_key: str) -> str:
+            if project_key not in project_id_cache:
+                project_id_cache[project_key] = self._idc.ext_to_int_project_id(
+                    project_key
+                )
+            return project_id_cache[project_key]
+
+        verify_internal_project_id = self._make_project_verifier(internal_project_id)
+        for processed_span in processed_spans:
+            for scope_spans in processed_span.resource_spans.scope_spans:
+                for span in scope_spans.spans:
+                    _rewrite_otel_ref_attrs_inplace(
+                        span.attributes,
+                        cached_ext_to_int,
+                        verify_internal_project_id,
+                    )
+
     def _ref_apply(
         self,
         method: Callable[[A], B],
@@ -286,6 +329,11 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
 
         if req.wb_user_id is not None:
             req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
+
+        # Convert refs carried in the raw protobuf span attributes (embedded in
+        # message content, typed ref arrays, etc.) — `_ref_apply` below can't
+        # descend into `ResourceSpans`. See `_rewrite_processed_spans_refs_inplace`.
+        self._rewrite_processed_spans_refs_inplace(req.processed_spans, req.project_id)
 
         return self._ref_apply(
             self._internal_trace_server.otel_export, req, req.project_id
@@ -1372,46 +1420,14 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     def genai_otel_export(
         self, req: tsi.agent_types.GenAIOTelExportReq
     ) -> tsi.agent_types.GenAIOTelExportRes:
-        # Convert `req.project_id` DIRECTLY (not through the memoized wrapper
-        # below): this is the request's own project translation and must
-        # always hit the id converter once.
+        # Convert `req.project_id` DIRECTLY: this is the request's own project
+        # translation and must always hit the id converter once.
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         if req.wb_user_id is not None:
             req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
-        # `_ref_apply`'s universal walker can't descend into the raw
-        # protobuf `ResourceSpans` payload, so refs carried in span
-        # attributes escape the standard ext→int conversion. Rewrite them
-        # in-place here so the inner trace server sees a request that's
-        # already in internal-ref form, matching the invariant every other
-        # resolver relies on. This covers both the typed ref-array columns
-        # (`weave.content_refs` / `weave.artifact_refs` / `weave.object_refs`)
-        # AND refs embedded in ordinary string attributes (e.g. a dataset ref
-        # inside the `gen_ai.input.messages` / `gen_ai.output.messages` JSON).
-        #
-        # A SINGLE memoized closure funnels every ext→int project lookup
-        # (array items AND embedded string refs) so `ext_to_int_project_id`
-        # runs at most once per distinct entity/project pair across the whole
-        # batch. `req.project_id` is already internal here, so the verifier
-        # accepts the request's own project plus access-checked cross-project
-        # internal refs — exactly what `_ref_apply` does.
-        project_id_cache: dict[str, str] = {}
-
-        def cached_ext_to_int(project_key: str) -> str:
-            if project_key not in project_id_cache:
-                project_id_cache[project_key] = self._idc.ext_to_int_project_id(
-                    project_key
-                )
-            return project_id_cache[project_key]
-
-        verify_internal_project_id = self._make_project_verifier(req.project_id)
-        for processed_span in req.processed_spans:
-            for scope_spans in processed_span.resource_spans.scope_spans:
-                for span in scope_spans.spans:
-                    _rewrite_otel_ref_attrs_inplace(
-                        span.attributes,
-                        cached_ext_to_int,
-                        verify_internal_project_id,
-                    )
+        # This path doesn't use `_ref_apply`, so rewrite refs carried in the raw
+        # protobuf span attributes here. See `_rewrite_processed_spans_refs_inplace`.
+        self._rewrite_processed_spans_refs_inplace(req.processed_spans, req.project_id)
         return self._internal_trace_server.genai_otel_export(req)
 
     def agent_spans_query(

--- a/weave/trace_server/opentelemetry/genai_extraction.py
+++ b/weave/trace_server/opentelemetry/genai_extraction.py
@@ -25,7 +25,11 @@ from weave.trace_server.agents.schema import (
     NormalizedMessage,
 )
 from weave.trace_server.base64_content_conversion import replace_base64_in_raw_messages
-from weave.trace_server.opentelemetry.helpers import get_attribute, to_json_serializable
+from weave.trace_server.opentelemetry.helpers import (
+    get_attribute,
+    to_json_serializable,
+    try_convert_numeric_keys_to_list,
+)
 from weave.trace_server.opentelemetry.python_spans import Span
 from weave.trace_server.query_builder.agent_query_builder import (
     safe_float,
@@ -235,20 +239,6 @@ def extract_tool_call_result(
 # ---------------------------------------------------------------------------
 
 
-def _text_from_parts(parts: list[Any]) -> str:
-    """Concatenate text from a list of message parts."""
-    texts: list[str] = []
-    for p in parts:
-        if isinstance(p, str):
-            texts.append(p)
-        elif isinstance(p, dict):
-            if "content" in p and isinstance(p["content"], str):
-                texts.append(p["content"])
-            elif "text" in p and isinstance(p["text"], str):
-                texts.append(p["text"])
-    return "\n".join(texts)
-
-
 def _normalize_single_message(
     msg: dict[str, Any], *, default_role: str = ""
 ) -> NormalizedMessage:
@@ -268,7 +258,11 @@ def _normalize_single_message(
     elif isinstance(msg.get("content"), str):
         content = msg["content"]
     elif isinstance(msg.get("content"), list):
-        content = _text_from_parts(msg["content"])
+        # Multimodal content (e.g. OpenAI-style ``[{text}, {image_url}]``) is
+        # preserved as a JSON parts array so the full payload — including
+        # non-text parts such as converted images — survives. Flattening to
+        # text here silently dropped image/blob parts.
+        content = _json_str(msg["content"])
 
     return NormalizedMessage(
         role=role,
@@ -335,31 +329,40 @@ def _normalize_system_instructions(raw: Any) -> list[str]:
 
 
 def _extract_raw_input(attrs: dict[str, Any]) -> Any:
-    """Return raw input messages from attrs."""
-    return _get(
-        attrs,
-        *semconv.INPUT_MESSAGES.lookup_keys,
-        "weave.prompt",
-        "gen_ai.prompt",
+    """Return raw input messages from attrs.
+
+    Legacy indexed conventions (``gen_ai.prompt.{i}.*``) unflatten to a
+    numeric-keyed dict (``{"0": {...}}``); ``try_convert_numeric_keys_to_list``
+    turns that back into a message list, matching how the non-agents path
+    normalizes inputs in ``parse_weave_values``.
+    """
+    return try_convert_numeric_keys_to_list(
+        _get(
+            attrs,
+            *semconv.INPUT_MESSAGES.lookup_keys,
+            "weave.prompt",
+            "gen_ai.prompt",
+        )
     )
 
 
 def _extract_raw_output(attrs: dict[str, Any], events: list[dict[str, Any]]) -> Any:
-    """Return raw output messages from attrs, legacy completion attrs, or events."""
+    """Return raw output messages from attrs, legacy completion attrs, or events.
+
+    Numeric-keyed dicts from indexed conventions (``gen_ai.completion.{i}.*``)
+    are converted back to a message list, as in the non-agents path.
+    """
     val = _get(attrs, *semconv.OUTPUT_MESSAGES.lookup_keys)
-    if val is not None:
-        return val
-
-    val = _get(attrs, *semconv.COMPLETION.lookup_keys)
-    if val is not None:
-        return val
-
-    for event in events:
-        if event.get("name") == "gen_ai.content.completion":
-            event_attrs = event.get("attributes", {})
-            val = get_attribute(event_attrs, "gen_ai.completion")
-            if val is not None:
-                return val
+    if val is None:
+        val = _get(attrs, *semconv.COMPLETION.lookup_keys)
+    if val is None:
+        for event in events:
+            if event.get("name") == "gen_ai.content.completion":
+                event_attrs = event.get("attributes", {})
+                val = get_attribute(event_attrs, "gen_ai.completion")
+                if val is not None:
+                    break
+    return try_convert_numeric_keys_to_list(val)
 
     return None
 

--- a/weave/trace_server/opentelemetry/genai_extraction.py
+++ b/weave/trace_server/opentelemetry/genai_extraction.py
@@ -368,8 +368,6 @@ def _extract_raw_output(attrs: dict[str, Any], events: list[dict[str, Any]]) -> 
                     break
     return try_convert_numeric_keys_to_list(val)
 
-    return None
-
 
 # ---------------------------------------------------------------------------
 # Custom attributes -> typed Maps

--- a/weave/trace_server/opentelemetry/genai_extraction.py
+++ b/weave/trace_server/opentelemetry/genai_extraction.py
@@ -24,8 +24,12 @@ from weave.trace_server.agents.schema import (
     AgentSpanCHInsertable,
     NormalizedMessage,
 )
-from weave.trace_server.base64_content_conversion import replace_base64_in_raw_messages
+from weave.trace_server.base64_content_conversion import (
+    replace_base64_in_raw_messages,
+    replace_base64_with_content_objects,
+)
 from weave.trace_server.opentelemetry.helpers import (
+    _set_value_in_nested_dict,
     get_attribute,
     to_json_serializable,
     try_convert_numeric_keys_to_list,
@@ -453,6 +457,83 @@ def _flatten_attrs(attrs: dict[str, Any], prefix: str = "") -> list[tuple[str, A
 
 
 # ---------------------------------------------------------------------------
+# Inline blob stripping
+# ---------------------------------------------------------------------------
+
+
+def _strip_message_attr(
+    attrs: dict[str, Any],
+    lookup_keys: tuple[str, ...],
+    project_id: str,
+    trace_server: "TraceServerInterface",
+) -> None:
+    """Strip base64 from the first present message-payload attribute key.
+
+    Only the first present lookup key is considered (matching how extraction
+    resolves aliases via ``_get``). If that value is a ``str`` it is a
+    JSON-encoded message payload that the generic leaf walker cannot descend
+    into, so parse-and-strip it and write the (now structured) result back at
+    the same key. If it is already a dict/list the generic pass has handled it,
+    so nothing is done.
+    """
+    for key in lookup_keys:
+        value = get_attribute(attrs, key)
+        if value is None:
+            continue
+        if isinstance(value, str):
+            stripped = replace_base64_in_raw_messages(value, project_id, trace_server)
+            # Mirror ``get_attribute``'s flat-vs-nested resolution: write back to
+            # the flat dotted key if present, otherwise into the nested tree.
+            if key in attrs:
+                attrs[key] = stripped
+            else:
+                _set_value_in_nested_dict(attrs, key, stripped)
+        return
+
+
+def strip_inline_blobs_from_span(
+    span: Span,
+    project_id: str,
+    trace_server: "TraceServerInterface",
+) -> None:
+    """Strip inline base64 / base64 data-URIs from a span into stored Content refs.
+
+    Mutates ``span.attributes`` in place. This is the single explicit
+    inline-blob-stripping step for the OTel *agents* ingest path and is run
+    *before* the pure ``extract_genai_span`` transform.
+
+    Two passes are required because base64 lands in two different output
+    columns with two different shapes:
+
+    1. Generic pass — ``replace_base64_with_content_objects`` walks the whole
+       attribute tree and replaces any leaf string that is itself a data-URI /
+       base64 blob. This cleans the lossless dumps (``attributes_dump`` /
+       ``raw_span_dump``) and the typed custom-attribute maps, and it catches
+       structured message payloads (dict/list) where the blob is already a
+       leaf.
+
+    2. Message-payload pass — the ``gen_ai.{input,output}.messages`` payload
+       frequently arrives as a *JSON-encoded string*. The generic walker in
+       pass 1 cannot descend into a JSON-string leaf, so base64 buried inside
+       it survives pass 1. For each of the input / output message attributes we
+       take the first present lookup key and, when its value is such a string,
+       parse-strip-and-write-back via ``replace_base64_in_raw_messages`` — which
+       cleans the ``input_messages`` / ``output_messages`` columns (and, as a
+       side benefit, the dumps for the JSON-string case too, since the attribute
+       is now a stripped structure).
+    """
+    span.attributes = replace_base64_with_content_objects(
+        span.attributes, project_id, trace_server
+    )
+    _strip_message_attr(
+        span.attributes, semconv.INPUT_MESSAGES.lookup_keys, project_id, trace_server
+    )
+    _strip_message_attr(
+        span.attributes, semconv.OUTPUT_MESSAGES.lookup_keys, project_id, trace_server
+    )
+
+
+# ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
 
@@ -464,16 +545,14 @@ def extract_genai_span(
     wb_run_id: str = "",
     wb_run_step: int = 0,
     wb_run_step_end: int = 0,
-    trace_server: "TraceServerInterface | None" = None,
 ) -> AgentSpanCHInsertable:
     """Extract GenAI semantic convention fields from a parsed OTel span.
 
     Returns an `AgentSpanCHInsertable` ready for ClickHouse insert.
 
-    When *trace_server* is provided, inline base64 / base64 data-URIs in the
-    input and output message payloads are stripped into stored Content refs,
-    mirroring the non-OTel calls path. Left as ``None`` (e.g. in unit tests)
-    the extraction is a pure transform with no file storage.
+    This is a pure transform: it reads ``span`` and produces the insertable
+    with no file storage or other side effects. Inline base64 stripping is a
+    separate, explicit step (`strip_inline_blobs_from_span`) run before this.
     """
     attrs = span.attributes
     events_dicts = [e.as_dict() for e in span.events]
@@ -486,11 +565,6 @@ def extract_genai_span(
 
     raw_output = _extract_raw_output(attrs, events_dicts)
     raw_input = _extract_raw_input(attrs)
-    if trace_server is not None:
-        raw_input = replace_base64_in_raw_messages(raw_input, project_id, trace_server)
-        raw_output = replace_base64_in_raw_messages(
-            raw_output, project_id, trace_server
-        )
     output_msgs = _normalize_raw_messages(raw_output, default_role="assistant")
     reasoning_content = extract_reasoning_content(raw_output)
 

--- a/weave/trace_server/opentelemetry/genai_extraction.py
+++ b/weave/trace_server/opentelemetry/genai_extraction.py
@@ -12,7 +12,7 @@ The main entry point is `extract_genai_span()` which takes a parsed OTel
 import json
 import math
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from weave.trace_server.agents import semconv
 from weave.trace_server.agents.constants import (
@@ -24,12 +24,16 @@ from weave.trace_server.agents.schema import (
     AgentSpanCHInsertable,
     NormalizedMessage,
 )
+from weave.trace_server.base64_content_conversion import replace_base64_in_raw_messages
 from weave.trace_server.opentelemetry.helpers import get_attribute, to_json_serializable
 from weave.trace_server.opentelemetry.python_spans import Span
 from weave.trace_server.query_builder.agent_query_builder import (
     safe_float,
     safe_int,
 )
+
+if TYPE_CHECKING:
+    from weave.trace_server.trace_server_interface import TraceServerInterface
 
 # Known operation name prefixes for span-name inference.
 _KNOWN_OP_PREFIXES = (
@@ -457,10 +461,16 @@ def extract_genai_span(
     wb_run_id: str = "",
     wb_run_step: int = 0,
     wb_run_step_end: int = 0,
+    trace_server: "TraceServerInterface | None" = None,
 ) -> AgentSpanCHInsertable:
     """Extract GenAI semantic convention fields from a parsed OTel span.
 
     Returns an `AgentSpanCHInsertable` ready for ClickHouse insert.
+
+    When *trace_server* is provided, inline base64 / base64 data-URIs in the
+    input and output message payloads are stripped into stored Content refs,
+    mirroring the non-OTel calls path. Left as ``None`` (e.g. in unit tests)
+    the extraction is a pure transform with no file storage.
     """
     attrs = span.attributes
     events_dicts = [e.as_dict() for e in span.events]
@@ -472,6 +482,12 @@ def extract_genai_span(
     status_code = span.status.code.name
 
     raw_output = _extract_raw_output(attrs, events_dicts)
+    raw_input = _extract_raw_input(attrs)
+    if trace_server is not None:
+        raw_input = replace_base64_in_raw_messages(raw_input, project_id, trace_server)
+        raw_output = replace_base64_in_raw_messages(
+            raw_output, project_id, trace_server
+        )
     output_msgs = _normalize_raw_messages(raw_output, default_role="assistant")
     reasoning_content = extract_reasoning_content(raw_output)
 
@@ -537,9 +553,7 @@ def extract_genai_span(
             _get(attrs, *semconv.REQUEST_CHOICE_COUNT.lookup_keys)
         ),
         output_type=_get_str(attrs, *semconv.OUTPUT_TYPE.lookup_keys),
-        input_messages=_normalize_raw_messages(
-            _extract_raw_input(attrs), default_role="user"
-        ),
+        input_messages=_normalize_raw_messages(raw_input, default_role="user"),
         output_messages=output_msgs,
         system_instructions=_normalize_system_instructions(
             _get(attrs, *semconv.SYSTEM_INSTRUCTIONS.lookup_keys)

--- a/weave/trace_server/opentelemetry/genai_extraction.py
+++ b/weave/trace_server/opentelemetry/genai_extraction.py
@@ -466,6 +466,7 @@ def _strip_message_attr(
     lookup_keys: tuple[str, ...],
     project_id: str,
     trace_server: "TraceServerInterface",
+    wb_user_id: str | None = None,
 ) -> None:
     """Strip base64 from the first present message-payload attribute key.
 
@@ -481,7 +482,9 @@ def _strip_message_attr(
         if value is None:
             continue
         if isinstance(value, str):
-            stripped = replace_base64_in_raw_messages(value, project_id, trace_server)
+            stripped = replace_base64_in_raw_messages(
+                value, project_id, trace_server, wb_user_id
+            )
             # Mirror ``get_attribute``'s flat-vs-nested resolution: write back to
             # the flat dotted key if present, otherwise into the nested tree.
             if key in attrs:
@@ -495,6 +498,7 @@ def strip_inline_blobs_from_span(
     span: Span,
     project_id: str,
     trace_server: "TraceServerInterface",
+    wb_user_id: str | None = None,
 ) -> None:
     """Strip inline base64 / base64 data-URIs from a span into stored Content refs.
 
@@ -523,13 +527,21 @@ def strip_inline_blobs_from_span(
        is now a stripped structure).
     """
     span.attributes = replace_base64_with_content_objects(
-        span.attributes, project_id, trace_server
+        span.attributes, project_id, trace_server, wb_user_id
     )
     _strip_message_attr(
-        span.attributes, semconv.INPUT_MESSAGES.lookup_keys, project_id, trace_server
+        span.attributes,
+        semconv.INPUT_MESSAGES.lookup_keys,
+        project_id,
+        trace_server,
+        wb_user_id,
     )
     _strip_message_attr(
-        span.attributes, semconv.OUTPUT_MESSAGES.lookup_keys, project_id, trace_server
+        span.attributes,
+        semconv.OUTPUT_MESSAGES.lookup_keys,
+        project_id,
+        trace_server,
+        wb_user_id,
     )
 
 

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -17,6 +17,7 @@ does not round-trip dataclasses safely through getattr / setattr.
 """
 
 import dataclasses
+import json
 import logging
 from collections.abc import Callable
 from typing import Any, NamedTuple, TypeVar, cast
@@ -34,9 +35,50 @@ B = TypeVar("B")
 weave_prefix = ri.WEAVE_SCHEME + ":///"
 weave_internal_prefix = ri.WEAVE_INTERNAL_SCHEME + ":///"
 
+# Cap on how deep the embedded-ref path re-parses JSON-inside-JSON. Some
+# payloads store refs inside a JSON-serialized string (e.g. an agent message's
+# ``content`` parts array); the mapper re-parses those and re-runs itself over
+# the decoded structure. A JSON blob can itself hold another JSON-string leaf,
+# so an adversarial or pathological payload could nest arbitrarily and exceed
+# Python's recursion limit. Realistic nesting is a handful of levels deep, so 8
+# leaves ample headroom while staying far below ``sys.getrecursionlimit()``
+# (1000 by default). This bounds only the JSON-in-JSON descent — the underlying
+# ``_walk`` container traversal is unchanged. Mirrors
+# ``chat_view._MAX_REF_SEARCH_DEPTH``.
+_MAX_REF_SEARCH_DEPTH = 8
+
 
 class InvalidInternalRef(ValueError):
     pass
+
+
+def _convert_embedded_json_refs(s: str, mapper: Callable[[Any], Any]) -> str:
+    """Rewrite refs buried inside a JSON-serialized string ``s``.
+
+    ``s`` is assumed to be a leaf that does not itself start with a ref prefix
+    but does contain one as a substring (the caller gates on that cheap check
+    plus a depth cap before invoking this). We attempt to decode it as JSON and,
+    if it parses, re-run the SAME ``mapper`` over the decoded structure so
+    embedded refs convert with identical semantics to top-level leaves.
+
+    Returns the ORIGINAL string unchanged when it does not parse as JSON, or
+    when nothing inside it changed — avoiding a gratuitous re-serialization for
+    ref-free (or already-correct) payloads. Otherwise returns ``json.dumps`` of
+    the rewritten structure with default separators, which round-trips cleanly
+    because the producers serialize with ``json.dumps`` defaults too.
+
+    Any exception raised by ``mapper`` (e.g. an embedded ref failing a
+    verification/tolerance check) propagates unchanged, preserving the
+    whole-string raise semantics for embedded leaves.
+    """
+    try:
+        parsed = json.loads(s)
+    except (ValueError, TypeError):
+        return s
+    result = _map_values(parsed, mapper)
+    if result is parsed:
+        return s
+    return json.dumps(result)
 
 
 def replace_external_weave_ref(
@@ -93,6 +135,8 @@ def universal_ext_to_int_ref_converter(
         references.
     """
     ext_to_int_project_cache: dict[str, str] = {}
+    # Tracks JSON-in-JSON descent depth for the embedded-ref path (below).
+    embedded_depth = 0
 
     def replace_ref(ref_str: str) -> str:
         return replace_external_weave_ref(
@@ -100,6 +144,7 @@ def universal_ext_to_int_ref_converter(
         )
 
     def mapper(obj: B) -> B:
+        nonlocal embedded_depth
         if isinstance(obj, str):
             if obj.startswith(weave_prefix):
                 result = replace_ref(obj)
@@ -122,6 +167,20 @@ def universal_ext_to_int_ref_converter(
                 ):
                     return obj
                 raise InvalidExternalRef("Encountered unexpected internal ref format.")
+            elif embedded_depth < _MAX_REF_SEARCH_DEPTH and (
+                weave_prefix in obj or weave_internal_prefix in obj
+            ):
+                # The string does not start with a ref but embeds one inside a
+                # JSON blob (e.g. a message ``content`` parts array). Descend
+                # so embedded external refs convert to internal and embedded
+                # internal refs go through the same verify check as top-level
+                # leaves. Gated by the cheap substring pre-check above and the
+                # depth cap so ref-free strings never pay for ``json.loads``.
+                embedded_depth += 1
+                try:
+                    return cast(B, _convert_embedded_json_refs(obj, mapper))
+                finally:
+                    embedded_depth -= 1
         return obj
 
     return _map_values(obj, mapper)
@@ -155,6 +214,8 @@ def universal_int_to_ext_ref_converter(
         references.
     """
     int_to_ext_project_cache: dict[str, str | None] = {}
+    # Tracks JSON-in-JSON descent depth for the embedded-ref path (below).
+    embedded_depth = 0
 
     def replace_ref(ref_str: str) -> str:
         if not ref_str.startswith(weave_internal_prefix):
@@ -174,6 +235,7 @@ def universal_int_to_ext_ref_converter(
         return f"{ri.WEAVE_SCHEME}:///{external_project_id}/{tail}"
 
     def mapper(obj: D) -> D:
+        nonlocal embedded_depth
         if isinstance(obj, str):
             if obj.startswith(weave_internal_prefix):
                 return cast(D, replace_ref(obj))
@@ -183,6 +245,20 @@ def universal_int_to_ext_ref_converter(
                 if not tolerate_external_refs:
                     raise InvalidInternalRef("Encountered unexpected ref format.")
                 logger.error("Returning stored external ref unchanged: %s", obj)
+            elif embedded_depth < _MAX_REF_SEARCH_DEPTH and (
+                weave_prefix in obj or weave_internal_prefix in obj
+            ):
+                # The string does not start with a ref but embeds one inside a
+                # JSON blob (e.g. a message ``content`` parts array). Descend
+                # so embedded internal refs externalize and embedded external
+                # refs hit the same tolerate/raise policy as top-level leaves.
+                # Gated by the cheap substring pre-check above and the depth cap
+                # so ref-free strings never pay for ``json.loads``.
+                embedded_depth += 1
+                try:
+                    return cast(D, _convert_embedded_json_refs(obj, mapper))
+                finally:
+                    embedded_depth -= 1
         return obj
 
     return _map_values(obj, mapper)

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -14,6 +14,11 @@ zero new objects are allocated.
 Pydantic models with nested dataclasses inside `Any` fields fall back to
 the legacy `model_dump` / `model_validate` round-trip, since Pydantic
 does not round-trip dataclasses safely through getattr / setattr.
+
+Refs can also be buried inside a JSON-serialized string leaf (e.g. an agent
+message's `content` parts array). Such leaves are decoded and re-walked so the
+embedded refs convert with the same semantics as top-level ones, bounded by
+`_MAX_REF_SEARCH_DEPTH` to cap JSON-in-JSON nesting.
 """
 
 import dataclasses
@@ -35,15 +40,10 @@ B = TypeVar("B")
 weave_prefix = ri.WEAVE_SCHEME + ":///"
 weave_internal_prefix = ri.WEAVE_INTERNAL_SCHEME + ":///"
 
-# Cap on how deep the embedded-ref path re-parses JSON-inside-JSON. Some
-# payloads store refs inside a JSON-serialized string (e.g. an agent message's
-# ``content`` parts array); the mapper re-parses those and re-runs itself over
-# the decoded structure. A JSON blob can itself hold another JSON-string leaf,
-# so an adversarial or pathological payload could nest arbitrarily and exceed
-# Python's recursion limit. Realistic nesting is a handful of levels deep, so 8
-# leaves ample headroom while staying far below ``sys.getrecursionlimit()``
-# (1000 by default). This bounds only the JSON-in-JSON descent — the underlying
-# ``_walk`` container traversal is unchanged. Mirrors
+# Caps the JSON-in-JSON descent for refs embedded inside a JSON-serialized
+# string leaf: a decoded blob can hold another JSON-string leaf, so a
+# pathological payload could nest without bound. Realistic nesting is a few
+# levels; 8 leaves headroom below sys.getrecursionlimit(). Mirrors
 # ``chat_view._MAX_REF_SEARCH_DEPTH``.
 _MAX_REF_SEARCH_DEPTH = 8
 
@@ -55,21 +55,12 @@ class InvalidInternalRef(ValueError):
 def _convert_embedded_json_refs(s: str, mapper: Callable[[Any], Any]) -> str:
     """Rewrite refs buried inside a JSON-serialized string ``s``.
 
-    ``s`` is assumed to be a leaf that does not itself start with a ref prefix
-    but does contain one as a substring (the caller gates on that cheap check
-    plus a depth cap before invoking this). We attempt to decode it as JSON and,
-    if it parses, re-run the SAME ``mapper`` over the decoded structure so
-    embedded refs convert with identical semantics to top-level leaves.
-
-    Returns the ORIGINAL string unchanged when it does not parse as JSON, or
-    when nothing inside it changed — avoiding a gratuitous re-serialization for
-    ref-free (or already-correct) payloads. Otherwise returns ``json.dumps`` of
-    the rewritten structure with default separators, which round-trips cleanly
-    because the producers serialize with ``json.dumps`` defaults too.
-
-    Any exception raised by ``mapper`` (e.g. an embedded ref failing a
-    verification/tolerance check) propagates unchanged, preserving the
-    whole-string raise semantics for embedded leaves.
+    Decode ``s`` as JSON and re-run ``mapper`` over the result so embedded refs
+    convert with the same semantics as top-level leaves. Returns ``s`` unchanged
+    when it does not parse as JSON or when nothing inside it changed (avoiding a
+    gratuitous re-dump); otherwise returns the re-serialized structure. Any
+    exception from ``mapper`` propagates, preserving whole-string raise
+    semantics.
     """
     try:
         parsed = json.loads(s)
@@ -79,6 +70,38 @@ def _convert_embedded_json_refs(s: str, mapper: Callable[[Any], Any]) -> str:
     if result is parsed:
         return s
     return json.dumps(result)
+
+
+def _make_ref_string_mapper(convert_ref: Callable[[str], str]) -> Callable[[B], B]:
+    """Build a copy-on-write mapper that rewrites weave refs in string leaves.
+
+    ``convert_ref`` handles a string that starts with a ref prefix, returning
+    its converted form (or raising for a disallowed ref). A string that instead
+    embeds a ref inside a JSON blob (e.g. a message ``content`` parts array) is
+    decoded and re-run through the same mapper so embedded refs convert exactly
+    like top-level ones. The substring pre-check keeps ref-free strings off the
+    ``json.loads`` path, and ``_MAX_REF_SEARCH_DEPTH`` caps the JSON-in-JSON
+    descent.
+    """
+    depth = 0
+
+    def mapper(obj: B) -> B:
+        nonlocal depth
+        if not isinstance(obj, str):
+            return obj
+        if obj.startswith(weave_prefix) or obj.startswith(weave_internal_prefix):
+            return cast(B, convert_ref(obj))
+        if depth < _MAX_REF_SEARCH_DEPTH and (
+            weave_prefix in obj or weave_internal_prefix in obj
+        ):
+            depth += 1
+            try:
+                return cast(B, _convert_embedded_json_refs(obj, mapper))
+            finally:
+                depth -= 1
+        return obj
+
+    return mapper
 
 
 def replace_external_weave_ref(
@@ -135,59 +158,31 @@ def universal_ext_to_int_ref_converter(
         references.
     """
     ext_to_int_project_cache: dict[str, str] = {}
-    # Tracks JSON-in-JSON descent depth for the embedded-ref path (below).
-    embedded_depth = 0
 
-    def replace_ref(ref_str: str) -> str:
-        return replace_external_weave_ref(
-            ref_str, convert_ext_to_int_project_id, ext_to_int_project_cache
-        )
+    def convert_ref(ref_str: str) -> str:
+        if ref_str.startswith(weave_prefix):
+            return replace_external_weave_ref(
+                ref_str, convert_ext_to_int_project_id, ext_to_int_project_cache
+            )
+        # Internal ref: accept only when the verify callback confirms the
+        # project_id, else a client could smuggle refs to arbitrary private
+        # projects.
+        rest = ref_str[len(weave_internal_prefix) :]
+        parts = rest.split("/", 2)
+        if len(parts) < 2:
+            raise InvalidExternalRef(
+                "Invalid internal ref format: missing project_id or kind."
+            )
+        if verify_internal_project_id is not None and verify_internal_project_id(
+            parts[0]
+        ):
+            return ref_str
+        raise InvalidExternalRef("Encountered unexpected internal ref format.")
 
-    def mapper(obj: B) -> B:
-        nonlocal embedded_depth
-        if isinstance(obj, str):
-            if obj.startswith(weave_prefix):
-                result = replace_ref(obj)
-                return cast(B, result)
-            elif obj.startswith(weave_internal_prefix):
-                # Internal refs are only accepted when the verify callback
-                # confirms the project_id is valid. Without this check, a
-                # malicious client could embed refs to arbitrary private
-                # projects.
-                rest = obj[len(weave_internal_prefix) :]
-                parts = rest.split("/", 2)
-                if len(parts) < 2:
-                    raise InvalidExternalRef(
-                        "Invalid internal ref format: missing project_id or kind."
-                    )
-                ref_project_id = parts[0]
-                if (
-                    verify_internal_project_id is not None
-                    and verify_internal_project_id(ref_project_id)
-                ):
-                    return obj
-                raise InvalidExternalRef("Encountered unexpected internal ref format.")
-            elif embedded_depth < _MAX_REF_SEARCH_DEPTH and (
-                weave_prefix in obj or weave_internal_prefix in obj
-            ):
-                # The string does not start with a ref but embeds one inside a
-                # JSON blob (e.g. a message ``content`` parts array). Descend
-                # so embedded external refs convert to internal and embedded
-                # internal refs go through the same verify check as top-level
-                # leaves. Gated by the cheap substring pre-check above and the
-                # depth cap so ref-free strings never pay for ``json.loads``.
-                embedded_depth += 1
-                try:
-                    return cast(B, _convert_embedded_json_refs(obj, mapper))
-                finally:
-                    embedded_depth -= 1
-        return obj
-
-    return _map_values(obj, mapper)
+    return _map_values(obj, _make_ref_string_mapper(convert_ref))
 
 
 C = TypeVar("C")
-D = TypeVar("D")
 
 
 def universal_int_to_ext_ref_converter(
@@ -214,54 +209,30 @@ def universal_int_to_ext_ref_converter(
         references.
     """
     int_to_ext_project_cache: dict[str, str | None] = {}
-    # Tracks JSON-in-JSON descent depth for the embedded-ref path (below).
-    embedded_depth = 0
 
-    def replace_ref(ref_str: str) -> str:
-        if not ref_str.startswith(weave_internal_prefix):
-            raise ValueError(f"Invalid URI: {ref_str}")
-        rest = ref_str[len(weave_internal_prefix) :]
-        parts = rest.split("/", 1)
-        if len(parts) != 2:
-            raise InvalidInternalRef(f"Invalid URI: {ref_str}")
-        project_id, tail = parts
-        if project_id not in int_to_ext_project_cache:
-            int_to_ext_project_cache[project_id] = convert_int_to_ext_project_id(
-                project_id
-            )
-        external_project_id = int_to_ext_project_cache[project_id]
-        if not external_project_id:
-            return f"{ri.WEAVE_PRIVATE_SCHEME}://///{tail}"
-        return f"{ri.WEAVE_SCHEME}:///{external_project_id}/{tail}"
+    def convert_ref(ref_str: str) -> str:
+        if ref_str.startswith(weave_internal_prefix):
+            rest = ref_str[len(weave_internal_prefix) :]
+            parts = rest.split("/", 1)
+            if len(parts) != 2:
+                raise InvalidInternalRef(f"Invalid URI: {ref_str}")
+            project_id, tail = parts
+            if project_id not in int_to_ext_project_cache:
+                int_to_ext_project_cache[project_id] = convert_int_to_ext_project_id(
+                    project_id
+                )
+            external_project_id = int_to_ext_project_cache[project_id]
+            if not external_project_id:
+                return f"{ri.WEAVE_PRIVATE_SCHEME}://///{tail}"
+            return f"{ri.WEAVE_SCHEME}:///{external_project_id}/{tail}"
+        # External ref stored where an internal one belongs. Agent reads
+        # tolerate it (already external-shaped); other paths raise loudly.
+        if not tolerate_external_refs:
+            raise InvalidInternalRef("Encountered unexpected ref format.")
+        logger.error("Returning stored external ref unchanged: %s", ref_str)
+        return ref_str
 
-    def mapper(obj: D) -> D:
-        nonlocal embedded_depth
-        if isinstance(obj, str):
-            if obj.startswith(weave_internal_prefix):
-                return cast(D, replace_ref(obj))
-            elif obj.startswith(weave_prefix):
-                # External ref stored where an internal one belongs. Agent reads
-                # tolerate it (already external-shaped); other paths raise loudly.
-                if not tolerate_external_refs:
-                    raise InvalidInternalRef("Encountered unexpected ref format.")
-                logger.error("Returning stored external ref unchanged: %s", obj)
-            elif embedded_depth < _MAX_REF_SEARCH_DEPTH and (
-                weave_prefix in obj or weave_internal_prefix in obj
-            ):
-                # The string does not start with a ref but embeds one inside a
-                # JSON blob (e.g. a message ``content`` parts array). Descend
-                # so embedded internal refs externalize and embedded external
-                # refs hit the same tolerate/raise policy as top-level leaves.
-                # Gated by the cheap substring pre-check above and the depth cap
-                # so ref-free strings never pay for ``json.loads``.
-                embedded_depth += 1
-                try:
-                    return cast(D, _convert_embedded_json_refs(obj, mapper))
-                finally:
-                    embedded_depth -= 1
-        return obj
-
-    return _map_values(obj, mapper)
+    return _map_values(obj, _make_ref_string_mapper(convert_ref))
 
 
 E = TypeVar("E")


### PR DESCRIPTION
## Description

New agents OTel export endpoint and old one were not converting base64 and data urls to content server side like they would be when contained in SDK traces. This fixes it by making chat_view.py recursively check all fields for refs and adding the object save + ref replacement to both paths.

## Testing

Tested with a basic script where images are submitted and model is asked what is in it. 
<img width="1291" height="707" alt="image" src="https://github.com/user-attachments/assets/a1eb06fa-05b8-44e5-b1de-9fa5b0c47ae9" />
