### PR TITLE
perf(weave): negative-cache mimetype-rejected base64 blobs on ingest

### DIFF
--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -112,10 +112,12 @@ def reset_project_version_cache():
 
 @pytest.fixture(autouse=True)
 def reset_content_ref_cache():
-    """The module-level published-content ref cache would leak refs across tests."""
+    """The module-level published-content ref caches would leak refs across tests."""
     base64_content_conversion._content_ref_cache.clear()
+    base64_content_conversion._rejected_blob_cache.clear()
     yield
     base64_content_conversion._content_ref_cache.clear()
+    base64_content_conversion._rejected_blob_cache.clear()
 
 
 def _get_worker_db_suffix(request, default: str = "_test") -> str:

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -15,6 +15,7 @@ from weave.trace_server.base64_content_conversion import (
     replace_base64_with_content_objects,
     store_content_object,
 )
+from weave.trace_server.content.content import Content as ServerContent
 from weave.trace_server.trace_server_interface import (
     CallEndReq,
     CallStartReq,
@@ -341,6 +342,34 @@ class TestContentRefCache:
             {"img": data_uri}, "proj_fail", working_server
         )
         _assert_content_ref(result["img"], "proj_fail")
+
+    def test_mimetype_rejected_blob_is_negative_cached(self, monkeypatch):
+        """A blob the mimetype filter keeps inline is decoded once, then cached."""
+        b64_text = base64.b64encode(b"plain text " * 1000).decode("ascii")
+        assert len(b64_text) > AUTO_CONVERSION_MIN_SIZE
+
+        decode_count = 0
+        real_from_base64 = ServerContent.from_base64
+
+        def counting_from_base64(val: str) -> ServerContent:
+            nonlocal decode_count
+            decode_count += 1
+            return real_from_base64(val)
+
+        monkeypatch.setattr(ServerContent, "from_base64", counting_from_base64)
+
+        trace_server = MagicMock()
+        first = replace_base64_with_content_objects(
+            {"doc": b64_text}, "proj", trace_server
+        )
+        second = replace_base64_with_content_objects(
+            {"doc": b64_text}, "proj", trace_server
+        )
+        assert first["doc"] == b64_text
+        assert second["doc"] == b64_text
+        assert decode_count == 1
+        assert trace_server.file_create.call_count == 0
+        assert trace_server.obj_create.call_count == 0
 
 
 class TestStandaloneBase64Detection:

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -57,6 +57,12 @@ CONTENT_REF_CACHE_SIZE = 100_000
 _content_ref_cache: LRUCache[tuple[str, str], str] = LRUCache(
     maxsize=CONTENT_REF_CACHE_SIZE
 )
+# Companion LRU set of bare-base64 blobs the mimetype filter keeps inline; a hit
+# skips the repeat decode. The rejection is deterministic per string, so it stays
+# correct for the pod's lifetime. Transient publish failures are never cached.
+_rejected_blob_cache: LRUCache[tuple[str, str], None] = LRUCache(
+    maxsize=CONTENT_REF_CACHE_SIZE
+)
 _content_ref_cache_lock = threading.Lock()
 
 
@@ -72,6 +78,16 @@ def _content_ref_cache_get(key: tuple[str, str]) -> str | None:
 def _content_ref_cache_put(key: tuple[str, str], ref: str) -> None:
     with _content_ref_cache_lock:
         _content_ref_cache[key] = ref
+
+
+def _rejected_blob_cache_contains(key: tuple[str, str]) -> bool:
+    with _content_ref_cache_lock:
+        return key in _rejected_blob_cache
+
+
+def _rejected_blob_cache_put(key: tuple[str, str]) -> None:
+    with _content_ref_cache_lock:
+        _rejected_blob_cache[key] = None
 
 
 def is_base64(value: str) -> bool:
@@ -252,6 +268,8 @@ def replace_base64_with_content_objects(
                 cache_key = _content_ref_cache_key(project_id, val)
                 if (cached := _content_ref_cache_get(cache_key)) is not None:
                     return cached
+                if _rejected_blob_cache_contains(cache_key):
+                    return val
                 try:
                     # All we care about here is if this is an object that we can handle in some way.
                     # 'aaaa' is valid base64 and will come out as text/plain
@@ -271,6 +289,7 @@ def replace_base64_with_content_objects(
                         )
                         _content_ref_cache_put(cache_key, ref)
                         return ref
+                    _rejected_blob_cache_put(cache_key)
                 except Exception as e:
                     logger.warning(
                         "Failed to create content from standalone base64: %s", e


### PR DESCRIPTION
## Summary
- follow-up to #7527: bare-base64 blobs rejected by the mimetype filter missed the ref cache forever, so repeat agent payloads re-paid the full decode + mimetype sniff every turn (showing up as real CPU in prod)
- companion LRU set of rejected keys (same key scheme, same lock): a hit returns the value inline without decoding; only deterministic rejections are cached, transient publish failures still are not

## Performance
p50 per call, repeated mimetype-rejected blob in an agent-shaped payload (local; remaining hit cost is the sha256 keying #7527 already pays):

| blob (decoded) | miss (master) | hit (PR) | speedup |
|---|---|---|---|
| 16 KiB | 2.8 ms | 39 us | 73x |
| 256 KiB | 4.2 ms | 0.5 ms | 8x |
| 1 MiB | 8.4 ms | 2.2 ms | 4x |
| 8 MiB | 46.9 ms | 17.5 ms | 3x |

## Testing
unit test proving the second occurrence of a rejected blob skips the decode entirely