### PR TITLE
fix(weave): canonicalize self-refs in generated builtin object schemas

### DIFF
--- a/scripts/generate_base_object_schemas.py
+++ b/scripts/generate_base_object_schemas.py
@@ -17,30 +17,47 @@ OUTPUT_DIR = (
 )
 OUTPUT_PATH = OUTPUT_DIR / "generated_builtin_object_class_schemas.json"
 
+JSONValue = dict[str, "JSONValue"] | list["JSONValue"] | str | int | float | bool | None
 
-def generate_schemas() -> None:
-    """Generate JSON schemas for all registered base objects in BUILTIN_OBJECT_REGISTRY.
-    Creates a top-level schema that includes all registered objects and writes it
-    to 'generated_builtin_object_class_schemas.json'.
-    """
-    # Dynamically create a parent model with all registered objects as properties
+
+def build_schema() -> dict[str, JSONValue]:
+    """Build the canonical JSON schema for all registered builtin object classes."""
     CompositeModel = create_model(  # noqa: N806
         "CompositeBaseObject",
         **{name: (cls, ...) for name, cls in BUILTIN_OBJECT_REGISTRY.items()},
     )
+    schema = CompositeModel.model_json_schema(mode="validation")
+    _canonicalize_self_refs(schema, set(schema.get("$defs", {})))
+    return schema
 
-    # Generate the schema using the composite model
-    top_level_schema = CompositeModel.model_json_schema(mode="validation")
 
-    # make sure the output directory exists
+def generate_schemas() -> None:
+    """Generate and write JSON schemas for all registered builtin object classes."""
+    schema = build_schema()
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-
-    # Write schema to file
     with OUTPUT_PATH.open("w") as f:
-        json.dump(top_level_schema, f, indent=2)
-
+        json.dump(schema, f, indent=2)
     print(f"Generated schema for {len(BUILTIN_OBJECT_REGISTRY)} objects")
     print(f"Wrote schema to {OUTPUT_PATH.absolute()}")
+
+
+def _canonicalize_self_refs(node: JSONValue, defs: set[str]) -> None:
+    """Rewrite pydantic's degenerate self-ref union members ({"title": X}) to stable {"$ref": "#/$defs/X"}."""
+    if isinstance(node, dict):
+        members = node.get("anyOf")
+        if isinstance(members, list):
+            for i, member in enumerate(members):
+                if (
+                    isinstance(member, dict)
+                    and member.keys() == {"title"}
+                    and member["title"] in defs
+                ):
+                    members[i] = {"$ref": f"#/$defs/{member['title']}"}
+        for value in node.values():
+            _canonicalize_self_refs(value, defs)
+    elif isinstance(node, list):
+        for value in node:
+            _canonicalize_self_refs(value, defs)
 
 
 if __name__ == "__main__":

--- a/tests/trace/test_base_object_classes.py
+++ b/tests/trace/test_base_object_classes.py
@@ -11,6 +11,7 @@
 4. We ensure that invalid schemas are properly rejected from the server.
 """
 
+import json
 import time
 from typing import Literal
 
@@ -18,6 +19,11 @@ import pytest
 from pydantic import ValidationError
 
 import weave
+from scripts.generate_base_object_schemas import (
+    OUTPUT_PATH,
+    _canonicalize_self_refs,
+    build_schema,
+)
 from weave.trace import base_objects
 from weave.trace.refs import ObjectRef
 from weave.trace.serialization.serialize import to_json
@@ -1266,4 +1272,27 @@ def test_monitor_create_accepts_valid_query_fields(client: WeaveClient):
         "dynamic-monitor",
         "no-query-monitor",
         "opaque-monitor",
+    }
+
+
+def test_builtin_object_class_schemas_in_sync_and_canonical():
+    """Checked-in schema matches the generator and self-refs canonicalize to $ref."""
+    assert build_schema() == json.loads(OUTPUT_PATH.read_text()), (
+        "generated builtin object class schemas are stale; "
+        "run `make generate_base_object_schemas`"
+    )
+
+    # Pydantic emits {"title": X} placeholders for some recursive self-references
+    # depending on the installed version; the generator rewrites them to a stable $ref.
+    schema = {
+        "$defs": {"AndOperation": {"type": "object"}},
+        "anyOf": [{"title": "AndOperation"}, {"$ref": "#/$defs/AndOperation"}],
+    }
+    _canonicalize_self_refs(schema, set(schema["$defs"]))
+    assert schema == {
+        "$defs": {"AndOperation": {"type": "object"}},
+        "anyOf": [
+            {"$ref": "#/$defs/AndOperation"},
+            {"$ref": "#/$defs/AndOperation"},
+        ],
     }


### PR DESCRIPTION
## Summary
- The generated builtin object class schema JSON is non-reproducible: pydantic emits a degenerate `{"title": X}` placeholder instead of `{"$ref": "#/$defs/X"}` for some recursive self-references, and which members come out degenerate depends on the installed pydantic version. Regenerating in a different env produced spurious diffs (reported on latest master).
- `build_schema()` now rewrites those placeholders to a stable `$ref`, so output is deterministic across pydantic versions. Committed file is unchanged (already canonical on master).

## Testing
adds a test asserting the committed schema equals canonical generator output and that self-refs canonicalize to `$ref`.