### PR TITLE
fix(weave): idempotent migrations, additive 029, and partial-migration auto-recovery

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -26,6 +26,26 @@ DEFAULT_MIGRATION_DIR = os.path.abspath(
 )
 
 
+def _count_result(n: int) -> Mock:
+    """Mock a `SELECT count()` query result with a single row/column of `n`."""
+    res = Mock()
+    res.result_rows = [(n,)]
+    return res
+
+
+def _stub_divergence_precheck(sql: str) -> Mock | None:
+    """Stub the divergence pre-check queries in `_apply_migrations_locked`.
+
+    A row in the migrations table (count 1) makes the guard a no-op, so tests
+    that mock the inner migration methods reach the path they exercise.
+    """
+    if "system.tables" in sql:
+        return _count_result(0)
+    if "count()" in sql and ".migrations" in sql:
+        return _count_result(1)
+    return None
+
+
 def _make_ch_client(database_engine: str = "Atomic") -> Mock:
     """Create a mock CH client that returns *database_engine* for system.databases queries.
 
@@ -42,6 +62,9 @@ def _make_ch_client(database_engine: str = "Atomic") -> Mock:
     def _query_side_effect(sql, *args, **kwargs):
         if "system.databases" in sql:
             return engine_result
+        precheck = _stub_divergence_precheck(sql)
+        if precheck is not None:
+            return precheck
         return Mock()
 
     ch_client.query.side_effect = _query_side_effect
@@ -62,6 +85,9 @@ def _make_ch_client_with_database_engines(database_engines: dict[str, str]) -> M
             else:
                 engine_result.result_rows = []
             return engine_result
+        precheck = _stub_divergence_precheck(sql)
+        if precheck is not None:
+            return precheck
         return Mock()
 
     ch_client.query.side_effect = _query_side_effect

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -409,6 +409,30 @@ def test_apply_migrations_raises_on_unrecoverable_partial(mock_migration_lock):
         migrator.apply_migrations("test_db")
 
 
+def test_apply_migrations_raises_on_non_recoverable_one_shot(mock_migration_lock):
+    # A one-shot migration (006 seed, 024 swap) is partial==curr+1 but must NOT be
+    # re-run; recovery refuses it and requires manual repair.
+    ch_client = _make_ch_client()
+    migrator = trace_server_migrator.get_clickhouse_trace_server_migrator(
+        ch_client, post_migration_hook=None
+    )
+    migrator._migration_row_exists = Mock(return_value=True)
+    migrator._get_migration_status = Mock(
+        return_value={"curr_version": 5, "partially_applied_version": 6}
+    )
+    migrator._get_migrations = Mock(
+        return_value={
+            i: {"up": f"{i}.up.sql", "down": f"{i}.down.sql"} for i in range(1, 7)
+        }
+    )
+    migrator._apply_migration = Mock()
+    migrator._has_migrations_to_apply = Mock(return_value=True)
+
+    with pytest.raises(MigrationError, match="cannot be auto-recovered"):
+        migrator.apply_migrations("test_db")
+    migrator._apply_migration.assert_not_called()
+
+
 def test_apply_migrations_costs_disabled_does_not_call_costs(mock_migration_lock):
     ch_client = _make_ch_client()
     migrator = trace_server_migrator.get_clickhouse_trace_server_migrator(

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -357,20 +357,55 @@ def test_migration_dir_must_be_absolute():
         )
 
 
-def test_apply_migrations_raises_on_partially_applied(mock_migration_lock):
+def test_apply_migrations_recovers_partially_applied(mock_migration_lock):
+    # partial == curr+1 is recoverable: re-run the interrupted (idempotent)
+    # migration, then continue with the rest instead of dead-ending.
     ch_client = _make_ch_client()
     migrator = trace_server_migrator.get_clickhouse_trace_server_migrator(
         ch_client, post_migration_hook=None
     )
+    migrator._migration_row_exists = Mock(return_value=True)
     migrator._get_migration_status = Mock(
+        side_effect=[
+            {"curr_version": 1, "partially_applied_version": 2},
+            {"curr_version": 2, "partially_applied_version": None},
+        ]
+    )
+    migrator._get_migrations = Mock(
         return_value={
-            "curr_version": 1,
-            "partially_applied_version": 2,
+            2: {"up": "2.up.sql", "down": "2.down.sql"},
+            3: {"up": "3.up.sql", "down": "3.down.sql"},
+        }
+    )
+    migrator._determine_migrations_to_apply = Mock(return_value=[(3, "3.up.sql")])
+    migrator._apply_migration = Mock()
+    migrator._has_migrations_to_apply = Mock(return_value=True)
+
+    migrator.apply_migrations("test_db")
+
+    migrator._apply_migration.assert_any_call("test_db", 2, "2.up.sql")
+    migrator._apply_migration.assert_any_call("test_db", 3, "3.up.sql")
+
+
+def test_apply_migrations_raises_on_unrecoverable_partial(mock_migration_lock):
+    # A partial version that isn't the expected next migration (curr+1) is not
+    # safe to auto-recover; require manual repair.
+    ch_client = _make_ch_client()
+    migrator = trace_server_migrator.get_clickhouse_trace_server_migrator(
+        ch_client, post_migration_hook=None
+    )
+    migrator._migration_row_exists = Mock(return_value=True)
+    migrator._get_migration_status = Mock(
+        return_value={"curr_version": 1, "partially_applied_version": 5}
+    )
+    migrator._get_migrations = Mock(
+        return_value={
+            i: {"up": f"{i}.up.sql", "down": f"{i}.down.sql"} for i in range(1, 6)
         }
     )
     migrator._has_migrations_to_apply = Mock(return_value=True)
 
-    with pytest.raises(MigrationError, match="partially applied migration version 2"):
+    with pytest.raises(MigrationError, match="cannot be auto-recovered"):
         migrator.apply_migrations("test_db")
 
 

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -4,6 +4,7 @@ Runs actual SQL against a single-node ClickHouse with embedded Keeper.
 """
 
 import os
+import re
 import uuid
 
 import clickhouse_connect
@@ -11,6 +12,7 @@ import pytest
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.clickhouse_trace_server_migrator import (
+    MigrationError,
     get_clickhouse_trace_server_migrator,
 )
 
@@ -64,6 +66,77 @@ def _get_latest_migration_version(migration_dir: str) -> int:
     ]
     assert versions, f"No up migrations found in {migration_dir}"
     return max(versions)
+
+
+def _reset_migration_version(
+    ch_client, mgmt_db: str, target_db: str, version: int
+) -> None:
+    """Rewind the recorded migration version so apply_migrations re-runs the ups.
+
+    Mirrors the migrator's own status write (ALTER ... UPDATE, mutations_sync=2),
+    which is synchronous, so the next version read is immediately consistent.
+    """
+    ch_client.command(
+        f"ALTER TABLE {mgmt_db}.migrations "
+        f"UPDATE curr_version = {version}, partially_applied_version = NULL "
+        f"WHERE db_name = '{target_db}' SETTINGS mutations_sync = 2"
+    )
+
+
+def _table_swap_versions(migration_dir: str) -> list[int]:
+    """Versions whose up.sql performs a bare `RENAME TABLE`.
+
+    A table swap is one-shot by nature: the RENAME errors once its target
+    exists, and auto-retrying a swap can lose data on a partial-failure
+    interleaving (live rows stranded under the backup name). This is why the
+    migrator errors on partial application rather than re-running. Such
+    migrations are excluded from the idempotency re-run; their forward run is
+    covered by test_all_production_migrations_*.
+    """
+    swaps = []
+    for fname in os.listdir(migration_dir):
+        if not fname.endswith(".up.sql"):
+            continue
+        sql = open(os.path.join(migration_dir, fname), encoding="utf-8").read()
+        without_comments = re.sub(r"(?m)^\s*--.*$", "", sql)
+        if re.search(r"\bRENAME\s+TABLE\b", without_comments, re.IGNORECASE):
+            swaps.append(int(fname.split("_", 1)[0]))
+    return sorted(swaps)
+
+
+def _rerunnable_segments(latest: int, excluded: list[int]) -> list[tuple[int, int]]:
+    """Contiguous (reset_to, apply_to) ranges of re-runnable migrations.
+
+    Splits 1..latest around the excluded versions. reset_to is the version to
+    rewind curr_version to; apply_to is the target_version to migrate up to.
+    """
+    segments = []
+    lo = 1
+    for boundary in [*excluded, latest + 1]:
+        if boundary - 1 >= lo:
+            segments.append((lo - 1, boundary - 1))
+        lo = boundary + 1
+    return segments
+
+
+def _schema_snapshot(ch_client, db_name: str) -> tuple[list, list]:
+    """Table engines and (table, column, type) triples for a database.
+
+    Comparing this before and after a re-run upgrades the idempotency check from
+    'no error' to 'schema unchanged', so an IF NOT EXISTS guard that silently
+    skips a needed change (or a re-run that alters something) is caught rather
+    than masked. Column type/existence is the drift IF NOT EXISTS can hide;
+    view query text is intentionally not compared (the re-run reverts and
+    restores it across segments).
+    """
+    tables = ch_client.query(
+        f"SELECT name, engine FROM system.tables WHERE database = '{db_name}' ORDER BY name"
+    ).result_rows
+    columns = ch_client.query(
+        f"SELECT table, name, type FROM system.columns WHERE database = '{db_name}' "
+        "ORDER BY table, name"
+    ).result_rows
+    return [tuple(r) for r in tables], [tuple(r) for r in columns]
 
 
 def _table_exists(ch_client, db_name: str, table_name: str) -> bool:
@@ -569,3 +642,122 @@ def test_migration_client_timeout_outlasts_replicated_ddl(ch_keeper_server):
         for db in (target_db, mgmt_db):
             client.command(f"DROP DATABASE IF EXISTS {db}")
         client.close()
