### PR TITLE
fix(weave): soft-delete calls_complete via lightweight UPDATE, reclaim async

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -16,6 +16,7 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     _is_minimal_filter,
     _maybe_convert_datetime_operands,
     build_calls_complete_delete_query,
+    build_calls_complete_soft_delete_query,
     build_calls_complete_update_end_query,
     build_calls_complete_update_query,
     build_calls_stats_query,
@@ -4246,6 +4247,32 @@ def test_build_calls_complete_delete_query_with_started_at_window() -> None:
     expected = sqlparse.format(
         """
         DELETE FROM calls_complete ON CLUSTER my_cluster
+        WHERE project_id = {project_id:String}
+        AND started_at >= fromUnixTimestamp64Micro({started_at_min:Int64}, 'UTC')
+        AND started_at <= fromUnixTimestamp64Micro({started_at_max:Int64}, 'UTC')
+        AND id IN {call_ids:Array(String)}
+        """,
+        reindent=True,
+    )
+
+    assert query == expected, f"\nExpected:\n{expected}\n\nGot:\n{query}"
+
+
+def test_build_calls_complete_soft_delete_query() -> None:
+    """Soft-delete marks deleted_at via a lightweight UPDATE, pruned by the started_at window."""
+    query = build_calls_complete_soft_delete_query(
+        table_name="calls_complete",
+        project_id_param="project_id",
+        call_ids_param="call_ids",
+        started_at_min_param="started_at_min",
+        started_at_max_param="started_at_max",
+        cluster_name="my_cluster",
+    )
+
+    expected = sqlparse.format(
+        """
+        UPDATE calls_complete ON CLUSTER my_cluster
+        SET deleted_at = now64(3)
         WHERE project_id = {project_id:String}
         AND started_at >= fromUnixTimestamp64Micro({started_at_min:Int64}, 'UTC')
         AND started_at <= fromUnixTimestamp64Micro({started_at_max:Int64}, 'UTC')

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -1,7 +1,6 @@
 import base64
 import datetime
 import json
-import time
 import uuid
 from typing import Any
 
@@ -207,18 +206,6 @@ def _fetch_calls_stream(trace_server, project_id: str) -> list[tsi.CallSchema]:
     return list(
         trace_server.calls_query_stream(tsi.CallsQueryReq(project_id=project_id))
     )
-
-
-def _wait_for_live_call_ids(
-    trace_server, project_id: str, expected: set[str], timeout: float = 10.0
-) -> set[str]:
-    """Poll live call ids until they match `expected` (async calls_complete delete)."""
-    deadline = time.monotonic() + timeout
-    while True:
-        got = {c.id for c in _fetch_calls_stream(trace_server, project_id)}
-        if got == expected or time.monotonic() >= deadline:
-            return got
-        time.sleep(0.05)
 
 
 def _find_call_by_id(
@@ -1473,16 +1460,16 @@ def test_calls_delete(trace_server, clickhouse_trace_server):
         tsi.CallsDeleteReq(project_id=project_id, call_ids=[call_ids[0]])
     )
     assert res.num_deleted == 1
-    assert _wait_for_live_call_ids(
-        trace_server, project_id, {call_ids[1], call_ids[2]}
-    ) == {call_ids[1], call_ids[2]}
+    remaining = _fetch_calls_stream(trace_server, project_id)
+    assert len(remaining) == 2
+    assert call_ids[0] not in {c.id for c in remaining}
 
     # Delete multiple calls
     res = trace_server.calls_delete(
         tsi.CallsDeleteReq(project_id=project_id, call_ids=[call_ids[1], call_ids[2]])
     )
     assert res.num_deleted == 2
-    assert _wait_for_live_call_ids(trace_server, project_id, set()) == set()
+    assert len(_fetch_calls_stream(trace_server, project_id)) == 0
 
 
 def test_calls_delete_cascade(trace_server, clickhouse_trace_server):
@@ -1499,9 +1486,8 @@ def test_calls_delete_cascade(trace_server, clickhouse_trace_server):
         tsi.CallsDeleteReq(project_id=project1, call_ids=[ids1["child1"]])
     )
     assert res.num_deleted == 1
-    assert _wait_for_live_call_ids(
-        trace_server, project1, {ids1["root"], ids1["child2"]}
-    ) == {ids1["root"], ids1["child2"]}
+    remaining = {c.id for c in _fetch_calls_stream(trace_server, project1)}
+    assert remaining == {ids1["root"], ids1["child2"]}
 
     # Test 2: Middle node deletion cascades to subtree only
     project2 = f"{TEST_ENTITY}/calls_complete_cascade_middle"
@@ -1516,9 +1502,9 @@ def test_calls_delete_cascade(trace_server, clickhouse_trace_server):
         tsi.CallsDeleteReq(project_id=project2, call_ids=[ids2["middle"]])
     )
     assert res.num_deleted == 3  # middle + 2 leaves
-    assert _wait_for_live_call_ids(trace_server, project2, {ids2["root"]}) == {
-        ids2["root"]
-    }
+    remaining = _fetch_calls_stream(trace_server, project2)
+    assert len(remaining) == 1
+    assert remaining[0].id == ids2["root"]
 
     # Test 3: Root deletion cascades to entire tree
     project3 = f"{TEST_ENTITY}/calls_complete_cascade_root"
@@ -1533,7 +1519,7 @@ def test_calls_delete_cascade(trace_server, clickhouse_trace_server):
         tsi.CallsDeleteReq(project_id=project3, call_ids=[ids3["root"]])
     )
     assert res.num_deleted == 4
-    assert _wait_for_live_call_ids(trace_server, project3, set()) == set()
+    assert len(_fetch_calls_stream(trace_server, project3)) == 0
 
 
 def test_calls_delete_cascade_spans_started_at_window(
@@ -1589,7 +1575,8 @@ def test_calls_delete_cascade_spans_started_at_window(
         tsi.CallsDeleteReq(project_id=project_id, call_ids=[root])
     )
     assert res.num_deleted == 3
-    assert _wait_for_live_call_ids(trace_server, project_id, {other}) == {other}
+    remaining = {c.id for c in _fetch_calls_stream(trace_server, project_id)}
+    assert remaining == {other}
 
 
 def test_calls_delete_cascade_started_at_window_merged_residence(

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 import json
+import time
 import uuid
 from typing import Any
 
@@ -206,6 +207,18 @@ def _fetch_calls_stream(trace_server, project_id: str) -> list[tsi.CallSchema]:
     return list(
         trace_server.calls_query_stream(tsi.CallsQueryReq(project_id=project_id))
     )
+
+
+def _wait_for_live_call_ids(
+    trace_server, project_id: str, expected: set[str], timeout: float = 10.0
+) -> set[str]:
+    """Poll live call ids until they match `expected` (async calls_complete delete)."""
+    deadline = time.monotonic() + timeout
+    while True:
+        got = {c.id for c in _fetch_calls_stream(trace_server, project_id)}
+        if got == expected or time.monotonic() >= deadline:
+            return got
+        time.sleep(0.05)
 
 
 def _find_call_by_id(
@@ -1460,16 +1473,16 @@ def test_calls_delete(trace_server, clickhouse_trace_server):
         tsi.CallsDeleteReq(project_id=project_id, call_ids=[call_ids[0]])
     )
     assert res.num_deleted == 1
-    remaining = _fetch_calls_stream(trace_server, project_id)
-    assert len(remaining) == 2
-    assert call_ids[0] not in {c.id for c in remaining}
+    assert _wait_for_live_call_ids(
+        trace_server, project_id, {call_ids[1], call_ids[2]}
+    ) == {call_ids[1], call_ids[2]}
 
     # Delete multiple calls
     res = trace_server.calls_delete(
         tsi.CallsDeleteReq(project_id=project_id, call_ids=[call_ids[1], call_ids[2]])
     )
     assert res.num_deleted == 2
-    assert len(_fetch_calls_stream(trace_server, project_id)) == 0
+    assert _wait_for_live_call_ids(trace_server, project_id, set()) == set()
 
 
 def test_calls_delete_cascade(trace_server, clickhouse_trace_server):
@@ -1486,8 +1499,9 @@ def test_calls_delete_cascade(trace_server, clickhouse_trace_server):
         tsi.CallsDeleteReq(project_id=project1, call_ids=[ids1["child1"]])
     )
     assert res.num_deleted == 1
-    remaining = {c.id for c in _fetch_calls_stream(trace_server, project1)}
-    assert remaining == {ids1["root"], ids1["child2"]}
+    assert _wait_for_live_call_ids(
+        trace_server, project1, {ids1["root"], ids1["child2"]}
+    ) == {ids1["root"], ids1["child2"]}
 
     # Test 2: Middle node deletion cascades to subtree only
     project2 = f"{TEST_ENTITY}/calls_complete_cascade_middle"
@@ -1502,9 +1516,9 @@ def test_calls_delete_cascade(trace_server, clickhouse_trace_server):
         tsi.CallsDeleteReq(project_id=project2, call_ids=[ids2["middle"]])
     )
     assert res.num_deleted == 3  # middle + 2 leaves
-    remaining = _fetch_calls_stream(trace_server, project2)
-    assert len(remaining) == 1
-    assert remaining[0].id == ids2["root"]
+    assert _wait_for_live_call_ids(trace_server, project2, {ids2["root"]}) == {
+        ids2["root"]
+    }
 
     # Test 3: Root deletion cascades to entire tree
     project3 = f"{TEST_ENTITY}/calls_complete_cascade_root"
@@ -1519,7 +1533,7 @@ def test_calls_delete_cascade(trace_server, clickhouse_trace_server):
         tsi.CallsDeleteReq(project_id=project3, call_ids=[ids3["root"]])
     )
     assert res.num_deleted == 4
-    assert len(_fetch_calls_stream(trace_server, project3)) == 0
+    assert _wait_for_live_call_ids(trace_server, project3, set()) == set()
 
 
 def test_calls_delete_cascade_spans_started_at_window(
@@ -1575,8 +1589,7 @@ def test_calls_delete_cascade_spans_started_at_window(
         tsi.CallsDeleteReq(project_id=project_id, call_ids=[root])
     )
     assert res.num_deleted == 3
-    remaining = {c.id for c in _fetch_calls_stream(trace_server, project_id)}
-    assert remaining == {other}
+    assert _wait_for_live_call_ids(trace_server, project_id, {other}) == {other}
 
 
 def test_calls_delete_cascade_started_at_window_merged_residence(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -3647,22 +3647,18 @@ def build_calls_complete_update_end_query(
         """
 
 
-def build_calls_complete_delete_query(
-    table_name: str,
+def _calls_complete_id_window_where(
     project_id_param: str,
     call_ids_param: str,
-    started_at_min_param: str | None = None,
-    started_at_max_param: str | None = None,
-    cluster_name: str | None = None,
+    started_at_min_param: str | None,
+    started_at_max_param: str | None,
 ) -> str:
-    """Build the calls_complete DELETE query for call end data.
+    """Shared WHERE for calls_complete delete/soft-delete.
 
-    When started_at bounds are given they bracket the partition key
-    (PARTITION BY toYYYYMM(started_at)) and primary key prefix
-    (project_id, started_at, id), so the delete prunes partitions instead of
-    scanning every one. Bounds are Int64 microseconds since epoch.
+    started_at bounds bracket the partition key (toYYYYMM(started_at)) and primary
+    key prefix (project_id, started_at, id) so the statement prunes partitions.
+    Bounds are Int64 microseconds since epoch.
     """
-    formatted_table = _format_table_name_with_cluster(table_name, cluster_name)
     conditions = [f"project_id = {{{project_id_param}:String}}"]
     if started_at_min_param is not None:
         conditions.append(
@@ -3673,7 +3669,47 @@ def build_calls_complete_delete_query(
             f"started_at <= fromUnixTimestamp64Micro({{{started_at_max_param}:Int64}}, 'UTC')"
         )
     conditions.append(f"id IN {{{call_ids_param}:Array(String)}}")
-    where_clause = " AND ".join(conditions)
+    return " AND ".join(conditions)
+
+
+def build_calls_complete_soft_delete_query(
+    table_name: str,
+    project_id_param: str,
+    call_ids_param: str,
+    started_at_min_param: str | None = None,
+    started_at_max_param: str | None = None,
+    cluster_name: str | None = None,
+) -> str:
+    """Build the calls_complete soft-delete: a lightweight UPDATE marking deleted_at.
+
+    This writes a patch part (no mutation, no part rewrite) that the read path
+    applies on the fly via its deleted_at filter, so the calls disappear immediately.
+    """
+    formatted_table = _format_table_name_with_cluster(table_name, cluster_name)
+    where_clause = _calls_complete_id_window_where(
+        project_id_param, call_ids_param, started_at_min_param, started_at_max_param
+    )
+    raw_sql = f"""
+        UPDATE {formatted_table}
+        SET deleted_at = now64(3)
+        WHERE {where_clause}
+        """
+    return safely_format_sql(raw_sql, logger)
+
+
+def build_calls_complete_delete_query(
+    table_name: str,
+    project_id_param: str,
+    call_ids_param: str,
+    started_at_min_param: str | None = None,
+    started_at_max_param: str | None = None,
+    cluster_name: str | None = None,
+) -> str:
+    """Build the calls_complete physical DELETE (async reclamation after soft-delete)."""
+    formatted_table = _format_table_name_with_cluster(table_name, cluster_name)
+    where_clause = _calls_complete_id_window_where(
+        project_id_param, call_ids_param, started_at_min_param, started_at_max_param
+    )
     raw_sql = f"""
         DELETE FROM {formatted_table}
         WHERE {where_clause}

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -100,6 +100,7 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     QueryBuilderDynamicField,
     QueryBuilderField,
     build_calls_complete_delete_query,
+    build_calls_complete_soft_delete_query,
     build_calls_complete_started_at_select_query,
     build_calls_complete_update_end_query,
     build_calls_complete_update_query,
@@ -1980,8 +1981,27 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             started_at_max_param = pb.add_param(
                 datetime_to_microseconds(started_at_window[1] + pad)
             )
+        table_name = self._get_calls_complete_table_name()
+        # Logical delete: a lightweight UPDATE writes a patch part the read path
+        # applies on the fly (via its deleted_at filter), so the calls vanish
+        # immediately with no mutation and no part rewrite.
+        soft_delete_query = build_calls_complete_soft_delete_query(
+            table_name,
+            project_id_param,
+            call_ids_param,
+            started_at_min_param=started_at_min_param,
+            started_at_max_param=started_at_max_param,
+            cluster_name=self.clickhouse_cluster_name,
+        )
+        self._command(
+            soft_delete_query,
+            parameters=pb.get_params(),
+            settings=ch_settings.CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
+        )
+        # Physical reclamation runs async (sync=0) and unwaited: the marker above
+        # already hid the rows, so a slow reclaim never blocks the request.
         delete_query = build_calls_complete_delete_query(
-            self._get_calls_complete_table_name(),
+            table_name,
             project_id_param,
             call_ids_param,
             started_at_min_param=started_at_min_param,
@@ -1993,47 +2013,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             parameters=pb.get_params(),
             settings=ch_settings.CLICKHOUSE_ASYNC_DELETE_SETTINGS,
         )
-        self._await_calls_complete_deletion(project_id, call_ids, started_at_window)
-
-    @traced(name="clickhouse_trace_server_batched._await_calls_complete_deletion")
-    def _await_calls_complete_deletion(
-        self,
-        project_id: str,
-        call_ids: list[str],
-        started_at_window: tuple[datetime.datetime, datetime.datetime] | None,
-    ) -> None:
-        """Block until the async delete's row mask applies, up to a bounded window.
-
-        The DELETE runs async (lightweight_deletes_sync=0), so poll the read path
-        until the calls disappear. Returns early once reconciled; on timeout the
-        mutation is left to finish in the background so the request never blocks
-        past the gateway timeout.
-        """
-        if not call_ids:
-            return
-        poll_query = None
-        if started_at_window is not None:
-            pad = datetime.timedelta(
-                seconds=ch_settings.DELETE_STARTED_AT_PADDING_SECONDS
-            )
-            poll_query = started_at_gte_query(started_at_window[0] - pad)
-        deadline = time.monotonic() + ch_settings.DELETE_RECONCILE_TIMEOUT_SECONDS
-        while True:
-            still_present = next(
-                self.calls_query_stream(
-                    tsi.CallsQueryReq(
-                        project_id=project_id,
-                        filter=tsi.CallsFilter(call_ids=call_ids),
-                        query=poll_query,
-                        columns=["id"],
-                        limit=1,
-                    )
-                ),
-                None,
-            )
-            if still_present is None or time.monotonic() >= deadline:
-                return
-            time.sleep(ch_settings.DELETE_RECONCILE_POLL_INTERVAL_SECONDS)
 
     def _ensure_valid_update_field(self, req: tsi.CallUpdateReq) -> None:
         valid_update_fields = ["display_name"]

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1991,7 +1991,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self._command(
             delete_query,
             parameters=pb.get_params(),
-            settings=ch_settings.CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
+            settings=ch_settings.CLICKHOUSE_ASYNC_DELETE_SETTINGS,
         )
 
     def _ensure_valid_update_field(self, req: tsi.CallUpdateReq) -> None:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1993,6 +1993,47 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             parameters=pb.get_params(),
             settings=ch_settings.CLICKHOUSE_ASYNC_DELETE_SETTINGS,
         )
+        self._await_calls_complete_deletion(project_id, call_ids, started_at_window)
+
+    @traced(name="clickhouse_trace_server_batched._await_calls_complete_deletion")
+    def _await_calls_complete_deletion(
+        self,
+        project_id: str,
+        call_ids: list[str],
+        started_at_window: tuple[datetime.datetime, datetime.datetime] | None,
+    ) -> None:
+        """Block until the async delete's row mask applies, up to a bounded window.
+
+        The DELETE runs async (lightweight_deletes_sync=0), so poll the read path
+        until the calls disappear. Returns early once reconciled; on timeout the
+        mutation is left to finish in the background so the request never blocks
+        past the gateway timeout.
+        """
+        if not call_ids:
+            return
+        poll_query = None
+        if started_at_window is not None:
+            pad = datetime.timedelta(
+                seconds=ch_settings.DELETE_STARTED_AT_PADDING_SECONDS
+            )
+            poll_query = started_at_gte_query(started_at_window[0] - pad)
+        deadline = time.monotonic() + ch_settings.DELETE_RECONCILE_TIMEOUT_SECONDS
+        while True:
+            still_present = next(
+                self.calls_query_stream(
+                    tsi.CallsQueryReq(
+                        project_id=project_id,
+                        filter=tsi.CallsFilter(call_ids=call_ids),
+                        query=poll_query,
+                        columns=["id"],
+                        limit=1,
+                    )
+                ),
+                None,
+            )
+            if still_present is None or time.monotonic() >= deadline:
+                return
+            time.sleep(ch_settings.DELETE_RECONCILE_POLL_INTERVAL_SECONDS)
 
     def _ensure_valid_update_field(self, req: tsi.CallUpdateReq) -> None:
         valid_update_fields = ["display_name"]

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -120,6 +120,13 @@ CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS: dict[str, int | str] = (
     }
 )
 
