### PR TITLE
feat(weave_ts): Accept `agent_id`, `agent_description`, `agent_version` when creating `Conversation`s

### DIFF
--- a/sdks/node/src/__tests__/genai/conversation.test.ts
+++ b/sdks/node/src/__tests__/genai/conversation.test.ts
@@ -63,13 +63,19 @@ describe('Conversation', () => {
 
   it('startTurn emits given data on `invoke_agent` span', () => {
     const conversation = Conversation.create({
-      agentName: 'dispatcher',
       model: 'some-model',
+      agentId: 'dispatcher-prod',
+      agentName: 'dispatcher',
+      agentDescription: 'Routes queries to specialist agents.',
+      agentVersion: '2.0.1',
       conversationId: 'c-2',
     });
     const turn = conversation.startTurn({
-      agentName: 'weather-bot',
       model: 'gpt-4o',
+      agentId: 'weather-prod',
+      agentName: 'weather-bot',
+      agentDescription: 'Finds the most accurate weather',
+      agentVersion: '3.1.2',
       userMessage: "What's the weather?",
       systemInstructions: ['Be helpful', 'Be concise'],
     });
@@ -80,7 +86,10 @@ describe('Conversation', () => {
     expect(spanSnapshot(span)).toMatchInlineSnapshot(`
       {
         "attributes": {
+          "gen_ai.agent.description": "Finds the most accurate weather",
+          "gen_ai.agent.id": "weather-prod",
           "gen_ai.agent.name": "weather-bot",
+          "gen_ai.agent.version": "3.1.2",
           "gen_ai.conversation.id": "<uuid>",
           "gen_ai.input.messages": "[{"role":"user","parts":[{"type":"text","content":"What's the weather?"}]}]",
           "gen_ai.operation.name": "invoke_agent",
@@ -95,8 +104,11 @@ describe('Conversation', () => {
 
   it('startTurn falls back to conversation data when not given', () => {
     const conversation = Conversation.create({
-      agentName: 'dispatcher',
       model: 'some-model',
+      agentId: 'dispatcher-prod',
+      agentName: 'dispatcher',
+      agentDescription: 'Routes queries to specialist agents.',
+      agentVersion: '2.0.1',
       conversationId: 'c-3',
     });
     const turn = conversation.startTurn();
@@ -107,7 +119,10 @@ describe('Conversation', () => {
     expect(spanSnapshot(span)).toMatchInlineSnapshot(`
       {
         "attributes": {
+          "gen_ai.agent.description": "Routes queries to specialist agents.",
+          "gen_ai.agent.id": "dispatcher-prod",
           "gen_ai.agent.name": "dispatcher",
+          "gen_ai.agent.version": "2.0.1",
           "gen_ai.conversation.id": "<uuid>",
           "gen_ai.operation.name": "invoke_agent",
           "gen_ai.request.model": "some-model",

--- a/sdks/node/src/genai/conversation.ts
+++ b/sdks/node/src/genai/conversation.ts
@@ -6,11 +6,43 @@ import {Turn, type TurnInit} from './turn';
 import type {SpanEndOptions} from './spanBase';
 
 export interface ConversationInit {
-  agentName?: string;
   model?: string;
-  /** Conversation ID propagated to every span under this conversation as
-   *  `gen_ai.conversation.id`. Auto-generated if omitted. */
+
+  /**
+   * Stable agent identifier. Propagated as the default `agentId` to every
+   * `Turn` created via `startTurn()` unless the turn sets its own; emitted
+   * on each turn's `invoke_agent` span as `gen_ai.agent.id`.
+   */
+  agentId?: string;
+
+  /**
+   * Agent name. Propagated as the default `agentName` to every `Turn`
+   * created via `startTurn()` unless the turn sets its own; emitted on
+   * each turn's `invoke_agent` span as `gen_ai.agent.name`.
+   */
+  agentName?: string;
+
+  /**
+   * Human-readable agent description. Propagated as the default
+   * `agentDescription` to every `Turn` created via `startTurn()` unless
+   * the turn sets its own; emitted on each turn's `invoke_agent` span as
+   * `gen_ai.agent.description`.
+   */
+  agentDescription?: string;
+
+  /**
+   * Agent version string. Propagated as the default `agentVersion` to
+   * every `Turn` created via `startTurn()` unless the turn sets its own;
+   * emitted on each turn's `invoke_agent` span as `gen_ai.agent.version`.
+   */
+  agentVersion?: string;
+
+  /**
+   * Conversation ID propagated to every span under this conversation as
+   * `gen_ai.conversation.id`. Auto-generated if omitted.
+   */
   conversationId?: string;
+
   /**
    * Custom attributes stamped on every span the conversation emits.
    *
@@ -34,7 +66,10 @@ export class Conversation {
     public readonly agentName: string,
     public readonly model: string,
     public readonly conversationId: string,
-    public readonly attributes: Attributes
+    public readonly attributes: Attributes,
+    private readonly _agentId: string,
+    private readonly _agentDescription: string,
+    private readonly _agentVersion: string
   ) {}
 
   /** @deprecated Use {@link Conversation.conversationId} instead. */
@@ -53,7 +88,10 @@ export class Conversation {
       opts.agentName ?? '',
       opts.model ?? '',
       opts.conversationId ?? opts.sessionId ?? uuidv7(),
-      opts.attributes ?? {}
+      opts.attributes ?? {},
+      opts.agentId ?? '',
+      opts.agentDescription ?? '',
+      opts.agentVersion ?? ''
     );
     state.conversation = conversation;
     return conversation;
@@ -61,8 +99,9 @@ export class Conversation {
 
   /**
    * Start a new `Turn` under this `Conversation`. The turn inherits the
-   * conversation's `conversationId`; `agentName` and `model` fall back to
-   * the conversation's values when not provided on `opts`.
+   * conversation's `conversationId`; `agentName`, `agentId`, `agentDescription`,
+   * `agentVersion` and `model` fall back to the conversation's values when not
+   * provided on `opts`.
    *
    * @example
    * const turn = conversation.startTurn();
@@ -84,6 +123,9 @@ export class Conversation {
       ...opts,
       agentName: opts.agentName ?? this.agentName,
       model: opts.model ?? this.model,
+      agentId: opts.agentId ?? this._agentId,
+      agentDescription: opts.agentDescription ?? this._agentDescription,
+      agentVersion: opts.agentVersion ?? this._agentVersion,
       conversationId: this.conversationId,
     });
   }


### PR DESCRIPTION
## Description

* Python accepts `agent_id`, `agent_description`, `agent_version` when constructing `Conversation`s. (https://github.com/wandb/weave/pull/7439)

* Note: Python does not currently accept these via `start_conversation`, but we plan on adding those.

* Typescript does not yet support these fields -- this change adds them to `startConversation`.
