### PR TITLE
fix(weave): route agent traces to active project on re-init

### DIFF
--- a/tests/trace/test_conversation_tracing_setup.py
+++ b/tests/trace/test_conversation_tracing_setup.py
@@ -8,6 +8,9 @@ spans bleeding into the first-initialized project.
 
 from __future__ import annotations
 
+import base64
+import logging
+
 import pytest
 from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import TracerProvider
@@ -55,6 +58,95 @@ def test_conversation_tracing_reroutes_project_on_reinit(
     assert weave_init._conversation_span_exporter is exporter
     assert exporter._session.headers["project_id"] == "ent/proj-b"
     assert exporter._session.headers["Authorization"].startswith("Basic ")
+
+
+def test_conversation_tracing_reroutes_credentials_on_reinit(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Re-init with a new api key reroutes creds too, not just the project.
+
+    The exporter's project_id and Authorization are one logical unit; a stale
+    Authorization would export the new project's spans with the old account's
+    credentials (cross-account attribution / 403s).
+    """
+    weave_init._setup_conversation_tracing("ent", "proj-a", "key-a")
+    exporter = weave_init._conversation_span_exporter
+    assert exporter is not None
+    auth_a = exporter._session.headers["Authorization"]
+    assert auth_a == "Basic " + base64.b64encode(b"api:key-a").decode()
+
+    weave_init._setup_conversation_tracing("ent", "proj-b", "key-b")
+    assert weave_init._conversation_span_exporter is exporter
+    assert exporter._session.headers["project_id"] == "ent/proj-b"
+    assert exporter._session.headers["Authorization"] == (
+        "Basic " + base64.b64encode(b"api:key-b").decode()
+    )
+    assert exporter._session.headers["Authorization"] != auth_a
+
+    # Re-init without a key drops the stale Authorization rather than keeping it.
+    weave_init._setup_conversation_tracing("ent", "proj-c", None)
+    assert exporter._session.headers["project_id"] == "ent/proj-c"
+    assert "Authorization" not in exporter._session.headers
+
+
+def test_conversation_tracing_flush_semantics_on_reinit(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Flush precedes reheader; same project skips it; a timed-out flush still reroutes (warns)."""
+    weave_init._setup_conversation_tracing("ent", "proj-a", "key-a")
+    provider = weave_init._conversation_tracer_provider
+    exporter = weave_init._conversation_span_exporter
+    assert provider is not None
+    assert exporter is not None
+
+    flushed_project_ids: list[str | None] = []
+    flush_ok = True
+
+    def _spy_flush(*args: object, **kwargs: object) -> bool:
+        # Capture project_id visible at flush time to prove flush precedes reheader.
+        flushed_project_ids.append(exporter._session.headers.get("project_id"))
+        return flush_ok
+
+    monkeypatch.setattr(provider, "force_flush", _spy_flush)
+
+    weave_init._setup_conversation_tracing("ent", "proj-b", "key-b")
+    assert flushed_project_ids == ["ent/proj-a"]
+    assert exporter._session.headers["project_id"] == "ent/proj-b"
+
+    # Same project + creds: no reroute work, no blocking flush.
+    weave_init._setup_conversation_tracing("ent", "proj-b", "key-b")
+    assert flushed_project_ids == ["ent/proj-a"]
+
+    # A timed-out flush still reroutes (queued spans misroute to the new project) and warns.
+    flush_ok = False
+    with caplog.at_level(logging.WARNING):
+        weave_init._setup_conversation_tracing("ent", "proj-c", "key-c")
+    assert flushed_project_ids == ["ent/proj-a", "ent/proj-b"]
+    assert exporter._session.headers["project_id"] == "ent/proj-c"
+    assert "flush timed out" in caplog.text
+
+
+def test_conversation_tracing_disowns_provider_if_set_once_refused(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If OTel refuses our provider (set-once lost), shut it down and don't own it."""
+    shutdowns: list[bool] = []
+    orig_shutdown = TracerProvider.shutdown
+
+    def _spy_shutdown(self: TracerProvider, *args: object, **kwargs: object) -> None:
+        shutdowns.append(True)
+        orig_shutdown(self, *args, **kwargs)
+
+    monkeypatch.setattr(TracerProvider, "shutdown", _spy_shutdown)
+    # Simulate losing the set-once race: our set_tracer_provider call is ignored.
+    monkeypatch.setattr(otel_trace, "set_tracer_provider", lambda provider: None)
+
+    weave_init._setup_conversation_tracing("ent", "proj-a", "key-a")
+
+    assert shutdowns == [True]
+    assert weave_init._conversation_tracer_provider is None
+    assert weave_init._conversation_span_exporter is None
 
 
 def test_conversation_tracing_leaves_foreign_provider_untouched(

--- a/tests/trace/test_conversation_tracing_setup.py
+++ b/tests/trace/test_conversation_tracing_setup.py
@@ -1,0 +1,71 @@
+"""Tests for the conversation/agent OTel tracing setup in weave_init.
+
+The agent-trace exporter carries its target project in the ``project_id``
+header (not the immutable OTel Resource) so it can follow a second
+``weave.init()`` to a different project. Regression coverage for agent
+spans bleeding into the first-initialized project.
+"""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.util._once import Once
+
+from weave.trace import weave_init
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_tracer_provider(monkeypatch: pytest.MonkeyPatch):
+    """Isolate OTel's set-once global provider and weave's provider globals."""
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", None)
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr(weave_init, "_conversation_tracer_provider", None)
+    monkeypatch.setattr(weave_init, "_conversation_span_exporter", None)
+    monkeypatch.setattr(
+        weave_init.env, "weave_trace_server_url", lambda: "https://trace.wandb.test"
+    )
+
+
+def test_conversation_tracing_reroutes_project_on_reinit(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A second init to a new project reroutes the live exporter, not the Resource."""
+    weave_init._setup_conversation_tracing("ent", "proj-a", "sekret")
+
+    provider = otel_trace.get_tracer_provider()
+    exporter = weave_init._conversation_span_exporter
+    assert isinstance(provider, TracerProvider)
+    assert provider is weave_init._conversation_tracer_provider
+    assert exporter is not None
+
+    # Project rides the header; the Resource carries only service.name (an
+    # immutable Resource can't follow a re-init).
+    assert exporter._session.headers["project_id"] == "ent/proj-a"
+    assert exporter._session.headers["Authorization"].startswith("Basic ")
+    assert provider.resource.attributes["service.name"] == "weave-conversation-sdk"
+    assert "wandb.project" not in provider.resource.attributes
+    assert "wandb.entity" not in provider.resource.attributes
+
+    # Re-init to a different project: same provider + exporter objects (OTel's
+    # global provider is set-once), header now points at the new project.
+    weave_init._setup_conversation_tracing("ent", "proj-b", "sekret")
+    assert otel_trace.get_tracer_provider() is provider
+    assert weave_init._conversation_span_exporter is exporter
+    assert exporter._session.headers["project_id"] == "ent/proj-b"
+    assert exporter._session.headers["Authorization"].startswith("Basic ")
+
+
+def test_conversation_tracing_leaves_foreign_provider_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A user-installed provider is not hijacked and no exporter is created."""
+    user_provider = TracerProvider()
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", user_provider)
+
+    weave_init._setup_conversation_tracing("ent", "proj-a", "sekret")
+
+    assert otel_trace.get_tracer_provider() is user_provider
+    assert weave_init._conversation_span_exporter is None
+    assert weave_init._conversation_tracer_provider is None

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -33,10 +33,22 @@ from weave.trace_server_version import MIN_TRACE_SERVER_VERSION
 from weave.wandb_interface.context import get_wandb_api_context
 
 if TYPE_CHECKING:
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+        OTLPSpanExporter,
+    )
+    from opentelemetry.sdk.trace import TracerProvider
+
     from weave.trace.op import PostprocessInputsFunc, PostprocessOutputFunc
     from weave.trace_server.service_interface import ServerInfoRes
 
 logger = logging.getLogger(__name__)
+
+# The conversation/agent OTel provider is set once (OTel's global provider is
+# set-once and its Resource is immutable). A later weave.init() to a different
+# project reroutes by rewriting the exporter's project_id header instead of
+# rebuilding, so agent spans follow the active project.
+_conversation_tracer_provider: TracerProvider | None = None
+_conversation_span_exporter: OTLPSpanExporter | None = None
 
 
 class WeaveWandbAuthenticationException(Exception): ...
@@ -115,10 +127,13 @@ def _setup_conversation_tracing(entity: str, project: str, api_key: str | None) 
     Sets the global OTel TracerProvider so that ``trace.get_tracer("weave.conversation")``
     returns a real tracer.
 
-    No-ops if the trace server URL is not configured. Logs a warning and
-    returns early if opentelemetry is unavailable. Other errors propagate
-    so misconfiguration is visible to the user.
+    On a later weave.init() to a different project, reroutes the existing
+    exporter to the new project instead of rebuilding (see the module-level
+    provider globals). No-ops if the trace server URL is not configured. Logs
+    a warning and returns early if opentelemetry is unavailable. Other errors
+    propagate so misconfiguration is visible to the user.
     """
+    global _conversation_tracer_provider, _conversation_span_exporter  # noqa: PLW0603
     try:
         from opentelemetry import trace
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
@@ -135,13 +150,26 @@ def _setup_conversation_tracing(entity: str, project: str, api_key: str | None) 
         )
         return
 
-    # Don't reconfigure if already set up (e.g. from a previous init call
-    # or from a user who installed their own provider before weave.init()).
-    if isinstance(trace.get_tracer_provider(), TracerProvider):
-        return
-
     trace_server_url = env.weave_trace_server_url()
     if not trace_server_url:
+        return
+
+    project_id = f"{entity}/{project}"
+
+    # Re-init to a new project: our provider is already the global one and can't
+    # be swapped (OTel's set-once), so reroute the live exporter. Flush first so
+    # spans still queued under the old project export under the old project_id.
+    if _conversation_span_exporter is not None and (
+        trace.get_tracer_provider() is _conversation_tracer_provider
+    ):
+        if _conversation_tracer_provider is not None:
+            _conversation_tracer_provider.force_flush()
+        _conversation_span_exporter._session.headers["project_id"] = project_id
+        return
+
+    # A provider we didn't install is active (e.g. the user configured their
+    # own before weave.init()); leave it untouched.
+    if isinstance(trace.get_tracer_provider(), TracerProvider):
         return
 
     endpoint = otel_traces_endpoint(trace_server_url)
@@ -150,18 +178,14 @@ def _setup_conversation_tracing(entity: str, project: str, api_key: str | None) 
     # init_weave_get_server: res.set_auth(("api", api_key)) and
     # wandb_thin/internal_api.py: BasicAuth("api", api_key)).
     # HTTP Basic auth requires base64("user:pass").
-    headers: dict[str, str] = {}
+    # The project rides the project_id header, not the Resource: the Resource is
+    # immutable, so a header is the only field that can follow weave.init().
+    headers: dict[str, str] = {"project_id": project_id}
     if api_key:
         token = base64.b64encode(f"api:{api_key}".encode()).decode()
         headers["Authorization"] = f"Basic {token}"
 
-    resource = Resource.create(
-        {
-            "service.name": "weave-conversation-sdk",
-            "wandb.entity": entity,
-            "wandb.project": project,
-        }
-    )
+    resource = Resource.create({"service.name": "weave-conversation-sdk"})
     exporter = OTLPSpanExporter(endpoint=endpoint, headers=headers)
     # Honor WEAVE_INSECURE_DISABLE_SSL for the OTel exporter too, so
     # dev environments with self-signed certs can export spans.
@@ -177,6 +201,8 @@ def _setup_conversation_tracing(entity: str, project: str, api_key: str | None) 
     # deep-linking in the agent traces UI.
     provider.add_span_processor(EvalLinkSpanProcessor())
     trace.set_tracer_provider(provider)
+    _conversation_tracer_provider = provider
+    _conversation_span_exporter = exporter
 
 
 def init_weave(

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -45,10 +45,14 @@ logger = logging.getLogger(__name__)
 
 # The conversation/agent OTel provider is set once (OTel's global provider is
 # set-once and its Resource is immutable). A later weave.init() to a different
-# project reroutes by rewriting the exporter's project_id header instead of
-# rebuilding, so agent spans follow the active project.
+# project reroutes by rewriting the exporter's headers instead of rebuilding,
+# so agent spans (and their creds) follow the active project.
 _conversation_tracer_provider: TracerProvider | None = None
 _conversation_span_exporter: OTLPSpanExporter | None = None
+
+# Bound the pre-reroute flush so switching projects can't block weave.init() on a
+# stalled exporter; spans that miss the window export under the new project.
+_CONVERSATION_REROUTE_FLUSH_TIMEOUT_MS = 5000
 
 
 class WeaveWandbAuthenticationException(Exception): ...
@@ -155,16 +159,37 @@ def _setup_conversation_tracing(entity: str, project: str, api_key: str | None) 
         return
 
     project_id = f"{entity}/{project}"
+    headers = _conversation_headers(project_id, api_key)
 
-    # Re-init to a new project: our provider is already the global one and can't
-    # be swapped (OTel's set-once), so reroute the live exporter. Flush first so
-    # spans still queued under the old project export under the old project_id.
-    if _conversation_span_exporter is not None and (
-        trace.get_tracer_provider() is _conversation_tracer_provider
+    # Re-init while we own the global provider: it's set-once with an immutable
+    # Resource, so reroute the live exporter's headers instead of rebuilding.
+    existing_provider = _conversation_tracer_provider
+    existing_exporter = _conversation_span_exporter
+    if (
+        existing_provider is not None
+        and existing_exporter is not None
+        and trace.get_tracer_provider() is existing_provider
     ):
-        if _conversation_tracer_provider is not None:
-            _conversation_tracer_provider.force_flush()
-        _conversation_span_exporter._session.headers["project_id"] = project_id
+        # TODO: mutating the exporter's private requests.Session couples us to
+        # http-proto internals; a delegating SpanExporter would drop the poke.
+        current = existing_exporter._session.headers
+        if current.get("project_id") == headers["project_id"] and current.get(
+            "Authorization"
+        ) == headers.get("Authorization"):
+            return
+        # Bounded flush of spans queued under the old project before re-heading,
+        # so in-flight spans export under the old project_id (binds at export).
+        if not existing_provider.force_flush(_CONVERSATION_REROUTE_FLUSH_TIMEOUT_MS):
+            logger.warning(
+                "Conversation tracing: flush timed out (%dms) before project reroute; "
+                "some queued spans may export under the new project",
+                _CONVERSATION_REROUTE_FLUSH_TIMEOUT_MS,
+            )
+        current["project_id"] = headers["project_id"]
+        if "Authorization" in headers:
+            current["Authorization"] = headers["Authorization"]
+        else:
+            current.pop("Authorization", None)
         return
 
     # A provider we didn't install is active (e.g. the user configured their
@@ -173,18 +198,6 @@ def _setup_conversation_tracing(entity: str, project: str, api_key: str | None) 
         return
 
     endpoint = otel_traces_endpoint(trace_server_url)
-
-    # Match the auth pattern used by the rest of weave (see
-    # init_weave_get_server: res.set_auth(("api", api_key)) and
-    # wandb_thin/internal_api.py: BasicAuth("api", api_key)).
-    # HTTP Basic auth requires base64("user:pass").
-    # The project rides the project_id header, not the Resource: the Resource is
-    # immutable, so a header is the only field that can follow weave.init().
-    headers: dict[str, str] = {"project_id": project_id}
-    if api_key:
-        token = base64.b64encode(f"api:{api_key}".encode()).decode()
-        headers["Authorization"] = f"Basic {token}"
-
     resource = Resource.create({"service.name": "weave-conversation-sdk"})
     exporter = OTLPSpanExporter(endpoint=endpoint, headers=headers)
     # Honor WEAVE_INSECURE_DISABLE_SSL for the OTel exporter too, so
@@ -201,8 +214,24 @@ def _setup_conversation_tracing(entity: str, project: str, api_key: str | None) 
     # deep-linking in the agent traces UI.
     provider.add_span_processor(EvalLinkSpanProcessor())
     trace.set_tracer_provider(provider)
+    # No-op if another provider won the set-once race after our check above;
+    # only record ownership if ours took, else we leak/mis-route on re-init.
+    if trace.get_tracer_provider() is not provider:
+        provider.shutdown()
+        return
     _conversation_tracer_provider = provider
     _conversation_span_exporter = exporter
+
+
+def _conversation_headers(project_id: str, api_key: str | None) -> dict[str, str]:
+    """Export headers routing agent spans: project via project_id, creds via Basic auth."""
+    # Auth mirrors the rest of weave (BasicAuth base64("api:<key>")); one source
+    # of truth so setup and reroute never diverge into stale creds.
+    headers: dict[str, str] = {"project_id": project_id}
+    if api_key:
+        token = base64.b64encode(f"api:{api_key}".encode()).decode()
+        headers["Authorization"] = f"Basic {token}"
+    return headers
 
 
 def init_weave(


### PR DESCRIPTION
## Summary
- Agent/conversation OTel spans routed by the `TracerProvider` **Resource**, which is baked in on the first `weave.init()` and never rebuilt (OTel's global provider is set-once, its Resource immutable). A second `weave.init(project2)` left agent traces exporting under `project1` while classic traces correctly followed `project2`.
- Fix: carry the project in the mutable `project_id` export header instead of the Resource, and reroute the live exporter (flush-then-reheader) when init switches projects. `weave/trace/weave_init.py` `_setup_conversation_tracing`.
- Server precedence is Resource-attrs > `project_id` header, so the project is dropped from the Resource to let the header control routing (header-only routing confirmed on prod; it is the older/legacy ingest path so it is broadly supported).
- Scope: fixes sequential re-init. Routing is per-export batch, so one process interleaving concurrent work across projects is best-effort (was fully broken before, so this only improves it).

## Proof (prod, api.wandb.ai)
Procedure: `weave.init(A)` -> emit one agent turn (`log_turn`); `weave.init(B)` -> emit one agent turn; query `POST /agents/spans/query` for each project.

| project | before fix | after fix |
|---|---|---|
| A (1st init) | **2** spans (its own + B'"'"'s) | 1 span |
| B (2nd init) | **0** spans (bled to A) | 1 span |

Agents -> Spans UI for each project (note `agent-for-bleed-b` bleeding into project A, and B empty):

| | Before fix (bled) | After fix |
|---|---|---|
| 2nd-init project (B) | <img src="https://github.com/user-attachments/assets/40d4b6cf-e8fe-4a1e-b053-c11b78aed87d" width="430"> | <img src="https://github.com/user-attachments/assets/3c393405-eceb-44b0-9708-aad02364a7d1" width="430"> |
| 1st-init project (A) | <img src="https://github.com/user-attachments/assets/bead5146-1721-4d14-8549-f5e4cb23ad64" width="430"> | <img src="https://github.com/user-attachments/assets/d607ad6c-096c-400a-8b68-9aac8e21f465" width="430"> |

## Testing
adds `tests/trace/test_conversation_tracing_setup.py` (reroute-on-reinit + leaves a foreign provider untouched); plus the prod before/after above.
