### PR TITLE
fix(weave): preserve provider HTTP status code in completion error payload

### DIFF
--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -1444,7 +1444,7 @@ def test_litellm_error_response_preserves_status_code():
     )
     assert with_status.response == {
         "error": "RateLimitError: quota exceeded",
-        tsi.ERROR_STATUS_CODE_KEY: 429,
+        llm_mod.ERROR_STATUS_CODE_KEY: 429,
     }
 
     without_status = llm_mod._litellm_error_response(

--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -1433,6 +1433,26 @@ def test_completions_handles_error_response(
         assert span.status_message == "Rate limit exceeded"
 
 
+def test_litellm_error_response_preserves_status_code():
+    """Error payload strips the `litellm.` prefix and preserves any status code."""
+
+    class _StatusError(Exception):
+        status_code = 429
+
+    with_status = llm_mod._litellm_error_response(
+        _StatusError("litellm.RateLimitError: quota exceeded")
+    )
+    assert with_status.response == {
+        "error": "RateLimitError: quota exceeded",
+        tsi.ERROR_STATUS_CODE_KEY: 429,
+    }
+
+    without_status = llm_mod._litellm_error_response(
+        Exception("litellm.APIConnectionError: connection reset")
+    )
+    assert without_status.response == {"error": "APIConnectionError: connection reset"}
+
+
 def test_completions_usage_captured_in_span(
     completions_mock_server, completions_secret_fetcher, completions_mock_response
 ):

--- a/weave/trace_server/llm_completion.py
+++ b/weave/trace_server/llm_completion.py
@@ -383,13 +383,19 @@ def _build_litellm_kwargs(
     return completion_kwargs
 
 
+# Key in the `CompletionsCreateRes.response` error payload holding the provider
+# HTTP status code, so consumers can classify a failure by status class (4xx
+# account/config vs 5xx availability) instead of matching the error string.
+ERROR_STATUS_CODE_KEY = "error_status_code"
+
+
 def _litellm_error_response(e: Exception) -> tsi.CompletionsCreateRes:
     response: dict[str, Any] = {"error": str(e).replace("litellm.", "")}
     # litellm exceptions subclass the openai error hierarchy and carry the
     # provider HTTP status code; preserve it for status-class classification.
     status_code = getattr(e, "status_code", None)
     if isinstance(status_code, int):
-        response[tsi.ERROR_STATUS_CODE_KEY] = status_code
+        response[ERROR_STATUS_CODE_KEY] = status_code
     return tsi.CompletionsCreateRes(response=response)
 
 

--- a/weave/trace_server/llm_completion.py
+++ b/weave/trace_server/llm_completion.py
@@ -390,7 +390,7 @@ ERROR_STATUS_CODE_KEY = "error_status_code"
 
 
 def _litellm_error_response(e: Exception) -> tsi.CompletionsCreateRes:
-    response: dict[str, Any] = {"error": str(e).replace("litellm.", "")}
+    response: dict[str, Any] = {"error": str(e).replace("litellm.", "", 1)}
     # litellm exceptions subclass the openai error hierarchy and carry the
     # provider HTTP status code; preserve it for status-class classification.
     status_code = getattr(e, "status_code", None)

--- a/weave/trace_server/llm_completion.py
+++ b/weave/trace_server/llm_completion.py
@@ -384,8 +384,13 @@ def _build_litellm_kwargs(
 
 
 def _litellm_error_response(e: Exception) -> tsi.CompletionsCreateRes:
-    error_message = str(e).replace("litellm.", "")
-    return tsi.CompletionsCreateRes(response={"error": error_message})
+    response: dict[str, Any] = {"error": str(e).replace("litellm.", "")}
+    # litellm exceptions subclass the openai error hierarchy and carry the
+    # provider HTTP status code; preserve it for status-class classification.
+    status_code = getattr(e, "status_code", None)
+    if isinstance(status_code, int):
+        response[tsi.ERROR_STATUS_CODE_KEY] = status_code
+    return tsi.CompletionsCreateRes(response=response)
 
 
 def get_bedrock_credentials(

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -565,6 +565,12 @@ class CompletionsCreateReq(BaseModelStrict):
     )
 
 
+# Key in `CompletionsCreateRes.response` holding the provider HTTP status code
+# when the completion failed, so consumers can classify by status class (4xx
+# account/config vs 5xx availability) instead of matching the error string.
+ERROR_STATUS_CODE_KEY = "error_status_code"
+
+
 class CompletionsCreateRes(BaseModel):
     response: dict[str, Any]
     weave_call_id: str | None = None  # Deprecated: use span_id instead

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -565,12 +565,6 @@ class CompletionsCreateReq(BaseModelStrict):
     )
 
 
-# Key in `CompletionsCreateRes.response` holding the provider HTTP status code
-# when the completion failed, so consumers can classify by status class (4xx
-# account/config vs 5xx availability) instead of matching the error string.
-ERROR_STATUS_CODE_KEY = "error_status_code"
-
-
 class CompletionsCreateRes(BaseModel):
     response: dict[str, Any]
     weave_call_id: str | None = None  # Deprecated: use span_id instead


### PR DESCRIPTION
## Summary
- litellm exceptions carry a `status_code` (they subclass the openai error hierarchy); `_litellm_error_response` currently drops it and only keeps the stringified message.
- Preserve it as `ERROR_STATUS_CODE_KEY` on the `CompletionsCreateRes` error payload so consumers can classify a failure by status class (4xx account/config vs 5xx availability) instead of matching the error string.
- Enables the agent-scoring worker to stop paging on customer quota errors routed through our inference gateway (wandb/core follow-up).

## Testing
unit test