### PR TITLE
perf(weave): compute numeric-histogram bounds once (3 map scans -> 2)

### DIFF
--- a/tests/trace_server/query_builder/test_agent_stats_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_stats_query_builder.py
@@ -463,27 +463,26 @@ def test_numeric_bucket_stats_query_uses_value_buckets() -> None:
            WHERE s.ended_at > s.started_at
              AND isNotNull(if(s.ended_at > s.started_at, toFloat64(toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at)), NULL))
              AND isFinite(if(s.ended_at > s.started_at, toFloat64(toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at)), NULL)) ),
-          (SELECT tuple(toFloat64(min(bucket_value)), toFloat64(max(bucket_value)), count())
+          (SELECT CAST(tuple(toFloat64(min(bucket_value)), toFloat64(max(bucket_value)), count()) AS Tuple(min_bound Float64, max_bound Float64, value_count UInt64))
            FROM value_rows) AS bounds_tuple,
              all_buckets AS
           (SELECT toUInt64(number) AS bucket
            FROM numbers({genai_3:UInt64})),
              aggregated_data AS
-          (SELECT if(bounds_tuple.2 = bounds_tuple.1, toUInt64(0), toUInt64(least(toFloat64({genai_3:UInt64}) - 1.0, floor((value_rows.bucket_value - bounds_tuple.1) / if(bounds_tuple.2 > bounds_tuple.1, (bounds_tuple.2 - bounds_tuple.1) / {genai_3:Float64}, 1.0))))) AS bucket,
+          (SELECT if(bounds_tuple.max_bound = bounds_tuple.min_bound, toUInt64(0), toUInt64(least(toFloat64({genai_3:UInt64}) - 1.0, floor((value_rows.bucket_value - bounds_tuple.min_bound) / if(bounds_tuple.max_bound > bounds_tuple.min_bound, (bounds_tuple.max_bound - bounds_tuple.min_bound) / {genai_3:Float64}, 1.0))))) AS bucket,
                   countIf(v_spans) AS count_spans
            FROM value_rows
-           WHERE bounds_tuple.3 > 0
-             AND value_rows.bucket_value >= bounds_tuple.1
-             AND value_rows.bucket_value <= bounds_tuple.2
+           WHERE value_rows.bucket_value >= bounds_tuple.min_bound
+             AND value_rows.bucket_value <= bounds_tuple.max_bound
            GROUP BY bucket)
         SELECT all_buckets.bucket AS bucket_index,
-               if(bounds_tuple.2 = bounds_tuple.1, bounds_tuple.1, bounds_tuple.1 + toFloat64(all_buckets.bucket) * if(bounds_tuple.2 > bounds_tuple.1, (bounds_tuple.2 - bounds_tuple.1) / {genai_3:Float64}, 1.0)) AS bucket_min,
-               if(bounds_tuple.2 = bounds_tuple.1, bounds_tuple.2, if(all_buckets.bucket = {genai_3:UInt64} - toUInt64(1), bounds_tuple.2, bounds_tuple.1 + toFloat64(all_buckets.bucket + 1) * if(bounds_tuple.2 > bounds_tuple.1, (bounds_tuple.2 - bounds_tuple.1) / {genai_3:Float64}, 1.0))) AS bucket_max,
+               if(bounds_tuple.max_bound = bounds_tuple.min_bound, bounds_tuple.min_bound, bounds_tuple.min_bound + toFloat64(all_buckets.bucket) * if(bounds_tuple.max_bound > bounds_tuple.min_bound, (bounds_tuple.max_bound - bounds_tuple.min_bound) / {genai_3:Float64}, 1.0)) AS bucket_min,
+               if(bounds_tuple.max_bound = bounds_tuple.min_bound, bounds_tuple.max_bound, if(all_buckets.bucket = {genai_3:UInt64} - toUInt64(1), bounds_tuple.max_bound, bounds_tuple.min_bound + toFloat64(all_buckets.bucket + 1) * if(bounds_tuple.max_bound > bounds_tuple.min_bound, (bounds_tuple.max_bound - bounds_tuple.min_bound) / {genai_3:Float64}, 1.0))) AS bucket_max,
                COALESCE(aggregated_data.count_spans, 0) AS count_spans
         FROM all_buckets
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        WHERE bounds_tuple.3 > 0
-          AND (bounds_tuple.2 > bounds_tuple.1
+        WHERE bounds_tuple.value_count > 0
+          AND (bounds_tuple.max_bound > bounds_tuple.min_bound
                OR all_buckets.bucket = 0)
         ORDER BY bucket_index
     """
@@ -539,27 +538,26 @@ def test_numeric_bucket_stats_query_groups_custom_attr_measure() -> None:
           (SELECT avgOrNull(if((mapContains(s.custom_attrs_float, {genai_9:String})), toFloat64(s.custom_attrs_float[{genai_9:String}]), NULL)) AS bucket_value
            FROM filtered_spans s
            GROUP BY s.conversation_id),
-          (SELECT tuple(toFloat64(min(bucket_value)), toFloat64(max(bucket_value)), count())
+          (SELECT CAST(tuple(toFloat64(min(bucket_value)), toFloat64(max(bucket_value)), count()) AS Tuple(min_bound Float64, max_bound Float64, value_count UInt64))
            FROM value_rows) AS bounds_tuple,
              all_buckets AS
           (SELECT toUInt64(number) AS bucket
            FROM numbers({genai_8:UInt64})),
              aggregated_data AS
-          (SELECT if(bounds_tuple.2 = bounds_tuple.1, toUInt64(0), toUInt64(least(toFloat64({genai_8:UInt64}) - 1.0, floor((value_rows.bucket_value - bounds_tuple.1) / if(bounds_tuple.2 > bounds_tuple.1, (bounds_tuple.2 - bounds_tuple.1) / {genai_8:Float64}, 1.0))))) AS bucket,
+          (SELECT if(bounds_tuple.max_bound = bounds_tuple.min_bound, toUInt64(0), toUInt64(least(toFloat64({genai_8:UInt64}) - 1.0, floor((value_rows.bucket_value - bounds_tuple.min_bound) / if(bounds_tuple.max_bound > bounds_tuple.min_bound, (bounds_tuple.max_bound - bounds_tuple.min_bound) / {genai_8:Float64}, 1.0))))) AS bucket,
                   count() AS count
            FROM value_rows
-           WHERE bounds_tuple.3 > 0
-             AND value_rows.bucket_value >= bounds_tuple.1
-             AND value_rows.bucket_value <= bounds_tuple.2
+           WHERE value_rows.bucket_value >= bounds_tuple.min_bound
+             AND value_rows.bucket_value <= bounds_tuple.max_bound
            GROUP BY bucket)
         SELECT all_buckets.bucket AS bucket_index,
-               if(bounds_tuple.2 = bounds_tuple.1, bounds_tuple.1, bounds_tuple.1 + toFloat64(all_buckets.bucket) * if(bounds_tuple.2 > bounds_tuple.1, (bounds_tuple.2 - bounds_tuple.1) / {genai_8:Float64}, 1.0)) AS bucket_min,
-               if(bounds_tuple.2 = bounds_tuple.1, bounds_tuple.2, if(all_buckets.bucket = {genai_8:UInt64} - toUInt64(1), bounds_tuple.2, bounds_tuple.1 + toFloat64(all_buckets.bucket + 1) * if(bounds_tuple.2 > bounds_tuple.1, (bounds_tuple.2 - bounds_tuple.1) / {genai_8:Float64}, 1.0))) AS bucket_max,
+               if(bounds_tuple.max_bound = bounds_tuple.min_bound, bounds_tuple.min_bound, bounds_tuple.min_bound + toFloat64(all_buckets.bucket) * if(bounds_tuple.max_bound > bounds_tuple.min_bound, (bounds_tuple.max_bound - bounds_tuple.min_bound) / {genai_8:Float64}, 1.0)) AS bucket_min,
+               if(bounds_tuple.max_bound = bounds_tuple.min_bound, bounds_tuple.max_bound, if(all_buckets.bucket = {genai_8:UInt64} - toUInt64(1), bounds_tuple.max_bound, bounds_tuple.min_bound + toFloat64(all_buckets.bucket + 1) * if(bounds_tuple.max_bound > bounds_tuple.min_bound, (bounds_tuple.max_bound - bounds_tuple.min_bound) / {genai_8:Float64}, 1.0))) AS bucket_max,
                COALESCE(aggregated_data.count, 0) AS count
         FROM all_buckets
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        WHERE bounds_tuple.3 > 0
-          AND (bounds_tuple.2 > bounds_tuple.1
+        WHERE bounds_tuple.value_count > 0
+          AND (bounds_tuple.max_bound > bounds_tuple.min_bound
                OR all_buckets.bucket = 0)
         ORDER BY bucket_index
     """.replace("{_ATTR_SRC}", src_sql)

--- a/tests/trace_server/query_builder/test_agent_stats_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_stats_query_builder.py
@@ -463,32 +463,27 @@ def test_numeric_bucket_stats_query_uses_value_buckets() -> None:
            WHERE s.ended_at > s.started_at
              AND isNotNull(if(s.ended_at > s.started_at, toFloat64(toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at)), NULL))
              AND isFinite(if(s.ended_at > s.started_at, toFloat64(toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at)), NULL)) ),