+
+
+@pytest.mark.parametrize(
+    ("case_name", "replicated", "use_distributed"),
+    [
+        pytest.param("cloud", False, False, id="cloud"),
+        pytest.param("replicated", True, False, id="replicated"),
+        pytest.param("distributed", True, True, id="distributed"),
+    ],
+)
+def test_production_migrations_are_idempotent(
+    ch_client, case_name: str, replicated: bool, use_distributed: bool
+):
+    """Re-running the migration stack on an already-migrated DB is a safe no-op.
+
+    Partial-failure recovery re-runs a migration after the operator clears the
+    partial flag, so every migration's statements must tolerate re-execution.
+    This applies all migrations, then rewinds the recorded version and
+    re-applies the ups through each shape's SQL rewriter. Table-swap migrations
+    (see _table_swap_versions) are one-shot and excluded from the re-run; the
+    006 seed re-inserts without erroring.
+    """
+    mgmt_db = _unique_name(f"db_mgmt_idem_{case_name}")
+    target_db = _unique_name(f"idem_{case_name}")
+    ch_client.track_db(mgmt_db)
+    ch_client.track_db(target_db)
+
+    kwargs = {
+        "replicated": replicated,
+        "use_distributed": use_distributed,
+        "management_db": mgmt_db,
+        "migration_dir": _PROD_MIGRATION_DIR,
+        "post_migration_hook": None,
+    }
+    if replicated:
+        kwargs["replicated_cluster"] = _CLUSTER
+        kwargs["replicated_path"] = _REPLICATED_PATH
+    migrator = get_clickhouse_trace_server_migrator(ch_client, **kwargs)
+
+    latest = _get_latest_migration_version(_PROD_MIGRATION_DIR)
+    migrator.apply_migrations(target_db)
+    assert _get_migration_version(ch_client, mgmt_db, target_db) == latest
+
+    # 024 is the only table-swap; a new one must be a deliberate decision, not a
+    # silent addition, so pin the set. See _table_swap_versions for why swaps
+    # are one-shot.
+    swaps = _table_swap_versions(_PROD_MIGRATION_DIR)
+    assert swaps == [24], (
+        f"unexpected table-swap migration(s) {swaps}; a RENAME TABLE is one-shot, "
+        "so reassess idempotency and update this assertion deliberately"
+    )
+
+    # Re-apply every re-runnable migration by rewinding the recorded version and
+    # migrating back up through each contiguous segment around the swap(s). The
+    # schema must be byte-for-byte unchanged, so a guard that silently skips a
+    # needed change is caught rather than masked.
+    before = _schema_snapshot(ch_client, target_db)
+    for reset_to, apply_to in _rerunnable_segments(latest, swaps):
+        _reset_migration_version(ch_client, mgmt_db, target_db, reset_to)
+        migrator.apply_migrations(target_db, target_version=apply_to)
+
+    assert _get_migration_version(ch_client, mgmt_db, target_db) == latest
+    assert _schema_snapshot(ch_client, target_db) == before, (
+        "re-running migrations changed the table/column schema"
+    )
+
+
+@pytest.mark.parametrize(
+    ("case_name", "replicated", "use_distributed"),
+    [
+        pytest.param("cloud", False, False, id="cloud"),
+        pytest.param("replicated", True, False, id="replicated"),
+    ],
+)
+def test_migrations_refuse_populated_db_without_history(
+    ch_client, case_name: str, replicated: bool, use_distributed: bool
+):
+    """Refuse to migrate a populated data DB whose migration history is absent.
+
+    Simulates a diverged management DB (e.g. a renamed management_db): the data
+    DB already has tables, but a fresh management DB has no row for it. Without
+    this guard the IF [NOT] EXISTS migrations would silently re-run from version
+    0 against tables of unknown schema.
+    """
+
+    def make_migrator(mgmt_db: str):
+        kwargs = {
+            "replicated": replicated,
+            "use_distributed": use_distributed,
+            "management_db": mgmt_db,
+            "migration_dir": _PROD_MIGRATION_DIR,
+            "post_migration_hook": None,
+        }
+        if replicated:
+            kwargs["replicated_cluster"] = _CLUSTER
+            kwargs["replicated_path"] = _REPLICATED_PATH
+        return get_clickhouse_trace_server_migrator(ch_client, **kwargs)
+
+    target_db = _unique_name(f"orphan_{case_name}")
+    mgmt_a = _unique_name(f"db_mgmt_orphan_a_{case_name}")
+    mgmt_b = _unique_name(f"db_mgmt_orphan_b_{case_name}")
+    for db in (target_db, mgmt_a, mgmt_b):
+        ch_client.track_db(db)
+
+    make_migrator(mgmt_a).apply_migrations(target_db)
+    latest = _get_latest_migration_version(_PROD_MIGRATION_DIR)
+    assert _get_migration_version(ch_client, mgmt_a, target_db) == latest
+
+    # A fresh management DB has no history for the already-populated data DB.
+    with pytest.raises(MigrationError, match="no history"):
+        make_migrator(mgmt_b).apply_migrations(target_db)
+
+    # The guard refused before touching anything: the real history is intact and
+    # no version-0 row was seeded into the fresh management DB.
+    assert _get_migration_version(ch_client, mgmt_a, target_db) == latest
+    orphan_rows = ch_client.query(
+        f"SELECT count() FROM {mgmt_b}.migrations WHERE db_name = '{target_db}'"
+    ).result_rows[0][0]
+    assert orphan_rows == 0

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -83,6 +83,30 @@ def _reset_migration_version(
     )
 
 
+def _set_partial_migration(
+    ch_client, mgmt_db: str, target_db: str, curr: int, partial: int
+) -> None:
+    """Forge a crashed-mid-migration row: curr_version=curr, partial=partial.
+
+    Reproduces the state a pod leaves behind when it dies after _apply_migration
+    records partially_applied_version but before it records curr_version.
+    """
+    ch_client.command(
+        f"ALTER TABLE {mgmt_db}.migrations "
+        f"UPDATE curr_version = {curr}, partially_applied_version = {partial} "
+        f"WHERE db_name = '{target_db}' SETTINGS mutations_sync = 2"
+    )
+
+
+def _get_partial_version(ch_client, mgmt_db: str, target_db: str) -> int | None:
+    result = ch_client.query(
+        f"SELECT partially_applied_version FROM {mgmt_db}.migrations "
+        f"WHERE db_name = '{target_db}'"
+    )
+    assert len(result.result_rows) == 1, f"Migration status for {target_db} not found"
+    return result.result_rows[0][0]
+
+
 def _table_swap_versions(migration_dir: str) -> list[int]:
     """Versions whose up.sql performs a bare `RENAME TABLE`.
 
@@ -707,6 +731,71 @@ def test_production_migrations_are_idempotent(
     assert _schema_snapshot(ch_client, target_db) == before, (
         "re-running migrations changed the table/column schema"
     )
+
+
+@pytest.mark.parametrize(
+    ("case_name", "replicated", "use_distributed"),
+    [
+        pytest.param("cloud", False, False, id="cloud"),
+        pytest.param("replicated", True, False, id="replicated"),
+        pytest.param("distributed", True, True, id="distributed"),
+    ],
+)
+def test_partial_migration_auto_recovers(
+    ch_client, case_name: str, replicated: bool, use_distributed: bool
+):
+    """A crash mid-migration self-heals on the next startup instead of crash-looping.
+
+    _apply_migration records partially_applied_version before running the DDL and
+    clears it after, so a crash in between leaves the flag set. Recovery re-runs
+    that idempotent migration and converges to latest (the incident hard-raised
+    here and crash-looped for 44h). A one-shot migration (024 table swap) is never
+    auto-recovered: it raises for manual repair with the flag left intact.
+    """
+    mgmt_db = _unique_name(f"db_mgmt_recover_{case_name}")
+    target_db = _unique_name(f"recover_{case_name}")
+    ch_client.track_db(mgmt_db)
+    ch_client.track_db(target_db)
+
+    kwargs = {
+        "replicated": replicated,
+        "use_distributed": use_distributed,
+        "management_db": mgmt_db,
+        "migration_dir": _PROD_MIGRATION_DIR,
+        "post_migration_hook": None,
+    }
+    if replicated:
+        kwargs["replicated_cluster"] = _CLUSTER
+        kwargs["replicated_path"] = _REPLICATED_PATH
+    migrator = get_clickhouse_trace_server_migrator(ch_client, **kwargs)
+
+    latest = _get_latest_migration_version(_PROD_MIGRATION_DIR)
+    swaps = _table_swap_versions(_PROD_MIGRATION_DIR)
+    recoverable = latest not in swaps and latest != 6
+    assert recoverable, (
+        f"test assumes migration {latest} is re-runnable; it is one-shot, so forge "
+        "the partial state on a recoverable version instead"
+    )
+
+    migrator.apply_migrations(target_db)
+    clean_schema = _schema_snapshot(ch_client, target_db)
+
+    # Happy path: forge a crash mid-`latest`, then recover to a clean converge.
+    _set_partial_migration(ch_client, mgmt_db, target_db, latest - 1, latest)
+    migrator.apply_migrations(target_db)
+    assert _get_migration_version(ch_client, mgmt_db, target_db) == latest
+    assert _get_partial_version(ch_client, mgmt_db, target_db) is None
+    assert _schema_snapshot(ch_client, target_db) == clean_schema, (
+        "auto-recovery changed the schema; the re-run was not a no-op"
+    )
+
+    # Denylist: a one-shot swap is refused and the flag survives for manual repair.
+    swap = swaps[0]
+    _set_partial_migration(ch_client, mgmt_db, target_db, swap - 1, swap)
+    with pytest.raises(MigrationError, match="cannot be auto-recovered"):
+        migrator.apply_migrations(target_db)
+    assert _get_partial_version(ch_client, mgmt_db, target_db) == swap
+    assert _get_migration_version(ch_client, mgmt_db, target_db) == swap - 1
 
 
 @pytest.mark.parametrize(

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -12,6 +12,7 @@ import pytest
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.clickhouse_trace_server_migrator import (
+    _NON_RECOVERABLE_MIGRATION_VERSIONS,
     MigrationError,
     get_clickhouse_trace_server_migrator,
 )
@@ -161,6 +162,25 @@ def _schema_snapshot(ch_client, db_name: str) -> tuple[list, list]:
         "ORDER BY table, name"
     ).result_rows
     return [tuple(r) for r in tables], [tuple(r) for r in columns]
+
+
+def _row_count_snapshot(ch_client, db_name: str) -> dict[str, int]:
+    """Row counts for every MergeTree-family table in a database.
+
+    Comparing this before and after a re-run upgrades the idempotency check from
+    schema-only to data too, so a seed that duplicates rows on re-run (like 006) is
+    caught unless its version is excluded from the re-run via
+    _NON_RECOVERABLE_MIGRATION_VERSIONS. Views and Distributed tables have no
+    independent storage and are skipped.
+    """
+    tables = ch_client.query(
+        f"SELECT name FROM system.tables WHERE database = '{db_name}' "
+        "AND engine LIKE '%MergeTree%' ORDER BY name"
+    ).result_rows
+    return {
+        name: ch_client.query(f"SELECT count() FROM {db_name}.{name}").result_rows[0][0]
+        for (name,) in tables
+    }
 
 
 def _table_exists(ch_client, db_name: str, table_name: str) -> bool:
@@ -717,19 +737,34 @@ def test_production_migrations_are_idempotent(
         f"unexpected table-swap migration(s) {swaps}; a RENAME TABLE is one-shot, "
         "so reassess idempotency and update this assertion deliberately"
     )
+    # A structural swap is not re-runnable, so the recovery denylist must contain
+    # every one. This ties the SQL scan to the production denylist so the two can't
+    # drift; the row-count check below covers the seeds the scan can't detect.
+    assert set(swaps) <= _NON_RECOVERABLE_MIGRATION_VERSIONS, (
+        f"table-swap migration(s) {swaps} are missing from "
+        "_NON_RECOVERABLE_MIGRATION_VERSIONS"
+    )
 
     # Re-apply every re-runnable migration by rewinding the recorded version and
-    # migrating back up through each contiguous segment around the swap(s). The
-    # schema must be byte-for-byte unchanged, so a guard that silently skips a
-    # needed change is caught rather than masked.
+    # migrating back up through each contiguous segment around the excluded (one-
+    # shot) versions. Excluding exactly the production denylist means the re-run
+    # covers precisely the migrations recovery would re-run in prod. Schema and row
+    # counts must both be unchanged, so a guard that silently skips a needed change,
+    # or a non-idempotent seed that isn't denylisted, is caught rather than masked.
+    excluded = sorted(_NON_RECOVERABLE_MIGRATION_VERSIONS)
     before = _schema_snapshot(ch_client, target_db)
-    for reset_to, apply_to in _rerunnable_segments(latest, swaps):
+    before_counts = _row_count_snapshot(ch_client, target_db)
+    for reset_to, apply_to in _rerunnable_segments(latest, excluded):
         _reset_migration_version(ch_client, mgmt_db, target_db, reset_to)
         migrator.apply_migrations(target_db, target_version=apply_to)
 
     assert _get_migration_version(ch_client, mgmt_db, target_db) == latest
     assert _schema_snapshot(ch_client, target_db) == before, (
         "re-running migrations changed the table/column schema"
+    )
+    assert _row_count_snapshot(ch_client, target_db) == before_counts, (
+        "re-running migrations changed row counts; a non-idempotent seed is not in "
+        "_NON_RECOVERABLE_MIGRATION_VERSIONS"
     )
 
 

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -134,9 +134,11 @@ _COMMAND_PREVIEW_LENGTH = 100
 # Migrations that are one-shot by design and MUST NOT be auto-recovered: re-running
 # them is not a safe no-op. 006 re-inserts cost seed rows; 024 is a table-swap
 # RENAME that can half-apply and cross-wire tables on re-run. A partial application
-# of these needs manual repair. Every other migration is idempotent (guarded by
-# IF [NOT] EXISTS and enforced by the apply-twice migrator test), so re-running the
-# interrupted version converges the schema.
+# of these needs manual repair. This set is the single source of truth for "not
+# re-runnable": test_production_migrations_are_idempotent excludes exactly it from
+# the re-run and asserts both schema AND row counts are unchanged, so any other
+# migration that isn't schema- and data-idempotent (e.g. a new hardcoded seed)
+# fails that test until it is added here.
 _NON_RECOVERABLE_MIGRATION_VERSIONS = frozenset({6, 24})
 
 
@@ -415,8 +417,11 @@ class BaseClickHouseTraceServerMigrator(ABC):
             )
         status = self._get_migration_status(target_db)
         logger.info("""`%s` migration status: %s""", target_db, status)
-        if status["partially_applied_version"] is not None:
-            status = self._recover_partial_migration(target_db, status)
+        partial_version = status["partially_applied_version"]
+        if partial_version is not None:
+            status = self._recover_partial_migration(
+                target_db, status["curr_version"], partial_version
+            )
         migration_map = self._get_migrations()
         migrations_to_apply = self._determine_migrations_to_apply(
             status["curr_version"], migration_map, target_version
@@ -437,7 +442,9 @@ class BaseClickHouseTraceServerMigrator(ABC):
             target_db, status["curr_version"], applied_target_version
         )
 
-    def _recover_partial_migration(self, target_db: str, status: dict) -> dict:
+    def _recover_partial_migration(
+        self, target_db: str, curr_version: int, partial_version: int
+    ) -> MigrationStatus:
         """Re-run an interrupted migration instead of dead-ending on it.
 
         A migration that times out mid-DDL leaves partially_applied_version set,
