### PR TITLE
chore(weave_ts): Move type to keep typedoc on Turn

### DIFF
--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -38,6 +38,13 @@ export interface TurnInit extends SpanInitBase {
   agentVersion?: string;
 }
 
+type Opts = {
+  conversationId: string;
+  messages: Message[];
+  span: Span;
+  context: Context;
+} & Required<Omit<TurnInit, 'userMessage' | 'startTime'>>;
+
 /**
  * An agent invocation. Typically wraps the work to respond to a single
  * user message. Emits an `invoke_agent` span and acts as the root of the
@@ -81,14 +88,6 @@ export interface TurnInit extends SpanInitBase {
  *   turn.end();
  * }
  */
-
-type Opts = {
-  conversationId: string;
-  messages: Message[];
-  span: Span;
-  context: Context;
-} & Required<Omit<TurnInit, 'userMessage' | 'startTime'>>;
-
 export class Turn extends SpanBase {
   private _context: Context;
   private _conversationId: string;


### PR DESCRIPTION
## Description

* Introducing a type between the Typedoc and the class here (https://github.com/wandb/weave/pull/7468/changes#diff-63326c102d6dbfc795b379dc76168dd8415c2f14b42539425f260a16558af8f8R76-R82) caused this content to get stripped from docs/ when re-generating (https://github.com/wandb/docs/pull/2868/changes)

* This change moves it around so the typedoc sticks on `Turn`.