-             bounds AS
-          (SELECT toFloat64(min(bucket_value)) AS bucket_min_bound,
-                  toFloat64(max(bucket_value)) AS bucket_max_bound,
-                  count() AS value_count
-           FROM value_rows),
+          (SELECT tuple(toFloat64(min(bucket_value)), toFloat64(max(bucket_value)), count())
+           FROM value_rows) AS bounds_tuple,
              all_buckets AS
           (SELECT toUInt64(number) AS bucket
            FROM numbers({genai_3:UInt64})),
              aggregated_data AS
-          (SELECT if(bounds.bucket_max_bound = bounds.bucket_min_bound, toUInt64(0), toUInt64(least(toFloat64({genai_3:UInt64}) - 1.0, floor((value_rows.bucket_value - bounds.bucket_min_bound) / if(bounds.bucket_max_bound > bounds.bucket_min_bound, (bounds.bucket_max_bound - bounds.bucket_min_bound) / {genai_3:Float64}, 1.0))))) AS bucket,
+          (SELECT if(bounds_tuple.2 = bounds_tuple.1, toUInt64(0), toUInt64(least(toFloat64({genai_3:UInt64}) - 1.0, floor((value_rows.bucket_value - bounds_tuple.1) / if(bounds_tuple.2 > bounds_tuple.1, (bounds_tuple.2 - bounds_tuple.1) / {genai_3:Float64}, 1.0))))) AS bucket,
                   countIf(v_spans) AS count_spans
            FROM value_rows
-           CROSS JOIN bounds
-           WHERE bounds.value_count > 0
-             AND value_rows.bucket_value >= bounds.bucket_min_bound
-             AND value_rows.bucket_value <= bounds.bucket_max_bound
+           WHERE bounds_tuple.3 > 0
+             AND value_rows.bucket_value >= bounds_tuple.1
+             AND value_rows.bucket_value <= bounds_tuple.2
            GROUP BY bucket)
         SELECT all_buckets.bucket AS bucket_index,
-               if(bounds.bucket_max_bound = bounds.bucket_min_bound, bounds.bucket_min_bound, bounds.bucket_min_bound + toFloat64(all_buckets.bucket) * if(bounds.bucket_max_bound > bounds.bucket_min_bound, (bounds.bucket_max_bound - bounds.bucket_min_bound) / {genai_3:Float64}, 1.0)) AS bucket_min,
-               if(bounds.bucket_max_bound = bounds.bucket_min_bound, bounds.bucket_max_bound, if(all_buckets.bucket = {genai_3:UInt64} - toUInt64(1), bounds.bucket_max_bound, bounds.bucket_min_bound + toFloat64(all_buckets.bucket + 1) * if(bounds.bucket_max_bound > bounds.bucket_min_bound, (bounds.bucket_max_bound - bounds.bucket_min_bound) / {genai_3:Float64}, 1.0))) AS bucket_max,
+               if(bounds_tuple.2 = bounds_tuple.1, bounds_tuple.1, bounds_tuple.1 + toFloat64(all_buckets.bucket) * if(bounds_tuple.2 > bounds_tuple.1, (bounds_tuple.2 - bounds_tuple.1) / {genai_3:Float64}, 1.0)) AS bucket_min,
+               if(bounds_tuple.2 = bounds_tuple.1, bounds_tuple.2, if(all_buckets.bucket = {genai_3:UInt64} - toUInt64(1), bounds_tuple.2, bounds_tuple.1 + toFloat64(all_buckets.bucket + 1) * if(bounds_tuple.2 > bounds_tuple.1, (bounds_tuple.2 - bounds_tuple.1) / {genai_3:Float64}, 1.0))) AS bucket_max,
                COALESCE(aggregated_data.count_spans, 0) AS count_spans
         FROM all_buckets
-        CROSS JOIN bounds
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        WHERE bounds.value_count > 0
-          AND (bounds.bucket_max_bound > bounds.bucket_min_bound
+        WHERE bounds_tuple.3 > 0
+          AND (bounds_tuple.2 > bounds_tuple.1
                OR all_buckets.bucket = 0)
         ORDER BY bucket_index
     """
@@ -544,32 +539,27 @@ def test_numeric_bucket_stats_query_groups_custom_attr_measure() -> None:
           (SELECT avgOrNull(if((mapContains(s.custom_attrs_float, {genai_9:String})), toFloat64(s.custom_attrs_float[{genai_9:String}]), NULL)) AS bucket_value
            FROM filtered_spans s
            GROUP BY s.conversation_id),
-             bounds AS
-          (SELECT toFloat64(min(bucket_value)) AS bucket_min_bound,
-                  toFloat64(max(bucket_value)) AS bucket_max_bound,
-                  count() AS value_count
-           FROM value_rows),
+          (SELECT tuple(toFloat64(min(bucket_value)), toFloat64(max(bucket_value)), count())
+           FROM value_rows) AS bounds_tuple,
              all_buckets AS
           (SELECT toUInt64(number) AS bucket
            FROM numbers({genai_8:UInt64})),
              aggregated_data AS
-          (SELECT if(bounds.bucket_max_bound = bounds.bucket_min_bound, toUInt64(0), toUInt64(least(toFloat64({genai_8:UInt64}) - 1.0, floor((value_rows.bucket_value - bounds.bucket_min_bound) / if(bounds.bucket_max_bound > bounds.bucket_min_bound, (bounds.bucket_max_bound - bounds.bucket_min_bound) / {genai_8:Float64}, 1.0))))) AS bucket,
+          (SELECT if(bounds_tuple.2 = bounds_tuple.1, toUInt64(0), toUInt64(least(toFloat64({genai_8:UInt64}) - 1.0, floor((value_rows.bucket_value - bounds_tuple.1) / if(bounds_tuple.2 > bounds_tuple.1, (bounds_tuple.2 - bounds_tuple.1) / {genai_8:Float64}, 1.0))))) AS bucket,
                   count() AS count
            FROM value_rows
-           CROSS JOIN bounds
-           WHERE bounds.value_count > 0
-             AND value_rows.bucket_value >= bounds.bucket_min_bound
-             AND value_rows.bucket_value <= bounds.bucket_max_bound
+           WHERE bounds_tuple.3 > 0
+             AND value_rows.bucket_value >= bounds_tuple.1
+             AND value_rows.bucket_value <= bounds_tuple.2
            GROUP BY bucket)
         SELECT all_buckets.bucket AS bucket_index,
-               if(bounds.bucket_max_bound = bounds.bucket_min_bound, bounds.bucket_min_bound, bounds.bucket_min_bound + toFloat64(all_buckets.bucket) * if(bounds.bucket_max_bound > bounds.bucket_min_bound, (bounds.bucket_max_bound - bounds.bucket_min_bound) / {genai_8:Float64}, 1.0)) AS bucket_min,
-               if(bounds.bucket_max_bound = bounds.bucket_min_bound, bounds.bucket_max_bound, if(all_buckets.bucket = {genai_8:UInt64} - toUInt64(1), bounds.bucket_max_bound, bounds.bucket_min_bound + toFloat64(all_buckets.bucket + 1) * if(bounds.bucket_max_bound > bounds.bucket_min_bound, (bounds.bucket_max_bound - bounds.bucket_min_bound) / {genai_8:Float64}, 1.0))) AS bucket_max,
+               if(bounds_tuple.2 = bounds_tuple.1, bounds_tuple.1, bounds_tuple.1 + toFloat64(all_buckets.bucket) * if(bounds_tuple.2 > bounds_tuple.1, (bounds_tuple.2 - bounds_tuple.1) / {genai_8:Float64}, 1.0)) AS bucket_min,
+               if(bounds_tuple.2 = bounds_tuple.1, bounds_tuple.2, if(all_buckets.bucket = {genai_8:UInt64} - toUInt64(1), bounds_tuple.2, bounds_tuple.1 + toFloat64(all_buckets.bucket + 1) * if(bounds_tuple.2 > bounds_tuple.1, (bounds_tuple.2 - bounds_tuple.1) / {genai_8:Float64}, 1.0))) AS bucket_max,
                COALESCE(aggregated_data.count, 0) AS count
         FROM all_buckets
-        CROSS JOIN bounds
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        WHERE bounds.value_count > 0
-          AND (bounds.bucket_max_bound > bounds.bucket_min_bound
+        WHERE bounds_tuple.3 > 0
+          AND (bounds_tuple.2 > bounds_tuple.1
                OR all_buckets.bucket = 0)
         ORDER BY bucket_index
     """.replace("{_ATTR_SRC}", src_sql)

--- a/tests/trace_server/query_builder/test_agent_stats_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_stats_query_builder.py
@@ -463,7 +463,7 @@ def test_numeric_bucket_stats_query_uses_value_buckets() -> None:
            WHERE s.ended_at > s.started_at
              AND isNotNull(if(s.ended_at > s.started_at, toFloat64(toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at)), NULL))
              AND isFinite(if(s.ended_at > s.started_at, toFloat64(toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at)), NULL)) ),
