### PR TITLE
fix(weave): pass through external refs embedded in JSON strings on read

### DIFF
--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -235,7 +235,6 @@ def test_replace_external_weave_ref_rejects_malformed_tail():
         replace_external_weave_ref("weave:///just-entity", lambda p: p)
 
 
-@pytest.mark.disable_logging_error_check
 def test_universal_int_to_ext_ref_converter_tolerate_external_refs(caplog):
     """Egress: internal refs externalize and unresolvable projects fall back to
     a private ref. A stored external ref raises by default (surfacing
@@ -261,7 +260,7 @@ def test_universal_int_to_ext_ref_converter_tolerate_external_refs(caplog):
         "plain": "no-ref-here",
     }
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         converted = universal_int_to_ext_ref_converter(
             payload, int_to_ext, tolerate_external_refs=True
         )
@@ -428,7 +427,6 @@ def test_json_string_without_refs_is_not_reserialized():
     assert converted["content"] is blob
 
 
-@pytest.mark.disable_logging_error_check
 def test_json_string_with_only_tolerated_external_ref_is_returned_unchanged(caplog):
     """When an embedded ref does not change (already external), the ORIGINAL
     string is returned with no re-serialization (spacing preserved).
@@ -442,7 +440,7 @@ def test_json_string_with_only_tolerated_external_ref_is_returned_unchanged(capl
     blob = json.dumps([{"type": "image", "url": external_ref}], indent=2)
     payload = {"content": blob}
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         converted = universal_int_to_ext_ref_converter(payload, int_to_ext)
 
     assert converted is payload
@@ -450,7 +448,6 @@ def test_json_string_with_only_tolerated_external_ref_is_returned_unchanged(capl
     assert "Returning stored external ref unchanged" in caplog.text
 
 
-@pytest.mark.disable_logging_error_check
 def test_embedded_external_ref_passes_through_int_to_ext(caplog):
     """An embedded external ref passes through under the strict default (rows
     written before the converter descended into JSON strings contain them),
@@ -466,7 +463,7 @@ def test_embedded_external_ref_passes_through_int_to_ext(caplog):
     content = json.dumps({"source_refs": [external_ref], "call": internal_ref})
     payload = {"description": content}
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         converted = universal_int_to_ext_ref_converter(payload, int_to_ext)
 
     assert json.loads(converted["description"]) == {

--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -427,8 +427,8 @@ def test_json_string_without_refs_is_not_reserialized():
 
 @pytest.mark.disable_logging_error_check
 def test_json_string_with_only_tolerated_external_ref_is_returned_unchanged(caplog):
-    """When an embedded ref does not change (already-external + tolerate), the
-    ORIGINAL string is returned with no re-serialization (spacing preserved).
+    """When an embedded ref does not change (already external), the ORIGINAL
+    string is returned with no re-serialization (spacing preserved).
     """
     external_ref = "weave:///entity/project/object/x:d"
 
@@ -440,9 +440,7 @@ def test_json_string_with_only_tolerated_external_ref_is_returned_unchanged(capl
     payload = {"content": blob}
 
     with caplog.at_level(logging.ERROR):
-        converted = universal_int_to_ext_ref_converter(
-            payload, int_to_ext, tolerate_external_refs=True
-        )
+        converted = universal_int_to_ext_ref_converter(payload, int_to_ext)
 
     assert converted is payload
     assert converted["content"] is blob
@@ -450,29 +448,28 @@ def test_json_string_with_only_tolerated_external_ref_is_returned_unchanged(capl
 
 
 @pytest.mark.disable_logging_error_check
-def test_embedded_external_ref_respects_tolerate_flag_int_to_ext(caplog):
-    """An embedded external ref obeys the same tolerate/raise policy as a
-    top-level external ref on the int->ext path.
+def test_embedded_external_ref_passes_through_int_to_ext(caplog):
+    """An embedded external ref passes through under the strict default (rows
+    written before the converter descended into JSON strings contain them),
+    while an embedded internal ref in the same blob still converts.
     """
-    external_ref = "weave:///entity/project/object/x:d"
+    internal_project_id = "internal-project"
+    external_ref = "weave:///entity/project/op/scorer:abc"
+    internal_ref = f"weave-trace-internal:///{internal_project_id}/call/123"
 
     def int_to_ext(project_id: str) -> str | None:
-        return "entity/project"
+        return "entity/project" if project_id == internal_project_id else None
 
-    content = json.dumps([{"type": "image", "url": external_ref}])
-    payload = {"content": content}
+    content = json.dumps({"source_refs": [external_ref], "call": internal_ref})
+    payload = {"description": content}
 
-    # Strict default: embedded external ref raises, same as top-level.
-    with pytest.raises(InvalidInternalRef):
-        universal_int_to_ext_ref_converter(payload, int_to_ext)
-
-    # Tolerant: passed through + logged, embedded JSON preserved unchanged.
     with caplog.at_level(logging.ERROR):
-        converted = universal_int_to_ext_ref_converter(
-            payload, int_to_ext, tolerate_external_refs=True
-        )
+        converted = universal_int_to_ext_ref_converter(payload, int_to_ext)
 
-    assert json.loads(converted["content"]) == [{"type": "image", "url": external_ref}]
+    assert json.loads(converted["description"]) == {
+        "source_refs": [external_ref],
+        "call": "weave:///entity/project/call/123",
+    }
     assert "Returning stored external ref unchanged" in caplog.text
 
 

--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -5,6 +5,7 @@ import logging
 import pytest
 from pydantic import BaseModel, ConfigDict
 
+from tests.trace_server.conftest import TEST_ENTITY
 from weave.trace.refs import ObjectRef
 from weave.trace_server.errors import InvalidExternalRef
 from weave.trace_server.interface.query import Query
@@ -17,6 +18,8 @@ from weave.trace_server.trace_server_converter import (
 from weave.trace_server.trace_server_interface import (
     CallStartReq,
     ObjCreateReq,
+    ObjQueryReq,
+    ObjReadReq,
     ObjSchemaForInsert,
     StartedCallSchemaForInsert,
 )
@@ -521,3 +524,38 @@ def test_deeply_nested_json_in_json_terminates_without_recursion_error():
     # Termination + no RecursionError is the contract; the buried ref is below
     # the cap so the string comes back unchanged.
     assert converted["content"] == nested
+
+
+@pytest.mark.disable_logging_error_check
+def test_stored_embedded_external_ref_reads_back_through_server(trace_server):
+    """Functional guard for the legacy-data regression: rows written before the
+    converter descended into JSON strings hold external refs inside stringified
+    blobs. Reads through the external adapter must return them unchanged, not
+    raise InvalidInternalRef.
+    """
+    project_id = f"{TEST_ENTITY}/test-embedded-ext-ref-legacy"
+    external_ref = f"weave:///{project_id}/op/scorer:abc"
+    blob = json.dumps({"source_refs": [external_ref], "note": "legacy"})
+
+    # Register the ext<->int project mapping, then write the legacy row through
+    # the internal server (no ref conversion), exactly as pre-descent
+    # deployments persisted it.
+    internal_project_id = trace_server._idc.ext_to_int_project_id(project_id)
+    trace_server._internal_trace_server.obj_create(
+        ObjCreateReq(
+            obj=ObjSchemaForInsert(
+                project_id=internal_project_id,
+                object_id="legacy-obj",
+                val={"description": blob},
+            )
+        )
+    )
+
+    read = trace_server.obj_read(
+        ObjReadReq(project_id=project_id, object_id="legacy-obj", digest="latest")
+    )
+    assert read.obj.val == {"description": blob}
+
+    query = trace_server.objs_query(ObjQueryReq(project_id=project_id))
+    assert [obj.object_id for obj in query.objs] == ["legacy-obj"]
+    assert query.objs[0].val == {"description": blob}

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -162,7 +162,7 @@ def universal_ext_to_int_ref_converter(
     """
     ext_to_int_project_cache: dict[str, str] = {}
 
-    def convert_ref(ref_str: str, embedded: bool) -> str:
+    def convert_ref(ref_str: str, _embedded: bool) -> str:
         if ref_str.startswith(weave_prefix):
             return replace_external_weave_ref(
                 ref_str, convert_ext_to_int_project_id, ext_to_int_project_cache
@@ -198,6 +198,10 @@ def universal_int_to_ext_ref_converter(
     format of `weave-trace-internal:///project_id/...` and the external references are
     expected to be in the format of `weave:///entity/project/...`.
 
+    External refs embedded in JSON-string leaves always pass through (logged):
+    rows written before the converter descended into JSON strings legitimately
+    contain them.
+
     Args:
         obj: The object to convert.
         convert_int_to_ext_project_id: A function that takes an internal
@@ -205,10 +209,7 @@ def universal_int_to_ext_ref_converter(
         tolerate_external_refs: When True, a top-level ref already in
             external (`weave:///`) form is logged and passed through instead
             of raising. Used by agent reads, whose ingest path does not fully
-            convert refs and can therefore persist external refs. External
-            refs embedded in JSON-string leaves are always passed through:
-            rows written before the converter descended into JSON strings
-            legitimately contain them.
+            convert refs and can therefore persist external refs.
 
     Returns:
         The object with all internal references replaced with external
@@ -237,7 +238,7 @@ def universal_int_to_ext_ref_converter(
         # pass through; top-level ones raise unless the caller opted in.
         if not (embedded or tolerate_external_refs):
             raise InvalidInternalRef("Encountered unexpected ref format.")
-        logger.error("Returning stored external ref unchanged: %s", ref_str)
+        logger.warning("Returning stored external ref unchanged: %s", ref_str)
         return ref_str
 
     return _map_values(obj, _make_ref_string_mapper(convert_ref))

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -72,14 +72,17 @@ def _convert_embedded_json_refs(s: str, mapper: Callable[[Any], Any]) -> str:
     return json.dumps(result)
 
 
-def _make_ref_string_mapper(convert_ref: Callable[[str], str]) -> Callable[[B], B]:
+def _make_ref_string_mapper(
+    convert_ref: Callable[[str, bool], str],
+) -> Callable[[B], B]:
     """Build a copy-on-write mapper that rewrites weave refs in string leaves.
 
-    ``convert_ref`` handles a string that starts with a ref prefix, returning
-    its converted form (or raising for a disallowed ref). A string that instead
+    ``convert_ref`` handles a string that starts with a ref prefix (plus a bool
+    marking whether the leaf sits inside an embedded JSON blob), returning its
+    converted form (or raising for a disallowed ref). A string that instead
     embeds a ref inside a JSON blob (e.g. a message ``content`` parts array) is
-    decoded and re-run through the same mapper so embedded refs convert exactly
-    like top-level ones. The substring pre-check keeps ref-free strings off the
+    decoded and re-run through the same mapper so embedded refs convert like
+    top-level ones. The substring pre-check keeps ref-free strings off the
     ``json.loads`` path, and ``_MAX_REF_SEARCH_DEPTH`` caps the JSON-in-JSON
     descent.
     """
@@ -90,7 +93,7 @@ def _make_ref_string_mapper(convert_ref: Callable[[str], str]) -> Callable[[B], 
         if not isinstance(obj, str):
             return obj
         if obj.startswith(weave_prefix) or obj.startswith(weave_internal_prefix):
-            return cast(B, convert_ref(obj))
+            return cast(B, convert_ref(obj, depth > 0))
         if depth < _MAX_REF_SEARCH_DEPTH and (
             weave_prefix in obj or weave_internal_prefix in obj
         ):
@@ -159,7 +162,7 @@ def universal_ext_to_int_ref_converter(
     """
     ext_to_int_project_cache: dict[str, str] = {}
 
-    def convert_ref(ref_str: str) -> str:
+    def convert_ref(ref_str: str, embedded: bool) -> str:
         if ref_str.startswith(weave_prefix):
             return replace_external_weave_ref(
                 ref_str, convert_ext_to_int_project_id, ext_to_int_project_cache
@@ -199,10 +202,13 @@ def universal_int_to_ext_ref_converter(
         obj: The object to convert.
         convert_int_to_ext_project_id: A function that takes an internal
             project ID and returns the external project ID.
-        tolerate_external_refs: When True, a ref already in external
-            (`weave:///`) form is logged and passed through instead of
-            raising. Used by agent reads, whose ingest path does not fully
-            convert refs and can therefore persist external refs.
+        tolerate_external_refs: When True, a top-level ref already in
+            external (`weave:///`) form is logged and passed through instead
+            of raising. Used by agent reads, whose ingest path does not fully
+            convert refs and can therefore persist external refs. External
+            refs embedded in JSON-string leaves are always passed through:
+            rows written before the converter descended into JSON strings
+            legitimately contain them.
 
     Returns:
         The object with all internal references replaced with external
@@ -210,7 +216,7 @@ def universal_int_to_ext_ref_converter(
     """
     int_to_ext_project_cache: dict[str, str | None] = {}
 
-    def convert_ref(ref_str: str) -> str:
+    def convert_ref(ref_str: str, embedded: bool) -> str:
         if ref_str.startswith(weave_internal_prefix):
             rest = ref_str[len(weave_internal_prefix) :]
             parts = rest.split("/", 1)
@@ -225,9 +231,11 @@ def universal_int_to_ext_ref_converter(
             if not external_project_id:
                 return f"{ri.WEAVE_PRIVATE_SCHEME}://///{tail}"
             return f"{ri.WEAVE_SCHEME}:///{external_project_id}/{tail}"
-        # External ref stored where an internal one belongs. Agent reads
-        # tolerate it (already external-shaped); other paths raise loudly.
-        if not tolerate_external_refs:
+        # External ref stored where an internal one belongs. Embedded ones are
+        # expected legacy state (writes only started converting inside JSON
+        # strings mid-2026) and are already external-shaped, so they always
+        # pass through; top-level ones raise unless the caller opted in.
+        if not (embedded or tolerate_external_refs):
             raise InvalidInternalRef("Encountered unexpected ref format.")
         logger.error("Returning stored external ref unchanged: %s", ref_str)
         return ref_str


### PR DESCRIPTION
## Summary
- since #7500 (embedded-ref conversion at the server boundary), reads 500 with `InvalidInternalRef: Encountered unexpected ref format.` on any object whose val embeds a `weave:///` ref inside a JSON-serialized string. Rows written before the converter descended into JSON strings legitimately contain these, so this is expected legacy data, not corruption (26k+ object versions across 32 projects match, plus call payloads).
- embedded external refs on the int->ext path now always pass through (logged; they are already output-shaped). Top-level refs keep the strict raise-by-default + existing `tolerate_external_refs` knob.

## Testing
unit tests; also replayed all affected stored object versions from the erroring prod projects through the patched converter (27/27 previously raising now convert clean).