### PR TITLE
fix(weave): migrator ddl client outlasts replicated-ddl propagation timeout

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -2040,3 +2040,35 @@ def test_genai_otel_export_emit_gate(monkeypatch, online_eval, scoring, should_e
     else:
         mock_producer.produce_score_agent_spans.assert_not_called()
         mock_producer.flush.assert_not_called()
+
+
+def test_mint_client_forwards_send_receive_timeout():
+    server = chts.ClickHouseTraceServer(host="test_host")
+    with (
+        patch.object(chts.ClickHouseTraceServer, "_ensure_database"),
+        patch(
+            "weave.trace_server.clickhouse_trace_server_batched.clickhouse_connect.get_client"
+        ) as mock_get_client,
+    ):
+        mock_get_client.return_value = MagicMock()
+        server._mint_client(
+            send_receive_timeout=ch_settings.MIGRATION_CLIENT_SEND_RECEIVE_TIMEOUT_SEC
+        )
+        kwargs = mock_get_client.call_args.kwargs
+        assert (
+            kwargs["send_receive_timeout"]
+            == ch_settings.MIGRATION_CLIENT_SEND_RECEIVE_TIMEOUT_SEC
+        )
+
+
+def test_mint_client_omits_send_receive_timeout_by_default():
+    server = chts.ClickHouseTraceServer(host="test_host")
+    with (
+        patch.object(chts.ClickHouseTraceServer, "_ensure_database"),
+        patch(
+            "weave.trace_server.clickhouse_trace_server_batched.clickhouse_connect.get_client"
+        ) as mock_get_client,
+    ):
+        mock_get_client.return_value = MagicMock()
+        server._mint_client()
+        assert "send_receive_timeout" not in mock_get_client.call_args.kwargs

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -8,6 +8,7 @@ import sqlparse
 from clickhouse_connect.driver.exceptions import DatabaseError
 
 from weave.trace_server import clickhouse_trace_server_migrator as trace_server_migrator
+from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.clickhouse.utilities import split_migration_sql
 from weave.trace_server.clickhouse_trace_server_migrator import (
     _MAX_RETRIES,
@@ -205,8 +206,14 @@ def test_apply_migrations_with_target_version(
     assert migrator.ch_client.command.call_count == 2
     migrator.ch_client.command.assert_has_calls(
         [
-            call("CREATE TABLE test1 (id Int32)", settings=None),
-            call("CREATE TABLE test2 (id Int32)", settings=None),
+            call(
+                "CREATE TABLE test1 (id Int32)",
+                settings=ch_settings.MIGRATION_DDL_QUERY_SETTINGS,
+            ),
+            call(
+                "CREATE TABLE test2 (id Int32)",
+                settings=ch_settings.MIGRATION_DDL_QUERY_SETTINGS,
+            ),
         ]
     )
 
@@ -477,7 +484,8 @@ def test_execute_migration_command(migrator):
         migrator.ch_client.database == "original_db"
     )  # Should restore original database
     migrator.ch_client.command.assert_called_once_with(
-        "CREATE TABLE test (id Int32)", settings=None
+        "CREATE TABLE test (id Int32)",
+        settings=ch_settings.MIGRATION_DDL_QUERY_SETTINGS,
     )
 
 
@@ -485,7 +493,9 @@ def test_migration_non_replicated(migrator):
     # Test that non-replicated mode doesn't transform the SQL
     orig = "CREATE TABLE test (id String, project_id String) ENGINE = MergeTree ORDER BY (project_id, id);"
     migrator._execute_migration_command("test_db", orig)
-    migrator.ch_client.command.assert_called_once_with(orig, settings=None)
+    migrator.ch_client.command.assert_called_once_with(
+        orig, settings=ch_settings.MIGRATION_DDL_QUERY_SETTINGS
+    )
 
 
 def test_update_migration_status(migrator):
@@ -499,14 +509,14 @@ def test_update_migration_status(migrator):
     migrator._update_migration_status("test_db", 2, is_start=True)
     migrator.ch_client.command.assert_called_with(
         "ALTER TABLE db_management.migrations UPDATE partially_applied_version = 2 WHERE db_name = 'test_db'",
-        settings={"mutations_sync": 2},
+        settings={**ch_settings.MIGRATION_DDL_QUERY_SETTINGS, "mutations_sync": 2},
     )
 
     # Test end of migration
     migrator._update_migration_status("test_db", 2, is_start=False)
     migrator.ch_client.command.assert_called_with(
         "ALTER TABLE db_management.migrations UPDATE curr_version = 2, partially_applied_version = NULL WHERE db_name = 'test_db'",
-        settings={"mutations_sync": 2},
+        settings={**ch_settings.MIGRATION_DDL_QUERY_SETTINGS, "mutations_sync": 2},
     )
 
 
@@ -1875,3 +1885,31 @@ def test_split_migration_sql_equivalent_on_all_shipped_migrations() -> None:
             f"  old ({len(old_norm)}): {old_norm}\n"
             f"  new ({len(new_norm)}): {new_norm}"
         )
+
+
+def test_run_ddl_with_retry_passes_migration_ddl_settings(migrator):
+    migrator._run_ddl_with_retry("CREATE TABLE t (id Int32)")
+    migrator.ch_client.command.assert_called_once_with(
+        "CREATE TABLE t (id Int32)",
+        settings=ch_settings.MIGRATION_DDL_QUERY_SETTINGS,
+    )
+
+
+def test_run_ddl_with_retry_merges_caller_settings(migrator):
+    migrator._run_ddl_with_retry("SELECT 1", settings={"mutations_sync": 2})
+    migrator.ch_client.command.assert_called_once_with(
+        "SELECT 1",
+        settings={**ch_settings.MIGRATION_DDL_QUERY_SETTINGS, "mutations_sync": 2},
+    )
+
+
+def test_migration_timeout_ladder_invariants():
+    # The client read timeout must outlast both the ON CLUSTER DDL wait and the
+    # server's replicated-DDL wait (database_replicated_initial_query_timeout_sec,
+    # default 300s) so the client always gets a response rather than the read
+    # timeout that stranded the migration mid-DDL in the incident.
+    client = ch_settings.MIGRATION_CLIENT_SEND_RECEIVE_TIMEOUT_SEC
+    ddl_task = ch_settings.MIGRATION_DDL_QUERY_SETTINGS["distributed_ddl_task_timeout"]
+    server_replicated_ddl_default = 300
+    assert client > ddl_task
+    assert client > server_replicated_ddl_default

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -6,8 +6,10 @@ Runs actual SQL against a single-node ClickHouse with embedded Keeper.
 import os
 import uuid
 
+import clickhouse_connect
 import pytest
 
+from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.clickhouse_trace_server_migrator import (
     get_clickhouse_trace_server_migrator,
 )
@@ -530,3 +532,40 @@ def test_all_production_down_migrations_distributed(ch_client):
 
     # Migrate all the way back down
     migrator.apply_migrations(target_db, target_version=0)
+
+
+def test_migration_client_timeout_outlasts_replicated_ddl(ch_keeper_server):
+    """A client minted with the production migration timeout runs a full
+    replicated migration and carries the incident-fixing HTTP read timeout.
+    """
+    host, port = ch_keeper_server
+    client = clickhouse_connect.get_client(
+        host=host,
+        port=port,
+        autogenerate_session_id=False,
+        send_receive_timeout=ch_settings.MIGRATION_CLIENT_SEND_RECEIVE_TIMEOUT_SEC,
+    )
+    assert client.timeout.read_timeout == (
+        ch_settings.MIGRATION_CLIENT_SEND_RECEIVE_TIMEOUT_SEC
+    )
+
+    mgmt_db = _unique_name("db_mgmt_timeout")
+    target_db = _unique_name("timeout_repl")
+    try:
+        migrator = get_clickhouse_trace_server_migrator(
+            client,
+            replicated=True,
+            use_distributed=False,
+            replicated_cluster=_CLUSTER,
+            replicated_path=_REPLICATED_PATH,
+            management_db=mgmt_db,
+            migration_dir=_PROD_MIGRATION_DIR,
+            post_migration_hook=None,
+        )
+        latest_version = _get_latest_migration_version(_PROD_MIGRATION_DIR)
+        migrator.apply_migrations(target_db)
+        assert _get_migration_version(client, mgmt_db, target_db) == latest_version
+    finally:
+        for db in (target_db, mgmt_db):
+            client.command(f"DROP DATABASE IF EXISTS {db}")
+        client.close()

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7072,13 +7072,18 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             client.command(f"CREATE DATABASE IF NOT EXISTS {self._database}")
             self._database_ensured = True
 
-    def _mint_client(self) -> CHClient:
+    def _mint_client(self, send_receive_timeout: int | None = None) -> CHClient:
         """Create a new ClickHouse client using the shared pool manager.
 
         autogenerate_session_id=False: weave-trace uses no session features,
         and the default collides on overlapping queries with SESSION_IS_LOCKED
         (code 373). See PR #6655.
+        `send_receive_timeout` overrides the HTTP read timeout (migration clients
+        need to outlast replicated-DDL propagation); None keeps the library default.
         """
+        optional_kwargs: dict[str, int] = {}
+        if send_receive_timeout is not None:
+            optional_kwargs["send_receive_timeout"] = send_receive_timeout
         client = clickhouse_connect.get_client(
             host=self._host,
             port=self._port,
@@ -7087,6 +7092,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             secure=self._port == CLICKHOUSE_SECURE_PORT,
             pool_mgr=_CH_POOL_MANAGER,
             autogenerate_session_id=False,
+            **optional_kwargs,
         )
         self._ensure_database(client)
         client.database = self._database
@@ -7175,15 +7181,18 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     def _run_migrations(self) -> None:
         logger.info("Running migrations")
+        migration_timeout = ch_settings.MIGRATION_CLIENT_SEND_RECEIVE_TIMEOUT_SEC
         migrator = wf_migrator.get_clickhouse_trace_server_migrator(
-            self._mint_client(),
+            self._mint_client(send_receive_timeout=migration_timeout),
             replicated=wf_env.wf_clickhouse_replicated(),
             replicated_path=wf_env.wf_clickhouse_replicated_path(),
             replicated_cluster=wf_env.wf_clickhouse_replicated_cluster(),
             use_distributed=wf_env.wf_clickhouse_use_distributed_tables(),
             # Mint the heartbeat's client like the primary so it inherits
             # secure/pool/db settings (raw env would drop `secure=`).
-            heartbeat_client_factory=self._mint_client,
+            heartbeat_client_factory=partial(
+                self._mint_client, send_receive_timeout=migration_timeout
+            ),
         )
         migrator.apply_migrations(self._database)
 

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -608,7 +608,11 @@ class BaseClickHouseTraceServerMigrator(ABC):
         and 999 (KEEPER_EXCEPTION) when ON CLUSTER DDL hits a transient Keeper
         coordination error.
         """
-        self.ch_client.command(command, settings=settings)
+        merged_settings = {
+            **ch_settings.MIGRATION_DDL_QUERY_SETTINGS,
+            **(settings or {}),
+        }
+        self.ch_client.command(command, settings=merged_settings)
 
 
 class CloudClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator):

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -151,6 +151,17 @@ CLICKHOUSE_ASYNC_INSERT_SETTINGS: dict[str, int | str] = {
 }
 
 
+# HTTP read timeout for the migration client. Must exceed the server's
+# database_replicated_initial_query_timeout_sec (default 300s) so slow DDL completes.
+MIGRATION_CLIENT_SEND_RECEIVE_TIMEOUT_SEC = 900
+
+# Bounds only the ON CLUSTER (distributed DDL queue) wait; does not affect the
+# Replicated-DB-engine path, which the client read timeout above covers.
+MIGRATION_DDL_QUERY_SETTINGS: dict[str, int | str] = {
+    "distributed_ddl_task_timeout": 600,
+}
+
+
 def merge_default_query_settings(
     overrides: dict[str, int | str] | None = None,
 ) -> dict[str, int | str]:


### PR DESCRIPTION
## Summary
- migration client `send_receive_timeout` now exceeds the server's replicated-DDL propagation wait, so a slow cross-replica DDL returns a real result instead of a client read-timeout that leaves `partially_applied_version` set and crash-loops pods on the next start.
- routes every migrator DDL through explicit query settings (`distributed_ddl_task_timeout`) at the single `_run_ddl_with_retry` chokepoint; timeout constants live in ch settings.

## Testing
unit tests on the real ddl/mint-client paths; a functional test asserts the migration client carries the elevated read timeout and completes a full replicated migration (trace_server_migrator nox shard).