### PR TITLE
chore(weave): rename Turn/SubAgent factory methods to start_*()

### DIFF
--- a/tests/conversation/test_conversation.py
+++ b/tests/conversation/test_conversation.py
@@ -326,16 +326,16 @@ class TestSubAgent:
 
     def test_llm_returns_llm_and_inherits_model(self) -> None:
         sa = SubAgent(name="research-bot", model="gpt-4o-mini")
-        c = sa.llm(model="gpt-4o-mini")
+        c = sa.start_llm(model="gpt-4o-mini")
         assert isinstance(c, LLM)
         assert c.model == "gpt-4o-mini"
         # inherits model when not specified
-        c2 = sa.llm()
+        c2 = sa.start_llm()
         assert c2.model == "gpt-4o-mini"
 
     def test_tool_returns_tool(self) -> None:
         sa = SubAgent(name="bot")
-        t = sa.tool(name="web_search", arguments='{"q":"X"}', tool_call_id="tc_2")
+        t = sa.start_tool(name="web_search", arguments='{"q":"X"}', tool_call_id="tc_2")
         assert isinstance(t, Tool)
         assert t.name == "web_search"
 
@@ -346,10 +346,10 @@ class TestSubAgent:
 
     def test_subagent_with_nested_tools(self) -> None:
         with Turn(agent_name="bot") as turn:
-            with turn.subagent(name="sub") as sa:
-                with sa.tool(name="tool1", arguments='{"x":1}') as t1:
+            with turn.start_subagent(name="sub") as sa:
+                with sa.start_tool(name="tool1", arguments='{"x":1}') as t1:
                     t1.result = "result1"
-                with sa.tool(name="tool2", arguments='{"x":2}') as t2:
+                with sa.start_tool(name="tool2", arguments='{"x":2}') as t2:
                     t2.result = "result2"
         assert t1.result == "result1"
         assert t1.duration_ms >= 0
@@ -379,7 +379,7 @@ class TestTurn:
 
     def test_llm_returns_llm_and_inherits_model(self) -> None:
         t = Turn(model="gpt-4o")
