### PR TITLE
chore(weave): fix SYSTEM SYNC REPLICA ON CLUSTER order on 2s2r nightly

### DIFF
--- a/tests/trace_server/helpers.py
+++ b/tests/trace_server/helpers.py
@@ -28,7 +28,7 @@ def force_optimize(ch_client: CHClient, table: str) -> None:
     if wf_env.wf_clickhouse_use_distributed_tables():
         cluster = wf_env.wf_clickhouse_replicated_cluster()
         ch_client.command(f"OPTIMIZE TABLE {table}_local ON CLUSTER {cluster} FINAL")
-        ch_client.command(f"SYSTEM SYNC REPLICA {table}_local ON CLUSTER {cluster}")
+        ch_client.command(f"SYSTEM SYNC REPLICA ON CLUSTER {cluster} {table}_local")
     else:
         ch_client.command(f"OPTIMIZE TABLE {table} FINAL")
 


### PR DESCRIPTION
## Summary
- `force_optimize` emitted `SYSTEM SYNC REPLICA {table}_local ON CLUSTER {cluster}`; ClickHouse wants `ON CLUSTER` before the table, so it raised SYNTAX_ERROR (code 62) on CH 26.4 and failed every storage-size test on the replicated 2s2r nightly legs.
- Reordered to `SYSTEM SYNC REPLICA ON CLUSTER {cluster} {table}_local`. Introduced by #7420.

## Testing
2s2r nightly (trace + trace_server shards).
