### PR TITLE
perf(weave): per-source union-all for custom-attrs schema query

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -1285,25 +1285,44 @@ class TestMakeCustomAttrsSchemaQuery:
         )
 
         expected = """
-            SELECT tupleElement(attr, 1) AS source,
-                   tupleElement(attr, 2) AS key,
-                   tupleElement(attr, 3) AS value_type,
-                   count() AS span_count
+            SELECT source, key, value_type, span_count
             FROM (
-                SELECT s.custom_attrs_string.keys AS custom_attrs_string_keys,
-                       s.custom_attrs_int.keys AS custom_attrs_int_keys,
-                       s.custom_attrs_float.keys AS custom_attrs_float_keys,
-                       s.custom_attrs_bool.keys AS custom_attrs_bool_keys
+                SELECT 'custom_attrs_string' AS source,
+                       'string' AS value_type,
+                       key,
+                       count() AS span_count
                 FROM spans s
+                ARRAY JOIN s.custom_attrs_string.keys AS key
                 WHERE s.project_id = {genai_0:String}
-            ) filtered
-            ARRAY JOIN arrayConcat(
-                arrayMap(k -> tuple('custom_attrs_string', k, 'string'), filtered.custom_attrs_string_keys),
-                arrayMap(k -> tuple('custom_attrs_int', k, 'int'), filtered.custom_attrs_int_keys),
-                arrayMap(k -> tuple('custom_attrs_float', k, 'float'), filtered.custom_attrs_float_keys),
-                arrayMap(k -> tuple('custom_attrs_bool', k, 'bool'), filtered.custom_attrs_bool_keys)
-            ) AS attr
-            GROUP BY source, key, value_type
+                GROUP BY key
+                UNION ALL
+                SELECT 'custom_attrs_int' AS source,
+                       'int' AS value_type,
+                       key,
+                       count() AS span_count
+                FROM spans s
+                ARRAY JOIN s.custom_attrs_int.keys AS key
+                WHERE s.project_id = {genai_0:String}
+                GROUP BY key
+                UNION ALL
+                SELECT 'custom_attrs_float' AS source,
+                       'float' AS value_type,
+                       key,
+                       count() AS span_count
+                FROM spans s
+                ARRAY JOIN s.custom_attrs_float.keys AS key
+                WHERE s.project_id = {genai_0:String}
+                GROUP BY key
+                UNION ALL
+                SELECT 'custom_attrs_bool' AS source,
+                       'bool' AS value_type,
+                       key,
+                       count() AS span_count
+                FROM spans s
+                ARRAY JOIN s.custom_attrs_bool.keys AS key
+                WHERE s.project_id = {genai_0:String}
+                GROUP BY key
+            )
             ORDER BY span_count DESC, key ASC, source ASC
             LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
         """
