### PR TITLE
perf(weave): batch content object inserts in calls_complete

### DIFF
--- a/tests/trace_server/query_builder/test_objects_query_builder.py
+++ b/tests/trace_server/query_builder/test_objects_query_builder.py
@@ -493,14 +493,14 @@ def test_make_objects_val_query_and_parameters():
 
 def test_make_obj_name_type_collision_query():
     query, parameters = make_obj_name_type_collision_query(
-        project_id="test_project", object_id="object_1", kind="object"
+        project_id="test_project", object_ids=["object_1"], kind="object"
     )
 
     expected_query = """
-        SELECT DISTINCT base_object_class
+        SELECT DISTINCT object_id, base_object_class
         FROM object_versions
         WHERE project_id = {project_id: String}
-            AND object_id = {object_id: String}
+            AND object_id IN {object_ids: Array(String)}
             AND kind = {kind: String}
             AND deleted_at IS NULL
     """
@@ -508,6 +508,28 @@ def test_make_obj_name_type_collision_query():
     assert_sql(query, expected_query)
     assert parameters == {
         "project_id": "test_project",
-        "object_id": "object_1",
+        "object_ids": ["object_1"],
+        "kind": "object",
+    }
+
+
+def test_make_obj_name_type_collision_query_multiple_object_ids():
+    query, parameters = make_obj_name_type_collision_query(
+        project_id="test_project", object_ids=["object_1", "object_2"], kind="object"
+    )
+
+    expected_query = """
+        SELECT DISTINCT object_id, base_object_class
+        FROM object_versions
+        WHERE project_id = {project_id: String}
+            AND object_id IN {object_ids: Array(String)}
+            AND kind = {kind: String}
+            AND deleted_at IS NULL
+    """
+
+    assert_sql(query, expected_query)
+    assert parameters == {
+        "project_id": "test_project",
+        "object_ids": ["object_1", "object_2"],
         "kind": "object",
     }

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -10,6 +10,7 @@ from tests.trace.server_utils import find_server_layer
 from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from tests.trace_server.conftest import TEST_ENTITY
 from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
+from weave.shared import refs_internal as ri
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
@@ -18,6 +19,7 @@ from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceSe
 from weave.trace_server.errors import (
     CallsCompleteModeRequired,
     NotFoundError,
+    ObjectNameTypeCollision,
     RequestTooLarge,
 )
 from weave.trace_server.orm import ParamBuilder
