### PR TITLE
chore(weave): add column_visibility to ComparisonViewDefinition

### DIFF
--- a/weave/trace_server/interface/builtin_object_classes/comparison_view.py
+++ b/weave/trace_server/interface/builtin_object_classes/comparison_view.py
@@ -15,6 +15,8 @@ class ComparisonViewDefinition(BaseModel):
     Args:
         evaluation_call_ids (list[str]): List of evaluation call IDs being compared.
         selected_metrics (list[str] | None): List of metrics that are visible in plots.
+        column_visibility (dict[str, bool] | None): Results-table column visibility
+            keyed by column field. Absent/empty means the default columns.
 
     Examples:
         >>> definition = ComparisonViewDefinition(
@@ -25,6 +27,7 @@ class ComparisonViewDefinition(BaseModel):
 
     evaluation_call_ids: list[str]
     selected_metrics: list[str] | None = None
+    column_visibility: dict[str, bool] | None = None
 
 
 class ComparisonView(base_object_def.BaseObject):

--- a/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
+++ b/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
@@ -552,7 +552,7 @@
       "type": "object"
     },
     "ComparisonViewDefinition": {
-      "description": "Definition of a comparison view's configuration.\n\nArgs:\n    evaluation_call_ids (list[str]): List of evaluation call IDs being compared.\n    selected_metrics (list[str] | None): List of metrics that are visible in plots.\n\nExamples:\n    >>> definition = ComparisonViewDefinition(\n    ...     evaluation_call_ids=[\"call_1\", \"call_2\"],\n    ...     selected_metrics=[\"accuracy\", \"f1_score\"]\n    ... )",
+      "description": "Definition of a comparison view's configuration.\n\nArgs:\n    evaluation_call_ids (list[str]): List of evaluation call IDs being compared.\n    selected_metrics (list[str] | None): List of metrics that are visible in plots.\n    column_visibility (dict[str, bool] | None): Results-table column visibility\n        keyed by column field. Absent/empty means the default columns.\n\nExamples:\n    >>> definition = ComparisonViewDefinition(\n    ...     evaluation_call_ids=[\"call_1\", \"call_2\"],\n    ...     selected_metrics=[\"accuracy\", \"f1_score\"]\n    ... )",
       "properties": {
         "evaluation_call_ids": {
           "items": {
@@ -575,6 +575,21 @@
           ],
           "default": null,
           "title": "Selected Metrics"
+        },
+        "column_visibility": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Column Visibility"
         }
       },
       "required": [


### PR DESCRIPTION
## Summary
- Saved eval comparison views stored only `evaluation_call_ids` + `selected_metrics`, so results-table column choices were never persisted. Adds an optional `column_visibility` (field -> visible) + regenerated schema; absent/empty = default columns.
- Frontend consumer (capture on save, restore on load): wandb/core PR for https://github.com/wandb/core/pull/47403

## Testing
additive optional field; existing base-object round-trip tests unaffected.