@@ -1338,27 +1357,52 @@ class TestMakeCustomAttrsSchemaQuery:
         )
 
         expected = """
-            SELECT tupleElement(attr, 1) AS source,
-                   tupleElement(attr, 2) AS key,
-                   tupleElement(attr, 3) AS value_type,
-                   count() AS span_count
+            SELECT source, key, value_type, span_count
             FROM (
-                SELECT s.custom_attrs_string.keys AS custom_attrs_string_keys,
-                       s.custom_attrs_int.keys AS custom_attrs_int_keys,
-                       s.custom_attrs_float.keys AS custom_attrs_float_keys,
-                       s.custom_attrs_bool.keys AS custom_attrs_bool_keys
+                SELECT 'custom_attrs_string' AS source,
+                       'string' AS value_type,
+                       key,
+                       count() AS span_count
                 FROM spans s
+                ARRAY JOIN s.custom_attrs_string.keys AS key
                 WHERE s.project_id = {genai_0:String}
                 AND s.started_at >= {genai_1:DateTime64(6)}
                 AND (s.agent_name = {genai_2:String})
-            ) filtered
-            ARRAY JOIN arrayConcat(
-                arrayMap(k -> tuple('custom_attrs_string', k, 'string'), filtered.custom_attrs_string_keys),
-                arrayMap(k -> tuple('custom_attrs_int', k, 'int'), filtered.custom_attrs_int_keys),
-                arrayMap(k -> tuple('custom_attrs_float', k, 'float'), filtered.custom_attrs_float_keys),
-                arrayMap(k -> tuple('custom_attrs_bool', k, 'bool'), filtered.custom_attrs_bool_keys)
-            ) AS attr
-            GROUP BY source, key, value_type
+                GROUP BY key
+                UNION ALL
+                SELECT 'custom_attrs_int' AS source,
+                       'int' AS value_type,
+                       key,
+                       count() AS span_count
+                FROM spans s
+                ARRAY JOIN s.custom_attrs_int.keys AS key
+                WHERE s.project_id = {genai_0:String}
+                AND s.started_at >= {genai_1:DateTime64(6)}
+                AND (s.agent_name = {genai_2:String})
+                GROUP BY key
+                UNION ALL
+                SELECT 'custom_attrs_float' AS source,
+                       'float' AS value_type,
+                       key,
+                       count() AS span_count
+                FROM spans s
+                ARRAY JOIN s.custom_attrs_float.keys AS key
+                WHERE s.project_id = {genai_0:String}
+                AND s.started_at >= {genai_1:DateTime64(6)}
+                AND (s.agent_name = {genai_2:String})
+                GROUP BY key
+                UNION ALL
+                SELECT 'custom_attrs_bool' AS source,
+                       'bool' AS value_type,
+                       key,
+                       count() AS span_count
+                FROM spans s
+                ARRAY JOIN s.custom_attrs_bool.keys AS key
+                WHERE s.project_id = {genai_0:String}
+                AND s.started_at >= {genai_1:DateTime64(6)}
+                AND (s.agent_name = {genai_2:String})
+                GROUP BY key
+            )
             ORDER BY span_count DESC, key ASC, source ASC
             LIMIT {genai_3:UInt64} OFFSET {genai_4:UInt64}
         """

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1229,27 +1229,22 @@ def make_custom_attrs_schema_query(
     span_filters = _spans_filter_sql(pb, req)
     limit_slot = pb.add(req.limit + 1, param_type="UInt64")
     offset_slot = pb.add(req.offset, param_type="UInt64")
-    key_columns = ",\n               ".join(
-        f"s.{source}.keys AS {source}_keys" for source, _ in _CUSTOM_ATTR_SCHEMA_SOURCES
-    )
-    attr_arrays = ",\n            ".join(
-        f"arrayMap(k -> tuple('{source}', k, '{value_type}'), filtered.{source}_keys)"
+    source_branches = "\n            UNION ALL\n            ".join(
+        f"""SELECT '{source}' AS source,
+                   '{value_type}' AS value_type,
+                   key,
+                   count() AS span_count
+            FROM spans s
+            ARRAY JOIN s.{source}.keys AS key
+            WHERE {span_filters.where}
+            GROUP BY key"""
         for source, value_type in _CUSTOM_ATTR_SCHEMA_SOURCES
     )
     return f"""
-        SELECT tupleElement(attr, 1) AS source,
-               tupleElement(attr, 2) AS key,
-               tupleElement(attr, 3) AS value_type,
-               count() AS span_count
+        SELECT source, key, value_type, span_count
         FROM (
-            SELECT {key_columns}
-            FROM spans s
-            WHERE {span_filters.where}
-        ) filtered
-        ARRAY JOIN arrayConcat(
-            {attr_arrays}
-        ) AS attr
-        GROUP BY source, key, value_type
+            {source_branches}
+        )
         ORDER BY span_count DESC, key ASC, source ASC
         LIMIT {limit_slot} OFFSET {offset_slot}
     """

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1229,6 +1229,8 @@ def make_custom_attrs_schema_query(
     span_filters = _spans_filter_sql(pb, req)
     limit_slot = pb.add(req.limit + 1, param_type="UInt64")
     offset_slot = pb.add(req.offset, param_type="UInt64")
+    # Per-source UNION ALL: a scalar ARRAY JOIN + GROUP BY on the bare key is far
+    # cheaper (CPU, peak memory) than grouping on one concatenated per-row tuple array.
     source_branches = "\n            UNION ALL\n            ".join(
         f"""SELECT '{source}' AS source,
                    '{value_type}' AS value_type,


### PR DESCRIPTION
## Summary
- `make_custom_attrs_schema_query` built one concatenated tuple array per row (`arrayConcat` + a single `ARRAY JOIN`) then one big `GROUP BY`. Rewritten as a per-source `UNION ALL` of scalar `ARRAY JOIN <map>.keys` + `GROUP BY key`. Identical output (columns, per-key counts, ORDER BY, LIMIT n+1/OFFSET, ParamBuilder slots).
- Read-time only, no schema/MV/migration.

## Performance
Prod read-only (`weave-trace-prod-ro`), interleaved warm, master -> branch. Projects anonymized.

| project (rows scanned, attrs) | elapsed O->N | peak mem O->N | bytes read O->N |
|---|---|---|---|
| attribute-rich, 53M / 30d | 7.3s -> **2.3s** | ~3.5-4 -> **~2.5-3 GiB** (NEW ok at 3 GiB cap, OLD OOMs) | 74 -> 82 GB |
| thin, high-volume, 9M / 7d | 0.26s -> **0.13s** | ~0.5 -> ~1-4 GiB | 1.8 -> 3.1 GB |
| mid, 0.5M / 7d, 143 keys | 56 -> 53 ms | ~1-4 -> **<1 GiB** | 0.28 -> 0.35 GB |

The CPU win is fundamental (single-threaded it's still ~4-5x faster): OLD builds a `tuple(String,String,String)` per row and groups on it; NEW groups on a bare key.

## Caveats
- IO amplification: 4 independent scans read ~4x the marks and +10-70% bytes. Hidden warm; on cold Cloud reads that's 4x the mark GETs against object storage.
- Peak memory is data-dependent: **lower** on attribute-heavy projects (the OOM-prone ones), up to ~40-54% **higher** on thin high-volume ones (bounded, sub-GB, scales with core count not rows) - well under the 16 GiB cap either way.
- Cost scales with the number of `custom_attrs_*` map types (4 scans today); adding a 5th makes it 5 scans. A per-project distinct-keys cache would be the durable fix.

## Testing
updated the query-builder sql assertion; prod benchmark above; todo: ch integration test

## QA validation (zoo-qa)
PR build `b4cef29` vs master `c43af3b`, `POST /agents/spans/custom-attrs/schema`, server-side Datadog `@duration` grouped by version (1k agent spans / 100 typed keys):

| build | warm-floor MIN | p95 | MAX |
|---|---|---|---|
| master `c43af3b` | 21.0ms | 280ms | 442ms |
| PR `b4cef29` | 20.1ms | 310ms | 367ms |

Query-dominated warm floor at parity (21.0 vs 20.1ms); the p50/p95 spread is the ~94ms gql auth roundtrip + thin QA `diversity_sampling`, not this code path. Correctness parity (both return exactly 100 attrs, `has_more:false`), 0 errors on the PR build. The prod-scale win (7.3s->2.3s) isn't reproducible at smoke scale. Traces: PR [200](https://us5.datadoghq.com/apm/trace/6a45ff0500000000dd0f71f7d7d894e8), master [median](https://us5.datadoghq.com/apm/trace/6a45fd6a00000000ae25c13f02adf5da), master [max](https://us5.datadoghq.com/apm/trace/6a45fd64000000002e5c1e1470ab00d9).
