### PR TITLE
test(weave): add migration safety linter for idempotency and op ordering

### DIFF
--- a/tests/trace_server_migrator/test_migration_lint.py
+++ b/tests/trace_server_migrator/test_migration_lint.py
@@ -1,0 +1,109 @@
+"""Pure-python tests for the migration safety linter (no ClickHouse required)."""
+
+import os
+
+from weave.trace_server.migration_lint import (
+    lint_migration_dir,
+    lint_migration_sql,
+)
+
+_PROD_MIGRATION_DIR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__), "..", "..", "weave", "trace_server", "migrations"
+    )
+)
+
+# Highest version already shipped when the linter landed. Migrations at or below
+# this are grandfathered; anything newer must pass every rule.
+_GRANDFATHERED_THROUGH_VERSION = 35
+
+
+def test_r1_create_without_if_not_exists():
+    bad = "CREATE TABLE foo (a String) ENGINE = MergeTree() ORDER BY a;"
+    rules = {f.rule for f in lint_migration_sql("100_x.up.sql", bad)}
+    assert "R1" in rules
+
+    good = "CREATE TABLE IF NOT EXISTS foo (a String) ENGINE = MergeTree() ORDER BY a;"
+    assert lint_migration_sql("100_x.up.sql", good) == []
+
+
+def test_r2_drop_without_if_exists():
+    bad = "DROP TABLE foo;"
+    rules = {f.rule for f in lint_migration_sql("100_x.up.sql", bad)}
+    assert "R2" in rules
+
+    good = "DROP TABLE IF EXISTS foo;"
+    assert lint_migration_sql("100_x.up.sql", good) == []
+
+
+def test_r3_add_column_without_if_not_exists():
+    bad = "ALTER TABLE foo ADD COLUMN bar String;"
+    rules = {f.rule for f in lint_migration_sql("100_x.up.sql", bad)}
+    assert "R3" in rules
+
+    good = "ALTER TABLE foo ADD COLUMN IF NOT EXISTS bar String;"
+    assert lint_migration_sql("100_x.up.sql", good) == []
+
+
+def test_r4_irreversible_before_mutating():
+    bad = (
+        "ALTER TABLE foo RENAME COLUMN a TO b;\n"
+        "ALTER TABLE foo ADD COLUMN IF NOT EXISTS c String;"
+    )
+    rules = {f.rule for f in lint_migration_sql("100_x.up.sql", bad)}
+    assert "R4" in rules
+
+    good = (
+        "ALTER TABLE foo ADD COLUMN IF NOT EXISTS c String;\n"
+        "ALTER TABLE foo RENAME COLUMN a TO b;"
+    )
+    assert lint_migration_sql("100_x.up.sql", good) == []
+
+
+def test_compound_alter_flags_only_unguarded_clause():
+    bad = "ALTER TABLE foo ADD COLUMN IF NOT EXISTS a String, ADD COLUMN b String;"
+    rules = {f.rule for f in lint_migration_sql("100_x.up.sql", bad)}
+    assert "R3" in rules
+
+    good = (
+        "ALTER TABLE foo "
+        "ADD COLUMN IF NOT EXISTS a String, ADD COLUMN IF NOT EXISTS b String;"
+    )
+    assert lint_migration_sql("100_x.up.sql", good) == []
+
+
+def test_guarded_drop_then_recreate_is_clean():
+    sql = (
+        "DROP TABLE IF EXISTS foo;\n"
+        "CREATE TABLE IF NOT EXISTS foo (a String) ENGINE = MergeTree() ORDER BY a;"
+    )
+    assert lint_migration_sql("100_x.up.sql", sql) == []
+
+
+def test_ddl_keywords_in_string_literal_not_flagged():
+    sql = "INSERT INTO audit VALUES ('CREATE TABLE run', 'DROP COLUMN x');"
+    assert lint_migration_sql("100_x.up.sql", sql) == []
+
+
+def test_r4_ignores_ddl_keywords_in_string_literals():
+    # An INSERT payload carrying a DDL keyword must not trip the ordering state
+    # and falsely flag a following guarded statement.
+    sql = (
+        "INSERT INTO audit VALUES ('DROP TABLE x');\n"
+        "ALTER TABLE foo ADD COLUMN IF NOT EXISTS c String;"
+    )
+    assert lint_migration_sql("100_x.up.sql", sql) == []
+
+
+def test_dir_walker_flags_known_029_violations():
+    findings = lint_migration_dir(_PROD_MIGRATION_DIR, min_enforced_version=0)
+    rules_029 = {f.rule for f in findings if f.version == 29}
+    assert "R1" in rules_029, findings
+    assert "R4" in rules_029, findings
+
+
+def test_no_new_migrations_violate_rules():
+    findings = lint_migration_dir(
+        _PROD_MIGRATION_DIR, min_enforced_version=_GRANDFATHERED_THROUGH_VERSION
+    )
+    assert findings == [], findings

