### PR TITLE
chore(weave): skip migration-db init ddl when already present

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -25,12 +25,20 @@ DEFAULT_MIGRATION_DIR = os.path.abspath(
 )
 
 
+def _count_result(count: int) -> Mock:
+    """Mock a single-cell `SELECT count()` result."""
+    res = Mock()
+    res.result_rows = [(count,)]
+    return res
+
+
 def _make_ch_client(database_engine: str = "Atomic") -> Mock:
     """Create a mock CH client that returns *database_engine* for system.databases queries.
 
-    Only `system.databases` queries are stubbed; all other `query()` calls
-    fall through to the default Mock behaviour so they don't silently return
-    engine data for unrelated code paths.
+    `system.databases` engine queries and the management-DB readiness reads
+    (`system.tables` / `system.columns`) are stubbed; the readiness reads
+    return 0 so `_initialize_migration_db` treats the DB as absent and runs
+    its DDL. All other `query()` calls fall through to the default Mock.
     """
     ch_client = Mock()
     ch_client.database = "test_db"
@@ -41,6 +49,8 @@ def _make_ch_client(database_engine: str = "Atomic") -> Mock:
     def _query_side_effect(sql, *args, **kwargs):
         if "system.databases" in sql:
             return engine_result
+        if "system.tables" in sql or "system.columns" in sql:
+            return _count_result(0)
         return Mock()
 
     ch_client.query.side_effect = _query_side_effect
@@ -61,6 +71,8 @@ def _make_ch_client_with_database_engines(database_engines: dict[str, str]) -> M
             else:
                 engine_result.result_rows = []
             return engine_result
+        if "system.tables" in sql or "system.columns" in sql:
+            return _count_result(0)
         return Mock()
 
     ch_client.query.side_effect = _query_side_effect
@@ -606,12 +618,14 @@ def test_create_db_sql(mock_costs):
 
 def test_engine_discovery_init_behavior():
     """Cloud mode skips system.databases; replicated mode queries it and is configurable."""
-    # Cloud mode never touches system.databases
-    cloud_client = Mock()
+    # Cloud mode never queries system.databases (only the readiness reads).
+    cloud_client = _make_ch_client()
     CloudClickHouseTraceServerMigrator(
         cloud_client, migration_dir=DEFAULT_MIGRATION_DIR
     )
-    cloud_client.query.assert_not_called()
+    assert not any(
+        "system.databases" in c.args[0] for c in cloud_client.query.call_args_list
+    )
 
     # Replicated mode uses ENGINE_DISCOVERY_MAX_WAIT_SECONDS constant
     ReplicatedClickHouseTraceServerMigrator(
@@ -621,8 +635,16 @@ def test_engine_discovery_init_behavior():
     )
 
     # Replicated mode surfaces a clear error when system.databases is inaccessible
-    denied_client = Mock()
-    denied_client.query.side_effect = DatabaseError("access denied to system.databases")
+    denied_client = _make_ch_client()
+
+    def _deny_system_databases(sql, *args, **kwargs):
+        if "system.databases" in sql:
+            raise DatabaseError("access denied to system.databases")
+        if "system.tables" in sql or "system.columns" in sql:
+            return _count_result(0)
+        return Mock()
+
+    denied_client.query.side_effect = _deny_system_databases
     with pytest.raises(
         MigrationError, match="require SELECT access to system.databases"
     ):
@@ -666,18 +688,23 @@ def test_replicated_engine_discovery_wait_and_timeout(mock_sleep):
     """Engine discovery retries until visible, then uses the result for DDL.
     When it never appears, the error includes the CREATE DATABASE statement.
     """
-    # Succeeds after retries: engine becomes visible on the 3rd query
+    # Succeeds after retries: engine becomes visible on the 3rd system.databases query
     ch_client = Mock()
     ch_client.database = "original_db"
     query_result_empty = Mock()
     query_result_empty.result_rows = []
     query_result_replicated = Mock()
     query_result_replicated.result_rows = [("Replicated",)]