@@ -447,11 +454,15 @@ class BaseClickHouseTraceServerMigrator(ABC):
         is not consulted); a requested downgrade resumes after the flag clears.
         Only the expected next version, and only an idempotent one, is recovered;
         anything else, or a re-run failure, falls back to requiring manual repair.
+
+        Convergence is schema-level: in distributed/replicated mode a re-run of a
+        MODIFY QUERY drops and recreates the `_local` materialized view, so rows
+        inserted in that window are not aggregated into the target until the next
+        write. Data already at rest is unaffected.
         """
-        partial_version = status["partially_applied_version"]
         migration = self._get_migrations().get(partial_version)
         if (
-            partial_version != status["curr_version"] + 1
+            partial_version != curr_version + 1
             or partial_version in _NON_RECOVERABLE_MIGRATION_VERSIONS
             or migration is None
             or migration["up"] is None
@@ -514,7 +525,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
         """
         return add_heartbeat_column_sql(self.management_db)
 
-    def _get_migration_status(self, db_name: str) -> dict:
+    def _get_migration_status(self, db_name: str) -> MigrationStatus:
         column_names = ["db_name", "curr_version", "partially_applied_version"]
         select_columns = ", ".join(column_names)
         query = f"""
@@ -533,7 +544,11 @@ class BaseClickHouseTraceServerMigrator(ABC):
         if res is None or len(result_rows) == 0:
             raise MigrationError("Migration table not found")
 
-        return dict(zip(column_names, result_rows[0], strict=False))
+        _, curr_version, partially_applied_version = result_rows[0]
+        return {
+            "curr_version": curr_version,
+            "partially_applied_version": partially_applied_version,
+        }
 
     def _get_migrations(
         self,

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -131,6 +131,14 @@ _MAX_RETRIES = 3
 _RETRY_MAX_WAIT_SECONDS = 8
 _COMMAND_PREVIEW_LENGTH = 100
 
+# Migrations that are one-shot by design and MUST NOT be auto-recovered: re-running
+# them is not a safe no-op. 006 re-inserts cost seed rows; 024 is a table-swap
+# RENAME that can half-apply and cross-wire tables on re-run. A partial application
+# of these needs manual repair. Every other migration is idempotent (guarded by
+# IF [NOT] EXISTS and enforced by the apply-twice migrator test), so re-running the
+# interrupted version converges the schema.
+_NON_RECOVERABLE_MIGRATION_VERSIONS = frozenset({6, 24})
+
 
 def _is_transient_ch_error(exc: BaseException) -> bool:
     """Check if a ClickHouse error is a known transient replication error."""
@@ -407,7 +415,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
             )
         status = self._get_migration_status(target_db)
         logger.info("""`%s` migration status: %s""", target_db, status)
-        if status["partially_applied_version"]:
+        if status["partially_applied_version"] is not None:
             status = self._recover_partial_migration(target_db, status)
         migration_map = self._get_migrations()
         migrations_to_apply = self._determine_migrations_to_apply(
@@ -435,13 +443,16 @@ class BaseClickHouseTraceServerMigrator(ABC):
         A migration that times out mid-DDL leaves partially_applied_version set,
         which otherwise hard-blocks every restart. Migration DDL is idempotent,
         so re-running the interrupted version converges the schema and clears the
-        flag. Only the expected next version is recoverable; anything else, or a
-        re-run failure, falls back to requiring manual repair.
+        flag. Recovery always rolls the interrupted version forward (target_version
+        is not consulted); a requested downgrade resumes after the flag clears.
+        Only the expected next version, and only an idempotent one, is recovered;
+        anything else, or a re-run failure, falls back to requiring manual repair.
         """
         partial_version = status["partially_applied_version"]
         migration = self._get_migrations().get(partial_version)
         if (
             partial_version != status["curr_version"] + 1
+            or partial_version in _NON_RECOVERABLE_MIGRATION_VERSIONS
             or migration is None
             or migration["up"] is None
         ):

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -341,6 +341,29 @@ class BaseClickHouseTraceServerMigrator(ABC):
             > 0
         )
 