-        c = t.llm(
+        c = t.start_llm(
             model="gpt-4o",
             provider_name="openai",
             system_instructions=["Be helpful"],
@@ -389,12 +389,12 @@ class TestTurn:
         assert c.provider_name == "openai"
         assert c.system_instructions == ["Be helpful"]
         # inherits model when not specified
-        c2 = t.llm()
+        c2 = t.start_llm()
         assert c2.model == "gpt-4o"
 
     def test_tool_returns_tool(self) -> None:
         t = Turn()
-        tool = t.tool(
+        tool = t.start_tool(
             name="get_weather", arguments='{"city":"Tokyo"}', tool_call_id="tc_1"
         )
         assert isinstance(tool, Tool)
@@ -403,12 +403,12 @@ class TestTurn:
 
     def test_subagent_returns_subagent_and_inherits_model(self) -> None:
         t = Turn(model="gpt-4o")
-        sa = t.subagent(name="research-bot", model="gpt-4o-mini")
+        sa = t.start_subagent(name="research-bot", model="gpt-4o-mini")
         assert isinstance(sa, SubAgent)
         assert sa.name == "research-bot"
         assert sa.model == "gpt-4o-mini"
         # inherits model when not specified
-        sa2 = t.subagent(name="bot")
+        sa2 = t.start_subagent(name="bot")
         assert sa2.model == "gpt-4o"
 
     def test_context_manager_sets_timestamps(self) -> None:
@@ -549,16 +549,16 @@ class TestContextVars:
     def test_full_context_manager_pattern(self) -> None:
         with start_conversation(agent_name="weather-bot") as s:
             with s.start_turn(user_message="What's the weather?") as turn:
-                with turn.llm(model="gpt-4o") as llm:
+                with turn.start_llm(model="gpt-4o") as llm:
                     llm.output("Let me check.")
                     llm.usage = Usage(input_tokens=100, output_tokens=50)
-                with turn.tool(
+                with turn.start_tool(
                     name="get_weather",
                     arguments='{"city":"Tokyo"}',
                     tool_call_id="tc_1",
                 ) as tool:
                     tool.result = "75F"
-                with turn.llm(model="gpt-4o") as llm:
+                with turn.start_llm(model="gpt-4o") as llm:
                     llm.output("It's 75F in Tokyo!")
 
         assert get_current_conversation() is None

--- a/tests/conversation/test_conversation_otel.py
+++ b/tests/conversation/test_conversation_otel.py
@@ -1044,7 +1044,7 @@ class TestOTelSpanEmission:
     def test_llm_creates_chat_span(self, otel_spans: InMemorySpanExporter) -> None:
         with Conversation(agent_name="bot", conversation_id="convo-llm") as s:
             with s.start_turn() as turn:
-                with turn.llm(model="gpt-4o", provider_name="openai") as llm:
+                with turn.start_llm(model="gpt-4o", provider_name="openai") as llm:
                     llm.usage = Usage(input_tokens=100, output_tokens=50)
                     llm.output("Hello!")
 
@@ -1065,7 +1065,7 @@ class TestOTelSpanEmission:
     ) -> None:
         with Conversation(agent_name="bot", conversation_id="convo-tool") as s:
             with s.start_turn() as turn:
-                with turn.tool(
+                with turn.start_tool(
                     name="get_weather",
                     arguments='{"city":"Tokyo"}',
                     tool_call_id="tc_1",
@@ -1088,7 +1088,9 @@ class TestOTelSpanEmission:
     ) -> None:
         with Conversation(agent_name="orchestrator") as s:
             with s.start_turn() as turn:
-                with turn.subagent(name="research-bot", model="gpt-4o-mini") as sa:
+                with turn.start_subagent(
+                    name="research-bot", model="gpt-4o-mini"
+                ) as sa:
                     pass
 
         spans = otel_spans.get_finished_spans()
@@ -1106,7 +1108,7 @@ class TestOTelSpanEmission:
     ) -> None:
         with Conversation(agent_name="orchestrator") as s:
             with s.start_turn() as turn:
-                with turn.subagent(
+                with turn.start_subagent(
                     name="research-bot",
                     system_instructions=["You research things"],
                 ):
@@ -1124,9 +1126,9 @@ class TestOTelSpanEmission:
         """LLM and Tool are both children of Turn (flat model)."""
         with Conversation(agent_name="bot") as s:
             with s.start_turn() as turn:
-                with turn.llm(model="gpt-4o") as llm:
+                with turn.start_llm(model="gpt-4o") as llm:
                     llm.output("checking...")
-                with turn.tool(name="search", arguments='{"q":"X"}') as tool:
+                with turn.start_tool(name="search", arguments='{"q":"X"}') as tool:
                     tool.result = "found"
 
         spans = otel_spans.get_finished_spans()
@@ -1158,9 +1160,9 @@ class TestOTelSpanEmission:
         monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", NoOpTracerProvider())
         with Conversation(agent_name="bot") as s:
             with s.start_turn() as turn:
-                with turn.llm(model="gpt-4o") as llm:
+                with turn.start_llm(model="gpt-4o") as llm:
                     llm.output("Hello")
-                with turn.tool(name="search") as tool:
+                with turn.start_tool(name="search") as tool:
                     tool.result = "done"
         # Should not raise — just silently use no-op spans
 
@@ -1169,11 +1171,11 @@ class TestOTelSpanEmission:
     ) -> None:
         with Conversation(agent_name="bot", include_content=False) as s:
             with s.start_turn(user_message="secret input") as turn:
-                with turn.llm(model="gpt-4o") as llm:
+                with turn.start_llm(model="gpt-4o") as llm:
                     llm.input_messages.append(Message(role="user", content="secret"))
                     llm.output("secret output")
                     llm.system_instructions = ["be helpful"]
-                with turn.tool(name="search", arguments='{"q":"secret"}') as tool:
+                with turn.start_tool(name="search", arguments='{"q":"secret"}') as tool:
                     tool.result = "secret result"
 
         spans = otel_spans.get_finished_spans()
@@ -1252,7 +1254,7 @@ class TestErrorRecording:
         with start_conversation(agent_name="bot") as conversation:
             with conversation.start_turn() as turn:
                 try:
-                    with turn.llm(model="gpt-4o") as llm:
+                    with turn.start_llm(model="gpt-4o") as llm:
                         raise ValueError("LLM call failed")
                 except ValueError:
                     pass
@@ -1269,7 +1271,7 @@ class TestErrorRecording:
         with start_conversation(agent_name="bot") as conversation:
             with conversation.start_turn() as turn:
                 try:
-                    with turn.tool(name="search") as tool:
+                    with turn.start_tool(name="search") as tool:
                         raise RuntimeError("tool broke")
                 except RuntimeError:
                     pass
@@ -1300,7 +1302,7 @@ class TestErrorRecording:
         with start_conversation(agent_name="bot") as conversation:
             with conversation.start_turn() as turn:
                 try:
-                    with turn.subagent(name="sub") as sa:
+                    with turn.start_subagent(name="sub") as sa:
                         raise RuntimeError("sub broke")
                 except RuntimeError:
                     pass
@@ -1382,7 +1384,7 @@ class TestStartTimeFromLogicalConstruction:
     ) -> None:
         with start_conversation(agent_name="bot") as s:
             with s.start_turn() as turn:
-                llm = turn.llm(model="gpt-4o")
+                llm = turn.start_llm(model="gpt-4o")
                 assert llm.started_at is not None
                 expected_ns = int(llm.started_at.timestamp() * 1_000_000_000)
                 time.sleep(0.05)
@@ -2290,7 +2292,7 @@ class TestSubAgentRecord:
         """End-to-end: record() values flow through to the OTel attrs."""
         with Conversation(agent_name="orchestrator") as s:
             with s.start_turn() as turn:
-                with turn.subagent(name="research-bot") as sa:
+                with turn.start_subagent(name="research-bot") as sa:
                     sa.record(
                         system_instructions=["You research things"],
                         agent_id="agent-9",

--- a/tests/conversation/test_conversation_settings.py
+++ b/tests/conversation/test_conversation_settings.py
@@ -98,9 +98,9 @@ def test_disabled_streaming_emits_no_spans(otel_spans: InMemorySpanExporter):
             agent_name="a", conversation_id="convo-disabled-streaming"
         ) as s:
             with s.start_turn() as t:
-                with t.llm(model="gpt-4o"):
+                with t.start_llm(model="gpt-4o"):
                     pass
-                with t.tool(name="search"):
+                with t.start_tool(name="search"):
                     pass
     assert otel_spans.get_finished_spans() == ()
 
@@ -151,7 +151,7 @@ def _streaming_tool_with_pii() -> None:
         start_conversation(conversation_id="convo-pii-streaming-tool") as sess,
         sess.start_turn() as t,
     ):
-        with t.tool(name="lookup") as tool:
+        with t.start_tool(name="lookup") as tool:
             tool.arguments = f'{{"email":"{_PII_EMAIL}"}}'
             tool.result = f"found {_PII_EMAIL}"
 
@@ -161,7 +161,7 @@ def _streaming_llm_messages_with_pii() -> None:
         start_conversation(conversation_id="convo-pii-streaming-llm-messages") as sess,
         sess.start_turn() as t,
     ):
