### PR TITLE
feat(weave): first-class sdk feedback for agent spans + turns

### DIFF
--- a/tests/trace/test_client_feedback.py
+++ b/tests/trace/test_client_feedback.py
@@ -1,5 +1,6 @@
 import pytest
 
+from weave.trace.feedback import RefFeedbackQuery
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import InvalidRequest
 from weave.trace_server.interface.query import Query
@@ -288,3 +289,63 @@ def test_feedback_query_created_at_filter(client):
         "payload": {"key": "value123"},
     }
     assert query_since("2999-01-01T00:00:00.000000Z") == []
+
+
+def test_agent_feedback_apis(client):
+    span_fb = client.get_agent_span_feedback("0123456789abcdef")
+    turn_fb = client.get_agent_turn_feedback("0123456789abcdef0123456789abcdef")
+    assert (
+        span_fb.weave_ref
+        == f"weave:///{client.entity}/{client.project}/agent_span/0123456789abcdef"
+    )
+    assert (
+        turn_fb.weave_ref
+        == f"weave:///{client.entity}/{client.project}/agent_turn/0123456789abcdef0123456789abcdef"
+    )
+
+    span_reaction_id = span_fb.add_reaction("👍", creator="griffin")
+    span_note_id = span_fb.add_note("solid answer")
+    turn_reaction_id = turn_fb.add_reaction("👎")
+
+    # Call refs keep the classic reaction type.
+    call_fb = RefFeedbackQuery(
+        f"weave:///{client.entity}/{client.project}/call/00000000-0000-0000-0000-000000000000"
+    )
+    call_reaction_id = call_fb.add_reaction("👍")
+
+    res = client.server.feedback_query(
+        tsi.FeedbackQueryReq(project_id=client.project_id)
+    )
+    rows = {row["id"]: row for row in res.result}
+
+    span_reaction = rows[span_reaction_id]
+    assert span_reaction["weave_ref"] == span_fb.weave_ref
+    assert span_reaction["feedback_type"] == "wandb.agent_user_feedback"
+    assert span_reaction["scorer_tags"] == ["👍"]
+    assert span_reaction["scorer_tag_reasons"] == {"👍": "Set by user"}
+    assert span_reaction["scorer_tag_confidences"] == {"👍": 1.0}
+    assert span_reaction["payload"] == {"emoji": "👍", "scorer_tags": ["👍"]}
+    assert span_reaction["creator"] == "griffin"
+
+    span_note = rows[span_note_id]
+    assert span_note["weave_ref"] == span_fb.weave_ref
+    assert span_note["feedback_type"] == "wandb.note.1"
+    assert span_note["payload"] == {"note": "solid answer"}
+
+    turn_reaction = rows[turn_reaction_id]
+    assert turn_reaction["weave_ref"] == turn_fb.weave_ref
+    assert turn_reaction["feedback_type"] == "wandb.agent_user_feedback"
+    assert turn_reaction["scorer_tags"] == ["👎"]
+
+    call_reaction = rows[call_reaction_id]
+    assert call_reaction["feedback_type"] == "wandb.reaction.1"
+    assert call_reaction["payload"] == {
+        "emoji": "👍",
+        "alias": ":thumbs_up:",
+        "detoned": "👍",
+        "detoned_alias": ":thumbs_up:",
+    }
+
+    # The ref-scoped query only sees its own rows.
+    assert {f.id for f in span_fb.refresh()} == {span_reaction_id, span_note_id}
+    assert {f.id for f in turn_fb.refresh()} == {turn_reaction_id}

--- a/tests/trace/test_client_feedback.py
+++ b/tests/trace/test_client_feedback.py
@@ -1,8 +1,10 @@
 import pytest
 
+from weave.trace import feedback
 from weave.trace.feedback import RefFeedbackQuery
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import InvalidRequest
+from weave.trace_server.interface import feedback_types
 from weave.trace_server.interface.query import Query
 
 
@@ -292,8 +294,14 @@ def test_feedback_query_created_at_filter(client):
 
 
 def test_agent_feedback_apis(client):