-    ch_client.query.side_effect = [
-        query_result_empty,
-        query_result_empty,
-        query_result_replicated,
-    ]
+    engine_results = [query_result_empty, query_result_empty, query_result_replicated]
+
+    def _engine_after_retries(sql, *args, **kwargs):
+        if "system.databases" in sql:
+            return engine_results.pop(0)
+        if "system.tables" in sql or "system.columns" in sql:
+            return _count_result(0)
+        return Mock()
+
+    ch_client.query.side_effect = _engine_after_retries
 
     migrator = ReplicatedClickHouseTraceServerMigrator(
         ch_client,
@@ -708,7 +735,13 @@ def test_replicated_engine_discovery_wait_and_timeout(mock_sleep):
     # Times out: engine never becomes visible, error includes the SQL context
     timeout_client = Mock()
     timeout_client.database = "original_db"
-    timeout_client.query.return_value = query_result_empty
+
+    def _engine_never_visible(sql, *args, **kwargs):
+        if "system.tables" in sql or "system.columns" in sql:
+            return _count_result(0)
+        return query_result_empty
+
+    timeout_client.query.side_effect = _engine_never_visible
 
     with (
         patch(

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -530,3 +530,49 @@ def test_all_production_down_migrations_distributed(ch_client):
 
     # Migrate all the way back down
     migrator.apply_migrations(target_db, target_version=0)
+
+
+@pytest.mark.parametrize(
+    ("case_name", "replicated", "use_distributed"),
+    [
+        pytest.param("cloud", False, False, id="cloud"),
+        pytest.param("replicated", True, False, id="replicated"),
+        pytest.param("distributed", True, True, id="distributed"),
+    ],
+)
+def test_initialize_migration_db_skips_ddl_when_ready(
+    ch_client, monkeypatch, case_name: str, replicated: bool, use_distributed: bool
+):
+    """A subsequent init-container startup issues no management-DB DDL.
+
+    The management/lock tables' (ON CLUSTER in replicated/distributed mode) DDL
+    should run once; once present, _initialize_migration_db must short-circuit
+    rather than re-enqueue distributed DDL on every replica of every deploy.
+    """
+    mgmt_db = _unique_name(f"db_mgmt_ready_{case_name}")
+    ch_client.track_db(mgmt_db)
+
+    kwargs = {
+        "replicated": replicated,
+        "use_distributed": use_distributed,
+        "management_db": mgmt_db,
+        "migration_dir": _PROD_MIGRATION_DIR,
+        "post_migration_hook": None,
+    }
+    if replicated:
+        kwargs["replicated_cluster"] = _CLUSTER
+        kwargs["replicated_path"] = _REPLICATED_PATH
+    migrator = get_clickhouse_trace_server_migrator(ch_client, **kwargs)
+
+    # First construction created the management DB and its tables.
+    assert _table_exists(ch_client, mgmt_db, "migrations")
+    assert _table_exists(ch_client, mgmt_db, "migration_lock")
+    assert migrator._management_db_ready()
+
+    # A second startup against the ready management DB issues no DDL.
+    issued: list = []
+    monkeypatch.setattr(
+        migrator, "_run_ddl_with_retry", lambda sql, *a, **k: issued.append(sql)
+    )
+    migrator._initialize_migration_db()
+    assert issued == []

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -407,7 +407,14 @@ class BaseClickHouseTraceServerMigrator(ABC):
         )
 
     def _initialize_migration_db(self) -> None:
-        """Initialize the management database, migrations table, and lock table."""
+        """Create the management database, migrations table, and lock table.
+
+        Runs on every construction (every init-container startup), and the DDL
+        is `ON CLUSTER` in replicated/distributed mode, so skip it once the
+        objects exist rather than re-enqueue distributed DDL on every deploy.
+        """
+        if self._management_db_ready():
+            return
         self._ensure_database(self.management_db)
         create_table_sql = self._create_management_table_sql()
         self._run_ddl_with_retry(create_table_sql)
@@ -416,6 +423,36 @@ class BaseClickHouseTraceServerMigrator(ABC):
         # Evolve lock tables created before `heartbeat_at` existed. Idempotent
         # (ADD COLUMN IF NOT EXISTS), so it is a no-op on fresh tables.
         self._run_ddl_with_retry(self._evolve_lock_table_sql())
+
+    def _management_db_ready(self) -> bool:
+        """Whether everything `_initialize_migration_db` sets up already exists.
+
+        Includes the lock table's `heartbeat_at` column (its one schema
+        evolution); any new evolution added there must be reflected here.
+        """
+        return (
+            self._management_table_exists("migrations")
+            and self._management_table_exists(LOCK_TABLE)
+            and self._management_column_exists(LOCK_TABLE, "heartbeat_at")
+        )
+
+    def _management_table_exists(self, table: str) -> bool:
+        """Whether `table` exists in the management database."""
+        res = self.ch_client.query(
+            "SELECT count() FROM system.tables "
+            "WHERE database = %(db)s AND name = %(table)s",
+            parameters={"db": self.management_db, "table": table},
+        )
+        return res.result_rows[0][0] > 0
+
+    def _management_column_exists(self, table: str, column: str) -> bool:
+        """Whether `column` exists on a management-database table."""
+        res = self.ch_client.query(
+            "SELECT count() FROM system.columns "
+            "WHERE database = %(db)s AND table = %(table)s AND name = %(column)s",
+            parameters={"db": self.management_db, "table": table, "column": column},
+        )
+        return res.result_rows[0][0] > 0
 
     def _create_lock_table_sql(self) -> str:
         """Generate SQL for the migration lock table.
@@ -1064,82 +1101,89 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
         curr_db = self.ch_client.database
         self.ch_client.database = target_db
         try:
-            command_for_match = SQLPatterns.LINE_COMMENT.sub("", command)
-
-            # Skip MATERIALIZE commands (not supported by distributed tables)
-            if SQLPatterns.MATERIALIZE.search(command_for_match):
-                logger.warning(
-                    "Skipping MATERIALIZE command (not supported in distributed mode): %s",
-                    command,
-                )
-                return
-
-            # Run INSERT ... VALUES seeds (the Distributed engine fans rows to
-            # shards); skip INSERT ... SELECT backfills, which need per-shard handling.
-            if SQLPatterns.INSERT_STMT.search(command_for_match):
-                if SQLPatterns.INSERT_SELECT_STMT.search(command_for_match):
-                    logger.warning(
-                        "Skipping INSERT ... SELECT backfill (not supported in distributed mode): %s...",
-                        command[:_COMMAND_PREVIEW_LENGTH],
-                    )
-                    return
-                self._run_distributed_insert(command)
-                return
-
-            # Handle RENAME TABLE (local rename + drop/recreate distributed table)
-            if SQLPatterns.RENAME_TABLE_STMT.search(command_for_match):
-                self._execute_distributed_rename(command)
-                return
-
-            # Handle CREATE MATERIALIZED VIEW: rewrite to create only the
-            # local-source / local-target variant. See module docstring.
-            if SQLPatterns.CREATE_MATERIALIZED_VIEW_STMT.search(command_for_match):
-                if self._uses_replicated_db_engine(target_db):
-                    self._run_ddl_with_retry(command)
-                else:
-                    self._execute_materialized_view_create(command)
-                return
-
-            # Handle CREATE VIEW (non-materialized) / DROP VIEW: just add ON CLUSTER.
-            if SQLPatterns.CREATE_VIEW_STMT.search(
-                command_for_match
-            ) or SQLPatterns.DROP_VIEW_STMT.search(command_for_match):
-                # When the DB uses ENGINE = Replicated, it auto-converts MergeTree
-                # and handles DDL replication — skip explicit engine conversion and ON CLUSTER.
-                if self._uses_replicated_db_engine(target_db):
-                    formatted_command = command
-                    self._run_ddl_with_retry(formatted_command)
-                    return
-                formatted_command = self._format_replicated_sql(command)
-                formatted_command = self._add_on_cluster_clause(
-                    formatted_command, target_db=target_db
-                )
-                self._run_ddl_with_retry(formatted_command)
-                # For DROP VIEW: also drop the `_local` twin in case this was a
-                # materialized view. IF EXISTS makes it a no-op for plain views.
-                if SQLPatterns.DROP_VIEW_STMT.search(command_for_match):
-                    self._drop_local_view_twin(command_for_match, target_db)
-                return
-
-            # Engine handling matrix for distributed local tables:
-            # - distributed + Atomic DB: explicit ZK args plus ON CLUSTER
-            # - distributed + Replicated DB: Replicated*MergeTree() with no
-            #   explicit ZK args and no ON CLUSTER
-            if self._uses_replicated_db_engine(target_db):
-                formatted_command = self._format_replicated_sql(command)
-            else:
-                formatted_command = self._format_replicated_sql_distributed(
-                    command, target_db
-                )
-
-            # Handle ALTER TABLE
-            if SQLPatterns.ALTER_TABLE_STMT.search(command_for_match):
-                self._execute_distributed_alter(formatted_command)
-            else:
-                # Handle CREATE TABLE and other DDL
-                self._execute_distributed_ddl(formatted_command)
+            self._dispatch_distributed_command(target_db, command)
         finally:
             self.ch_client.database = curr_db
+
+    def _dispatch_distributed_command(self, target_db: str, command: str) -> None:
+        """Route one migration command to its distributed-mode handler.
+
+        Runs with `self.ch_client.database` already pointed at `target_db`.
+        """
+        command_for_match = SQLPatterns.LINE_COMMENT.sub("", command)
+
+        # Skip MATERIALIZE commands (not supported by distributed tables)
+        if SQLPatterns.MATERIALIZE.search(command_for_match):
+            logger.warning(
+                "Skipping MATERIALIZE command (not supported in distributed mode): %s",
+                command,
+            )
+            return
+
+        # Run INSERT ... VALUES seeds (the Distributed engine fans rows to
+        # shards); skip INSERT ... SELECT backfills, which need per-shard handling.
+        if SQLPatterns.INSERT_STMT.search(command_for_match):
+            if SQLPatterns.INSERT_SELECT_STMT.search(command_for_match):
+                logger.warning(
+                    "Skipping INSERT ... SELECT backfill (not supported in distributed mode): %s...",
+                    command[:_COMMAND_PREVIEW_LENGTH],
+                )
+                return
+            self._run_distributed_insert(command)
+            return
+
+        # Handle RENAME TABLE (local rename + drop/recreate distributed table)
+        if SQLPatterns.RENAME_TABLE_STMT.search(command_for_match):
+            self._execute_distributed_rename(command)
+            return
+
+        # Handle CREATE MATERIALIZED VIEW: rewrite to create only the
+        # local-source / local-target variant. See module docstring.
+        if SQLPatterns.CREATE_MATERIALIZED_VIEW_STMT.search(command_for_match):
+            if self._uses_replicated_db_engine(target_db):
+                self._run_ddl_with_retry(command)
+            else:
+                self._execute_materialized_view_create(command)
+            return
+
+        # Handle CREATE VIEW (non-materialized) / DROP VIEW: just add ON CLUSTER.
+        if SQLPatterns.CREATE_VIEW_STMT.search(
+            command_for_match
+        ) or SQLPatterns.DROP_VIEW_STMT.search(command_for_match):
+            # When the DB uses ENGINE = Replicated, it auto-converts MergeTree
+            # and handles DDL replication -> skip explicit engine conversion and ON CLUSTER.
+            if self._uses_replicated_db_engine(target_db):
+                formatted_command = command
+                self._run_ddl_with_retry(formatted_command)
+                return
+            formatted_command = self._format_replicated_sql(command)
+            formatted_command = self._add_on_cluster_clause(
+                formatted_command, target_db=target_db
+            )
+            self._run_ddl_with_retry(formatted_command)
+            # For DROP VIEW: also drop the `_local` twin in case this was a
+            # materialized view. IF EXISTS makes it a no-op for plain views.
+            if SQLPatterns.DROP_VIEW_STMT.search(command_for_match):
+                self._drop_local_view_twin(command_for_match, target_db)
+            return
+
+        # Engine handling matrix for distributed local tables:
+        # - distributed + Atomic DB: explicit ZK args plus ON CLUSTER
+        # - distributed + Replicated DB: Replicated*MergeTree() with no
+        #   explicit ZK args and no ON CLUSTER
+        if self._uses_replicated_db_engine(target_db):
+            formatted_command = self._format_replicated_sql(command)
+        else:
+            formatted_command = self._format_replicated_sql_distributed(
+                command, target_db
+            )
+
+        # Handle ALTER TABLE
+        if SQLPatterns.ALTER_TABLE_STMT.search(command_for_match):
+            self._execute_distributed_alter(formatted_command)
+        else:
+            # Handle CREATE TABLE and other DDL
+            self._execute_distributed_ddl(formatted_command)
 
     def _format_replicated_sql_distributed(self, sql_query: str, target_db: str) -> str:
         """Format SQL query to use replicated engines with explicit paths for distributed mode."""


### PR DESCRIPTION
## Summary
- `_initialize_migration_db` runs on every migrator construction (every init-container startup) and issues CREATE DATABASE / CREATE TABLE / ALTER for the management, migrations, and lock tables. In replicated/distributed mode those are `ON CLUSTER`, so each startup re-enqueues distributed DDL on every replica even when everything already exists.
- Gate it on a cheap local `system.tables` / `system.columns` read (`_management_db_ready`) so the DDL runs only when the migrations or lock table (or the lock table's `heartbeat_at` column) is actually missing. First-time setup is unchanged.
- Also extract the distributed `_execute_migration_command` dispatch into `_dispatch_distributed_command` (behavior-preserving) so the `try` clause is a single call; keeps the method readable and under lint's try-length limit.

## Testing
`test_initialize_migration_db_skips_ddl_when_ready` (cloud/replicated/distributed): after first construction, a second `_initialize_migration_db` issues zero DDL. Distributed migration + down suites still pass, confirming the dispatch extraction is behavior-preserving. Pre-existing unrelated `test_distributed_legacy_replicated_management_db` failure (local-CH `ORDER BY (col)` render) is on master.