### PR TITLE
perf(weave): cache published content refs to dedupe repeat base64 blobs on ingest

### DIFF
--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -15,7 +15,10 @@ from tests.trace_server.conftest_lib.trace_server_external_adapter import (
 from tests.trace_server.workers.evaluate_model_test_worker import (
     EvaluateModelTestDispatcher,
 )
-from weave.trace_server import clickhouse_trace_server_batched
+from weave.trace_server import (
+    base64_content_conversion,
+    clickhouse_trace_server_batched,
+)
 from weave.trace_server import clickhouse_trace_server_migrator as wf_migrator
 from weave.trace_server import (
     clickhouse_trace_server_settings as ch_settings,
@@ -105,6 +108,14 @@ def reset_project_version_cache():
     project_version.reset_project_residence_cache()
     yield
     project_version.reset_project_residence_cache()
+
+
+@pytest.fixture(autouse=True)
+def reset_content_ref_cache():
+    """The module-level published-content ref cache would leak refs across tests."""
+    base64_content_conversion._content_ref_cache.clear()
+    yield
+    base64_content_conversion._content_ref_cache.clear()
 
 
 def _get_worker_db_suffix(request, default: str = "_test") -> str:

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -267,6 +267,82 @@ class TestBase64Replacement:
         assert processed_end.end.output == long_b64
 
 
+class TestContentRefCache:
+    """Repeat blobs reuse the published ref instead of re-running the pipeline."""
+
+    def test_repeat_blobs_reuse_cached_ref(self):
+        """Identical blobs dedupe within a request and across requests, per project."""
+        trace_server = MagicMock()
+        trace_server.file_create = MagicMock(
+            side_effect=[
+                FileCreateRes(digest="content_digest"),
+                FileCreateRes(digest="metadata_digest"),
+            ]
+        )
+        _mock_obj_create(trace_server)
+
+        b64_data = base64.b64encode(b"a" * LARGE_TEST_DATA_SIZE).decode("ascii")
+        data_uri = f"data:image/png;base64,{b64_data}"
+
+        # Within-request: the same blob twice publishes exactly once.
+        result = replace_base64_with_content_objects(
+            {"first": data_uri, "second": [data_uri]}, "proj_a", trace_server
+        )
+        _assert_content_ref(result["first"], "proj_a")
+        assert result["second"][0] == result["first"]
+        assert trace_server.file_create.call_count == 2
+        assert trace_server.obj_create.call_count == 1
+
+        # Cross-request, same project: served from cache with no server work.
+        fresh_server = MagicMock()
+        cached = replace_base64_with_content_objects(
+            {"img": data_uri}, "proj_a", fresh_server
+        )
+        assert cached["img"] == result["first"]
+        fresh_server.file_create.assert_not_called()
+        fresh_server.obj_create.assert_not_called()
+
+        # Different project: the key is project-scoped, so it publishes again.
+        other_server = MagicMock()
+        other_server.file_create = MagicMock(
+            side_effect=[
+                FileCreateRes(digest="content_digest_b"),
+                FileCreateRes(digest="metadata_digest_b"),
+            ]
+        )
+        _mock_obj_create(other_server)
+        other = replace_base64_with_content_objects(
+            {"img": data_uri}, "proj_b", other_server
+        )
+        _assert_content_ref(other["img"], "proj_b")
+        assert other_server.obj_create.call_count == 1
+
+    def test_failed_publish_is_not_cached(self):
+        """A failed publish leaves the value inline and does not poison the cache."""
+        b64_data = base64.b64encode(b"b" * LARGE_TEST_DATA_SIZE).decode("ascii")
+        data_uri = f"data:image/png;base64,{b64_data}"
+
+        broken_server = MagicMock()
+        broken_server.file_create = MagicMock(side_effect=RuntimeError("bucket down"))
+        unchanged = replace_base64_with_content_objects(
+            {"img": data_uri}, "proj_fail", broken_server
+        )
+        assert unchanged["img"] == data_uri
+
+        working_server = MagicMock()
+        working_server.file_create = MagicMock(
+            side_effect=[
+                FileCreateRes(digest="content_digest"),
+                FileCreateRes(digest="metadata_digest"),
+            ]
+        )
+        _mock_obj_create(working_server)
+        result = replace_base64_with_content_objects(
+            {"img": data_uri}, "proj_fail", working_server
+        )
+        _assert_content_ref(result["img"], "proj_fail")
+
+
 class TestStandaloneBase64Detection:
     """Test detection and conversion of standalone base64 strings (new functionality)."""
 

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -4,10 +4,14 @@ This module handles automatic detection and replacement of base64 encoded conten
 with content objects stored in bucket storage.
 """
 
+import hashlib
 import json
 import logging
 import re
+import threading
 from typing import Any, TypeVar
+
+from cachetools import LRUCache
 
 from weave.shared.refs_internal import InternalObjectRef
 from weave.trace_server.content.content import Content
@@ -44,6 +48,30 @@ BASE64_PATTERN = re.compile(r"^[A-Za-z0-9+/]+={0,2}$")
 # fall below 8 KiB now stay inline in ClickHouse, which is the pre-feature
 # behaviour and is handled correctly by the existing storage path.
 AUTO_CONVERSION_MIN_SIZE = 8192  # 8 KiB
+
+# Per-pod memo of published content refs keyed by (project_id, sha256 of the raw
+# base64/data-URI string). Agent payloads re-send the same blobs on every chat
+# turn (e.g. screenshot history); a hit skips the decode, both file uploads, and
+# the obj_create insert entirely and returns the previously published ref.
+CONTENT_REF_CACHE_SIZE = 100_000
+_content_ref_cache: LRUCache[tuple[str, str], str] = LRUCache(
+    maxsize=CONTENT_REF_CACHE_SIZE
+)
+_content_ref_cache_lock = threading.Lock()
+
+
+def _content_ref_cache_key(project_id: str, raw_val: str) -> tuple[str, str]:
+    return (project_id, hashlib.sha256(raw_val.encode("utf-8")).hexdigest())
+
+
+def _content_ref_cache_get(key: tuple[str, str]) -> str | None:
+    with _content_ref_cache_lock:
+        return _content_ref_cache.get(key)
+
+
+def _content_ref_cache_put(key: tuple[str, str], ref: str) -> None:
+    with _content_ref_cache_lock:
+        _content_ref_cache[key] = ref
 
 
 def is_base64(value: str) -> bool:
@@ -200,9 +228,12 @@ def replace_base64_with_content_objects(
         if isinstance(val, str) and len(val) > AUTO_CONVERSION_MIN_SIZE:
             # Check for data URI pattern first
             if is_data_uri(val):
+                cache_key = _content_ref_cache_key(project_id, val)
+                if (cached := _content_ref_cache_get(cache_key)) is not None:
+                    return cached
                 try:
                     # Publish the content and replace the base64 with its ref.
-                    return store_content_object_ref(
+                    ref = store_content_object_ref(
                         Content.from_data_url(val),
                         project_id,
                         trace_server,
@@ -213,8 +244,14 @@ def replace_base64_with_content_objects(
                         "Failed to create and store content from data URI with error %s",
                         e,
                     )
+                else:
+                    _content_ref_cache_put(cache_key, ref)
+                    return ref
 
             if is_base64(val):
+                cache_key = _content_ref_cache_key(project_id, val)
+                if (cached := _content_ref_cache_get(cache_key)) is not None:
+                    return cached
                 try:
                     # All we care about here is if this is an object that we can handle in some way.
                     # 'aaaa' is valid base64 and will come out as text/plain
@@ -226,12 +263,14 @@ def replace_base64_with_content_objects(
                         "text/plain",
                         "application/octet-stream",
                     }:
-                        return store_content_object_ref(
+                        ref = store_content_object_ref(
                             content,
                             project_id,
                             trace_server,
                             wb_user_id,
                         )
+                        _content_ref_cache_put(cache_key, ref)
+                        return ref
                 except Exception as e:
                     logger.warning(
                         "Failed to create content from standalone base64: %s", e


### PR DESCRIPTION
## Summary
- since #7489, ingest publishes every inline base64/data-URI blob >8KiB as a Content object; agent payloads re-send the same screenshots in every chat turn, so a single 24-call `calls/complete` batch ran 228 obj_create pipelines (object_versions/aliases insert rates now track calls 1:1 in prod)
- add a per-pod LRU keyed `(project_id, sha256(raw string))` -> published ref: a hit skips the base64 decode, both file uploads, and the obj_create/alias inserts, deduping both within a request and across requests
- failed publishes are not cached; bare-base64 strings rejected by the mimetype filter are also not cached (they stay inline)

## Testing
unit tests for within-request, cross-request, cross-project, and failed-publish cases; autouse cache reset in the trace_server conftest mirrors `reset_project_version_cache`

## QA validation (zoo-qa)
A/B on QA (`weave-trace.qa.wandb.ai`), same driver both builds: one `calls/complete` batch of 20 calls, each embedding the same >8KiB base64 PNG in `inputs` and `output` (40 occurrences/request), fired twice per build.

| build | request | obj_create spans | root `@duration` |
|---|---|---|---|
| master `8e02f41` | 1st | 40 ([trace](https://us5.datadoghq.com/apm/trace/96f617ec31dbd37dd31668966efac426)) | 19.7s |
| master `8e02f41` | repeat | 40 ([trace](https://us5.datadoghq.com/apm/trace/d0e92fac83d02ae51a9bb8ac1d2ea7f9)) | 20.2s |
| PR `62c7ff3` (pin) | 1st | 1 ([trace](https://us5.datadoghq.com/apm/trace/ca0a899f000334a6a12763cb606b16c2)) | 1.9s |
| PR `62c7ff3` (pin) | repeat | 1 ([trace](https://us5.datadoghq.com/apm/trace/ba5278189da4b46fd1ad02b48dfc29b3)) | 1.3s |

- correctness: read-back shows both fields resolved to the identical published Content ref; no double-publish
- errors: zero new error classes vs master (only mis-leveled uvicorn startup INFO from the rollout)
- caveat: the LRU is per uvicorn worker process (QA runs 2 workers/pod), so cross-request hits are probabilistic (~1/(replicas*workers)); a 6-request burst showed hits (0 stores, ~300-440ms) interleaved with misses. The motivating within-request case is deterministic: 40 -> 1 every run.