-        with t.llm(
+        with t.start_llm(
             model="gpt-4o", system_instructions=[f"contact {_PII_EMAIL}"]
         ) as llm:
             llm.input_messages = [Message(role="user", content=_PII_EMAIL)]
@@ -176,7 +176,7 @@ def _streaming_llm_reasoning_with_pii() -> None:
         start_conversation(conversation_id="convo-pii-streaming-llm-reasoning") as sess,
         sess.start_turn() as t,
     ):
-        with t.llm(model="gpt-4o") as llm:
+        with t.start_llm(model="gpt-4o") as llm:
             llm.reasoning = Reasoning(content=f"think about {_PII_EMAIL}")
             llm.output_messages = [Message(role="assistant", content="ok")]
 
@@ -296,7 +296,7 @@ def _content_off_tool() -> None:
         conversation_id="convo-content-off-tool", include_content=False
     ) as sess:
         with sess.start_turn() as t:
-            with t.tool(name="lookup") as tool:
+            with t.start_tool(name="lookup") as tool:
                 tool.arguments = f'{{"email":"{_PII_EMAIL}"}}'
 
 
@@ -305,7 +305,7 @@ def _content_off_llm() -> None:
         conversation_id="convo-content-off-llm", include_content=False
     ) as sess:
         with sess.start_turn() as t:
-            with t.llm(model="gpt-4o") as llm:
+            with t.start_llm(model="gpt-4o") as llm:
                 llm.input_messages = [Message(role="user", content=_PII_EMAIL)]
                 llm.reasoning = Reasoning(content="think")
 
@@ -357,7 +357,7 @@ def _reasoning_content_off_streaming() -> None:
         conversation_id="convo-reasoning-off-streaming", include_content=False
     ) as sess:
         with sess.start_turn() as t:
-            with t.llm(model="gpt-4o") as llm:
+            with t.start_llm(model="gpt-4o") as llm:
                 llm.reasoning = Reasoning(content="sensitive reasoning")
 
 