+    # The client mirrors these because the layering contract bars the import.
+    assert feedback.AGENT_USER_FEEDBACK_TYPE == feedback_types.AGENT_USER_FEEDBACK_TYPE
+    assert feedback.NOTE_FEEDBACK_TYPE == feedback_types.NOTE_FEEDBACK_TYPE
+    assert feedback.REACTION_FEEDBACK_TYPE == feedback_types.REACTION_FEEDBACK_TYPE
+
     span_fb = client.get_agent_span_feedback("0123456789abcdef")
     turn_fb = client.get_agent_turn_feedback("0123456789abcdef0123456789abcdef")
+    conv_fb = client.get_agent_conversation_feedback("sess-demo")
     assert (
         span_fb.weave_ref
         == f"weave:///{client.entity}/{client.project}/agent_span/0123456789abcdef"
@@ -302,10 +310,15 @@ def test_agent_feedback_apis(client):
         turn_fb.weave_ref
         == f"weave:///{client.entity}/{client.project}/agent_turn/0123456789abcdef0123456789abcdef"
     )
+    assert (
+        conv_fb.weave_ref
+        == f"weave:///{client.entity}/{client.project}/agent_conversation/sess-demo"
+    )
 
     span_reaction_id = span_fb.add_reaction("👍", creator="griffin")
     span_note_id = span_fb.add_note("solid answer")
     turn_reaction_id = turn_fb.add_reaction("👎")
