### PR TITLE
fix(weave): tag db_inserts with service/env/version

### DIFF
--- a/tests/trace_server/test_datadog.py
+++ b/tests/trace_server/test_datadog.py
@@ -8,6 +8,8 @@ can't silently drift them.
 
 from __future__ import annotations
 
+import socket
+
 import pytest
 
 from weave.trace_server import datadog
@@ -132,3 +134,62 @@ def test_parse_port_non_numeric_does_not_raise_at_import(
     host, port = datadog._resolve_dogstatsd_addr()
     assert host == "agent.example.com"
     assert port == 8125  # fell back to default
+
+
+# ---------------------------------------------------------------------------
+# Unified service tags — service/env/version attached to every counter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        # Nothing set → no unified tags.
+        ({}, []),
+        # Only DD_SERVICE set.
+        ({"DD_SERVICE": "weave-trace"}, ["service:weave-trace"]),
+        # All three set, in service/env/version order.
+        (
+            {"DD_SERVICE": "weave-trace", "DD_ENV": "qa", "DD_VERSION": "abc123"},
+            ["service:weave-trace", "env:qa", "version:abc123"],
+        ),
+        # Empty-string values are skipped (unset, not `service:`).
+        ({"DD_SERVICE": "", "DD_ENV": "prod"}, ["env:prod"]),
+    ],
+)
+def test_resolve_unified_tags(
+    env: dict[str, str], expected: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for var in ("DD_SERVICE", "DD_ENV", "DD_VERSION"):
+        monkeypatch.delenv(var, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    assert datadog._resolve_unified_tags() == expected
+
+
+def test_record_db_insert_emits_full_packet_with_unified_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real UDP server receives table/path + service/env/version in order.
+
+    This is the regression guard: over UDP host-port (QA + the prod
+    fallback) there is no agent origin detection, so the counter must
+    carry service/version itself or it drops off service-scoped dashboards.
+    """
+    server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    server.bind(("127.0.0.1", 0))
+    server.settimeout(2.0)
+    monkeypatch.setattr(
+        datadog, "_client", datadog._StatsDClient(*server.getsockname())
+    )
+    monkeypatch.setattr(
+        datadog, "_UNIFIED_TAGS", ["service:weave-trace", "env:qa", "version:abc123"]
+    )
+    try:
+        datadog.record_db_insert(table="calls_complete", count=3, path="otel")
+        assert server.recv(4096) == (
+            b"weave_trace_server.db_inserts:3|c"
+            b"|#table:calls_complete,path:otel,service:weave-trace,env:qa,version:abc123"
+        )
+    finally:
+        server.close()

--- a/weave/trace_server/datadog.py
+++ b/weave/trace_server/datadog.py
@@ -73,6 +73,20 @@ def _resolve_dogstatsd_addr() -> tuple[str, int]:
     return host, port
 
 
+def _resolve_unified_tags() -> list[str]:
+    """Constant `service`/`env`/`version` tags from the DD unified-service env vars.
+
+    Sent on every counter so the metric is attributed even over transports
+    without agent origin detection (UDP host-port, including QA).
+    """
+    by_tag = {
+        "service": os.environ.get("DD_SERVICE"),
+        "env": os.environ.get("DD_ENV"),
+        "version": os.environ.get("DD_VERSION"),
+    }
+    return [f"{tag}:{value}" for tag, value in by_tag.items() if value]
+
+
 def format_packet(metric: str, value: int, tags: list[str]) -> bytes:
     """Format a DogStatsD counter packet. Public so tests can pin the wire format."""
     tag_suffix = f"|#{','.join(tags)}" if tags else ""
@@ -139,6 +153,7 @@ class _StatsDClient:
 
 
 _client = _StatsDClient(*_resolve_dogstatsd_addr())
+_UNIFIED_TAGS = _resolve_unified_tags()
 
 
 @contextlib.contextmanager
@@ -206,7 +221,7 @@ def record_db_insert(*, table: str, count: int, path: str | None = None) -> None
     _client.emit(
         DB_INSERT_METRIC,
         count,
-        [f"table:{table}", f"path:{resolved_path}"],
+        [f"table:{table}", f"path:{resolved_path}", *_UNIFIED_TAGS],
     )
 
 


### PR DESCRIPTION
## Summary
- `db_inserts` lost its `service`/`version` tags when #7268 inlined a bare DogStatsD client (ddtrace previously added them from `DD_SERVICE`/`DD_ENV`/`DD_VERSION`). Over any transport without agent origin detection (UDP host-port, incl. all of QA and the prod fallback) the counter drops off every `service:weave-trace`-scoped dashboard and monitor, which is what happened in prod ~Jun 30.
- Re-add them as constant tags read from the env vars already set on every weave-trace pod. Supersedes #7475 (UDS restore): fixes tagging over the transport prod already delivers on, and is verifiable on QA.

## Testing
unit test: resolver env-var cases + a real UDP server asserting the full packet carries service/env/version.

## QA validation (zoo-qa)
Deployed PR build `d35aa977` to zoo-qa (UDP host-port, the transport that dropped the tags) and fired 398 insert-driving `call_start_v2`/`call_end_v2` requests. Server-side `weave_trace_server.db_inserts`, same 10-min window straddling the flip:

| build (`version`) | `service` tag | `{service:weave-trace}` query |
|---|---|---|
| master `f3b2c104` | `N/A` (untagged) | null (invisible) |
| PR `d35aa977` | `weave-trace` | 89 (visible) |

PR emissions carry both `service:weave-trace` and `version:d35aa977...`; the service-scoped query went null -> 89, no new error class.

![db_inserts service/version tags, QA before/after](https://github.com/user-attachments/assets/ba68007c-7cb7-43ef-b050-076270028c4b)