+    def _migration_row_exists(self, db_name: str) -> bool:
+        """Whether the migrations table already tracks `db_name`."""
+        res = self.ch_client.query(
+            f"SELECT count() FROM {self.management_db}.migrations "
+            f"WHERE db_name = %(db_name)s",
+            parameters={"db_name": db_name},
+        )
+        return res.result_rows[0][0] > 0
+
+    def _target_db_initialized(self, db_name: str) -> bool:
+        """Whether `db_name` already holds migration-managed tables.
+
+        `call_parts` is created by migration 001 and never dropped by an up
+        migration, so its presence marks a database migrations have already run
+        against.
+        """
+        res = self.ch_client.query(
+            "SELECT count() FROM system.tables "
+            "WHERE database = %(db_name)s AND name = 'call_parts'",
+            parameters={"db_name": db_name},
+        )
+        return res.result_rows[0][0] > 0
+
     def _read_migration_status(self, db_name: str) -> MigrationStatus:
         """Read migration status without writing.
 
@@ -364,6 +387,24 @@ class BaseClickHouseTraceServerMigrator(ABC):
         self, target_db: str, target_version: int | None = None
     ) -> None:
         """Inner migration logic, called while holding the migration lock."""
+        # Refuse to migrate a database we have no history for but that already
+        # holds migration-managed tables: no row in the migrations table means we
+        # would start from version 0, yet the tables exist, so the management and
+        # data databases have diverged (a renamed management_db, a restore of one
+        # without the other). Running from 0 would re-apply DDL against tables of
+        # unknown schema; the IF NOT EXISTS guards would let it pass silently.
+        if not self._migration_row_exists(target_db) and self._target_db_initialized(
+            target_db
+        ):
+            raise MigrationError(
+                f"`{target_db}` already contains migration-managed tables but has no "
+                f"history in `{self.management_db}.migrations`. The management and "
+                f"data databases have diverged (e.g. a renamed management_db, or a "
+                f"restore of one without the other). Refusing to run migrations from "
+                f"scratch to avoid applying DDL to tables of unknown schema. To adopt "
+                f"this database deliberately, insert a row into "
+                f"`{self.management_db}.migrations` with its true curr_version."
+            )
         status = self._get_migration_status(target_db)
         logger.info("""`%s` migration status: %s""", target_db, status)
         if status["partially_applied_version"]:

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -408,11 +408,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
         status = self._get_migration_status(target_db)
         logger.info("""`%s` migration status: %s""", target_db, status)
         if status["partially_applied_version"]:
-            raise MigrationError(
-                f"Unable to apply migrations to `{target_db}`. Found partially applied "
-                f"migration version {status['partially_applied_version']}. "
-                f"Please fix the database manually and try again."
-            )
+            status = self._recover_partial_migration(target_db, status)
         migration_map = self._get_migrations()
         migrations_to_apply = self._determine_migrations_to_apply(
             status["curr_version"], migration_map, target_version
@@ -432,6 +428,41 @@ class BaseClickHouseTraceServerMigrator(ABC):
         self._run_post_migration_hook(
             target_db, status["curr_version"], applied_target_version
         )
+
+    def _recover_partial_migration(self, target_db: str, status: dict) -> dict:
+        """Re-run an interrupted migration instead of dead-ending on it.
+
+        A migration that times out mid-DDL leaves partially_applied_version set,
+        which otherwise hard-blocks every restart. Migration DDL is idempotent,
+        so re-running the interrupted version converges the schema and clears the
+        flag. Only the expected next version is recoverable; anything else, or a
+        re-run failure, falls back to requiring manual repair.
+        """
+        partial_version = status["partially_applied_version"]
+        migration = self._get_migrations().get(partial_version)
+        if (
+            partial_version != status["curr_version"] + 1
+            or migration is None
+            or migration["up"] is None
+        ):
+            raise MigrationError(
+                f"Unable to apply migrations to `{target_db}`. Found partially applied "
+                f"migration version {partial_version} that cannot be auto-recovered. "
+                f"Please fix the database manually and try again."
+            )
+        logger.warning(
+            "Found partially applied migration %s on `%s`; re-running it idempotently to recover.",
+            partial_version,
+            target_db,
+        )
+        try:
+            self._apply_migration(target_db, partial_version, migration["up"])
+        except Exception as exc:
+            raise MigrationError(
+                f"Unable to auto-recover partially applied migration {partial_version} "
+                f"on `{target_db}`: {exc}. Please fix the database manually and try again."
+            ) from exc
+        return self._get_migration_status(target_db)
 
     def _run_post_migration_hook(
         self, target_db: str, current_version: int, target_version: int | None

--- a/weave/trace_server/migrations/001_init.down.sql
+++ b/weave/trace_server/migrations/001_init.down.sql
@@ -1,15 +1,15 @@
-DROP TABLE call_parts;
-DROP TABLE calls_merged;
-DROP VIEW calls_merged_view;
+DROP TABLE IF EXISTS call_parts;
+DROP TABLE IF EXISTS calls_merged;
+DROP VIEW IF EXISTS calls_merged_view;
 
-DROP TABLE object_versions;
-DROP VIEW object_versions_deduped;
+DROP TABLE IF EXISTS object_versions;
+DROP VIEW IF EXISTS object_versions_deduped;
 
-DROP TABLE tables;
-DROP VIEW tables_deduped;
+DROP TABLE IF EXISTS tables;
+DROP VIEW IF EXISTS tables_deduped;
 
-DROP TABLE table_rows;
-DROP VIEW table_rows_deduped;
+DROP TABLE IF EXISTS table_rows;
+DROP VIEW IF EXISTS table_rows_deduped;
 
-DROP TABLE files;
-DROP VIEW files_deduped;
+DROP TABLE IF EXISTS files;
+DROP VIEW IF EXISTS files_deduped;

--- a/weave/trace_server/migrations/001_init.up.sql
+++ b/weave/trace_server/migrations/001_init.up.sql
@@ -6,7 +6,7 @@ end data, but this is not practically possible given the current APIs. The
 `calls_merged` table is a materialized view that aggregates the start and end
 data into a single row.
 */
-CREATE TABLE call_parts (
+CREATE TABLE IF NOT EXISTS call_parts (
     /*
     `id`: The unique identifier for the call. This is typically a UUID.
     */
@@ -103,7 +103,7 @@ CREATE TABLE call_parts (
 ) ENGINE = MergeTree
 ORDER BY (project_id, id);
 
-CREATE TABLE calls_merged (
+CREATE TABLE IF NOT EXISTS calls_merged (
     project_id String,
     id String,
     # While these fields are all marked as null, the practical expectation
@@ -127,7 +127,7 @@ CREATE TABLE calls_merged (
 ) ENGINE = AggregatingMergeTree
 ORDER BY (project_id, id);
 
-CREATE MATERIALIZED VIEW calls_merged_view TO calls_merged AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS calls_merged_view TO calls_merged AS
 SELECT project_id,
     id,
     anySimpleState(wb_run_id) as wb_run_id,
@@ -148,7 +148,7 @@ FROM call_parts
 GROUP BY project_id,
     id;
 
-CREATE TABLE object_versions (
+CREATE TABLE IF NOT EXISTS object_versions (
     project_id String,
     object_id String,
     kind Enum('op', 'object'),
@@ -160,7 +160,7 @@ CREATE TABLE object_versions (
 ) ENGINE = ReplacingMergeTree()
 ORDER BY (project_id, kind, object_id, digest);
 
-CREATE VIEW object_versions_deduped AS
+CREATE VIEW IF NOT EXISTS object_versions_deduped AS
 SELECT project_id,
     object_id,
     created_at,
@@ -201,7 +201,7 @@ ORDER BY project_id,
     object_id,
     created_at;
 
-CREATE TABLE table_rows (
+CREATE TABLE IF NOT EXISTS table_rows (
     project_id String,
     digest String,
     refs Array(String),
@@ -209,7 +209,7 @@ CREATE TABLE table_rows (
     created_at DateTime64(3) DEFAULT now64(3)
 ) ENGINE = ReplacingMergeTree()
 ORDER BY (project_id, digest);
-CREATE VIEW table_rows_deduped AS
+CREATE VIEW IF NOT EXISTS table_rows_deduped AS
 SELECT project_id, digest, val_dump
 FROM (
         SELECT *,
@@ -220,14 +220,14 @@ WHERE rn = 1
 ORDER BY project_id,
     digest;
 
-CREATE TABLE tables (
+CREATE TABLE IF NOT EXISTS tables (
     project_id String,
     digest String,
     row_digests Array(String),
     created_at DateTime64(3) DEFAULT now64(3)
 ) ENGINE = ReplacingMergeTree()
 ORDER BY (project_id, digest);
-CREATE VIEW tables_deduped AS
+CREATE VIEW IF NOT EXISTS tables_deduped AS
 SELECT *
 FROM (
         SELECT *,
@@ -238,7 +238,7 @@ WHERE rn = 1
 ORDER BY project_id,
     digest;
 
-CREATE TABLE files (
+CREATE TABLE IF NOT EXISTS files (
     project_id String,
     digest String,
     chunk_index UInt32,
@@ -249,7 +249,7 @@ CREATE TABLE files (
 ) ENGINE = ReplacingMergeTree()
 ORDER BY (project_id, digest, chunk_index);
 
-CREATE VIEW files_deduped AS
+CREATE VIEW IF NOT EXISTS files_deduped AS
 SELECT *
 FROM (
         SELECT *,

--- a/weave/trace_server/migrations/002_add_deleted_at.down.sql
+++ b/weave/trace_server/migrations/002_add_deleted_at.down.sql
@@ -4,10 +4,10 @@ This migration undoes adding the `deleted_at` column to:
     - the object_versions_deduped and calls_merged_view views
 */
 
-ALTER TABLE object_versions DROP COLUMN deleted_at;
+ALTER TABLE object_versions DROP COLUMN IF EXISTS deleted_at;
 
-DROP VIEW object_versions_deduped;
-CREATE VIEW object_versions_deduped as
+DROP VIEW IF EXISTS object_versions_deduped;
+CREATE VIEW IF NOT EXISTS object_versions_deduped as
     SELECT project_id,
         object_id,
         created_at,
@@ -71,6 +71,6 @@ ALTER TABLE calls_merged_view MODIFY QUERY
     GROUP BY project_id,
         id;
 
-ALTER TABLE calls_merged DROP COLUMN deleted_at;
+ALTER TABLE calls_merged DROP COLUMN IF EXISTS deleted_at;
 
-ALTER TABLE call_parts DROP COLUMN deleted_at;
+ALTER TABLE call_parts DROP COLUMN IF EXISTS deleted_at;

--- a/weave/trace_server/migrations/002_add_deleted_at.up.sql
+++ b/weave/trace_server/migrations/002_add_deleted_at.up.sql
@@ -6,10 +6,10 @@ This migration adds:
 */
 
 ALTER TABLE object_versions
-    ADD COLUMN deleted_at Nullable(DateTime64(3)) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS deleted_at Nullable(DateTime64(3)) DEFAULT NULL;
 
-DROP VIEW object_versions_deduped;
-CREATE VIEW object_versions_deduped as
+DROP VIEW IF EXISTS object_versions_deduped;
+CREATE VIEW IF NOT EXISTS object_versions_deduped as
     SELECT project_id,
         object_id,
         created_at,
@@ -52,10 +52,10 @@ CREATE VIEW object_versions_deduped as
         created_at;
 
 ALTER TABLE call_parts
-    ADD COLUMN deleted_at Nullable(DateTime64(3)) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS deleted_at Nullable(DateTime64(3)) DEFAULT NULL;
 
 ALTER TABLE calls_merged
-    ADD COLUMN deleted_at SimpleAggregateFunction(any, Nullable(DateTime64(3)));
+    ADD COLUMN IF NOT EXISTS deleted_at SimpleAggregateFunction(any, Nullable(DateTime64(3)));
 
 ALTER TABLE calls_merged_view MODIFY QUERY
     SELECT project_id,

--- a/weave/trace_server/migrations/003_feedback.down.sql
+++ b/weave/trace_server/migrations/003_feedback.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE feedback;
+DROP TABLE IF EXISTS feedback;

--- a/weave/trace_server/migrations/003_feedback.up.sql
+++ b/weave/trace_server/migrations/003_feedback.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE feedback (
+CREATE TABLE IF NOT EXISTS feedback (
     /*
     `id`: The unique identifier for the feedback. This is a UUID.
     */

--- a/weave/trace_server/migrations/004_add_display_name.down.sql
+++ b/weave/trace_server/migrations/004_add_display_name.down.sql
@@ -25,7 +25,7 @@ ALTER TABLE calls_merged_view MODIFY QUERY
     GROUP BY project_id,
         id;
 
-ALTER TABLE calls_merged DROP COLUMN display_name;
+ALTER TABLE calls_merged DROP COLUMN IF EXISTS display_name;
 
-ALTER TABLE call_parts DROP COLUMN display_name;
+ALTER TABLE call_parts DROP COLUMN IF EXISTS display_name;
 

--- a/weave/trace_server/migrations/004_add_display_name.up.sql
+++ b/weave/trace_server/migrations/004_add_display_name.up.sql
@@ -8,10 +8,10 @@
 */
 
 ALTER TABLE call_parts
-    ADD COLUMN display_name Nullable(String) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS display_name Nullable(String) DEFAULT NULL;
 
 ALTER TABLE calls_merged
-    ADD COLUMN display_name AggregateFunction(argMax, Nullable(String), DateTime64(3));
+    ADD COLUMN IF NOT EXISTS display_name AggregateFunction(argMax, Nullable(String), DateTime64(3));
 
 ALTER TABLE calls_merged_view MODIFY QUERY
     SELECT project_id,

--- a/weave/trace_server/migrations/005_add_cost.down.sql
+++ b/weave/trace_server/migrations/005_add_cost.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE llm_token_prices;
+DROP TABLE IF EXISTS llm_token_prices;

--- a/weave/trace_server/migrations/005_add_cost.up.sql
+++ b/weave/trace_server/migrations/005_add_cost.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE llm_token_prices (
+CREATE TABLE IF NOT EXISTS llm_token_prices (
      /*
     `id`: The unique identifier for the call. This is typically a UUID.
     */

--- a/weave/trace_server/migrations/006_seed_costs.up.sql
+++ b/weave/trace_server/migrations/006_seed_costs.up.sql
@@ -1,5 +1,8 @@
-INSERT INTO llm_token_prices 
-    (id, pricing_level, pricing_level_id, provider_id, llm_id, effective_date, prompt_token_cost, prompt_token_cost_unit, completion_token_cost, completion_token_cost_unit, created_by, created_at) 
+-- One-shot seed. Not idempotent: llm_token_prices is a plain MergeTree with no
+-- dedup key, so re-running duplicates every row. The migrator applies each
+-- migration exactly once, so this seed runs a single time per database.
+INSERT INTO llm_token_prices
+    (id, pricing_level, pricing_level_id, provider_id, llm_id, effective_date, prompt_token_cost, prompt_token_cost_unit, completion_token_cost, completion_token_cost_unit, created_by, created_at)
 VALUES 
     (generateUUIDv4(), 'default', 'default', 'openai', 'gpt-4', now(), 3e-05, 'USD', 6e-05, 'USD', 'system', now()), 
     (generateUUIDv4(), 'default', 'default', 'openai', 'gpt-4o', now(), 5e-06, 'USD', 1.5e-05, 'USD', 'system', now()), 

--- a/weave/trace_server/migrations/007_add_refs_to_feedback.down.sql
+++ b/weave/trace_server/migrations/007_add_refs_to_feedback.down.sql
@@ -1,5 +1,5 @@
 ALTER TABLE feedback 
-    DROP COLUMN annotation_ref,
-    DROP COLUMN runnable_ref,
-    DROP COLUMN call_ref,
-    DROP COLUMN trigger_ref;
+    DROP COLUMN IF EXISTS annotation_ref,
+    DROP COLUMN IF EXISTS runnable_ref,
+    DROP COLUMN IF EXISTS call_ref,
+    DROP COLUMN IF EXISTS trigger_ref;

--- a/weave/trace_server/migrations/007_add_refs_to_feedback.up.sql
+++ b/weave/trace_server/migrations/007_add_refs_to_feedback.up.sql
@@ -28,21 +28,21 @@ ALTER TABLE feedback
     `annotation_ref`: The ref pointing to the annotation definition for this feedback.
     Expected to be present on any feedback type starting with `wandb.annotation`.
     */
-    ADD COLUMN annotation_ref Nullable(String) DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS annotation_ref Nullable(String) DEFAULT NULL,
     /*
     `runnable_ref`: The ref pointing to the runnable definition for this feedback.
     This can be an op, a configured action, etc...
     Expected to be present on any feedback type starting with `wandb.runnable`.
     */
-    ADD COLUMN runnable_ref Nullable(String) DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS runnable_ref Nullable(String) DEFAULT NULL,
     /*
     `call_ref`: The ref pointing to the resulting call associated with generating this feedback.
     Expected (but not required) to be present on any feedback that has `runnable_ref` as a
     call-producing op.
     */
-    ADD COLUMN call_ref Nullable(String) DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS call_ref Nullable(String) DEFAULT NULL,
     /*
     `trigger_ref`: The ref pointing to the trigger definition which resulted in this feedback.
     Will be present when the runnable_ref has been executed by a trigger, not a human/small batch job.
     */
-    ADD COLUMN trigger_ref Nullable(String) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS trigger_ref Nullable(String) DEFAULT NULL;

--- a/weave/trace_server/migrations/008_stats_views.up.sql
+++ b/weave/trace_server/migrations/008_stats_views.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE files_stats
+CREATE TABLE IF NOT EXISTS files_stats
 (
     project_id String,
     digest String,
@@ -11,7 +11,7 @@ CREATE TABLE files_stats
 ) ENGINE = AggregatingMergeTree()
 ORDER BY (project_id, digest, chunk_index);
 
-CREATE MATERIALIZED VIEW files_stats_view
+CREATE MATERIALIZED VIEW IF NOT EXISTS files_stats_view
 TO files_stats
 AS
 SELECT
@@ -29,7 +29,7 @@ GROUP BY
     files.digest,
     files.chunk_index;
 
-CREATE TABLE table_rows_stats
+CREATE TABLE IF NOT EXISTS table_rows_stats
 (
     project_id String,
     digest String,
@@ -39,7 +39,7 @@ CREATE TABLE table_rows_stats
 ) ENGINE = AggregatingMergeTree()
 ORDER BY (project_id, digest);
 
-CREATE MATERIALIZED VIEW table_rows_stats_view
+CREATE MATERIALIZED VIEW IF NOT EXISTS table_rows_stats_view
 TO table_rows_stats
 AS
 SELECT
@@ -54,7 +54,7 @@ GROUP BY
     table_rows.digest;
 
 
-CREATE TABLE object_versions_stats
+CREATE TABLE IF NOT EXISTS object_versions_stats
 (
     project_id String,
     kind Enum('op', 'object'),
@@ -67,7 +67,7 @@ CREATE TABLE object_versions_stats
 ) ENGINE = AggregatingMergeTree()
 ORDER BY (project_id, kind, object_id, digest);
 
-CREATE MATERIALIZED VIEW object_versions_stats_view
+CREATE MATERIALIZED VIEW IF NOT EXISTS object_versions_stats_view
 TO object_versions_stats
 AS
 SELECT
@@ -86,7 +86,7 @@ GROUP BY
     object_versions.object_id,
     object_versions.digest;
 
-CREATE TABLE feedback_stats
+CREATE TABLE IF NOT EXISTS feedback_stats
 (
     project_id String,
     weave_ref String,
@@ -100,7 +100,7 @@ CREATE TABLE feedback_stats
 ) ENGINE = AggregatingMergeTree()
 ORDER BY (project_id, weave_ref, wb_user_id, id);
 
-CREATE MATERIALIZED VIEW feedback_stats_view
+CREATE MATERIALIZED VIEW IF NOT EXISTS feedback_stats_view
 TO feedback_stats
 AS
 SELECT
@@ -120,7 +120,7 @@ GROUP BY
     feedback.wb_user_id,
     feedback.id;
 
-CREATE TABLE calls_merged_stats
+CREATE TABLE IF NOT EXISTS calls_merged_stats
 (
     project_id String,
     id String,
@@ -143,7 +143,7 @@ CREATE TABLE calls_merged_stats
 ORDER BY (project_id, id);
 
 -- NOTE: This needs to be generally kept in sync with calls_merged.
-CREATE MATERIALIZED VIEW calls_merged_stats_view
+CREATE MATERIALIZED VIEW IF NOT EXISTS calls_merged_stats_view
 TO calls_merged_stats
 AS
 SELECT

--- a/weave/trace_server/migrations/010_add_user_to_objects.down.sql
+++ b/weave/trace_server/migrations/010_add_user_to_objects.down.sql
@@ -1,5 +1,5 @@
 ALTER TABLE object_versions
-    DROP COLUMN wb_user_id;
+    DROP COLUMN IF EXISTS wb_user_id;
 
 ALTER TABLE object_versions_stats
-    DROP COLUMN wb_user_id;
+    DROP COLUMN IF EXISTS wb_user_id;

--- a/weave/trace_server/migrations/010_add_user_to_objects.up.sql
+++ b/weave/trace_server/migrations/010_add_user_to_objects.up.sql
@@ -1,5 +1,5 @@
 ALTER TABLE object_versions
-    ADD COLUMN wb_user_id Nullable(String) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS wb_user_id Nullable(String) DEFAULT NULL;
 
 ALTER TABLE object_versions_stats
-    ADD COLUMN wb_user_id Nullable(String) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS wb_user_id Nullable(String) DEFAULT NULL;

--- a/weave/trace_server/migrations/011_add_file_bucket_storage.down.sql
+++ b/weave/trace_server/migrations/011_add_file_bucket_storage.down.sql
@@ -14,7 +14,7 @@ GROUP BY
     files.digest,
     files.chunk_index;
 
-ALTER TABLE files_stats DROP COLUMN file_storage_uri;
+ALTER TABLE files_stats DROP COLUMN IF EXISTS file_storage_uri;
 
-ALTER TABLE files DROP COLUMN bytes_stored;
-ALTER TABLE files DROP COLUMN file_storage_uri;
+ALTER TABLE files DROP COLUMN IF EXISTS bytes_stored;
+ALTER TABLE files DROP COLUMN IF EXISTS file_storage_uri;

--- a/weave/trace_server/migrations/011_add_file_bucket_storage.up.sql
+++ b/weave/trace_server/migrations/011_add_file_bucket_storage.up.sql
@@ -1,7 +1,7 @@
-ALTER TABLE files ADD COLUMN bytes_stored Nullable(UInt32);
-ALTER TABLE files ADD COLUMN file_storage_uri Nullable(String);
+ALTER TABLE files ADD COLUMN IF NOT EXISTS bytes_stored Nullable(UInt32);
+ALTER TABLE files ADD COLUMN IF NOT EXISTS file_storage_uri Nullable(String);
 
-ALTER TABLE files_stats ADD COLUMN file_storage_uri Nullable(String);
+ALTER TABLE files_stats ADD COLUMN IF NOT EXISTS file_storage_uri Nullable(String);
 
 ALTER TABLE files_stats_view MODIFY QUERY
 SELECT

--- a/weave/trace_server/migrations/012_add_sortable_timestamp.down.sql
+++ b/weave/trace_server/migrations/012_add_sortable_timestamp.down.sql
@@ -1,4 +1,4 @@
-ALTER TABLE calls_merged DROP INDEX idx_sortable_datetime;
+ALTER TABLE calls_merged DROP INDEX IF EXISTS idx_sortable_datetime;
 
 ALTER TABLE calls_merged_view MODIFY QUERY
     SELECT project_id,
@@ -23,4 +23,4 @@ ALTER TABLE calls_merged_view MODIFY QUERY
     FROM call_parts
     GROUP BY project_id,
         id;
-ALTER TABLE calls_merged DROP COLUMN sortable_datetime;
+ALTER TABLE calls_merged DROP COLUMN IF EXISTS sortable_datetime;

--- a/weave/trace_server/migrations/012_add_sortable_timestamp.up.sql
+++ b/weave/trace_server/migrations/012_add_sortable_timestamp.up.sql
@@ -1,6 +1,6 @@
 -- Create non-nullable Datetime field in the call_merged table
 ALTER TABLE calls_merged 
-    ADD COLUMN sortable_datetime Datetime(6) DEFAULT coalesce(started_at, ended_at, NOW());
+    ADD COLUMN IF NOT EXISTS sortable_datetime Datetime(6) DEFAULT coalesce(started_at, ended_at, NOW());
 
 -- Add the column to the materialized view 
 ALTER TABLE calls_merged_view MODIFY QUERY
@@ -30,6 +30,6 @@ ALTER TABLE calls_merged_view MODIFY QUERY
 ALTER TABLE calls_merged MATERIALIZE COLUMN sortable_datetime SETTINGS mutations_sync = 1;
 
 -- Add minmax index  on the new column
-ALTER TABLE calls_merged ADD INDEX idx_sortable_datetime (sortable_datetime) TYPE minmax GRANULARITY 1 SETTINGS alter_sync = 1;
+ALTER TABLE calls_merged ADD INDEX IF NOT EXISTS idx_sortable_datetime (sortable_datetime) TYPE minmax GRANULARITY 1 SETTINGS alter_sync = 1;
 -- Materialize the index, actually generating index marks for all the granules
 ALTER TABLE calls_merged MATERIALIZE INDEX idx_sortable_datetime SETTINGS mutations_sync = 1;

--- a/weave/trace_server/migrations/013_add_wb_run_step.down.sql
+++ b/weave/trace_server/migrations/013_add_wb_run_step.down.sql
@@ -22,7 +22,7 @@ GROUP BY
     call_parts.project_id,
     call_parts.id;
 
-ALTER TABLE calls_merged_stats DROP COLUMN wb_run_step;
+ALTER TABLE calls_merged_stats DROP COLUMN IF EXISTS wb_run_step;
 
 ALTER TABLE calls_merged_view MODIFY QUERY
     SELECT project_id,
@@ -48,5 +48,5 @@ ALTER TABLE calls_merged_view MODIFY QUERY
     GROUP BY project_id,
         id;
 
-ALTER TABLE calls_merged DROP COLUMN wb_run_step;
-ALTER TABLE call_parts DROP COLUMN wb_run_step;
+ALTER TABLE calls_merged DROP COLUMN IF EXISTS wb_run_step;
+ALTER TABLE call_parts DROP COLUMN IF EXISTS wb_run_step;

--- a/weave/trace_server/migrations/013_add_wb_run_step.up.sql
+++ b/weave/trace_server/migrations/013_add_wb_run_step.up.sql
@@ -1,10 +1,10 @@
 -- Add wb_run_step to raw call parts table
 ALTER TABLE call_parts
-    ADD COLUMN wb_run_step Nullable(UInt64) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS wb_run_step Nullable(UInt64) DEFAULT NULL;
 
 -- Add wb_run_step to aggregated calls table
 ALTER TABLE calls_merged
-    ADD COLUMN wb_run_step SimpleAggregateFunction(any, Nullable(UInt64));
+    ADD COLUMN IF NOT EXISTS wb_run_step SimpleAggregateFunction(any, Nullable(UInt64));
 
 -- Update materialized view to include wb_run_step
 ALTER TABLE calls_merged_view MODIFY QUERY
@@ -34,7 +34,7 @@ ALTER TABLE calls_merged_view MODIFY QUERY
 
 -- Add wb_run_step to stats table
 ALTER TABLE calls_merged_stats
-    ADD COLUMN wb_run_step SimpleAggregateFunction(any, Nullable(UInt64));
+    ADD COLUMN IF NOT EXISTS wb_run_step SimpleAggregateFunction(any, Nullable(UInt64));
 
 -- Update stats materialized view
 ALTER TABLE calls_merged_stats_view MODIFY QUERY

--- a/weave/trace_server/migrations/014_add_leaf_object_class.down.sql
+++ b/weave/trace_server/migrations/014_add_leaf_object_class.down.sql
@@ -16,7 +16,7 @@ GROUP BY
     object_versions.digest;
 
 ALTER TABLE object_versions
-    DROP COLUMN leaf_object_class;
+    DROP COLUMN IF EXISTS leaf_object_class;
 
 ALTER TABLE object_versions_stats
-    DROP COLUMN leaf_object_class;
+    DROP COLUMN IF EXISTS leaf_object_class;

--- a/weave/trace_server/migrations/014_add_leaf_object_class.up.sql
+++ b/weave/trace_server/migrations/014_add_leaf_object_class.up.sql
@@ -1,8 +1,8 @@
 ALTER TABLE object_versions
-    ADD COLUMN leaf_object_class Nullable(String) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS leaf_object_class Nullable(String) DEFAULT NULL;
 
 ALTER TABLE object_versions_stats
-    ADD COLUMN leaf_object_class SimpleAggregateFunction(any, Nullable(String));
+    ADD COLUMN IF NOT EXISTS leaf_object_class SimpleAggregateFunction(any, Nullable(String));
 
 ALTER TABLE object_versions_stats_view MODIFY QUERY
 SELECT

--- a/weave/trace_server/migrations/015_add_thread_id.down.sql
+++ b/weave/trace_server/migrations/015_add_thread_id.down.sql
@@ -26,7 +26,7 @@ ALTER TABLE calls_merged_view MODIFY QUERY
         id;
 
 -- Remove thread_id from aggregated calls table
-ALTER TABLE calls_merged DROP COLUMN thread_id;
+ALTER TABLE calls_merged DROP COLUMN IF EXISTS thread_id;
 
 -- Remove thread_id from raw call parts table
-ALTER TABLE call_parts DROP COLUMN thread_id; 
+ALTER TABLE call_parts DROP COLUMN IF EXISTS thread_id; 

--- a/weave/trace_server/migrations/015_add_thread_id.up.sql
+++ b/weave/trace_server/migrations/015_add_thread_id.up.sql
@@ -1,10 +1,10 @@
 -- Add thread_id to raw call parts table
 ALTER TABLE call_parts
-    ADD COLUMN thread_id Nullable(String) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS thread_id Nullable(String) DEFAULT NULL;
 
 -- Add thread_id to aggregated calls table
 ALTER TABLE calls_merged
-    ADD COLUMN thread_id SimpleAggregateFunction(any, Nullable(String));
+    ADD COLUMN IF NOT EXISTS thread_id SimpleAggregateFunction(any, Nullable(String));
 
 -- Update materialized view to include thread_id
 ALTER TABLE calls_merged_view MODIFY QUERY

--- a/weave/trace_server/migrations/016_add_thread_id_to_stats.down.sql
+++ b/weave/trace_server/migrations/016_add_thread_id_to_stats.down.sql
@@ -25,4 +25,4 @@ GROUP BY
     call_parts.id;
 
 -- Remove thread_id from stats table
-ALTER TABLE calls_merged_stats DROP COLUMN thread_id; 
+ALTER TABLE calls_merged_stats DROP COLUMN IF EXISTS thread_id; 

--- a/weave/trace_server/migrations/016_add_thread_id_to_stats.up.sql
+++ b/weave/trace_server/migrations/016_add_thread_id_to_stats.up.sql
@@ -1,6 +1,6 @@
 -- Add thread_id to stats table
 ALTER TABLE calls_merged_stats
-    ADD COLUMN thread_id SimpleAggregateFunction(any, Nullable(String));
+    ADD COLUMN IF NOT EXISTS thread_id SimpleAggregateFunction(any, Nullable(String));
 
 -- Update stats materialized view to include thread_id
 ALTER TABLE calls_merged_stats_view MODIFY QUERY

--- a/weave/trace_server/migrations/017_add_turn_id.down.sql
+++ b/weave/trace_server/migrations/017_add_turn_id.down.sql
@@ -26,7 +26,7 @@ GROUP BY
     call_parts.id;
 
 -- Remove turn_id from stats table
-ALTER TABLE calls_merged_stats DROP COLUMN turn_id;
+ALTER TABLE calls_merged_stats DROP COLUMN IF EXISTS turn_id;
 
 -- Revert materialized view to exclude turn_id
 ALTER TABLE calls_merged_view MODIFY QUERY
@@ -56,7 +56,7 @@ ALTER TABLE calls_merged_view MODIFY QUERY
         id;
 
 -- Remove turn_id from aggregated calls table
-ALTER TABLE calls_merged DROP COLUMN turn_id;
+ALTER TABLE calls_merged DROP COLUMN IF EXISTS turn_id;
 
 -- Remove turn_id from raw call parts table
-ALTER TABLE call_parts DROP COLUMN turn_id; 
+ALTER TABLE call_parts DROP COLUMN IF EXISTS turn_id; 

--- a/weave/trace_server/migrations/017_add_turn_id.up.sql
+++ b/weave/trace_server/migrations/017_add_turn_id.up.sql
@@ -1,10 +1,10 @@
 -- Add turn_id to raw call parts table
 ALTER TABLE call_parts
-    ADD COLUMN turn_id Nullable(String) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS turn_id Nullable(String) DEFAULT NULL;
 
 -- Add turn_id to aggregated calls table
 ALTER TABLE calls_merged
-    ADD COLUMN turn_id SimpleAggregateFunction(any, Nullable(String));
+    ADD COLUMN IF NOT EXISTS turn_id SimpleAggregateFunction(any, Nullable(String));
 
 -- Update materialized view to include turn_id
 ALTER TABLE calls_merged_view MODIFY QUERY
@@ -36,7 +36,7 @@ ALTER TABLE calls_merged_view MODIFY QUERY
 
 -- Add turn_id to stats table
 ALTER TABLE calls_merged_stats
-    ADD COLUMN turn_id SimpleAggregateFunction(any, Nullable(String));
+    ADD COLUMN IF NOT EXISTS turn_id SimpleAggregateFunction(any, Nullable(String));
 
 -- Update stats materialized view to include turn_id
 ALTER TABLE calls_merged_stats_view MODIFY QUERY

--- a/weave/trace_server/migrations/018_add_wb_run_id_idx.down.sql
+++ b/weave/trace_server/migrations/018_add_wb_run_id_idx.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE calls_merged DROP INDEX idx_wb_run_id;
+ALTER TABLE calls_merged DROP INDEX IF EXISTS idx_wb_run_id;

--- a/weave/trace_server/migrations/018_add_wb_run_id_idx.up.sql
+++ b/weave/trace_server/migrations/018_add_wb_run_id_idx.up.sql
@@ -1,6 +1,6 @@
 -- Add set index, 100 max unique wb_run_ids in the index per (1) granule
 ALTER TABLE calls_merged
-    ADD INDEX idx_wb_run_id (wb_run_id) TYPE set(100) GRANULARITY 1
+    ADD INDEX IF NOT EXISTS idx_wb_run_id (wb_run_id) TYPE set(100) GRANULARITY 1
     SETTINGS alter_sync = 1;
 -- Materialize the index, actually generating index marks for all the granules
 ALTER TABLE calls_merged MATERIALIZE INDEX idx_wb_run_id SETTINGS mutations_sync = 1;

--- a/weave/trace_server/migrations/019_add_wb_run_step_end.down.sql
+++ b/weave/trace_server/migrations/019_add_wb_run_step_end.down.sql
@@ -28,7 +28,7 @@ GROUP BY
 
 -- Remove wb_run_step_end from stats table
 ALTER TABLE calls_merged_stats
-    DROP COLUMN wb_run_step_end;
+    DROP COLUMN IF EXISTS wb_run_step_end;
 
 -- Rollback materialized view to remove wb_run_step_end
 ALTER TABLE calls_merged_view MODIFY QUERY
@@ -60,8 +60,8 @@ ALTER TABLE calls_merged_view MODIFY QUERY
 
 -- Remove wb_run_step_end from aggregated calls table
 ALTER TABLE calls_merged
-    DROP COLUMN wb_run_step_end;
+    DROP COLUMN IF EXISTS wb_run_step_end;
 
 -- Remove wb_run_step_end from raw call parts table
 ALTER TABLE call_parts
-    DROP COLUMN wb_run_step_end;
+    DROP COLUMN IF EXISTS wb_run_step_end;

--- a/weave/trace_server/migrations/019_add_wb_run_step_end.up.sql
+++ b/weave/trace_server/migrations/019_add_wb_run_step_end.up.sql
@@ -1,10 +1,10 @@
 -- Add wb_run_step_end to raw call parts table
 ALTER TABLE call_parts
-    ADD COLUMN wb_run_step_end Nullable(UInt64) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS wb_run_step_end Nullable(UInt64) DEFAULT NULL;
 
 -- Add wb_run_step_end to aggregated calls table
 ALTER TABLE calls_merged
-    ADD COLUMN wb_run_step_end SimpleAggregateFunction(any, Nullable(UInt64));
+    ADD COLUMN IF NOT EXISTS wb_run_step_end SimpleAggregateFunction(any, Nullable(UInt64));
 
 -- Update materialized view to include wb_run_step_end
 ALTER TABLE calls_merged_view MODIFY QUERY
@@ -37,7 +37,7 @@ ALTER TABLE calls_merged_view MODIFY QUERY
 
 -- Add wb_run_step_end to stats table
 ALTER TABLE calls_merged_stats
-    ADD COLUMN wb_run_step_end SimpleAggregateFunction(any, Nullable(UInt64));
+    ADD COLUMN IF NOT EXISTS wb_run_step_end SimpleAggregateFunction(any, Nullable(UInt64));
 
 -- Update stats materialized view
 ALTER TABLE calls_merged_stats_view MODIFY QUERY

--- a/weave/trace_server/migrations/020_add_otel_column.down.sql
+++ b/weave/trace_server/migrations/020_add_otel_column.down.sql
@@ -29,7 +29,7 @@ GROUP BY
 
 -- Remove otel_dump from stats table
 ALTER TABLE calls_merged_stats
-    DROP COLUMN otel_dump;
+    DROP COLUMN IF EXISTS otel_dump;
 
 -- Rollback materialized view to remove otel_dump
 ALTER TABLE calls_merged_view MODIFY QUERY
@@ -61,8 +61,8 @@ ALTER TABLE calls_merged_view MODIFY QUERY
         id;
 
 -- Remove otel_dump from aggregated calls table
-ALTER TABLE calls_merged DROP COLUMN otel_dump;
+ALTER TABLE calls_merged DROP COLUMN IF EXISTS otel_dump;
 
 -- Remove otel_dump from raw call parts table
 ALTER TABLE call_parts
-    DROP COLUMN otel_dump;
+    DROP COLUMN IF EXISTS otel_dump;

--- a/weave/trace_server/migrations/020_add_otel_column.up.sql
+++ b/weave/trace_server/migrations/020_add_otel_column.up.sql
@@ -1,10 +1,10 @@
 -- Add otel_dump to raw call parts table
 ALTER TABLE call_parts
-    ADD COLUMN otel_dump Nullable(String);
+    ADD COLUMN IF NOT EXISTS otel_dump Nullable(String);
 
 -- Add otel_dump to aggregated calls table
 ALTER TABLE calls_merged
-    ADD COLUMN otel_dump SimpleAggregateFunction(any, Nullable(String));
+    ADD COLUMN IF NOT EXISTS otel_dump SimpleAggregateFunction(any, Nullable(String));
 
 -- Update materialized view to include otel_dump
 ALTER TABLE calls_merged_view MODIFY QUERY
@@ -38,7 +38,7 @@ ALTER TABLE calls_merged_view MODIFY QUERY
 
 -- Add otel_dump to stats table
 ALTER TABLE calls_merged_stats
-    ADD COLUMN otel_dump SimpleAggregateFunction(any, Nullable(String));
+    ADD COLUMN IF NOT EXISTS otel_dump SimpleAggregateFunction(any, Nullable(String));
 
 -- Update stats materialized view
 ALTER TABLE calls_merged_stats_view MODIFY QUERY

--- a/weave/trace_server/migrations/021_fix_otel_stats.down.sql
+++ b/weave/trace_server/migrations/021_fix_otel_stats.down.sql
@@ -1,5 +1,5 @@
-ALTER TABLE calls_merged_stats DROP COLUMN otel_dump_size_bytes;
-ALTER TABLE calls_merged_stats ADD COLUMN otel_dump SimpleAggregateFunction(any, Nullable(String));
+ALTER TABLE calls_merged_stats DROP COLUMN IF EXISTS otel_dump_size_bytes;
+ALTER TABLE calls_merged_stats ADD COLUMN IF NOT EXISTS otel_dump SimpleAggregateFunction(any, Nullable(String));
 
 ALTER TABLE calls_merged_stats_view MODIFY QUERY
 SELECT

--- a/weave/trace_server/migrations/021_fix_otel_stats.up.sql
+++ b/weave/trace_server/migrations/021_fix_otel_stats.up.sql
@@ -1,9 +1,9 @@
 -- Drop errantly added DUMP from stats table
-ALTER TABLE calls_merged_stats DROP COLUMN otel_dump;
+ALTER TABLE calls_merged_stats DROP COLUMN IF EXISTS otel_dump;
  
 -- Add otel_dump_size_bytes (NOT DUMP) to stats table
 ALTER TABLE calls_merged_stats
-    ADD COLUMN otel_dump_size_bytes SimpleAggregateFunction(any, Nullable(UInt64));
+    ADD COLUMN IF NOT EXISTS otel_dump_size_bytes SimpleAggregateFunction(any, Nullable(UInt64));
 
 -- Update stats materialized view with the bytes field
 ALTER TABLE calls_merged_stats_view MODIFY QUERY

--- a/weave/trace_server/migrations/022_calls_complete.up.sql
+++ b/weave/trace_server/migrations/022_calls_complete.up.sql
@@ -7,7 +7,7 @@
 -- ran the original version of this file. For fresh installs, 024's rename
 -- dance is harmless on empty tables.
 
-CREATE TABLE calls_complete (
+CREATE TABLE IF NOT EXISTS calls_complete (
     -- Primary fields
     id              String,
     project_id      String,
@@ -75,7 +75,7 @@ SETTINGS
     enable_block_offset_column=1;
 
 
-CREATE TABLE calls_complete_stats
+CREATE TABLE IF NOT EXISTS calls_complete_stats
 (
     project_id String,
     id String,
@@ -102,7 +102,7 @@ CREATE TABLE calls_complete_stats
 ) ENGINE = AggregatingMergeTree()
 ORDER BY (project_id, id);
 
-CREATE MATERIALIZED VIEW calls_complete_stats_view
+CREATE MATERIALIZED VIEW IF NOT EXISTS calls_complete_stats_view
 TO calls_complete_stats
 AS
 SELECT

--- a/weave/trace_server/migrations/023_add_annotation_queues.down.sql
+++ b/weave/trace_server/migrations/023_add_annotation_queues.down.sql
@@ -11,7 +11,7 @@ Feedback records are stored separately and will not be deleted.
 
 -- Remove queue_id column from feedback table
 ALTER TABLE feedback
-    DROP COLUMN queue_id;
+    DROP COLUMN IF EXISTS queue_id;
 
 -- Drop tables in reverse dependency order
 DROP TABLE IF EXISTS annotator_queue_items_progress;

--- a/weave/trace_server/migrations/023_add_annotation_queues.up.sql
+++ b/weave/trace_server/migrations/023_add_annotation_queues.up.sql
@@ -16,7 +16,7 @@ Key features:
 -- ============================================================================
 -- annotation_queues: Queue definitions and metadata
 -- ============================================================================
-CREATE TABLE annotation_queues (
+CREATE TABLE IF NOT EXISTS annotation_queues (
     /*
     `id`: String (UUID format), unique identifier for the queue. This is the primary reference.
     */
@@ -76,7 +76,7 @@ SETTINGS
 -- ============================================================================
 -- annotation_queue_items: Queue membership (which calls belong to each queue)
 -- ============================================================================
-CREATE TABLE annotation_queue_items (
+CREATE TABLE IF NOT EXISTS annotation_queue_items (
     /*
     `id`: String (UUID format), unique identifier for this queue item. This is the primary reference.
     */
@@ -165,12 +165,12 @@ ALTER TABLE feedback
     `queue_id`: The queue ID this feedback was created from.
     References annotation_queues.id. NULL when feedback is created outside of queues.
     */
-    ADD COLUMN queue_id Nullable(String) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS queue_id Nullable(String) DEFAULT NULL;
 
 -- ============================================================================
 -- annotator_queue_items_progress: Per-annotator workflow state tracking
 -- ============================================================================
-CREATE TABLE annotator_queue_items_progress (
+CREATE TABLE IF NOT EXISTS annotator_queue_items_progress (
     /*
     `id`: String (UUID format), unique identifier for this progress record. This is the primary reference.
     */

--- a/weave/trace_server/migrations/024_calls_complete_v2.down.sql
+++ b/weave/trace_server/migrations/024_calls_complete_v2.down.sql
@@ -6,11 +6,12 @@ DROP TABLE IF EXISTS calls_complete_stats;
 DROP VIEW IF EXISTS calls_complete_migration_view;
 DROP TABLE IF EXISTS calls_complete;
 
--- Restore from backup if available
+-- Restore from backup if available. One-shot: this RENAME is not idempotent
+-- (fails once calls_complete_old is consumed), matching the up migration's swap.
 RENAME TABLE calls_complete_old TO calls_complete;
 
 -- Recreate original stats table
-CREATE TABLE calls_complete_stats
+CREATE TABLE IF NOT EXISTS calls_complete_stats
 (
     project_id String,
     id String,
@@ -37,7 +38,7 @@ CREATE TABLE calls_complete_stats
 ) ENGINE = AggregatingMergeTree()
 ORDER BY (project_id, id);
 
-CREATE MATERIALIZED VIEW calls_complete_stats_view
+CREATE MATERIALIZED VIEW IF NOT EXISTS calls_complete_stats_view
 TO calls_complete_stats
 AS
 SELECT

--- a/weave/trace_server/migrations/024_calls_complete_v2.up.sql
+++ b/weave/trace_server/migrations/024_calls_complete_v2.up.sql
@@ -9,6 +9,11 @@
 --   7. Add bloom filter index on summary_dump
 --   8. Add table-level settings: min_bytes_for_wide_part=0
 --
+-- One-shot data migration. The backfill INSERT and the RENAME swap below are
+-- not idempotent (a re-run fails once calls_complete_old exists), so recovering
+-- from a partial failure requires manual intervention. CREATE/DROP steps carry
+-- IF [NOT] EXISTS to minimise the manual cleanup surface.
+--
 -- Migration procedure:
 --   Step 1: Create new table calls_complete_new
 --   Step 2: Create materialized view to sync live inserts
@@ -17,7 +22,7 @@
 --   Step 5: Recreate stats table and materialized view
 
 -- Step 1: Create new table
-CREATE TABLE calls_complete_new (
+CREATE TABLE IF NOT EXISTS calls_complete_new (
     -- Primary fields
     id              String,
     project_id      String,
@@ -83,7 +88,7 @@ SETTINGS
 
 -- Step 2: Create materialized view for live sync during migration
 -- This captures any inserts to the old table while backfill is running.
-CREATE MATERIALIZED VIEW calls_complete_migration_view
+CREATE MATERIALIZED VIEW IF NOT EXISTS calls_complete_migration_view
 TO calls_complete_new
 AS
 SELECT
@@ -159,7 +164,7 @@ RENAME TABLE calls_complete_new TO calls_complete;
 
 
 -- Step 5: Recreate stats table with updated types (non-nullable where changed)
-CREATE TABLE calls_complete_stats
+CREATE TABLE IF NOT EXISTS calls_complete_stats
 (
     project_id String,
     id String,
@@ -186,7 +191,7 @@ CREATE TABLE calls_complete_stats
 ) ENGINE = AggregatingMergeTree()
 ORDER BY (project_id, id);
 
-CREATE MATERIALIZED VIEW calls_complete_stats_view
+CREATE MATERIALIZED VIEW IF NOT EXISTS calls_complete_stats_view
 TO calls_complete_stats
 AS
 SELECT

--- a/weave/trace_server/migrations/029_add_ttl_support.down.sql
+++ b/weave/trace_server/migrations/029_add_ttl_support.down.sql
@@ -1,6 +1,9 @@
 -- Rollback Migration 029: Remove TTL support
 
--- Step 1: Remove TTL clauses from all tables that had MODIFY TTL in the up migration
+-- Step 1: Remove TTL clauses from all tables that had MODIFY TTL in the up migration.
+-- REMOVE TTL has no IF EXISTS form and errors on a table with no TTL, so this down
+-- is not re-runnable. Downs are manual-only (auto-recovery only re-runs ups), so
+-- an operator applies it once against the state the up left.
 ALTER TABLE call_parts REMOVE TTL;
 ALTER TABLE calls_merged REMOVE TTL;
 ALTER TABLE calls_merged_stats REMOVE TTL;

--- a/weave/trace_server/migrations/029_add_ttl_support.down.sql
+++ b/weave/trace_server/migrations/029_add_ttl_support.down.sql
@@ -102,13 +102,13 @@ ALTER TABLE calls_merged_view MODIFY QUERY
         id;
 
 -- Step 6: Drop expire_at column from calls_merged
-ALTER TABLE calls_merged DROP COLUMN expire_at;
+ALTER TABLE calls_merged DROP COLUMN IF EXISTS expire_at;
 
 -- Step 7: Drop expire_at column from call_parts
-ALTER TABLE call_parts DROP COLUMN expire_at;
+ALTER TABLE call_parts DROP COLUMN IF EXISTS expire_at;
 
 -- Step 8: Rename expire_at back to ttl_at on calls_complete
-ALTER TABLE calls_complete RENAME COLUMN expire_at TO ttl_at;
+ALTER TABLE calls_complete RENAME COLUMN IF EXISTS expire_at TO ttl_at;
 
 -- Step 8b: Re-apply TTL expression after column rename.
 ALTER TABLE calls_complete MODIFY TTL toDateTime(ttl_at) DELETE SETTINGS materialize_ttl_after_modify = 0;

--- a/weave/trace_server/migrations/029_add_ttl_support.down.sql
+++ b/weave/trace_server/migrations/029_add_ttl_support.down.sql
@@ -107,11 +107,10 @@ ALTER TABLE calls_merged DROP COLUMN IF EXISTS expire_at;
 -- Step 7: Drop expire_at column from call_parts
 ALTER TABLE call_parts DROP COLUMN IF EXISTS expire_at;
 
--- Step 8: Rename expire_at back to ttl_at on calls_complete
-ALTER TABLE calls_complete RENAME COLUMN IF EXISTS expire_at TO ttl_at;
-
--- Step 8b: Re-apply TTL expression after column rename.
+-- Step 8: Restore the TTL to ttl_at, then drop the additive expire_at column.
+-- The up migration adds expire_at (keeping ttl_at), so the reverse drops it.
 ALTER TABLE calls_complete MODIFY TTL toDateTime(ttl_at) DELETE SETTINGS materialize_ttl_after_modify = 0;
+ALTER TABLE calls_complete DROP COLUMN IF EXISTS expire_at;
 
 -- Step 9: Drop project_ttl_settings table
 DROP TABLE IF EXISTS project_ttl_settings;

--- a/weave/trace_server/migrations/029_add_ttl_support.up.sql
+++ b/weave/trace_server/migrations/029_add_ttl_support.up.sql
@@ -22,6 +22,10 @@ SETTINGS
 -- ttl_at is kept so a rollback to a pre-029 app can still write it. A RENAME
 -- would be irreversible mid-migration and, under prod write load on CH 25.10,
 -- spawns a mutation that can stall against concurrent lightweight updates.
+-- DateTime (not DateTime64(3) like the sibling tables) matches ttl_at's type so
+-- the TTL swap and the rollback path stay type-stable. No backfill from ttl_at is
+-- needed: TTL ships with this migration, so every existing row still holds the
+-- 2100 sentinel that ttl_at defaults to.
 ALTER TABLE calls_complete
     ADD COLUMN IF NOT EXISTS expire_at DateTime DEFAULT '2100-01-01 00:00:00';
 

--- a/weave/trace_server/migrations/029_add_ttl_support.up.sql
+++ b/weave/trace_server/migrations/029_add_ttl_support.up.sql
@@ -7,7 +7,7 @@
 -- Stores the per-project retention duration as an append-only audit trail.
 -- Use argMax(retention_days, updated_at) to read the latest setting.
 -- retention_days = 0 means "no TTL" (infinite retention).
-CREATE TABLE project_ttl_settings (
+CREATE TABLE IF NOT EXISTS project_ttl_settings (
     project_id      String,
     retention_days  Int32,
     updated_at      DateTime64(3) DEFAULT now64(3),
@@ -19,7 +19,7 @@ SETTINGS
     enable_block_offset_column = 1;
 
 -- Step 1b: Rename ttl_at to expire_at on calls_complete
-ALTER TABLE calls_complete RENAME COLUMN ttl_at TO expire_at;
+ALTER TABLE calls_complete RENAME COLUMN IF EXISTS ttl_at TO expire_at;
 
 -- Step 1c: Re-apply TTL expression after column rename.
 -- toDateTime() wrapper required for CH < 25.6 compatibility (PR #80710).
@@ -29,11 +29,11 @@ ALTER TABLE calls_complete MODIFY TTL toDateTime(expire_at) DELETE SETTINGS mate
 
 -- Step 2: Add expire_at to call_parts
 ALTER TABLE call_parts
-    ADD COLUMN expire_at DateTime64(3) DEFAULT toDateTime64('2100-01-01 00:00:00', 3);
+    ADD COLUMN IF NOT EXISTS expire_at DateTime64(3) DEFAULT toDateTime64('2100-01-01 00:00:00', 3);
 
 -- Step 3: Add expire_at to calls_merged
 ALTER TABLE calls_merged
-    ADD COLUMN expire_at SimpleAggregateFunction(min, DateTime64(3))
+    ADD COLUMN IF NOT EXISTS expire_at SimpleAggregateFunction(min, DateTime64(3))
     DEFAULT toDateTime64('2100-01-01 00:00:00', 3);
 
 -- Step 4: Update calls_merged_view to propagate expire_at from call_parts

--- a/weave/trace_server/migrations/029_add_ttl_support.up.sql
+++ b/weave/trace_server/migrations/029_add_ttl_support.up.sql
@@ -18,10 +18,14 @@ SETTINGS
     enable_block_number_column = 1,
     enable_block_offset_column = 1;
 
--- Step 1b: Rename ttl_at to expire_at on calls_complete
-ALTER TABLE calls_complete RENAME COLUMN IF EXISTS ttl_at TO expire_at;
+-- Step 1b: Add expire_at to calls_complete (additive, not a rename).
+-- ttl_at is kept so a rollback to a pre-029 app can still write it. A RENAME
+-- would be irreversible mid-migration and, under prod write load on CH 25.10,
+-- spawns a mutation that can stall against concurrent lightweight updates.
+ALTER TABLE calls_complete
+    ADD COLUMN IF NOT EXISTS expire_at DateTime DEFAULT '2100-01-01 00:00:00';
 
--- Step 1c: Re-apply TTL expression after column rename.
+-- Step 1c: Set the TTL to expire_at.
 -- toDateTime() wrapper required for CH < 25.6 compatibility (PR #80710).
 -- materialize_ttl_after_modify=0: set TTL metadata only. Every row has the
 -- 2100 sentinel so eager materialization rewrites every part to delete nothing.


### PR DESCRIPTION
## Summary

- **029 is additive, not a rename.** `ADD COLUMN IF NOT EXISTS expire_at` on `calls_complete`, keeping `ttl_at`. A `RENAME COLUMN` (even `IF EXISTS`) still spawns a mutation that collides with the patch parts from concurrent `call_end_v2` lightweight `UPDATE`s under load on CH 25.10.x ([ClickHouse#99164](https://github.com/ClickHouse/ClickHouse/pull/99164)), and it drops `ttl_at` (a rolled-back 0.80.x app then writes a column that no longer exists, silently losing writes). Additive avoids both; no application change (0.82 already writes `expire_at`).
- **Auto-recovery of partial migrations.** A migration interrupted mid-DDL leaves `partially_applied_version` set; the migrator now re-runs that idempotent migration to converge, instead of hard-raising and crash-looping on every restart. Recovery is gated: only the migration immediately after the recorded version, and never a one-shot (006 seed re-insert, 024 table-swap RENAME — re-running them is not a safe no-op), is re-run; anything else, or a re-run failure, raises for manual repair. **No retry cap by design** — a cap would re-latch into the manual-only crash-loop this PR exists to kill when ClickHouse has a transient failure streak; the crash-loop cadence is already bounded by the lock + k8s backoff.
- **Idempotent everywhere.** `IF [NOT] EXISTS` / `IF EXISTS` guards on every up + down statement, so a recovery re-run is a safe no-op through the cloud/replicated/distributed rewriters. 006's cost seed and 024's table swap remain one-shot by design (documented in their `up.sql`).
- **Divergence guard.** The migrator refuses to run when a data DB already holds migration-managed tables but has no row in the migrations table (a diverged `management_db`, e.g. a rename or a one-sided restore), rather than re-applying DDL from version 0 against tables of unknown schema.

## Testing

- `test_partial_migration_auto_recovers` (cloud/replicated/distributed, real CH): forge a crashed-mid-migration row, then re-run and assert self-heal to latest with the flag cleared and schema byte-for-byte unchanged; a one-shot swap (024) is refused and the flag survives for manual repair.
- `test_production_migrations_are_idempotent` (cloud/replicated/distributed): the apply-twice guarantee. Apply all migrations, rewind the recorded version, re-apply through each rewriter, assert table/column/engine schema is byte-for-byte unchanged. Swap set derived from SQL (`_table_swap_versions`), pinned `[24]` so a new one-shot can't land unnoticed.
- `test_migrations_refuse_populated_db_without_history` (cloud/replicated): a fresh management DB pointed at an already-migrated data DB raises.
- Unit: partial-migration auto-recovery gate (recovers `curr+1`, raises on any other partial or a denylisted one-shot without executing).
- Validated on a real 1 shard x 3 replica ClickHouse (25.12): full migrate + 3-replica schema convergence (`uniqExact(cityHash64(create_table_query)) = 1`) + auto-recovery self-heal. Leg-C A/B on CH 25.10.7.6 under concurrent call_start `INSERT` + `call_end_v2` lightweight `UPDATE`: old `RENAME` fails (`MutatePart` error 49, 2/2 rounds); additive 029 clean (0/2). Shipped for the 0.82.x line as `wandb/weave-trace:0.82.2-migration-hardening.1` (wandb/core#47401).

## Follow-ups (not in this PR)

- **Alert on migrator CrashLoopBackOff**: the real fix for "44h to notice" is alerting, not schema. Recovery self-heals the transient case; a genuinely stuck migration still crash-loops (by design, unbounded count but bounded cadence: one attempt per pod start, serialized by the migration lock, throttled by k8s backoff plateauing at ~5m) and should page.