+    conv_reaction_id = conv_fb.add_reaction("👍")
 
     # Call refs keep the classic reaction type.
     call_fb = RefFeedbackQuery(
@@ -336,6 +349,11 @@ def test_agent_feedback_apis(client):
     assert turn_reaction["weave_ref"] == turn_fb.weave_ref
     assert turn_reaction["feedback_type"] == "wandb.agent_user_feedback"
     assert turn_reaction["scorer_tags"] == ["👎"]
+
+    conv_reaction = rows[conv_reaction_id]
+    assert conv_reaction["weave_ref"] == conv_fb.weave_ref
+    assert conv_reaction["feedback_type"] == "wandb.agent_user_feedback"
+    assert conv_reaction["scorer_tags"] == ["👍"]
 
     call_reaction = rows[call_reaction_id]
     assert call_reaction["feedback_type"] == "wandb.reaction.1"

--- a/weave/trace/feedback.py
+++ b/weave/trace/feedback.py
@@ -189,9 +189,6 @@ class RefFeedbackQuery(FeedbackQuery):
 
     def __init__(self, ref: str) -> None:
         parsed_ref = Ref.parse_uri(ref)
-        # All ref types have entity and project attributes
-        if not hasattr(parsed_ref, "entity") or not hasattr(parsed_ref, "project"):
-            raise ValueError(f"Invalid ref type: {type(parsed_ref)}")
         query = {
             "$expr": {
                 "$eq": [
@@ -201,8 +198,8 @@ class RefFeedbackQuery(FeedbackQuery):
             }
         }
         super().__init__(
-            entity=parsed_ref.entity,  # type: ignore
-            project=parsed_ref.project,  # type: ignore
+            entity=parsed_ref.entity,
+            project=parsed_ref.project,
             query=Query(**query),
         )
         self.weave_ref = ref

--- a/weave/trace/feedback.py
+++ b/weave/trace/feedback.py
@@ -12,10 +12,26 @@ from weave.trace.display import display
 from weave.trace.display.rich import pydantic_util
 from weave.trace.display.rich.container import AbstractRichContainer
 from weave.trace.display.rich.refs import Refs
-from weave.trace.refs import ObjectRef, Ref
+from weave.trace.refs import (
+    AgentConversationRef,
+    AgentSpanRef,
+    AgentTurnRef,
+    AnyRef,
+    ObjectRef,
+    Ref,
+)
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.interface.query import Query
 from weave.utils.project_id import to_project_id
+
+# Mirrors weave.trace_server.interface.feedback_types; the client/server import
+# boundary forbids importing it here.
+AGENT_USER_FEEDBACK_TYPE = "wandb.agent_user_feedback"
+NOTE_FEEDBACK_TYPE = "wandb.note.1"
+REACTION_FEEDBACK_TYPE = "wandb.reaction.1"
+
+# Reason the Agent UI records for human reactions; keep in sync with Reactions.tsx.
+AGENT_REACTION_REASON = "Set by user"
 
 
 class Feedbacks(AbstractRichContainer[tsi.Feedback]):
@@ -48,7 +64,7 @@ class Feedbacks(AbstractRichContainer[tsi.Feedback]):
 
         type_ = feedback.feedback_type
         display_type = type_
-        if type_ == "wandb.reaction.1":
+        if type_ == REACTION_FEEDBACK_TYPE:
             display_type = "reaction"
             if util.is_notebook():
                 # TODO: Emojis mess up table alignment in Jupyter 😢
@@ -56,7 +72,7 @@ class Feedbacks(AbstractRichContainer[tsi.Feedback]):
                 content = feedback.payload["alias"]
             else:
                 content = feedback.payload["emoji"]
-        elif type_ == "wandb.note.1":
+        elif type_ == NOTE_FEEDBACK_TYPE:
             display_type = "note"
             content = feedback.payload["note"]
         else:
@@ -169,6 +185,7 @@ class RefFeedbackQuery(FeedbackQuery):
     """Object for interacting with feedback associated with a particular ref."""
 
     weave_ref: str
+    _parsed_ref: AnyRef
 
     def __init__(self, ref: str) -> None:
         parsed_ref = Ref.parse_uri(ref)
@@ -189,6 +206,12 @@ class RefFeedbackQuery(FeedbackQuery):
             query=Query(**query),
         )
         self.weave_ref = ref
+        self._parsed_ref = parsed_ref
+
+    def _create(self, freq: tsi.FeedbackCreateReq) -> str:
+        response = self.client.server.feedback_create(freq)
+        self.feedbacks = None  # Clear cache
+        return response.id
 
     def _add(
         self,
@@ -212,9 +235,22 @@ class RefFeedbackQuery(FeedbackQuery):
                     "annotation_ref must be a valid object ref, eg weave:///<entity>/<project>/object/<name>:<digest>"
                 ) from None
             freq.annotation_ref = annotation_ref
-        response = self.client.server.feedback_create(freq)
-        self.feedbacks = None  # Clear cache
-        return response.id
+        return self._create(freq)
+
+    def _add_agent_reaction(self, emoji: str, creator: str | None) -> str:
+        return self._create(
+            tsi.FeedbackCreateReq(
+                project_id=to_project_id(self.entity, self.project),
+                weave_ref=self.weave_ref,
+                feedback_type=AGENT_USER_FEEDBACK_TYPE,
+                scorer_tags=[emoji],
+                scorer_tag_reasons={emoji: AGENT_REACTION_REASON},
+                scorer_tag_confidences={emoji: 1.0},
+                # Mirror the tag so wandb.reaction.1 consumers can read it too.
+                payload={"emoji": emoji, "scorer_tags": [emoji]},
+                creator=creator,
+            )
+        )
 
     def add(
         self,
@@ -236,8 +272,13 @@ class RefFeedbackQuery(FeedbackQuery):
         return self._add(feedback_type, feedback, creator, annotation_ref)
 
     def add_reaction(self, emoji: str, creator: str | None = None) -> str:
+        """Add an emoji reaction, written as the type the target's UI renders."""
+        if isinstance(
+            self._parsed_ref, (AgentSpanRef, AgentTurnRef, AgentConversationRef)
+        ):
+            return self._add_agent_reaction(emoji, creator)
         return self._add(
-            "wandb.reaction.1",
+            REACTION_FEEDBACK_TYPE,
             {
                 "emoji": emoji,
             },
@@ -246,7 +287,7 @@ class RefFeedbackQuery(FeedbackQuery):
 
     def add_note(self, note: str, creator: str | None = None) -> str:
         return self._add(
-            "wandb.note.1",
+            NOTE_FEEDBACK_TYPE,
             {
                 "note": note,
             },

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -40,7 +40,7 @@ from weave.trace.casting import CallsFilterLike, QueryLike, SortByLike
 from weave.trace.concurrent.futures import FutureExecutor
 from weave.trace.constants import TRACE_CALL_EMOJI
 from weave.trace.context import call_context
-from weave.trace.feedback import FeedbackQuery
+from weave.trace.feedback import FeedbackQuery, RefFeedbackQuery
 from weave.trace.interface_query_builder import (
     exists_expr,
     get_field_expr,
@@ -73,6 +73,8 @@ from weave.trace.ref_util import (
     set_ref,
 )
 from weave.trace.refs import (
+    AgentSpanRef,
+    AgentTurnRef,
     CallRef,
     ObjectRef,
     OpRef,
@@ -2249,6 +2251,31 @@ class WeaveClient:
             limit=limit,
             show_refs=True,
         )
+
+    def get_agent_span_feedback(self, span_id: str) -> RefFeedbackQuery:
+        """Feedback interface for an agent span (one message in the Agent view).
+
+        Examples:
+            ```python
+            fb = client.get_agent_span_feedback("fad093438c77f8b8")
+            fb.add_reaction("👍")
+            fb.add_note("Great answer")
+            ```
+        """
+        ref = AgentSpanRef(entity=self.entity, project=self.project, span_id=span_id)
+        return RefFeedbackQuery(ref.uri)
+
+    def get_agent_turn_feedback(self, trace_id: str) -> RefFeedbackQuery:
+        """Feedback interface for an agent turn (one user->agent exchange).
+
+        Examples:
+            ```python
+            fb = client.get_agent_turn_feedback("9c5d048e5cda3663428307043c7e0244")
+            fb.add_reaction("👍")
+            ```
+        """
+        ref = AgentTurnRef(entity=self.entity, project=self.project, trace_id=trace_id)
+        return RefFeedbackQuery(ref.uri)
 
     def add_cost(
         self,

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -73,6 +73,7 @@ from weave.trace.ref_util import (
     set_ref,
 )
 from weave.trace.refs import (
+    AgentConversationRef,
     AgentSpanRef,
     AgentTurnRef,
     CallRef,
@@ -2257,7 +2258,7 @@ class WeaveClient:
 
         Examples:
             ```python
-            fb = client.get_agent_span_feedback("fad093438c77f8b8")
+            fb = client.get_agent_span_feedback("<span_id>")
             fb.add_reaction("👍")
             fb.add_note("Great answer")
             ```
@@ -2270,11 +2271,25 @@ class WeaveClient:
 
         Examples:
             ```python
-            fb = client.get_agent_turn_feedback("9c5d048e5cda3663428307043c7e0244")
+            fb = client.get_agent_turn_feedback("<trace_id>")
             fb.add_reaction("👍")
             ```
         """
         ref = AgentTurnRef(entity=self.entity, project=self.project, trace_id=trace_id)
+        return RefFeedbackQuery(ref.uri)
+
+    def get_agent_conversation_feedback(self, conversation_id: str) -> RefFeedbackQuery:
+        """Feedback interface for an agent conversation (a session of turns).
+
+        Examples:
+            ```python
+            fb = client.get_agent_conversation_feedback("<conversation_id>")
+            fb.add_reaction("👍")
+            ```
+        """
+        ref = AgentConversationRef(
+            entity=self.entity, project=self.project, conversation_id=conversation_id
+        )
         return RefFeedbackQuery(ref.uri)
 
     def add_cost(


### PR DESCRIPTION
## Summary
- `client.get_agent_span_feedback(span_id)` / `get_agent_turn_feedback(trace_id)` / `get_agent_conversation_feedback(conversation_id)` return a `RefFeedbackQuery` for agent refs, no more hand-building `weave:///.../agent_span/...` uris
- `add_reaction` on an agent ref now writes `wandb.agent_user_feedback` with scorer_tags (the shape the Agent UI's thumbs write and render) instead of `wandb.reaction.1`, which the agent view ignores; call/object refs unchanged

## Usage
```python
client = weave.init("entity/project")
fb = client.get_agent_span_feedback(span_id)
fb.add_reaction("👍")   # renders as the Agent UI thumbs
fb.add_note("solid answer")
# same interface for turns and conversations
client.get_agent_turn_feedback(trace_id).add_reaction("👍")
```

## Testing
functional test creating span/turn/conversation/call feedback then asserting the full stored rows, both backends

### UI

<img width="1025" height="861" alt="image" src="https://github.com/user-attachments/assets/adc25b53-721c-441b-a8be-8c50f28ddedb" />