+# calls_complete deletes run async (sync=0): the DELETE returns once the mutation is
+# scheduled instead of blocking on materialization, avoiding the request-timeout cancel.
+CLICKHOUSE_ASYNC_DELETE_SETTINGS: dict[str, int | str] = {
+    **CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
+    "lightweight_deletes_sync": 0,
+}
+
 # The new ClickHouse query analyzer (v24+) has a bug serializing SortingStep
 # for non-Full sorting modes on distributed tables, which causes error 48
 # ("Serialization of SortingStep is implemented only for Full sorting").

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -120,10 +120,9 @@ CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS: dict[str, int | str] = (
     }
 )
 
-# Physical reclamation of soft-deleted calls_complete rows: sync=0 so the DELETE
-# returns once scheduled and never blocks the request (the soft-delete already hid them).
+# Physical reclamation of soft-deleted calls_complete rows: sync=0 lets the lightweight
+# DELETE return once scheduled (never blocks). A DELETE needs none of the UPDATE settings.
 CLICKHOUSE_ASYNC_DELETE_SETTINGS: dict[str, int | str] = {
-    **CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
     "lightweight_deletes_sync": 0,
 }
 

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -12,6 +12,10 @@ MAX_DELETE_CALLS_COUNT = 1000
 # Pad the started_at window used to prune partitions on the calls/delete path,
 # absorbing cross-process clock skew between a call and its descendants.
 DELETE_STARTED_AT_PADDING_SECONDS = 1