@@ -651,6 +653,188 @@ def test_calls_complete_converts_data_uri_inputs_and_outputs(
     assert fetched_call.inputs["image"].startswith(f"weave:///{project_id}/object/")
     assert isinstance(fetched_call.output["image"], str)
     assert fetched_call.output["image"].startswith(f"weave:///{project_id}/object/")
+
+
+def test_calls_complete_batches_content_object_inserts(
+    trace_server, clickhouse_trace_server, monkeypatch
+):
+    """A batch of object-heavy calls writes content objects once per project.
+
+    Duplicate content across calls in the batch collapses to the same ref,
+    and the whole batch issues exactly one insert into object_versions and
+    one into aliases instead of one pair of inserts per object.
+    """
+    project_id = f"{TEST_ENTITY}/calls_complete_batched_objects"
+    internal_project_id = b64(project_id)
+
+    raw_a = b"a" * (AUTO_CONVERSION_MIN_SIZE + 10)
+    raw_b = b"b" * (AUTO_CONVERSION_MIN_SIZE + 10)
+    data_uri_a = f"data:image/png;base64,{base64.b64encode(raw_a).decode('ascii')}"
+    data_uri_b = f"data:image/png;base64,{base64.b64encode(raw_b).decode('ascii')}"
+
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+    ended_at = started_at + datetime.timedelta(seconds=1)
+    call_1_id, call_2_id, call_3_id = (str(uuid.uuid4()) for _ in range(3))
+    calls = [
+        _make_completed_call(
+            project_id,
+            call_1_id,
+            str(uuid.uuid4()),
+            started_at,
+            ended_at,
+            inputs={"image": data_uri_a},
+            output={"image": data_uri_a},
+        ),
+        _make_completed_call(
+            project_id,
+            call_2_id,
+            str(uuid.uuid4()),
+            started_at,
+            ended_at,
+            inputs={"image": data_uri_a},
+        ),
+        _make_completed_call(
+            project_id,
+            call_3_id,
+            str(uuid.uuid4()),
+            started_at,
+            ended_at,
+            inputs={"image": data_uri_b},
+        ),
+    ]
+
+    insert_tables = []
+    original_insert = clickhouse_trace_server._insert
+
+    def _spy_insert(table, *args, **kwargs):
+        insert_tables.append(table)
+        return original_insert(table, *args, **kwargs)
+
+    monkeypatch.setattr(clickhouse_trace_server, "_insert", _spy_insert)
+
+    trace_server.calls_complete(tsi.CallsUpsertCompleteReq(batch=calls))
+
+    assert insert_tables.count("object_versions") == 1
+    assert insert_tables.count("aliases") == 1
+    assert (
+        _count_project_rows(
+            clickhouse_trace_server.ch_client, "object_versions", internal_project_id
+        )
+        == 2
+    )
+    assert (
+        _count_project_rows(
+            clickhouse_trace_server.ch_client, "aliases", internal_project_id
+        )
+        == 2
+    )
+
+    inputs_1, output_1 = _fetch_call_dumps(
+        clickhouse_trace_server.ch_client,
+        "calls_complete",
+        internal_project_id,
+        call_1_id,
+    )
+    inputs_2, _ = _fetch_call_dumps(
+        clickhouse_trace_server.ch_client,
+        "calls_complete",
+        internal_project_id,
+        call_2_id,
+    )
+    inputs_3, _ = _fetch_call_dumps(
+        clickhouse_trace_server.ch_client,
+        "calls_complete",
+        internal_project_id,
+        call_3_id,
+    )
+
+    ref_a_input = inputs_1["image"]
+    ref_a_output = output_1["image"]
+    ref_a_dup = inputs_2["image"]
+    ref_b = inputs_3["image"]
+
+    assert ref_a_input.startswith(
+        f"weave-trace-internal:///{internal_project_id}/object/"
+    )
+    assert ref_a_input == ref_a_output == ref_a_dup
+    assert ref_b != ref_a_input
+
+    parsed_a = ri.parse_internal_uri(ref_a_input)
+    parsed_b = ri.parse_internal_uri(ref_b)
+    obj_a = clickhouse_trace_server.obj_read(
+        tsi.ObjReadReq(
+            project_id=parsed_a.project_id,
+            object_id=parsed_a.name,
+            digest=parsed_a.version,
+        )
+    )
+    obj_b = clickhouse_trace_server.obj_read(
+        tsi.ObjReadReq(
+            project_id=parsed_b.project_id,
+            object_id=parsed_b.name,
+            digest=parsed_b.version,
+        )
+    )
+    assert obj_a.obj.val["_type"] == "CustomWeaveType"
+    assert obj_a.obj.val["weave_type"] == {
+        "type": "weave.type_wrappers.Content.content.Content"
+    }
+    assert obj_b.obj.val["_type"] == "CustomWeaveType"
+    assert obj_a.obj.val != obj_b.obj.val
+
+
+def test_obj_create_batch_check_name_collisions(trace_server, clickhouse_trace_server):
+    """check_name_collisions=True runs the WB-30574 name/type guard in one
+    batched query and matches obj_create's per-object rejection; the OTel
+    default (check_name_collisions=False) skips the guard entirely.
+    """
+    project_id = f"{TEST_ENTITY}/obj_create_batch_collision"
+    internal_project_id = b64(project_id)
+
+    trace_server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=project_id,
+                object_id="shared_name",
+                val={"_bases": ["Object", "BaseModel"], "_class_name": "TypeA"},
+            )
+        )
+    )
+
+    # A fresh object_id in the same batched call is unaffected.
+    clickhouse_trace_server.obj_create_batch(
+        [
+            tsi.ObjSchemaForInsert(
+                project_id=internal_project_id,
+                object_id="fresh_name",
+                val={"_bases": ["Object", "BaseModel"], "_class_name": "TypeB"},
+            )
+        ],
+        check_name_collisions=True,
+    )
+
+    with pytest.raises(ObjectNameTypeCollision):
+        clickhouse_trace_server.obj_create_batch(
+            [
+                tsi.ObjSchemaForInsert(
+                    project_id=internal_project_id,
+                    object_id="shared_name",
+                    val={"_bases": ["Object", "BaseModel"], "_class_name": "TypeC"},
+                )
+            ],
+            check_name_collisions=True,
+        )
+
+    # Default (OTel ingest path) skips the guard entirely.
+    clickhouse_trace_server.obj_create_batch(
+        [
+            tsi.ObjSchemaForInsert(
+                project_id=internal_project_id,
+                object_id="shared_name",
+                val={"_bases": ["Object", "BaseModel"], "_class_name": "TypeC"},
+            )
+        ]
+    )
 
 
 def test_call_start_end_v2_updates_calls_complete(

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -19,7 +19,6 @@ from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceSe
 from weave.trace_server.errors import (
     CallsCompleteModeRequired,
     NotFoundError,
-    ObjectNameTypeCollision,
     RequestTooLarge,
 )
 from weave.trace_server.orm import ParamBuilder
@@ -785,66 +784,13 @@ def test_calls_complete_batches_content_object_inserts(
     assert obj_a.obj.val != obj_b.obj.val
 
 
-def test_obj_create_batch_check_name_collisions(trace_server, clickhouse_trace_server):
-    """check_name_collisions=True runs the WB-30574 name/type guard in one
-    batched query and matches obj_create's per-object rejection; the OTel
-    default (check_name_collisions=False) skips the guard entirely.
-    """
-    project_id = f"{TEST_ENTITY}/obj_create_batch_collision"
-    internal_project_id = b64(project_id)
-
-    trace_server.obj_create(
-        tsi.ObjCreateReq(
-            obj=tsi.ObjSchemaForInsert(
-                project_id=project_id,
-                object_id="shared_name",
-                val={"_bases": ["Object", "BaseModel"], "_class_name": "TypeA"},
-            )
-        )
-    )
-
-    # A fresh object_id in the same batched call is unaffected.
-    clickhouse_trace_server.obj_create_batch(
-        [
-            tsi.ObjSchemaForInsert(
-                project_id=internal_project_id,
-                object_id="fresh_name",
-                val={"_bases": ["Object", "BaseModel"], "_class_name": "TypeB"},
-            )
-        ],
-        check_name_collisions=True,
-    )
-
-    with pytest.raises(ObjectNameTypeCollision):
-        clickhouse_trace_server.obj_create_batch(
-            [
-                tsi.ObjSchemaForInsert(
-                    project_id=internal_project_id,
-                    object_id="shared_name",
-                    val={"_bases": ["Object", "BaseModel"], "_class_name": "TypeC"},
-                )
-            ],
-            check_name_collisions=True,
-        )
-
-    # Default (OTel ingest path) skips the guard entirely.
-    clickhouse_trace_server.obj_create_batch(
-        [
-            tsi.ObjSchemaForInsert(
-                project_id=internal_project_id,
-                object_id="shared_name",
-                val={"_bases": ["Object", "BaseModel"], "_class_name": "TypeC"},
-            )
-        ]
-    )
-
-
 def test_calls_complete_tolerates_content_object_name_collision(
     trace_server, clickhouse_trace_server
 ):
     """A content object whose object_id is already bound to a different
-    base_object_class is skipped with a dangling ref; the calls and the
-    batch's other content objects still land.
+    base_object_class is skipped: its calls keep the original inline data
+    URI (no dangling ref), the batch's other content objects still land,
+    and the skipped ref is never published to the content-ref cache.
     """
     seed_project_id = f"{TEST_ENTITY}/calls_complete_collision_seed"
     project_id = f"{TEST_ENTITY}/calls_complete_collision"
@@ -929,19 +875,11 @@ def test_calls_complete_tolerates_content_object_name_collision(
         internal_project_id,
         call_b_id,
     )
-    parsed_a = ri.parse_internal_uri(inputs_a["image"])
-    parsed_b = ri.parse_internal_uri(inputs_b["image"])
-    assert parsed_a.name == content_object_id_a
 
-    # The colliding object was skipped (its ref dangles); the other landed.
-    with pytest.raises(NotFoundError):
-        clickhouse_trace_server.obj_read(
-            tsi.ObjReadReq(
-                project_id=parsed_a.project_id,
-                object_id=parsed_a.name,
-                digest=parsed_a.version,
-            )
-        )
+    # The colliding object was skipped and its call keeps the original
+    # inline value verbatim; the other content object landed and resolves.
+    assert inputs_a["image"] == data_uri_a
+    parsed_b = ri.parse_internal_uri(inputs_b["image"])
     obj_b = clickhouse_trace_server.obj_read(
         tsi.ObjReadReq(
             project_id=parsed_b.project_id,
@@ -957,6 +895,32 @@ def test_calls_complete_tolerates_content_object_name_collision(
         )
         == 2
     )
+
+    # The skipped ref was never published to the content-ref cache: a later
+    # batch with the same payload restores inline again instead of embedding
+    # a cached ref that resolves to nothing.
+    call_c_id = str(uuid.uuid4())
+    trace_server.calls_complete(
+        tsi.CallsUpsertCompleteReq(
+            batch=[
+                _make_completed_call(
+                    project_id,
+                    call_c_id,
+                    str(uuid.uuid4()),
+                    started_at,
+                    ended_at,
+                    inputs={"image": data_uri_a},
+                )
+            ]
+        )
+    )
+    inputs_c, _ = _fetch_call_dumps(
+        clickhouse_trace_server.ch_client,
+        "calls_complete",
+        internal_project_id,
+        call_c_id,
+    )
+    assert inputs_c["image"] == data_uri_a
 
 
 def test_call_start_end_v2_updates_calls_complete(

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -837,6 +837,126 @@ def test_obj_create_batch_check_name_collisions(trace_server, clickhouse_trace_s
     )
 
 
+def test_calls_complete_tolerates_content_object_name_collision(
+    trace_server, clickhouse_trace_server
+):
+    """A content object whose object_id is already bound to a different
+    base_object_class is skipped with a dangling ref; the calls and the
+    batch's other content objects still land.
+    """
+    seed_project_id = f"{TEST_ENTITY}/calls_complete_collision_seed"
+    project_id = f"{TEST_ENTITY}/calls_complete_collision"
+    internal_project_id = b64(project_id)
+
+    raw_a = b"a" * (AUTO_CONVERSION_MIN_SIZE + 10)
+    raw_b = b"b" * (AUTO_CONVERSION_MIN_SIZE + 10)
+    data_uri_a = f"data:image/png;base64,{base64.b64encode(raw_a).decode('ascii')}"
+    data_uri_b = f"data:image/png;base64,{base64.b64encode(raw_b).decode('ascii')}"
+
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+    ended_at = started_at + datetime.timedelta(seconds=1)
+
+    # Learn the deterministic content object_id for payload a in a seed project.
+    seed_call_id = str(uuid.uuid4())
+    trace_server.calls_complete(
+        tsi.CallsUpsertCompleteReq(
+            batch=[
+                _make_completed_call(
+                    seed_project_id,
+                    seed_call_id,
+                    str(uuid.uuid4()),
+                    started_at,
+                    ended_at,
+                    inputs={"image": data_uri_a},
+                )
+            ]
+        )
+    )
+    seed_inputs, _ = _fetch_call_dumps(
+        clickhouse_trace_server.ch_client,
+        "calls_complete",
+        b64(seed_project_id),
+        seed_call_id,
+    )
+    content_object_id_a = ri.parse_internal_uri(seed_inputs["image"]).name
+
+    # Bind that object_id to a different base_object_class in the target project.
+    trace_server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=project_id,
+                object_id=content_object_id_a,
+                val={"_bases": ["Object", "BaseModel"], "_class_name": "TypeA"},
+            )
+        )
+    )
+
+    call_a_id, call_b_id = str(uuid.uuid4()), str(uuid.uuid4())
+    trace_server.calls_complete(
+        tsi.CallsUpsertCompleteReq(
+            batch=[
+                _make_completed_call(
+                    project_id,
+                    call_a_id,
+                    str(uuid.uuid4()),
+                    started_at,
+                    ended_at,
+                    inputs={"image": data_uri_a},
+                ),
+                _make_completed_call(
+                    project_id,
+                    call_b_id,
+                    str(uuid.uuid4()),
+                    started_at,
+                    ended_at,
+                    inputs={"image": data_uri_b},
+                ),
+            ]
+        )
+    )
+
+    inputs_a, _ = _fetch_call_dumps(
+        clickhouse_trace_server.ch_client,
+        "calls_complete",
+        internal_project_id,
+        call_a_id,
+    )
+    inputs_b, _ = _fetch_call_dumps(
+        clickhouse_trace_server.ch_client,
+        "calls_complete",
+        internal_project_id,
+        call_b_id,
+    )
+    parsed_a = ri.parse_internal_uri(inputs_a["image"])
+    parsed_b = ri.parse_internal_uri(inputs_b["image"])
+    assert parsed_a.name == content_object_id_a
+
+    # The colliding object was skipped (its ref dangles); the other landed.
+    with pytest.raises(NotFoundError):
+        clickhouse_trace_server.obj_read(
+            tsi.ObjReadReq(
+                project_id=parsed_a.project_id,
+                object_id=parsed_a.name,
+                digest=parsed_a.version,
+            )
+        )
+    obj_b = clickhouse_trace_server.obj_read(
+        tsi.ObjReadReq(
+            project_id=parsed_b.project_id,
+            object_id=parsed_b.name,
+            digest=parsed_b.version,
+        )
+    )
+    assert obj_b.obj.val["_type"] == "CustomWeaveType"
+    # object_versions holds the seeded user object plus content object b only.
+    assert (
+        _count_project_rows(
+            clickhouse_trace_server.ch_client, "object_versions", internal_project_id
+        )
+        == 2
+    )
+
+
 def test_call_start_end_v2_updates_calls_complete(
     trace_server, clickhouse_trace_server
 ):

--- a/tests/trace_server/test_clickhouse_batching.py
+++ b/tests/trace_server/test_clickhouse_batching.py
@@ -92,10 +92,16 @@ def test_clickhouse_batching():
         # Use properly base64 encoded project_id (entity/project format)
         project_id = base64.b64encode(b"test_entity/test_project").decode("utf-8")
 
-        # Simulate a legacy project by returning merged-only residence.
-        mock_query_result = MagicMock()
-        mock_query_result.result_rows = [[0, 1]]  # has_complete=0, has_merged=1
-        mock_ch_client.query.return_value = mock_query_result
+        # Simulate a legacy project by returning merged-only residence; the
+        # WB-30574 collision query must see no rows (fresh object_ids), like
+        # a real DB, or every content obj_create would be rejected.
+        residence_result = MagicMock()
+        residence_result.result_rows = [[0, 1]]  # has_complete=0, has_merged=1
+        empty_result = MagicMock()
+        empty_result.result_rows = []
+        mock_ch_client.query.side_effect = lambda sql, *args, **kwargs: (
+            empty_result if "base_object_class" in sql else residence_result
+        )
 
         # Create a batch of call start requests
         batch_req = tsi.CallCreateBatchReq(
@@ -154,25 +160,14 @@ def test_clickhouse_batching():
         # Execute the batch
         trace_server.call_start_batch(batch_req)
 
-        # THE KEY ASSERTION:
-        # Verify that there are exactly 2 inserts:
-        # 1 for files and 1 for call_parts (order may vary)
-        insert_call_count = mock_ch_client.insert.call_count
-        assert insert_call_count == 2, (
-            f"Expected exactly 2 ClickHouse insert calls for 3 batched calls "
-            f"(and 3 base64 content objects, which are stored in files), "
-            f"but got {insert_call_count} insert calls"
-        )
-
-        # Check that both files and call_parts were inserted (order may vary)
-        insert_tables = [
-            mock_ch_client.insert.call_args_list[0][0][0],
-            mock_ch_client.insert.call_args_list[1][0][0],
-        ]
-        assert set(insert_tables) == {"files", "call_parts"}, (
-            f"Expected inserts to files and call_parts tables, "
-            f"but got inserts to: {insert_tables}"
-        )
+        # THE KEY ASSERTION: one batched files insert and one batched
+        # call_parts insert for the whole request. The 3 distinct content
+        # objects each publish via obj_create (unbatched on this path), so
+        # object_versions and aliases get one insert per object.
+        insert_tables = [call[0][0] for call in mock_ch_client.insert.call_args_list]
+        assert sorted(insert_tables) == sorted(
+            ["files", "call_parts"] + ["object_versions", "aliases"] * 3
+        ), f"Unexpected inserts: {insert_tables}"
 
 
 def test_clickhouse_batching_deduplicates_identical_files():
@@ -188,9 +183,13 @@ def test_clickhouse_batching_deduplicates_identical_files():
         trace_server = ClickHouseTraceServer(host="test_host")
         project_id = base64.b64encode(b"test_entity/test_project").decode("utf-8")
 
-        mock_query_result = MagicMock()
-        mock_query_result.result_rows = [[0, 1]]
-        mock_ch_client.query.return_value = mock_query_result
+        residence_result = MagicMock()
+        residence_result.result_rows = [[0, 1]]
+        empty_result = MagicMock()
+        empty_result.result_rows = []
+        mock_ch_client.query.side_effect = lambda sql, *args, **kwargs: (
+            empty_result if "base_object_class" in sql else residence_result
+        )
 
         # 3 calls with the SAME content
         same_content = "IDENTICAL CONTENT"
@@ -199,8 +198,12 @@ def test_clickhouse_batching_deduplicates_identical_files():
         )
         trace_server.call_start_batch(batch_req)
 
+        # Dedup collapses the object too: one object_versions + aliases pair
+        # for the single unique content object, alongside the batched inserts.
         insert_tables = [call[0][0] for call in mock_ch_client.insert.call_args_list]
-        assert set(insert_tables) == {"files", "call_parts"}
+        assert sorted(insert_tables) == sorted(
+            ["files", "call_parts", "object_versions", "aliases"]
+        ), f"Unexpected inserts: {insert_tables}"
 
         # The files insert should contain chunks for only 1 unique file
         # (content + metadata), not 3 copies.

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -76,28 +76,74 @@ def _content_ref_cache_put(key: tuple[str, str], ref: str) -> None:
         _content_ref_cache[key] = ref
 
 
-def _content_ref_cache_pop(key: tuple[str, str]) -> None:
-    with _content_ref_cache_lock:
-        _content_ref_cache.pop(key, None)
+def _lookup_content_ref(
+    cache_key: tuple[str, str], pending_objs: "PendingContentObjs | None"
+) -> str | None:
+    """Known ref for this content: the global cache of published refs first,
+    then this request's queued-but-uncommitted objects.
+    """
+    if (cached := _content_ref_cache_get(cache_key)) is not None:
+        return cached
+    if pending_objs is not None:
+        return pending_objs.get_ref(cache_key)
+    return None
+
+
+@dataclass
+class _PendingContentEntry:
+    project_id: str
+    object_id: str
+    cache_key: tuple[str, str]
+    ref: str
+    raw_val: str
 
 
 @dataclass
 class PendingContentObjs:
-    """Content objects queued for one batched write, with the ref-cache keys
-    each object populated so a failed or skipped write can evict its refs.
+    """Content objects queued for one batched write.
+
+    Tracks enough per object to dedupe repeats of the same content within the
+    batch (`get_ref`), publish the global ref cache only once the whole batch
+    has committed (`publish_refs`), and restore the original raw value
+    wherever a skipped object's ref was embedded (`restore_map`).
     """
 
     objs: list[ObjSchemaForInsert] = field(default_factory=list)
-    _cache_keys: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
+    _entries: list[_PendingContentEntry] = field(default_factory=list)
+    _ref_by_cache_key: dict[tuple[str, str], str] = field(default_factory=dict)
+    _skipped: set[tuple[str, str]] = field(default_factory=set)
 
-    def add(self, obj: ObjSchemaForInsert, cache_key: tuple[str, str] | None) -> None:
+    def add(self, obj: ObjSchemaForInsert, ref: str, raw_val: str) -> None:
+        cache_key = _content_ref_cache_key(obj.project_id, raw_val)
         self.objs.append(obj)
-        if cache_key is not None:
-            self._cache_keys.setdefault(obj.object_id, []).append(cache_key)
+        self._entries.append(
+            _PendingContentEntry(obj.project_id, obj.object_id, cache_key, ref, raw_val)
+        )
+        self._ref_by_cache_key[cache_key] = ref
 
-    def evict_cached_refs(self, object_id: str) -> None:
-        for key in self._cache_keys.pop(object_id, []):
-            _content_ref_cache_pop(key)
+    def get_ref(self, cache_key: tuple[str, str]) -> str | None:
+        return self._ref_by_cache_key.get(cache_key)
+
+    def mark_skipped(self, project_id: str, object_id: str) -> None:
+        self._skipped.add((project_id, object_id))
+
+    def restore_map(self) -> dict[str, str]:
+        """Refs of skipped objects mapped to the raw values they replaced."""
+        return {
+            e.ref: e.raw_val
+            for e in self._entries
+            if (e.project_id, e.object_id) in self._skipped
+        }
+
+    def publish_refs(self) -> None:
+        """Publish non-skipped refs to the global cache.
+
+        Call only after the batch has fully committed (objects, files, and
+        calls): a cache hit must always mean the ref resolves.
+        """
+        for e in self._entries:
+            if (e.project_id, e.object_id) not in self._skipped:
+                _content_ref_cache_put(e.cache_key, e.ref)
 
 
 def is_base64(value: str) -> bool:
@@ -174,7 +220,7 @@ def store_content_object_ref(
     trace_server: TraceServerInterface,
     wb_user_id: str | None = None,
     pending_objs: PendingContentObjs | None = None,
-    cache_key: tuple[str, str] | None = None,
+    raw_val: str | None = None,
 ) -> str:
     """Store a Content object, publish it, and return its internal weave ref.
 
@@ -184,37 +230,44 @@ def store_content_object_ref(
     the inline object. The version is the server-computed object digest, so
     identical content dedupes to the same ref.
 
-    When ``pending_objs`` is given, the object is appended to it instead of
+    When ``pending_objs`` is given, the object is queued there instead of
     being written via ``obj_create`` immediately, so a caller can batch many
-    objects into one insert.
+    objects into one insert. ``raw_val`` (required in that mode) is the
+    original string being replaced, kept so a skipped write can restore it.
     """
     obj_val = store_content_object(content_obj, project_id, trace_server)
     object_id = make_object_id(content_obj.filename, "content")
     if pending_objs is not None:
-        digest_result = compute_object_digest_result(obj_val, None)
+        if raw_val is None:
+            raise ValueError("raw_val is required when queueing into pending_objs")
+        digest = compute_object_digest_result(obj_val, None).digest
+        ref = _content_ref(project_id, object_id, digest)
         pending_objs.add(
             ObjSchemaForInsert(
                 project_id=project_id,
                 object_id=object_id,
                 val=obj_val,
                 wb_user_id=wb_user_id,
-                expected_digest=digest_result.digest,
+                expected_digest=digest,
             ),
-            cache_key,
+            ref,
+            raw_val,
         )
-        digest = digest_result.digest
-    else:
-        res = trace_server.obj_create(
-            ObjCreateReq(
-                obj=ObjSchemaForInsert(
-                    project_id=project_id,
-                    object_id=object_id,
-                    val=obj_val,
-                    wb_user_id=wb_user_id,
-                )
+        return ref
+    res = trace_server.obj_create(
+        ObjCreateReq(
+            obj=ObjSchemaForInsert(
+                project_id=project_id,
+                object_id=object_id,
+                val=obj_val,
+                wb_user_id=wb_user_id,
             )
         )
-        digest = res.digest
+    )
+    return _content_ref(project_id, object_id, res.digest)
+
+
+def _content_ref(project_id: str, object_id: str, digest: str) -> str:
     # Coerce to a plain ``str``: ``.uri`` is a str subclass (``_CallableStr``)
     # that exact-type checks (JSON/serialization/ref extraction) can reject.
     return str(
@@ -277,8 +330,8 @@ def replace_base64_with_content_objects(
             # Check for data URI pattern first
             if is_data_uri(val):
                 cache_key = _content_ref_cache_key(project_id, val)
-                if (cached := _content_ref_cache_get(cache_key)) is not None:
-                    return cached
+                if (known := _lookup_content_ref(cache_key, pending_objs)) is not None:
+                    return known
                 try:
                     # Publish the content and replace the base64 with its ref.
                     ref = store_content_object_ref(
@@ -287,7 +340,7 @@ def replace_base64_with_content_objects(
                         trace_server,
                         wb_user_id,
                         pending_objs,
-                        cache_key,
+                        raw_val=val,
                     )
                 except Exception as e:
                     logger.warning(
@@ -295,13 +348,16 @@ def replace_base64_with_content_objects(
                         e,
                     )
                 else:
-                    _content_ref_cache_put(cache_key, ref)
+                    # In batch mode the global cache is published only after
+                    # the batch commits; pending_objs serves intra-batch hits.
+                    if pending_objs is None:
+                        _content_ref_cache_put(cache_key, ref)
                     return ref
 
             if is_base64(val):
                 cache_key = _content_ref_cache_key(project_id, val)
-                if (cached := _content_ref_cache_get(cache_key)) is not None:
-                    return cached
+                if (known := _lookup_content_ref(cache_key, pending_objs)) is not None:
+                    return known
                 try:
                     # All we care about here is if this is an object that we can handle in some way.
                     # 'aaaa' is valid base64 and will come out as text/plain
@@ -319,9 +375,10 @@ def replace_base64_with_content_objects(
                             trace_server,
                             wb_user_id,
                             pending_objs,
-                            cache_key,
+                            raw_val=val,
                         )
-                        _content_ref_cache_put(cache_key, ref)
+                        if pending_objs is None:
+                            _content_ref_cache_put(cache_key, ref)
                         return ref
                 except Exception as e:
                     logger.warning(
@@ -403,6 +460,31 @@ def process_complete_call_to_content(
         pending_objs,
     )
     return complete_call
+
+
+def restore_raw_content_values(
+    complete_call: CompletedCallSchemaForInsert,
+    raw_by_ref: dict[str, str],
+) -> CompletedCallSchemaForInsert:
+    """Replace embedded content refs with the raw values they came from.
+
+    Used when a queued content object was skipped at flush time (name/type
+    collision): the call payload keeps the original inline value instead of
+    a ref that resolves to nothing.
+    """
+    complete_call.inputs = _restore_refs(complete_call.inputs, raw_by_ref)
+    complete_call.output = _restore_refs(complete_call.output, raw_by_ref)
+    return complete_call
+
+
+def _restore_refs(val: Any, raw_by_ref: dict[str, str]) -> Any:
+    if isinstance(val, dict):
+        return {k: _restore_refs(v, raw_by_ref) for k, v in val.items()}
+    if isinstance(val, list):
+        return [_restore_refs(v, raw_by_ref) for v in val]
+    if isinstance(val, str):
+        return raw_by_ref.get(val, val)
+    return val
 
 
 def replace_base64_in_raw_messages(

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -9,6 +9,7 @@ import logging
 import re
 from typing import Any, TypeVar
 
+from weave.shared.digest import compute_object_digest_result
 from weave.shared.refs_internal import InternalObjectRef
 from weave.trace_server.content.content import Content
 from weave.trace_server.object_creation_utils import make_object_id
@@ -119,6 +120,7 @@ def store_content_object_ref(
     project_id: str,
     trace_server: TraceServerInterface,
     wb_user_id: str | None = None,
+    pending_objs: list[ObjSchemaForInsert] | None = None,
 ) -> str:
     """Store a Content object, publish it, and return its internal weave ref.
 
@@ -127,23 +129,41 @@ def store_content_object_ref(
     embed a compact ``weave-trace-internal:///…`` ref in the payload instead of
     the inline object. The version is the server-computed object digest, so
     identical content dedupes to the same ref.
+
+    When ``pending_objs`` is given, the object is appended to it instead of
+    being written via ``obj_create`` immediately, so a caller can batch many
+    objects into one insert.
     """
     obj_val = store_content_object(content_obj, project_id, trace_server)
     object_id = make_object_id(content_obj.filename, "content")
-    res = trace_server.obj_create(
-        ObjCreateReq(
-            obj=ObjSchemaForInsert(
+    if pending_objs is not None:
+        digest_result = compute_object_digest_result(obj_val, None)
+        pending_objs.append(
+            ObjSchemaForInsert(
                 project_id=project_id,
                 object_id=object_id,
                 val=obj_val,
                 wb_user_id=wb_user_id,
+                expected_digest=digest_result.digest,
             )
         )
-    )
+        digest = digest_result.digest
+    else:
+        res = trace_server.obj_create(
+            ObjCreateReq(
+                obj=ObjSchemaForInsert(
+                    project_id=project_id,
+                    object_id=object_id,
+                    val=obj_val,
+                    wb_user_id=wb_user_id,
+                )
+            )
+        )
+        digest = res.digest
     # Coerce to a plain ``str``: ``.uri`` is a str subclass (``_CallableStr``)
     # that exact-type checks (JSON/serialization/ref extraction) can reject.
     return str(
-        InternalObjectRef(project_id=project_id, name=object_id, version=res.digest).uri
+        InternalObjectRef(project_id=project_id, name=object_id, version=digest).uri
     )
 
 
@@ -155,6 +175,7 @@ def replace_base64_with_content_objects(
     project_id: str,
     trace_server: TraceServerInterface,
     wb_user_id: str | None = None,
+    pending_objs: list[ObjSchemaForInsert] | None = None,
 ) -> T:
     """Recursively replace base64 content with Content objects.
 
@@ -207,6 +228,7 @@ def replace_base64_with_content_objects(
                         project_id,
                         trace_server,
                         wb_user_id,
+                        pending_objs,
                     )
                 except Exception as e:
                     logger.warning(
@@ -231,6 +253,7 @@ def replace_base64_with_content_objects(
                             project_id,
                             trace_server,
                             wb_user_id,
+                            pending_objs,
                         )
                 except Exception as e:
                     logger.warning(
@@ -284,12 +307,15 @@ def process_call_req_to_content(
 def process_complete_call_to_content(
     complete_call: CompletedCallSchemaForInsert,
     trace_server: TraceServerInterface,
+    pending_objs: list[ObjSchemaForInsert] | None = None,
 ) -> CompletedCallSchemaForInsert:
     """Process a complete call to replace base64 content in inputs and outputs.
 
     Args:
         complete_call: Complete call schema with both inputs and outputs.
         trace_server: Trace server instance for file storage.
+        pending_objs: When given, content objects are queued here instead of
+            being written immediately, so a caller can batch the writes.
 
     Returns:
         CompletedCallSchemaForInsert with base64 content replaced by Content objects.
@@ -299,12 +325,14 @@ def process_complete_call_to_content(
         complete_call.project_id,
         trace_server,
         complete_call.wb_user_id,
+        pending_objs,
     )
     complete_call.output = replace_base64_with_content_objects(
         complete_call.output,
         complete_call.project_id,
         trace_server,
         complete_call.wb_user_id,
+        pending_objs,
     )
     return complete_call
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -434,6 +434,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._call_batch
             or self._calls_complete_batch
             or self._file_batch
+            or self._content_obj_batch
             or self._bucket_uploads
         ):
             try:
@@ -444,6 +445,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 self._file_batch = []
                 self._call_batch = []
                 self._calls_complete_batch = []
+                self._content_obj_batch = []
                 self._bucket_uploads = BucketUploadBatch()
                 self._flush_immediately = True
 
@@ -503,6 +505,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     @_calls_complete_batch.setter
     def _calls_complete_batch(self, value: list[list[Any]]) -> None:
         self._thread_local.calls_complete_batch = value
+
+    @property
+    def _content_obj_batch(self) -> list[tsi.ObjSchemaForInsert]:
+        if not hasattr(self._thread_local, "content_obj_batch"):
+            self._thread_local.content_obj_batch = []
+        return self._thread_local.content_obj_batch
+
+    @_content_obj_batch.setter
+    def _content_obj_batch(self, value: list[tsi.ObjSchemaForInsert]) -> None:
+        self._thread_local.content_obj_batch = value
 
     @classmethod
     def from_env(cls, use_async_insert: bool = True, **kwargs: Any) -> Self:
@@ -894,6 +906,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._file_batch = []
             self._call_batch = []
             self._calls_complete_batch = []
+            self._content_obj_batch = []
             self._bucket_uploads = BucketUploadBatch()
             self._flush_immediately = True
 
@@ -904,13 +917,22 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
            atomically with any inline-CH chunks accumulated alongside.
         2. File chunks, if this fails, we raise so that we don't insert calls that
            are missing file data. Forces retry.
-        3. Calls, if this fails, we raise so that clients can retry, and so we don't
+        3. Content objects, if this fails, we raise. Written after their file
+           bytes so a committed object row never references unwritten content.
+        4. Calls, if this fails, we raise so that clients can retry, and so we don't
            continue and push bad ids to the queue.
-        4. Produce to kafka, if this fails, we don't raise because all of the data
+        5. Produce to kafka, if this fails, we don't raise because all of the data
            is already in the database, we don't want the client to retry.
            TODO: consider kafka retry logic.
         """
         self._flush_file_batches()
+
+        # Raises on fail
+        try:
+            self._flush_content_objs()
+        except Exception:
+            logger.exception("Failed to flush content objects")
+            raise
 
         # Raises on fail
         try:
@@ -1083,10 +1105,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 process_complete_call_to_content(complete_call, self, pending_objs)
                 for complete_call in req.batch
             ]
-            # Content objects are written before the calls flush (on with-exit)
-            # so a committed call never references an unwritten object; refs of
-            # collision-skipped objects are swapped back to their raw values.
-            raw_by_ref = self._flush_pending_content_objs(pending_objs)
+            # Resolve collisions now (read-only) so call payloads can restore
+            # the raw values of skipped objects; the surviving object rows are
+            # staged and written on with-exit, after their file bytes.
+            raw_by_ref = self._resolve_pending_content_objs(pending_objs)
 
             for processed_complete_call in processed_calls:
                 if raw_by_ref:
@@ -1124,14 +1146,17 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         pending_objs.publish_refs()
         return tsi.CallsUpsertCompleteRes()
 
-    def _flush_pending_content_objs(
+    def _resolve_pending_content_objs(
         self, pending_objs: PendingContentObjs
     ) -> dict[str, str]:
-        """Write content objects queued by calls_complete's base64 walk.
+        """Resolve content objects queued by calls_complete's base64 walk.
 
-        Dedupes by (project_id, object_id, digest) so identical content
-        embedded in multiple calls of the batch is written once, then runs
-        one WB-30574 collision check and one obj_create_batch per project.
+        Read-only: dedupes by (project_id, object_id, digest) so identical
+        content embedded in multiple calls is written once, runs one WB-30574
+        collision check per project, and stages the survivors into
+        _content_obj_batch for the ordered flush. The actual obj_create_batch
+        write happens later in _flush_content_objs, after file bytes land.
+
         A collision must not fail the calls batch: the colliding object is
         skipped and reported in the returned {ref: raw_value} map so the
         caller can restore the original inline values in the call payloads.
@@ -1162,11 +1187,22 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 pending_objs.mark_skipped(project_id, collision.object_id)
 
             colliding_ids = {c.object_id for c in collisions}
-            to_write = [o for o in project_objs if o.object_id not in colliding_ids]
-            if to_write:
-                self.obj_create_batch(to_write)
+            self._content_obj_batch.extend(
+                o for o in project_objs if o.object_id not in colliding_ids
+            )
 
         return pending_objs.restore_map()
+
+    def _flush_content_objs(self) -> None:
+        """Write staged content objects, grouped by project (obj_create_batch
+        takes a single project). Runs after _flush_file_batches so a committed
+        object row never references content that has not landed in storage.
+        """
+        by_project: dict[str, list[tsi.ObjSchemaForInsert]] = {}
+        for obj in self._content_obj_batch:
+            by_project.setdefault(obj.project_id, []).append(obj)
+        for project_objs in by_project.values():
+            self.obj_create_batch(project_objs)
 
     @tag_db_insert_path("call_start_v2")
     def call_start_v2(self, req: tsi.CallStartV2Req) -> tsi.CallStartV2Res:
@@ -2309,7 +2345,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         Unlike obj_create, no WB-30574 name/type collision guard runs here:
         callers must know their object_ids are fresh or check beforehand
-        (see _flush_pending_content_objs).
+        (see _resolve_pending_content_objs).
         """
         set_current_span_dd_tags(
             {"clickhouse_trace_server_batched.create_obj_batch.count": str(len(batch))}

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1075,10 +1075,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             {"weave_trace_server.insert_call_count": len(req.batch)}
         )
 
+        pending_objs: list[tsi.ObjSchemaForInsert] = []
         with self.call_batch():
             for complete_call in req.batch:
                 processed_complete_call = process_complete_call_to_content(
-                    complete_call, self
+                    complete_call, self, pending_objs
                 )
 
                 # Determine write target based on project, this should be the same for all
@@ -1108,7 +1109,31 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     processed_complete_call.ended_at,
                 )
 
+            self._flush_pending_content_objs(pending_objs)
+
         return tsi.CallsUpsertCompleteRes()
+
+    def _flush_pending_content_objs(
+        self, pending_objs: list[tsi.ObjSchemaForInsert]
+    ) -> None:
+        """Write content objects queued by calls_complete's base64 walk.
+
+        Dedupes by (project_id, object_id, digest) so identical content
+        embedded in multiple calls of the batch is written once, then does
+        one obj_create_batch per project (it raises on multi-project input).
+        """
+        deduped: dict[tuple[str, str, str | None], tsi.ObjSchemaForInsert] = {}
+        for obj in pending_objs:
+            deduped.setdefault(
+                (obj.project_id, obj.object_id, obj.expected_digest), obj
+            )
+
+        by_project: dict[str, list[tsi.ObjSchemaForInsert]] = {}
+        for obj in deduped.values():
+            by_project.setdefault(obj.project_id, []).append(obj)
+
+        for project_objs in by_project.values():
+            self.obj_create_batch(project_objs, check_name_collisions=True)
 
     @tag_db_insert_path("call_start_v2")
     def call_start_v2(self, req: tsi.CallStartV2Req) -> tsi.CallStartV2Res:
@@ -2180,10 +2205,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         different-type would make refs ambiguous.
         """
         query, parameters = make_obj_name_type_collision_query(
-            project_id=project_id, object_id=object_id, kind=kind
+            project_id=project_id, object_ids=[object_id], kind=kind
         )
         result = self._query(query, parameters)
-        existing_classes = [row[0] for row in result.result_rows]
+        existing_classes = [row[1] for row in result.result_rows]
         mismatched = [c for c in existing_classes if c != new_base_object_class]
         if mismatched:
             raise ObjectNameTypeCollision(
@@ -2193,10 +2218,53 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 existing_base_object_classes=mismatched,
             )
 
+    def _reject_obj_name_type_collisions_batch(
+        self,
+        project_id: str,
+        checks: list[tuple[str, str, str | None]],
+    ) -> None:
+        """Batched WB-30574 collision guard for obj_create_batch: one query
+        per distinct kind in the batch instead of one query per object.
+
+        ``checks`` is a list of (object_id, kind, new_base_object_class).
+        """
+        by_kind: dict[str, dict[str, str | None]] = {}
+        for object_id, kind, new_base_object_class in checks:
+            by_kind.setdefault(kind, {})[object_id] = new_base_object_class
+
+        for kind, object_id_to_class in by_kind.items():
+            query, parameters = make_obj_name_type_collision_query(
+                project_id=project_id,
+                object_ids=sorted(object_id_to_class),
+                kind=kind,
+            )
+            result = self._query(query, parameters)
+            existing_by_object_id: dict[str, list[str | None]] = {}
+            for object_id, base_object_class in result.result_rows:
+                existing_by_object_id.setdefault(object_id, []).append(
+                    base_object_class
+                )
+
+            for object_id, new_base_object_class in object_id_to_class.items():
+                mismatched = [
+                    c
+                    for c in existing_by_object_id.get(object_id, [])
+                    if c != new_base_object_class
+                ]
+                if mismatched:
+                    raise ObjectNameTypeCollision(
+                        object_id=object_id,
+                        kind=kind,
+                        new_base_object_class=new_base_object_class,
+                        existing_base_object_classes=mismatched,
+                    )
+
     @traced(name="clickhouse_trace_server_batched.create_obj_batch")
     @tag_db_insert_path("obj_create_batch")
     def obj_create_batch(
-        self, batch: list[tsi.ObjSchemaForInsert]
+        self,
+        batch: list[tsi.ObjSchemaForInsert],
+        check_name_collisions: bool = False,
     ) -> list[tsi.ObjCreateRes]:
         """This method is for the special case where all objects are known to use a placeholder.
         We lose any knowledge of what version the created object is in return for an enormous
@@ -2208,6 +2276,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         inserted first; if the subsequent batched alias INSERT fails, the
         new versions exist but their "latest" alias is missing — readers
         see the prior latest until the alias write succeeds on retry.
+
+        ``check_name_collisions`` runs the WB-30574 name/type guard that
+        ``obj_create`` runs per object, batched into one query per distinct
+        kind. Callers that already know their object_ids are fresh (like
+        OTel ingest) can skip it.
         """
         set_current_span_dd_tags(
             {"clickhouse_trace_server_batched.create_obj_batch.count": str(len(batch))}
@@ -2226,6 +2299,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             )
 
         alias_rows: list[tuple[str, str, str, str]] = []
+        collision_checks: list[tuple[str, str, str | None]] = []
         for obj in batch:
             digest_result = compute_object_digest_result(
                 obj.val,
@@ -2234,11 +2308,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             processed_val = digest_result.processed_val
             json_val = digest_result.json_val
             digest = digest_result.digest
+            kind = get_kind(processed_val)
             ch_obj = ObjCHInsertable(
                 project_id=obj.project_id,
                 object_id=obj.object_id,
                 wb_user_id=obj.wb_user_id,
-                kind=get_kind(processed_val),
+                kind=kind,
                 base_object_class=digest_result.base_object_class,
                 leaf_object_class=digest_result.leaf_object_class,
                 refs=extract_refs_from_values(processed_val),
@@ -2251,6 +2326,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             alias_rows.append(
                 (obj.project_id, obj.object_id, digest, obj.wb_user_id or "")
             )
+            collision_checks.append(
+                (obj.object_id, kind, digest_result.base_object_class)
+            )
 
             # Record the inserted data
             obj_results.append(
@@ -2258,6 +2336,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     digest=digest,
                     object_id=obj.object_id,
                 )
+            )
+
+        if check_name_collisions:
+            self._reject_obj_name_type_collisions_batch(
+                project_id=next(iter(unique_projects)),
+                checks=collision_checks,
             )
 
         self._insert(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -86,6 +86,7 @@ from weave.trace_server.base64_content_conversion import (
     process_call_req_to_content,
     process_complete_call_to_content,
     replace_base64_with_content_objects,
+    restore_raw_content_values,
 )
 from weave.trace_server.call_stats_helpers import (
     rows_to_bucket_dicts,
@@ -1078,10 +1079,18 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         pending_objs = PendingContentObjs()
         with self.call_batch():
-            for complete_call in req.batch:
-                processed_complete_call = process_complete_call_to_content(
-                    complete_call, self, pending_objs
-                )
+            processed_calls = [
+                process_complete_call_to_content(complete_call, self, pending_objs)
+                for complete_call in req.batch
+            ]
+            # Content objects are written before the calls flush (on with-exit)
+            # so a committed call never references an unwritten object; refs of
+            # collision-skipped objects are swapped back to their raw values.
+            raw_by_ref = self._flush_pending_content_objs(pending_objs)
+
+            for processed_complete_call in processed_calls:
+                if raw_by_ref:
+                    restore_raw_content_values(processed_complete_call, raw_by_ref)
 
                 # Determine write target based on project, this should be the same for all
                 # calls in the batch, subsequent calls just hit the in-memory cache. This
@@ -1110,18 +1119,22 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     processed_complete_call.ended_at,
                 )
 
-            self._flush_pending_content_objs(pending_objs)
-
+        # Only now is a cached ref guaranteed to resolve: objects, files,
+        # and calls have all committed.
+        pending_objs.publish_refs()
         return tsi.CallsUpsertCompleteRes()
 
-    def _flush_pending_content_objs(self, pending_objs: PendingContentObjs) -> None:
+    def _flush_pending_content_objs(
+        self, pending_objs: PendingContentObjs
+    ) -> dict[str, str]:
         """Write content objects queued by calls_complete's base64 walk.
 
         Dedupes by (project_id, object_id, digest) so identical content
-        embedded in multiple calls of the batch is written once, then does
-        one obj_create_batch per project (it raises on multi-project input).
-        Any object that fails to write has its ref-cache entries evicted so
-        later requests do not reuse a ref that was never published.
+        embedded in multiple calls of the batch is written once, then runs
+        one WB-30574 collision check and one obj_create_batch per project.
+        A collision must not fail the calls batch: the colliding object is
+        skipped and reported in the returned {ref: raw_value} map so the
+        caller can restore the original inline values in the call payloads.
         """
         deduped: dict[tuple[str, str, str | None], tsi.ObjSchemaForInsert] = {}
         for obj in pending_objs.objs:
@@ -1133,24 +1146,27 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         for obj in deduped.values():
             by_project.setdefault(obj.project_id, []).append(obj)
 
-        for project_objs in by_project.values():
-            remaining = project_objs
-            while remaining:
-                try:
-                    self.obj_create_batch(remaining, check_name_collisions=True)
-                    break
-                except ObjectNameTypeCollision as e:
-                    # A collision must not fail the calls batch: drop the
-                    # colliding object (its ref dangles) and write the rest.
-                    logger.warning(
-                        "Skipping content object with name/type collision: %s", e
-                    )
-                    pending_objs.evict_cached_refs(e.object_id)
-                    remaining = [o for o in remaining if o.object_id != e.object_id]
-                except Exception:
-                    for obj in remaining:
-                        pending_objs.evict_cached_refs(obj.object_id)
-                    raise
+        for project_id, project_objs in by_project.items():
+            checks: list[tuple[str, str, str | None]] = []
+            for obj in project_objs:
+                digest_result = compute_object_digest_result(
+                    obj.val, obj.builtin_object_class
+                )
+                kind = get_kind(digest_result.processed_val)
+                checks.append((obj.object_id, kind, digest_result.base_object_class))
+            collisions = self._find_obj_name_type_collisions(project_id, checks)
+            for collision in collisions:
+                logger.warning(
+                    "Skipping content object with name/type collision: %s", collision
+                )
+                pending_objs.mark_skipped(project_id, collision.object_id)
+
+            colliding_ids = {c.object_id for c in collisions}
+            to_write = [o for o in project_objs if o.object_id not in colliding_ids]
+            if to_write:
+                self.obj_create_batch(to_write)
+
+        return pending_objs.restore_map()
 
     @tag_db_insert_path("call_start_v2")
     def call_start_v2(self, req: tsi.CallStartV2Req) -> tsi.CallStartV2Res:
@@ -2221,67 +2237,64 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         (WB-30574). Weave refs do not carry type, so allowing same-name
         different-type would make refs ambiguous.
         """
-        query, parameters = make_obj_name_type_collision_query(
-            project_id=project_id, object_ids=[object_id], kind=kind
+        collisions = self._find_obj_name_type_collisions(
+            project_id, [(object_id, kind, new_base_object_class)]
         )
-        result = self._query(query, parameters)
-        existing_classes = [row[1] for row in result.result_rows]
-        mismatched = [c for c in existing_classes if c != new_base_object_class]
-        if mismatched:
-            raise ObjectNameTypeCollision(
-                object_id=object_id,
-                kind=kind,
-                new_base_object_class=new_base_object_class,
-                existing_base_object_classes=mismatched,
-            )
+        if collisions:
+            raise collisions[0]
 
-    def _reject_obj_name_type_collisions_batch(
+    def _find_obj_name_type_collisions(
         self,
         project_id: str,
         checks: list[tuple[str, str, str | None]],
-    ) -> None:
-        """Batched WB-30574 collision guard for obj_create_batch: one query
-        per distinct kind in the batch instead of one query per object.
+    ) -> list[ObjectNameTypeCollision]:
+        """WB-30574 collision check: one query per distinct kind, returning
+        one ObjectNameTypeCollision per object_id bound to more than one
+        base_object_class, by committed rows or by conflicting entries
+        within ``checks`` itself. Callers decide whether to raise.
 
         ``checks`` is a list of (object_id, kind, new_base_object_class).
         """
-        by_kind: dict[str, dict[str, str | None]] = {}
+        by_kind: dict[str, dict[str, set[str | None]]] = {}
         for object_id, kind, new_base_object_class in checks:
-            by_kind.setdefault(kind, {})[object_id] = new_base_object_class
+            by_kind.setdefault(kind, {}).setdefault(object_id, set()).add(
+                new_base_object_class
+            )
 
-        for kind, object_id_to_class in by_kind.items():
+        collisions: list[ObjectNameTypeCollision] = []
+        for kind, object_id_to_classes in by_kind.items():
             query, parameters = make_obj_name_type_collision_query(
                 project_id=project_id,
-                object_ids=sorted(object_id_to_class),
+                object_ids=sorted(object_id_to_classes),
                 kind=kind,
             )
             result = self._query(query, parameters)
-            existing_by_object_id: dict[str, list[str | None]] = {}
+            existing_by_object_id: dict[str, set[str | None]] = {}
             for object_id, base_object_class in result.result_rows:
-                existing_by_object_id.setdefault(object_id, []).append(
+                existing_by_object_id.setdefault(object_id, set()).add(
                     base_object_class
                 )
 
-            for object_id, new_base_object_class in object_id_to_class.items():
-                mismatched = [
-                    c
-                    for c in existing_by_object_id.get(object_id, [])
-                    if c != new_base_object_class
-                ]
-                if mismatched:
-                    raise ObjectNameTypeCollision(
-                        object_id=object_id,
-                        kind=kind,
-                        new_base_object_class=new_base_object_class,
-                        existing_base_object_classes=mismatched,
+            for object_id, new_classes in object_id_to_classes.items():
+                bound = existing_by_object_id.get(object_id, set()) | new_classes
+                if len(bound) > 1:
+                    new_class = sorted(new_classes, key=str)[0]
+                    collisions.append(
+                        ObjectNameTypeCollision(
+                            object_id=object_id,
+                            kind=kind,
+                            new_base_object_class=new_class,
+                            existing_base_object_classes=sorted(
+                                (c for c in bound if c != new_class), key=str
+                            ),
+                        )
                     )
+        return collisions
 
     @traced(name="clickhouse_trace_server_batched.create_obj_batch")
     @tag_db_insert_path("obj_create_batch")
     def obj_create_batch(
-        self,
-        batch: list[tsi.ObjSchemaForInsert],
-        check_name_collisions: bool = False,
+        self, batch: list[tsi.ObjSchemaForInsert]
     ) -> list[tsi.ObjCreateRes]:
         """This method is for the special case where all objects are known to use a placeholder.
         We lose any knowledge of what version the created object is in return for an enormous
@@ -2294,10 +2307,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         new versions exist but their "latest" alias is missing — readers
         see the prior latest until the alias write succeeds on retry.
 
-        ``check_name_collisions`` runs the WB-30574 name/type guard that
-        ``obj_create`` runs per object, batched into one query per distinct
-        kind. Callers that already know their object_ids are fresh (like
-        OTel ingest) can skip it.
+        Unlike obj_create, no WB-30574 name/type collision guard runs here:
+        callers must know their object_ids are fresh or check beforehand
+        (see _flush_pending_content_objs).
         """
         set_current_span_dd_tags(
             {"clickhouse_trace_server_batched.create_obj_batch.count": str(len(batch))}
@@ -2316,7 +2328,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             )
 
         alias_rows: list[tuple[str, str, str, str]] = []
-        collision_checks: list[tuple[str, str, str | None]] = []
         for obj in batch:
             digest_result = compute_object_digest_result(
                 obj.val,
@@ -2325,12 +2336,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             processed_val = digest_result.processed_val
             json_val = digest_result.json_val
             digest = digest_result.digest
-            kind = get_kind(processed_val)
+            validate_expected_digest(
+                expected=obj.expected_digest,
+                actual=digest,
+                label=f"obj {obj.object_id!r}",
+            )
             ch_obj = ObjCHInsertable(
                 project_id=obj.project_id,
                 object_id=obj.object_id,
                 wb_user_id=obj.wb_user_id,
-                kind=kind,
+                kind=get_kind(processed_val),
                 base_object_class=digest_result.base_object_class,
                 leaf_object_class=digest_result.leaf_object_class,
                 refs=extract_refs_from_values(processed_val),
@@ -2343,9 +2358,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             alias_rows.append(
                 (obj.project_id, obj.object_id, digest, obj.wb_user_id or "")
             )
-            collision_checks.append(
-                (obj.object_id, kind, digest_result.base_object_class)
-            )
 
             # Record the inserted data
             obj_results.append(
@@ -2353,12 +2365,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     digest=digest,
                     object_id=obj.object_id,
                 )
-            )
-
-        if check_name_collisions:
-            self._reject_obj_name_type_collisions_batch(
-                project_id=next(iter(unique_projects)),
-                checks=collision_checks,
             )
 
         self._insert(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1133,7 +1133,18 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             by_project.setdefault(obj.project_id, []).append(obj)
 
         for project_objs in by_project.values():
-            self.obj_create_batch(project_objs, check_name_collisions=True)
+            remaining = project_objs
+            while remaining:
+                try:
+                    self.obj_create_batch(remaining, check_name_collisions=True)
+                    break
+                except ObjectNameTypeCollision as e:
+                    # A collision must not fail the calls batch: drop the
+                    # colliding object (its ref dangles) and write the rest.
+                    logger.warning(
+                        "Skipping content object with name/type collision: %s", e
+                    )
+                    remaining = [o for o in remaining if o.object_id != e.object_id]
 
     @tag_db_insert_path("call_start_v2")
     def call_start_v2(self, req: tsi.CallStartV2Req) -> tsi.CallStartV2Res:

--- a/weave/trace_server/query_builder/objects_query_builder.py
+++ b/weave/trace_server/query_builder/objects_query_builder.py
@@ -467,13 +467,15 @@ def make_objects_val_query_and_parameters(
 
 
 def make_obj_name_type_collision_query(
-    project_id: str, object_id: str, kind: str
+    project_id: str, object_ids: list[str], kind: str
 ) -> tuple[str, dict[str, Any]]:
-    """Build the query that returns the set of distinct base_object_class
-    values currently bound to a given (project_id, kind, object_id).
+    """Build the query that returns the distinct (object_id, base_object_class)
+    pairs currently bound to any of the given object_ids in a project.
 
-    Used by obj_create to enforce that an object_id maps to a single
-    base_object_class for the lifetime of the project (WB-30574).
+    Used by obj_create / obj_create_batch to enforce that an object_id maps
+    to a single base_object_class for the lifetime of the project (WB-30574).
+    Accepts many object_ids so a batch insert can run one collision check
+    instead of one per object.
 
     Queries `object_versions` directly rather than the
     `object_versions_deduped` view because the view computes two window
@@ -491,16 +493,16 @@ def make_obj_name_type_collision_query(
     silently rebinding a name to a new type.
     """
     query = """
-        SELECT DISTINCT base_object_class
+        SELECT DISTINCT object_id, base_object_class
         FROM object_versions
         WHERE project_id = {project_id: String}
-            AND object_id = {object_id: String}
+            AND object_id IN {object_ids: Array(String)}
             AND kind = {kind: String}
             AND deleted_at IS NULL
     """
     parameters = {
         "project_id": project_id,
-        "object_id": object_id,
+        "object_ids": object_ids,
         "kind": kind,
     }
     return query, parameters

--- a/weave/trace_server/query_builder/objects_query_builder.py
+++ b/weave/trace_server/query_builder/objects_query_builder.py
@@ -472,7 +472,7 @@ def make_obj_name_type_collision_query(
     """Build the query that returns the distinct (object_id, base_object_class)
     pairs currently bound to any of the given object_ids in a project.
 
-    Used by obj_create / obj_create_batch to enforce that an object_id maps
+    Used by the WB-30574 collision guards to enforce that an object_id maps
     to a single base_object_class for the lifetime of the project (WB-30574).
     Accepts many object_ids so a batch insert can run one collision check
     instead of one per object.


### PR DESCRIPTION
## Summary
- calls_complete stored each embedded content object with its own obj_create (collision query + object_versions insert + aliases insert, 2 serial CH round trips per object); object-heavy batches spent minutes in this loop
- collect content objects during the batch walk and write them with one obj_create_batch per project (one object_versions insert + one aliases insert), deduped by digest
- collision guard runs before the insert (one query per kind, full set, incl. intra-batch conflicts); a colliding content object keeps its original inline value in the payload instead of a dangling ref (OTel path unchanged)
- content-ref cache publishes only after the whole batch commits (objects, files, calls), so a cached ref always resolves; obj_create_batch now validates expected_digest

## Performance
QA A/B, identical driver both builds (one calls_complete batch: 8 calls, 15 distinct ~50-90KB content objects, ~2.2MB body), server-side Datadog spans:

| master 62c7ff3: 9.20s cold, 15+15 object_versions/aliases inserts per request | PR 8c4d091: 2.22s cold, 1+1 inserts per request |
|---|---|
| ![master](https://github.com/user-attachments/assets/7543351f-4293-417e-92fa-75e3b34e2021) | ![pr](https://github.com/user-attachments/assets/84672466-0a75-4c1f-9de9-4acd70a7af86) |

one create_obj_batch span carried all 15 objects in 0.3s; no new error classes on the PR build. insert reduction scales with object count (prod exemplar with 228 objects: 456 inserts -> 2).

## Testing
functional test: batch with base64 payloads asserts refs resolve, dupes collapse, and exactly one insert per table; collision tolerance now asserts the inline value is restored verbatim and the skipped ref never poisons the cache