@@ -437,7 +437,7 @@ def test_capture_info_settings(
     ):
         with start_conversation(conversation_id="convo-capture-info") as sess:
             with sess.start_turn() as t:
-                with t.tool(name="x"):
+                with t.start_tool(name="x"):
                     pass
 
     spans = otel_spans.get_finished_spans()
@@ -482,7 +482,7 @@ def test_settings_independent(otel_spans: InMemorySpanExporter, fake_presidio: N
             start_conversation(conversation_id="convo-settings-independent") as sess,
             sess.start_turn() as t,
         ):
-            with t.tool(name="lookup") as tool:
+            with t.start_tool(name="lookup") as tool:
                 tool.arguments = _PII_EMAIL
 
     tool_spans = _spans_with_prefix(otel_spans, "execute_tool")
@@ -498,6 +498,6 @@ def test_defaults_skip_redaction(otel_spans: InMemorySpanExporter):
             start_conversation(conversation_id="convo-defaults-skip-redaction") as sess,
             sess.start_turn() as t,
         ):
-            with t.tool(name="x") as tool:
+            with t.start_tool(name="x") as tool:
                 tool.arguments = _PII_EMAIL
     mock_get_engines.assert_not_called()

--- a/tests/conversation/test_deprecation.py
+++ b/tests/conversation/test_deprecation.py
@@ -13,6 +13,7 @@ import importlib
 import pytest
 
 import weave
+from weave.conversation.conversation import LLM, Conversation, SubAgent, Tool, Turn
 
 
 def test_start_session_forwards_and_warns() -> None:
@@ -86,3 +87,24 @@ def test_legacy_import_path_warns_and_reexports() -> None:
     assert legacy.TextPart is TextPart
     assert legacy.start_session is weave.start_session
     assert legacy.Session is weave.Session
+
+
+def test_turn_factory_aliases_warn_and_forward() -> None:
+    """``turn.llm``/``tool``/``subagent`` are deprecated aliases of ``start_*``."""
+    with Conversation(conversation_id="c"), Turn(agent_name="bot") as turn:
+        with pytest.warns(DeprecationWarning, match="start_llm"):
+            assert isinstance(turn.llm(model="gpt-4o"), LLM)
+        with pytest.warns(DeprecationWarning, match="start_tool"):
+            assert isinstance(turn.tool(name="t"), Tool)
+        with pytest.warns(DeprecationWarning, match="start_subagent"):
+            assert isinstance(turn.subagent(name="r"), SubAgent)
+
+
+def test_subagent_factory_aliases_warn_and_forward() -> None:
+    """``sub.llm``/``tool`` are deprecated aliases of ``start_*``."""
+    with Conversation(conversation_id="c"), Turn(agent_name="bot") as turn:
+        with turn.start_subagent(name="r") as sa:
+            with pytest.warns(DeprecationWarning, match="start_llm"):
+                assert isinstance(sa.llm(model="gpt-4o"), LLM)
+            with pytest.warns(DeprecationWarning, match="start_tool"):
+                assert isinstance(sa.tool(name="t"), Tool)

--- a/tests/conversation/test_span_attributes.py
+++ b/tests/conversation/test_span_attributes.py
@@ -196,11 +196,11 @@ def test_conversation_attributes_on_every_streaming_span(
     ) as conversation:
         turn = conversation.start_turn(agent_name="bot")
         with turn:
-            with turn.llm(model="gpt-4o"):
+            with turn.start_llm(model="gpt-4o"):
                 pass
-            with turn.tool(name="Edit"):
+            with turn.start_tool(name="Edit"):
                 pass
-            with turn.subagent(name="researcher"):
+            with turn.start_subagent(name="researcher"):
                 pass
     spans = otel_spans.get_finished_spans()
     names = {span.name for span in spans}

--- a/weave/conversation/conversation.py
+++ b/weave/conversation/conversation.py
@@ -746,7 +746,7 @@ class SubAgent(_SpanBase):
 
     _ended: bool = PrivateAttr(default=False)
 