+# Async calls_complete delete: block up to this long polling for the row mask to
+# apply, then return and let the mutation finish in the background.
+DELETE_RECONCILE_TIMEOUT_SECONDS = 10
+DELETE_RECONCILE_POLL_INTERVAL_SECONDS = 0.25
 INITIAL_CALLS_STREAM_BATCH_SIZE = 50
 MAX_CALLS_STREAM_BATCH_SIZE = 500
 BATCH_UPDATE_CHUNK_SIZE = 100  # Split large UPDATE queries to avoid SQL limits
@@ -120,8 +124,8 @@ CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS: dict[str, int | str] = (
     }
 )
 
-# calls_complete deletes run async (sync=0): the DELETE returns once the mutation is
-# scheduled instead of blocking on materialization, avoiding the request-timeout cancel.
+# calls_complete deletes run async (sync=0); _delete_calls_complete then polls for
+# reconciliation up to a bounded window instead of blocking past the gateway timeout.
 CLICKHOUSE_ASYNC_DELETE_SETTINGS: dict[str, int | str] = {
     **CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
     "lightweight_deletes_sync": 0,

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -12,10 +12,6 @@ MAX_DELETE_CALLS_COUNT = 1000
 # Pad the started_at window used to prune partitions on the calls/delete path,
 # absorbing cross-process clock skew between a call and its descendants.
 DELETE_STARTED_AT_PADDING_SECONDS = 1
-# Async calls_complete delete: block up to this long polling for the row mask to
-# apply, then return and let the mutation finish in the background.
-DELETE_RECONCILE_TIMEOUT_SECONDS = 10
-DELETE_RECONCILE_POLL_INTERVAL_SECONDS = 0.25
 INITIAL_CALLS_STREAM_BATCH_SIZE = 50
 MAX_CALLS_STREAM_BATCH_SIZE = 500
 BATCH_UPDATE_CHUNK_SIZE = 100  # Split large UPDATE queries to avoid SQL limits
@@ -124,8 +120,8 @@ CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS: dict[str, int | str] = (
     }
 )
 
