### PR TITLE
perf(weave): add tuned skip indexes on calls_complete (trace_id + attributes_dump)

### DIFF
--- a/weave/trace_server/migrations/036_add_calls_complete_skip_indexes.down.sql
+++ b/weave/trace_server/migrations/036_add_calls_complete_skip_indexes.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE calls_complete DROP INDEX IF EXISTS idx_attributes_dump;
+ALTER TABLE calls_complete DROP INDEX IF EXISTS idx_trace_id_bloom;

--- a/weave/trace_server/migrations/036_add_calls_complete_skip_indexes.up.sql
+++ b/weave/trace_server/migrations/036_add_calls_complete_skip_indexes.up.sql
@@ -1,0 +1,24 @@
+-- Migration 036: tune skip indexes on calls_complete for two hot filter shapes.
+--
+-- idx_trace_id_bloom: the existing idx_trace_id uses the default 0.025
+-- false-positive rate, which leaves ~43% of granules for a multi-value
+-- `trace_id IN (...)` fetch (survival is 1-(1-0.025)^N). A 0.001 filter drops
+-- that to ~2%. Kept alongside idx_trace_id so existing (un-materialized) parts
+-- still prune on the coarse index.
+--
+-- idx_attributes_dump: attributes_dump is the only *_dump column without a tokenbf,
+-- so the `attributes_dump LIKE '%"value"%'` custom-attribute optimization (e.g. a
+-- conversation_id lookup) has no index to prune on and scans the started_at window.
+-- This mirrors idx_inputs_dump / idx_output_dump / idx_summary_dump.
+--
+-- Intentionally NOT materialized: applies to new and newly-merged parts going
+-- forward, avoiding a full-column reindex mutation on large existing tables.
+ALTER TABLE calls_complete
+    ADD INDEX IF NOT EXISTS idx_trace_id_bloom
+        trace_id TYPE bloom_filter(0.001) GRANULARITY 1
+    SETTINGS alter_sync = 1;
+
+ALTER TABLE calls_complete
+    ADD INDEX IF NOT EXISTS idx_attributes_dump
+        attributes_dump TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
+    SETTINGS alter_sync = 1;


### PR DESCRIPTION
## Summary
- `idx_trace_id_bloom` `bloom_filter(0.001)` on `calls_complete.trace_id`: the existing default-rate `idx_trace_id` leaves ~43% of granules for a multi-value `trace_id IN (...)` fetch (survival = 1-(1-0.025)^N); 0.001 drops it to ~2%.
- `idx_attributes_dump` `tokenbf_v1(32768,3,0)`: `attributes_dump` was the only `*_dump` column without a token index, so the `LIKE '%"v"%'` custom-attribute optimization (e.g. conversation_id lookups) had nothing to prune on and scanned the `started_at` window. Mirrors `idx_inputs_dump`/`idx_output_dump`/`idx_summary_dump`.
- Both shapes cause 60s `/calls/stream_query` timeouts on large single-tenant projects.
- Intentionally not materialized: applies to new/newly-merged parts only (no full-column reindex on hot tables).

## Performance
`attributes.<k> == v` compiles to `attributes_dump LIKE '%"v"%'`, which today scans the whole `started_at` window (no token index). Measured on prod (read-only replica, CH 25.12) by toggling `use_skip_indexes` over the identical `tokenbf_v1(32768,3,0)` that `inputs_dump` already carries; `attributes_dump` today reads the same with the setting on or off, so OFF == current behavior, ON == with this index.

Specific-id lookup, one project per scale:

| project (window) | rows in window | granules: today -> indexed | wall-clock, RO replica: today -> indexed |
|---|---|---|---|
| large (3d) | 2.96M | 18,660 -> 0 | 4.0s -> 0.36s (~11x) |
| medium (7d) | 1.10M | 801 -> 0 | 0.08s -> 0.02s |
| small (7d) | 63k | 322 -> 0 | 0.03s -> 0.01s |

Rare-but-present needle (4 matching rows, medium): 801 -> 4 granules, 197x fewer rows (1.10M -> 5.6k), 167x less data (3.09 GB -> 18 MB). The RO replica is warm and highly parallel, so absolute latencies sit far below the prod serving path where the same ~196 GB scan drives the 60s timeout; granules/bytes are the real signal, latency just confirms direction. Caveat: only case-sensitive eq/IN prune (the tokenbf-friendly `LIKE '%"v"%'` the optimizer emits); `contains` + `case_insensitive` (`lower(dump) LIKE`) bypasses the index either way.

## Testing
migration up/down applied on local CH 26.6. `EXPLAIN indexes=1` on a 4M-row repro: `trace_id IN` 213/490 -> 7/490 granules; `attributes_dump` window 17/17 -> 1/17.