-          (SELECT CAST(tuple(toFloat64(min(bucket_value)), toFloat64(max(bucket_value)), count()) AS Tuple(min_bound Float64, max_bound Float64, value_count UInt64))
+          (SELECT CAST(tuple(toFloat64(min(bucket_value)), toFloat64(max(bucket_value)), count()) AS Tuple(min_bound Nullable(Float64), max_bound Nullable(Float64), value_count UInt64))
            FROM value_rows) AS bounds_tuple,
              all_buckets AS
           (SELECT toUInt64(number) AS bucket
@@ -538,7 +538,7 @@ def test_numeric_bucket_stats_query_groups_custom_attr_measure() -> None:
           (SELECT avgOrNull(if((mapContains(s.custom_attrs_float, {genai_9:String})), toFloat64(s.custom_attrs_float[{genai_9:String}]), NULL)) AS bucket_value
            FROM filtered_spans s
            GROUP BY s.conversation_id),
-          (SELECT CAST(tuple(toFloat64(min(bucket_value)), toFloat64(max(bucket_value)), count()) AS Tuple(min_bound Float64, max_bound Float64, value_count UInt64))
+          (SELECT CAST(tuple(toFloat64(min(bucket_value)), toFloat64(max(bucket_value)), count()) AS Tuple(min_bound Nullable(Float64), max_bound Nullable(Float64), value_count UInt64))
            FROM value_rows) AS bounds_tuple,
              all_buckets AS
           (SELECT toUInt64(number) AS bucket

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -1356,29 +1356,26 @@ def test_agent_span_stats_ungrouped_all_time(ch_server):
 
 
 def test_agent_span_stats_numeric_value_buckets(ch_server):
-    """Stats API can bucket the full filtered span set by numeric value range."""
+    """Stats API buckets the full filtered span set by numeric value range.
+
+    A known input_tokens distribution over min=0, max=40, bins=4 pins the
+    complete per-bucket output (index, edges, count) so a bounds miscompute
+    fails CI rather than a dashboard.
+    """
     project_id = _make_project_id("stats_hist")
     start = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
 
+    # width = (40-0)/4 = 10 -> buckets [0,10) [10,20) [20,30) [30,40].
+    # counts by bucket: 0,5 -> 2 | 12,18 -> 2 | 22 -> 1 | 35,38,40 -> 3.
+    token_values = [0, 5, 12, 18, 22, 35, 38, 40]
     spans = [
         _make_span(
             project_id,
-            input_tokens=10,
-            started_at=start + datetime.timedelta(seconds=10),
-            ended_at=start + datetime.timedelta(seconds=10, milliseconds=100),
-        ),
-        _make_span(
-            project_id,
-            input_tokens=20,
-            started_at=start + datetime.timedelta(seconds=20),
-            ended_at=start + datetime.timedelta(seconds=20, milliseconds=200),
-        ),
-        _make_span(
-            project_id,
-            input_tokens=30,
-            started_at=start + datetime.timedelta(seconds=30),
-            ended_at=start + datetime.timedelta(seconds=30, milliseconds=300),
-        ),
+            input_tokens=tokens,
+            started_at=start + datetime.timedelta(seconds=idx),
+            ended_at=start + datetime.timedelta(seconds=idx, milliseconds=100),
+        )
+        for idx, tokens in enumerate(token_values)
     ]
     _insert_spans(ch_server.ch_client, spans)
 
@@ -1393,7 +1390,7 @@ def test_agent_span_stats_numeric_value_buckets(ch_server):
                     source="field",
                     key="usage.input_tokens",
                 ),
-                bins=2,
+                bins=4,
             ),
             metrics=[
                 AgentSpanStatsMetricSpec(
@@ -1408,9 +1405,10 @@ def test_agent_span_stats_numeric_value_buckets(ch_server):
 
     assert res.bucket_type == "number"
     assert res.granularity is None
-    assert [row["count_spans"] for row in res.rows] == [1, 2]
-    assert res.rows[0]["bucket_min"] == 10
-    assert res.rows[-1]["bucket_max"] == 30
+    assert [row["bucket_index"] for row in res.rows] == [0, 1, 2, 3]
+    assert [row["bucket_min"] for row in res.rows] == [0, 10, 20, 30]
+    assert [row["bucket_max"] for row in res.rows] == [10, 20, 30, 40]
+    assert [row["count_spans"] for row in res.rows] == [2, 2, 1, 3]
 
 
 @pytest.mark.flaky(reruns=3)

--- a/weave/trace_server/query_builder/agent_stats_query_builder.py
+++ b/weave/trace_server/query_builder/agent_stats_query_builder.py
@@ -801,10 +801,12 @@ def _build_numeric_bucket_stats_query(
         if bucket.max is not None
         else "max(bucket_value)"
     )
-    # bounds is a scalar tuple evaluated once: (min, max, count).
-    bounds_min = f"{_BOUNDS_TUPLE}.1"
-    bounds_max = f"{_BOUNDS_TUPLE}.2"
-    bounds_count = f"{_BOUNDS_TUPLE}.3"
+    # bounds computed once as a scalar tuple (min, max, count).
+    # ClickHouse does NOT materialize table CTEs - each reference re-scans
+    # value_rows (re-decoding the attrs map). Do NOT convert back to a CTE.
+    bounds_min = f"{_BOUNDS_TUPLE}.min_bound"
+    bounds_max = f"{_BOUNDS_TUPLE}.max_bound"
+    bounds_count = f"{_BOUNDS_TUPLE}.value_count"
     bucket_width_sql = (
         f"if({bounds_max} > {bounds_min}, "
         f"({bounds_max} - {bounds_min}) "
@@ -878,11 +880,11 @@ def _build_numeric_bucket_stats_query(
         {value_rows_sql}
       ),
       (
-        SELECT tuple(
+        SELECT CAST(tuple(
           toFloat64({min_bound_sql}),
           toFloat64({max_bound_sql}),
           count()
-        )
+        ) AS Tuple(min_bound Float64, max_bound Float64, value_count UInt64))
         FROM {_CTE_VALUE_ROWS}
       ) AS {_BOUNDS_TUPLE},
       {_CTE_ALL_BUCKETS} AS (
@@ -894,8 +896,7 @@ def _build_numeric_bucket_stats_query(
           {bucket_index_sql} AS {_BUCKET_COLUMN},
           {agg_select_sql}
         FROM {_CTE_VALUE_ROWS}
-        WHERE {bounds_count} > 0
-          AND {_CTE_VALUE_ROWS}.bucket_value >= {bounds_min}
+        WHERE {_CTE_VALUE_ROWS}.bucket_value >= {bounds_min}
           AND {_CTE_VALUE_ROWS}.bucket_value <= {bounds_max}
         GROUP BY {_BUCKET_COLUMN}
       )

--- a/weave/trace_server/query_builder/agent_stats_query_builder.py
+++ b/weave/trace_server/query_builder/agent_stats_query_builder.py
@@ -804,6 +804,8 @@ def _build_numeric_bucket_stats_query(
     # bounds computed once as a scalar tuple (min, max, count).
     # ClickHouse does NOT materialize table CTEs - each reference re-scans
     # value_rows (re-decoding the attrs map). Do NOT convert back to a CTE.
+    # Not min()/max() OVER (): the unbounded frame buffers all matched rows
+    # (un-spillable, OOM-risk near the 16 GiB cap at scale); the extra scan is cheaper.
     bounds_min = f"{_BOUNDS_TUPLE}.min_bound"
     bounds_max = f"{_BOUNDS_TUPLE}.max_bound"
     bounds_count = f"{_BOUNDS_TUPLE}.value_count"

--- a/weave/trace_server/query_builder/agent_stats_query_builder.py
+++ b/weave/trace_server/query_builder/agent_stats_query_builder.py
@@ -886,7 +886,7 @@ def _build_numeric_bucket_stats_query(
           toFloat64({min_bound_sql}),
           toFloat64({max_bound_sql}),
           count()
-        ) AS Tuple(min_bound Float64, max_bound Float64, value_count UInt64))
+        ) AS Tuple(min_bound Nullable(Float64), max_bound Nullable(Float64), value_count UInt64))
         FROM {_CTE_VALUE_ROWS}
       ) AS {_BOUNDS_TUPLE},
       {_CTE_ALL_BUCKETS} AS (

--- a/weave/trace_server/query_builder/agent_stats_query_builder.py
+++ b/weave/trace_server/query_builder/agent_stats_query_builder.py
@@ -79,7 +79,7 @@ _CTE_FILTERED_SPANS = "filtered_spans"
 _CTE_FILTERED_METRIC_SPANS = "filtered_metric_spans"
 _CTE_QUALIFIED_CONVERSATIONS = "qualified_conversations"
 _CTE_VALUE_ROWS = "value_rows"
-_CTE_BOUNDS = "bounds"
+_BOUNDS_TUPLE = "bounds_tuple"
 _CTE_AGGREGATED_DATA = "aggregated_data"
 _CTE_TOP_GROUPS = "top_groups"
 
@@ -801,31 +801,35 @@ def _build_numeric_bucket_stats_query(
         if bucket.max is not None
         else "max(bucket_value)"
     )
+    # bounds is a scalar tuple evaluated once: (min, max, count).
+    bounds_min = f"{_BOUNDS_TUPLE}.1"
+    bounds_max = f"{_BOUNDS_TUPLE}.2"
+    bounds_count = f"{_BOUNDS_TUPLE}.3"
     bucket_width_sql = (
-        f"if({_CTE_BOUNDS}.bucket_max_bound > {_CTE_BOUNDS}.bucket_min_bound, "
-        f"({_CTE_BOUNDS}.bucket_max_bound - {_CTE_BOUNDS}.bucket_min_bound) "
+        f"if({bounds_max} > {bounds_min}, "
+        f"({bounds_max} - {bounds_min}) "
         f"/ {bins_float}, 1.0)"
     )
     bucket_index_raw_sql = (
-        f"if({_CTE_BOUNDS}.bucket_max_bound = {_CTE_BOUNDS}.bucket_min_bound, "
+        f"if({bounds_max} = {bounds_min}, "
         "toUInt64(0), "
         f"toUInt64(least(toFloat64({bins_uint}) - 1.0, floor("
-        f"({_CTE_VALUE_ROWS}.bucket_value - {_CTE_BOUNDS}.bucket_min_bound) "
+        f"({_CTE_VALUE_ROWS}.bucket_value - {bounds_min}) "
         f"/ {bucket_width_sql}))))"
     )
     bucket_index_sql = bucket_index_raw_sql
     bucket_min_sql = (
-        f"if({_CTE_BOUNDS}.bucket_max_bound = {_CTE_BOUNDS}.bucket_min_bound, "
-        f"{_CTE_BOUNDS}.bucket_min_bound, "
-        f"{_CTE_BOUNDS}.bucket_min_bound + "
+        f"if({bounds_max} = {bounds_min}, "
+        f"{bounds_min}, "
+        f"{bounds_min} + "
         f"toFloat64({_CTE_ALL_BUCKETS}.{_BUCKET_COLUMN}) * {bucket_width_sql})"
     )
     bucket_max_sql = (
-        f"if({_CTE_BOUNDS}.bucket_max_bound = {_CTE_BOUNDS}.bucket_min_bound, "
-        f"{_CTE_BOUNDS}.bucket_max_bound, "
+        f"if({bounds_max} = {bounds_min}, "
+        f"{bounds_max}, "
         f"if({_CTE_ALL_BUCKETS}.{_BUCKET_COLUMN} = {bins_uint} - toUInt64(1), "
-        f"{_CTE_BOUNDS}.bucket_max_bound, "
-        f"{_CTE_BOUNDS}.bucket_min_bound + "
+        f"{bounds_max}, "
+        f"{bounds_min} + "
         f"toFloat64({_CTE_ALL_BUCKETS}.{_BUCKET_COLUMN} + 1) * "
         f"{bucket_width_sql}))"
     )
@@ -873,13 +877,14 @@ def _build_numeric_bucket_stats_query(
       {_CTE_VALUE_ROWS} AS (
         {value_rows_sql}
       ),
-      {_CTE_BOUNDS} AS (
-        SELECT
-          toFloat64({min_bound_sql}) AS bucket_min_bound,
-          toFloat64({max_bound_sql}) AS bucket_max_bound,
-          count() AS value_count
+      (
+        SELECT tuple(
+          toFloat64({min_bound_sql}),
+          toFloat64({max_bound_sql}),
+          count()
+        )
         FROM {_CTE_VALUE_ROWS}
-      ),
+      ) AS {_BOUNDS_TUPLE},
       {_CTE_ALL_BUCKETS} AS (
         SELECT toUInt64(number) AS {_BUCKET_COLUMN}
         FROM numbers({bins_uint})
@@ -889,10 +894,9 @@ def _build_numeric_bucket_stats_query(
           {bucket_index_sql} AS {_BUCKET_COLUMN},
           {agg_select_sql}
         FROM {_CTE_VALUE_ROWS}
-        CROSS JOIN {_CTE_BOUNDS}
-        WHERE {_CTE_BOUNDS}.value_count > 0
-          AND {_CTE_VALUE_ROWS}.bucket_value >= {_CTE_BOUNDS}.bucket_min_bound
-          AND {_CTE_VALUE_ROWS}.bucket_value <= {_CTE_BOUNDS}.bucket_max_bound
+        WHERE {bounds_count} > 0
+          AND {_CTE_VALUE_ROWS}.bucket_value >= {bounds_min}
+          AND {_CTE_VALUE_ROWS}.bucket_value <= {bounds_max}
         GROUP BY {_BUCKET_COLUMN}
       )
     SELECT
@@ -901,12 +905,11 @@ def _build_numeric_bucket_stats_query(
       {bucket_max_sql} AS {_RESPONSE_BUCKET_MAX_COLUMN},
       {outer_metric_sql}
     FROM {_CTE_ALL_BUCKETS}
-    CROSS JOIN {_CTE_BOUNDS}
     LEFT JOIN {_CTE_AGGREGATED_DATA}
       ON {_CTE_ALL_BUCKETS}.{_BUCKET_COLUMN} = {_CTE_AGGREGATED_DATA}.{_BUCKET_COLUMN}
-    WHERE {_CTE_BOUNDS}.value_count > 0
+    WHERE {bounds_count} > 0
       AND (
-        {_CTE_BOUNDS}.bucket_max_bound > {_CTE_BOUNDS}.bucket_min_bound
+        {bounds_max} > {bounds_min}
         OR {_CTE_ALL_BUCKETS}.{_BUCKET_COLUMN} = 0
       )
     ORDER BY {_RESPONSE_BUCKET_INDEX_COLUMN}


### PR DESCRIPTION
## Summary
- The numeric-histogram `bounds` CTE was referenced twice, and ClickHouse re-evaluates table CTEs, so the `custom_attrs_int` map was decoded 3x (bounds x2 + aggregated_data x1).
- Computing `bounds` once as a scalar `WITH ... AS bounds_tuple` cuts it to 2 decodes. Read-time query-builder change only; 24-bucket output is byte-identical.

## Performance
local synthetic (prod read-only temporarily unreachable), 10M spans, key on 85% of rows, 24 buckets:

| metric | before | after | delta |
| --- | --- | --- | --- |
| value_rows scans (read_rows) | 3x (30.0M) | 2x (20.0M) | 3 -> 2 |
| read_bytes | 1.25 GiB | 854 MiB | -33% |
| elapsed (default threads) | 0.334s | 0.231s | -31% |
| peak_mem (max_threads=1) | 11.2 MiB | 10.7 MiB | bounded |

## Testing
updated the full-SQL unit tests; result set md5-identical before/after in local ClickHouse.