-# calls_complete deletes run async (sync=0); _delete_calls_complete then polls for
-# reconciliation up to a bounded window instead of blocking past the gateway timeout.
+# Physical reclamation of soft-deleted calls_complete rows: sync=0 so the DELETE
+# returns once scheduled and never blocks the request (the soft-delete already hid them).
 CLICKHOUSE_ASYNC_DELETE_SETTINGS: dict[str, int | str] = {
     **CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
     "lightweight_deletes_sync": 0,


### PR DESCRIPTION
https://coreweave.atlassian.net/browse/WB-36523

## Summary
- `calls_complete` deletes ran a synchronous physical `DELETE` (`lightweight_deletes_sync=2`) that blocks the request on an all-replica mask mutation. On large/hot deletes it exceeds the ~60s gateway timeout and ClickHouse cancels the query (394 -> 502). Fixes [WB-36523](https://coreweave.atlassian.net/browse/WB-36523).
- New shape: a lightweight `UPDATE deleted_at = now64(3)` writes a patch part the read path applies on the fly (no mutation, no part rewrite), then the physical `DELETE` fires async (`sync=0`, unwaited) purely to reclaim space. Correctness never depends on the slow reclaim.

## Performance
Verified on ClickHouse 25.12 (prod minor), `calls_complete` shape (ReplacingMergeTree, `enable_block_number_column=1`): lightweight `UPDATE deleted_at` = 6-12ms, patch part, 0 mutation-queue entries. Bumping `ttl_at` via the patch does NOT get reaped by background TTL (part `delete_ttl_info` isn't recomputed from the patch), so reclamation uses the async `DELETE`, not TTL.

## QA validation (zoo-qa)
Deployed to zoo-qa and A/B'd `POST /calls/delete` vs master (500-call `calls_complete` deletes, server-side `@duration` by `version`, n=9 each):

| build | P50 | P95 | MAX |
| --- | --- | --- | --- |
| master (synchronous physical DELETE) | 1.14s | 1.18s | 2.11s |
| PR (soft-delete marker + async reclaim) | **316ms** | 342ms | 1.59s |

~3.6x faster P50, no blocking on the mask mutation, no new error classes. Sample traces: [master](https://us5.datadoghq.com/apm/trace/6a46a9da00000000be9c951421f56acd) / [PR](https://us5.datadoghq.com/apm/trace/6a46af1700000000796e6359186fc315).

Read-your-write: 8/8 master, **7/8 PR**. The miss saw all rows still present right after delete = per-replica lag on the UPDATE patch part (marker landed on one replica, the follow-up read hit another before it propagated). So read-your-write is eventual on a multi-replica cluster; FE should optimistically hide deleted rows (+ "reconciling" toast) rather than rely on immediate server-side consistency.

## Local load test
Load-tested the two CH statements on single-node and a 2-replica + keeper cluster (CH 25.12, `calls_complete` shape), master (sync `DELETE`) vs PR (marker + async `DELETE`):
- Scattered-id deletes across a 1M-row partition: the blocking soft-delete marker is ~2x cheaper than the synchronous `DELETE` (72 vs 139ms @1k ids, 106 vs 195ms @5k). Net request win scales with how expensive the physical `DELETE` is; a small local partition keeps the sync `DELETE` cheap, so local doesn't reproduce the QA 3.6x and concurrent latency is marker-bound.
- Async reclaim stays a bounded background mutation queue under load (46 pending at 50-way concurrency, drains in 2.6s locally).
- The reclaim `DELETE` carries the `id IN` list, which CH rejects as a mutation predicate above ~30k ids; the delete path caps ids well under that (`MAX_DELETE_CALLS_COUNT`=1000 + 10k descendant limit), so reclaim always applies.

## Testing
existing `calls_complete` delete tests pass unchanged against real CH; added a query-builder unit test for the soft-delete UPDATE.


[WB-36523]: https://coreweave.atlassian.net/browse/WB-36523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
