### PR TITLE
chore(inference): fix 500 in catalog API

### DIFF
--- a/weave/trace_server/model_providers/model_providers.py
+++ b/weave/trace_server/model_providers/model_providers.py
@@ -76,7 +76,9 @@ Quantization = Literal[
     "fp32",
 ]
 
-LifecycleStage = Literal["general-availability", "experimental", "retired"]
+LifecycleStage = Literal[
+    "experimental", "general-availability", "deprecated", "retired"
+]
 
 InferenceEnvironment = Literal["cw-prod", "cw-qa"]
 


### PR DESCRIPTION
## Description

`/inference/catalog/models` was returning 500 after a data update that deprecated some models because that valid state was missing from `LifecycleStage`.

(FastAPI validates the API response against `response_model=CatalogModelsRes` via Pydantic.)

## Testing

How was this PR tested?