--- a/weave/trace_server/migration_lint.py
+++ b/weave/trace_server/migration_lint.py
@@ -1,0 +1,147 @@
+"""Static safety linter for ClickHouse migration SQL.
+
+Flags anti-patterns that make a migration unsafe to retry after a partial
+failure: non-idempotent DDL (CREATE/DROP/ADD without IF [NOT] EXISTS) and
+irreversible/destructive statements placed before further mutating steps.
+"""
+
+import os
+import re
+from dataclasses import dataclass
+
+from weave.trace_server.clickhouse.utilities import split_migration_sql
+
+
+@dataclass(frozen=True)
+class LintFinding:
+    version: int
+    file: str
+    rule: str
+    message: str
+
+
+def lint_migration_sql(file_name: str, sql: str) -> list[LintFinding]:
+    """Lint a single migration's SQL text for idempotency and op ordering."""
+    version = _parse_version(file_name)
+    findings: list[LintFinding] = []
+    statements = split_migration_sql(sql)
+
+    seen_irreversible = False
+    for statement in statements:
+        normalized = _normalize(statement)
+        head = _leading_keyword(normalized)
+
+        if head in {"CREATE", "DROP", "ALTER"}:
+            if _UNGUARDED_CREATE_RE.search(normalized):
+                findings.append(
+                    LintFinding(
+                        version,
+                        file_name,
+                        "R1",
+                        f"CREATE without IF NOT EXISTS: {_preview(statement)}",
+                    )
+                )
+            if _UNGUARDED_DROP_RE.search(normalized):
+                findings.append(
+                    LintFinding(
+                        version,
+                        file_name,
+                        "R2",
+                        f"DROP without IF EXISTS: {_preview(statement)}",
+                    )
+                )
+            if _UNGUARDED_ADD_RE.search(normalized):
+                findings.append(
+                    LintFinding(
+                        version,
+                        file_name,
+                        "R3",
+                        f"ADD without IF NOT EXISTS: {_preview(statement)}",
+                    )
+                )
+
+        # R4 ordering only considers real DDL statements; a DDL keyword inside a
+        # string literal (e.g. an INSERT payload) must not move this state.
+        if head in {"ALTER", "CREATE", "DROP", "RENAME"}:
+            if seen_irreversible and _MUTATING_RE.search(normalized):
+                findings.append(
+                    LintFinding(
+                        version,
+                        file_name,
+                        "R4",
+                        f"mutating statement follows an irreversible op: {_preview(statement)}",
+                    )
+                )
+            if _IRREVERSIBLE_RE.search(normalized):
+                seen_irreversible = True
+
+    return findings
+
+
+def lint_migration_dir(
+    migration_dir: str, min_enforced_version: int
+) -> list[LintFinding]:
+    """Lint migrations in a dir; R5 (down pairing) applies to every version, R1-R4 only past min_enforced_version."""
+    findings: list[LintFinding] = []
+    for file_name in os.listdir(migration_dir):
+        if not file_name.endswith(".up.sql"):
+            continue
+        version = _parse_version(file_name)
+
+        down_name = file_name[: -len(".up.sql")] + ".down.sql"
+        if not os.path.exists(os.path.join(migration_dir, down_name)):
+            findings.append(
+                LintFinding(
+                    version,
+                    file_name,
+                    "R5",
+                    f"missing matching down migration: {down_name}",
+                )
+            )
+
+        if version <= min_enforced_version:
+            continue
+        with open(os.path.join(migration_dir, file_name), encoding="utf-8") as f:
+            sql = f.read()
+        findings.extend(lint_migration_sql(file_name, sql))
+
+    return sorted(findings, key=lambda f: (f.version, f.rule, f.message))
+
+
+def _parse_version(file_name: str) -> int:
+    base = os.path.basename(file_name)
+    return int(base.split("_", 1)[0], 10)
+
+
+def _normalize(statement: str) -> str:
+    return re.sub(r"\s+", " ", statement).strip().upper()
+
+
+def _leading_keyword(normalized: str) -> str:
+    return normalized.split(" ", 1)[0] if normalized else ""
+
+
+def _preview(statement: str) -> str:
+    collapsed = re.sub(r"\s+", " ", statement).strip()
+    return collapsed[:80]
+
+
+# Idempotency rules match per clause: each CREATE/DROP/ADD object must be
+# immediately followed by its IF [NOT] EXISTS guard, so a partially guarded
+# compound ALTER still fires on the unguarded clause.
+_UNGUARDED_CREATE_RE = re.compile(
+    r"\bCREATE\s+(?:TABLE|(?:MATERIALIZED\s+)?VIEW|DICTIONARY)\s+(?!IF\s+NOT\s+EXISTS)"
+)
+_UNGUARDED_DROP_RE = re.compile(
+    r"\bDROP\s+(?:TABLE|VIEW|DICTIONARY|COLUMN|INDEX)\s+(?!IF\s+EXISTS)"
+)
+_UNGUARDED_ADD_RE = re.compile(r"\bADD\s+(?:COLUMN|INDEX)\s+(?!IF\s+NOT\s+EXISTS)")
+
+# A guarded DROP is safe to retry, so only unguarded drops and RENAME COLUMN
+# are irreversible for ordering purposes.
+_IRREVERSIBLE_RE = re.compile(
+    r"\bRENAME\s+COLUMN\b"
+    r"|\bDROP\s+COLUMN\s+(?!IF\s+EXISTS)"
+    r"|\bDROP\s+TABLE\s+(?!IF\s+EXISTS)"
+)
+_MUTATING_RE = re.compile(r"\bCREATE\b|\bADD\b|\bMODIFY\b")


### PR DESCRIPTION
## Summary
- static linter (`migration_lint.py`) flagging non-idempotent DDL (CREATE/DROP/ADD without IF [NOT] EXISTS) and irreversible ops (RENAME/DROP COLUMN) placed before further mutating steps.
- enforced on new migrations only (shipped ones grandfathered through the current max version); a guard test fails CI if a future migration violates the rules.

## Testing
unit tests per rule + a test proving it flags the real 029 anti-patterns; pure-python, runs in the trace_server_migrator shard.