### PR TITLE
chore(weave): db-qualify SYNC in 2s2r test helper

### DIFF
--- a/tests/trace_server/helpers.py
+++ b/tests/trace_server/helpers.py
@@ -28,7 +28,9 @@ def force_optimize(ch_client: CHClient, table: str) -> None:
     if wf_env.wf_clickhouse_use_distributed_tables():
         cluster = wf_env.wf_clickhouse_replicated_cluster()
         ch_client.command(f"OPTIMIZE TABLE {table}_local ON CLUSTER {cluster} FINAL")
-        ch_client.command(f"SYSTEM SYNC REPLICA ON CLUSTER {cluster} {table}_local")
+        ch_client.command(
+            f"SYSTEM SYNC REPLICA ON CLUSTER {cluster} {ch_client.database}.{table}_local"
+        )
     else:
         ch_client.command(f"OPTIMIZE TABLE {table} FINAL")
 


### PR DESCRIPTION
## Summary
- The 2s2r nightly leg failed with `Table default.calls_merged_local does not exist`. `SYSTEM SYNC REPLICA ON CLUSTER` resolves an unqualified table against each node's `default` DB, but the local tables live in the test DB. Qualify with `ch_client.database`.
- The `OPTIMIZE ... ON CLUSTER` line above works because DDL-queue propagates the session DB; `SYSTEM SYNC REPLICA` does not. #7420 / #7501 reordered these but never DB-qualified, so the leg stayed red.

## Testing
reproduced red on a local 2s2r cluster, then green with the change. full nightly dispatched on this branch (all shards, single-node + 1s3r + 2s2r, py3.10-3.13): 310/310 jobs pass -> https://github.com/wandb/weave/actions/runs/28562237909

<img width="513" height="245" alt="image" src="https://github.com/user-attachments/assets/afade9c7-254c-4aed-b25f-de443c6954d4" />