-    def llm(
+    def start_llm(
         self,
         *,
         model: str = "",
@@ -766,9 +766,35 @@ class SubAgent(_SpanBase):
         llm._token = _current_llm.set(llm)
         return llm
 
-    def tool(self, *, name: str, arguments: str = "", tool_call_id: str = "") -> Tool:
+    def start_tool(
+        self, *, name: str, arguments: str = "", tool_call_id: str = ""
+    ) -> Tool:
         """Start a tool execution within this sub-agent."""
         return Tool(name=name, arguments=arguments, tool_call_id=tool_call_id)
+
+    # Deprecated aliases — the factory methods were renamed to ``start_*`` to
+    # match the module-level ``start_*`` functions.
+    @deprecated("`llm` is deprecated; use `start_llm` instead.")
+    def llm(
+        self,
+        *,
+        model: str = "",
+        provider_name: str = "",
+        system_instructions: list[str] | None = None,
+    ) -> LLM:
+        """Deprecated alias for :meth:`start_llm`."""
+        return self.start_llm(
+            model=model,
+            provider_name=provider_name,
+            system_instructions=system_instructions,
+        )
+
+    @deprecated("`tool` is deprecated; use `start_tool` instead.")
+    def tool(self, *, name: str, arguments: str = "", tool_call_id: str = "") -> Tool:
+        """Deprecated alias for :meth:`start_tool`."""
+        return self.start_tool(
+            name=name, arguments=arguments, tool_call_id=tool_call_id
+        )
 
     def record(
         self,
@@ -913,7 +939,7 @@ class Turn(_SpanBase):
         self.messages.append(Message(role="user", content=content))
         return self
 
-    def llm(
+    def start_llm(
         self,
         *,
         model: str = "",
@@ -933,11 +959,13 @@ class Turn(_SpanBase):
         llm._token = _current_llm.set(llm)
         return llm
 
-    def tool(self, *, name: str, arguments: str = "", tool_call_id: str = "") -> Tool:
+    def start_tool(
+        self, *, name: str, arguments: str = "", tool_call_id: str = ""
+    ) -> Tool:
         """Start a tool execution (execute_tool span, child of this turn)."""
         return Tool(name=name, arguments=arguments, tool_call_id=tool_call_id)
 
-    def subagent(
+    def start_subagent(
         self,
         *,
         name: str,
@@ -949,6 +977,43 @@ class Turn(_SpanBase):
             name=name,
             model=model or self.model,
             system_instructions=system_instructions or [],
+        )
+
+    # Deprecated aliases — the factory methods were renamed to ``start_*`` to
+    # match the module-level ``start_*`` functions.
+    @deprecated("`llm` is deprecated; use `start_llm` instead.")
+    def llm(
+        self,
+        *,
+        model: str = "",
+        provider_name: str = "",
+        system_instructions: list[str] | None = None,
+    ) -> LLM:
+        """Deprecated alias for :meth:`start_llm`."""
+        return self.start_llm(
+            model=model,
+            provider_name=provider_name,
+            system_instructions=system_instructions,
+        )
+
+    @deprecated("`tool` is deprecated; use `start_tool` instead.")
+    def tool(self, *, name: str, arguments: str = "", tool_call_id: str = "") -> Tool:
+        """Deprecated alias for :meth:`start_tool`."""
+        return self.start_tool(
+            name=name, arguments=arguments, tool_call_id=tool_call_id
+        )
+
+    @deprecated("`subagent` is deprecated; use `start_subagent` instead.")
+    def subagent(
+        self,
+        *,
+        name: str,
+        model: str = "",
+        system_instructions: list[str] | None = None,
+    ) -> SubAgent:
+        """Deprecated alias for :meth:`start_subagent`."""
+        return self.start_subagent(
+            name=name, model=model, system_instructions=system_instructions
         )
 
     def record(
@@ -1276,7 +1341,7 @@ def start_llm(
     """
     turn = get_current_turn()
     if turn is not None:
-        return turn.llm(
+        return turn.start_llm(
             model=model,
             provider_name=provider_name,
             system_instructions=system_instructions,


### PR DESCRIPTION
## Summary

Rename the instance factory methods on `Turn` and `SubAgent` — `llm`/`tool`/`subagent` → `start_llm`/`start_tool`/`start_subagent` — to match the module-level `start_*` functions. The old names stay as `@deprecated` aliases that forward to the new ones.

These methods have shipped since **v0.52.38**, so a hard rename would break users; the deprecated aliases keep them working (with a `DeprecationWarning`).

Split out of #7133 per review — the rename is orthogonal to the span-nesting fix there, so #7133 stacks on top of this.

## Test plan
- [x] Full `tests/conversation/` suite green (309); deprecated aliases warn + forward (`test_deprecation.py`).
- [x] `ruff check` / `ruff format` clean.
