### PR TITLE
feat(weave): server-side ingest sampling for the spans model

### DIFF
--- a/tests/trace_server/test_spans_ingest_sampling.py
+++ b/tests/trace_server/test_spans_ingest_sampling.py
@@ -232,10 +232,12 @@ def test_unusable_trace_ids_fail_open_in_decisions(
         assert sampler_metrics["parse_failures"] == [1]
 
 
-# --- decision ladder (parsed spans, no backend) -----------------------------
+# --- per-span verdicts (parsed spans, no backend) ----------------------------
 
 
-def test_decide_spans_ladder_at_rate_zero(sampler_metrics: dict[str, list]) -> None:
+def test_decide_spans_all_verdicts_at_rate_zero(
+    sampler_metrics: dict[str, list],
+) -> None:
     config = ingest_sampling.SamplingConfig(rate=0.0, dry_run=False)
     eval_tid = (1).to_bytes(16, "big")
     plain_tid = (2).to_bytes(16, "big")

--- a/tests/trace_server/test_spans_ingest_sampling.py
+++ b/tests/trace_server/test_spans_ingest_sampling.py
@@ -29,6 +29,10 @@ from weave.trace_server.agents.types import (
     GenAIOTelExportReq,
 )
 from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
+from weave.trace_server.opentelemetry.helpers import (
+    AttributePathConflictError,
+    unflatten_key_values,
+)
 from weave.trace_server.opentelemetry.python_spans import Resource as PyResource
 from weave.trace_server.opentelemetry.python_spans import Span as PySpan
 from weave.trace_server.opentelemetry.python_spans import StatusCode
@@ -116,6 +120,13 @@ def _parse(span: PbSpan) -> PySpan:
     return PySpan.from_proto(span, PyResource.from_proto(PbResource()))
 
 
+def _conflict_error(span: PbSpan) -> str:
+    """The exact parse-failure message the server records for this span."""
+    with pytest.raises(AttributePathConflictError) as excinfo:
+        unflatten_key_values(span.attributes)
+    return str(excinfo.value)
+
+
 def _tid_with_verdict(rate: float, *, kept: bool, start: int = 1) -> bytes:
     """First 16-byte trace id (from ``start`` upward) whose verdict matches."""
     for i in range(start, start + 10_000):
@@ -154,7 +165,8 @@ def sampler_metrics(monkeypatch: pytest.MonkeyPatch) -> dict[str, list]:
 
 def test_keep_by_hash_matches_inline_sha256() -> None:
     # Pin the exact formula: the calls-model sampler uses the same one, and a
-    # trace living in both data models must get one verdict.
+    # trace living in both data models must get one verdict. Purity also gives
+    # cross-request determinism: the verdict depends on nothing but the string.
     for i in range(1, 50):
         tid = i.to_bytes(16, "big").hex()
         for rate in (0.0, 0.1, 0.5, 0.9, 1.0):
@@ -193,17 +205,29 @@ def test_sample_rate_env_falls_back_to_off_when_invalid(
 
 
 @pytest.mark.parametrize(
-    ("trace_id", "usable"),
+    ("trace_id_bytes", "usable"),
     [
-        ("a" * 32, True),
-        ("", False),  # empty proto bytes
-        ("a" * 30, False),  # 15-byte id
-        ("a" * 34, False),  # 17-byte id
-        ("0" * 32, False),  # OTel-invalid zero id
+        (b"\xaa" * 16, True),
+        (b"", False),  # empty proto bytes
+        (b"\xab" * 15, False),  # 15-byte id
+        (b"\xab" * 17, False),  # 17-byte id
+        (b"\x00" * 16, False),  # OTel-invalid zero id
     ],
 )
-def test_usable_trace_id(trace_id: str, usable: bool) -> None:
-    assert ingest_sampling._usable_trace_id(trace_id) is usable
+def test_unusable_trace_ids_fail_open_in_decisions(
+    sampler_metrics: dict[str, list], trace_id_bytes: bytes, usable: bool
+) -> None:
+    # At rate 0.0 a usable id is hash-dropped; an unusable one is kept
+    # fail-open and counted as a parse failure.
+    config = ingest_sampling.SamplingConfig(rate=0.0, dry_run=False)
+    span = _parse(_proto_span(trace_id_bytes, b"\x0a" * 8))
+    decisions = ingest_sampling.decide_spans(config, [span], [5])
+    if usable:
+        assert decisions == [ingest_sampling.SpanDecision(drop=True)]
+        assert sampler_metrics["parse_failures"] == []
+    else:
+        assert decisions == [ingest_sampling.SpanDecision(drop=False)]
+        assert sampler_metrics["parse_failures"] == [1]
 
 
 # --- decision ladder (parsed spans, no backend) -----------------------------
@@ -227,9 +251,10 @@ def test_decide_spans_ladder_at_rate_zero(sampler_metrics: dict[str, list]) -> N
         ingest_sampling.SpanDecision(drop=False),
         ingest_sampling.SpanDecision(drop=True),
     ]
-    assert sampler_metrics["seen"] == [1, 1, 1, 1]
+    # Counters are per span but emitted once per request (aggregated).
+    assert sampler_metrics["seen"] == [4]
     assert sampler_metrics["parse_failures"] == [1]
-    assert sampler_metrics["evals_kept"] == [1, 1]
+    assert sampler_metrics["evals_kept"] == [2]
     assert sampler_metrics["dropped"] == [(1, 40, False)]
 
 
@@ -281,29 +306,42 @@ def test_sampler_off_is_inert(
     monkeypatch: pytest.MonkeyPatch,
     rate_env: str | None,
 ) -> None:
-    """The default config must not change ingest behavior at all."""
+    """The default config must not change ingest behavior at all.
+
+    Pins the exact error_message (content and per-span order) on a request
+    mixing good spans with two distinct parse failures. Extraction failures
+    share the same extract_row helper in both branches, but no real OTel
+    payload can make the defensively-guarded extractor raise, so that branch
+    is covered by construction rather than by a fixture.
+    """
     if rate_env is None:
         monkeypatch.delenv("WEAVE_INGEST_SAMPLE_RATE", raising=False)
     else:
         monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", rate_env)
     project_id = make_project_id("spans_sampling_off")
     tid = (10).to_bytes(16, "big")
-    conflict = _proto_span(
+    conflict_a = _proto_span(
         (11).to_bytes(16, "big"),
         b"\x13" * 8,
         # "x" as a leaf and "x.y" under it can't both exist -> parse failure.
         attrs={"x": "leaf", "x.y": "nested"},
     )
+    conflict_b = _proto_span(
+        (12).to_bytes(16, "big"), b"\x14" * 8, attrs={"y": "leaf", "y.z": "nested"}
+    )
     res = _export(
         ch_server,
         project_id,
         _proto_span(tid, b"\x11" * 8),
+        conflict_a,
         _proto_span(tid, b"\x12" * 8, parent_span_id=b"\x11" * 8),
-        conflict,
+        conflict_b,
     )
     assert res.accepted_spans == 2
-    assert res.rejected_spans == 1
-    assert res.error_message != ""
+    assert res.rejected_spans == 2
+    assert res.error_message == "; ".join(
+        _conflict_error(span) for span in (conflict_a, conflict_b)
+    )
     assert len(_stored_spans(ch_server, project_id)) == 2
     # Disabled sampler emits nothing at all.
     assert sampler_metrics == {
@@ -332,10 +370,7 @@ def test_rate_zero_drops_non_eval_trace_whole(
     assert res.accepted_spans == 2
     assert res.rejected_spans == 0
     assert _stored_spans(ch_server, project_id) == []
-    assert [(c, d) for c, _, d in sampler_metrics["dropped"]] == [
-        (1, False),
-        (1, False),
-    ]
+    assert [(c, d) for c, _, d in sampler_metrics["dropped"]] == [(2, False)]
     assert all(size > 0 for _, size, _ in sampler_metrics["dropped"])
 
 
@@ -427,6 +462,7 @@ def test_mixed_request_drops_selectively(
     # Parse failures stay rejected in the sampled path exactly as today.
     assert res.accepted_spans == 2
     assert res.rejected_spans == 1
+    assert res.error_message == _conflict_error(conflict)
     stored = _stored_spans(ch_server, project_id)
     assert [s.trace_id for s in stored] == [kept_tid.hex()]
 
@@ -447,7 +483,7 @@ def test_unusable_trace_ids_fail_open(
     )
     assert res.accepted_spans == 4
     assert len(_stored_spans(ch_server, project_id)) == 4
-    assert sampler_metrics["parse_failures"] == [1, 1, 1, 1]
+    assert sampler_metrics["parse_failures"] == [4]
     assert sampler_metrics["dropped"] == []
 
 

--- a/tests/trace_server/test_spans_ingest_sampling.py
+++ b/tests/trace_server/test_spans_ingest_sampling.py
@@ -1,0 +1,527 @@
+"""Tests for the spans-model ingest sampler (agents/ingest_sampling.py).
+
+The pure decision/hash tests need no backend. The end-to-end ingest tests run
+the real OTel export path against ClickHouse via the ``ch_server`` fixture.
+See WB-36877.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import hashlib
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from opentelemetry.proto.common.v1.common_pb2 import InstrumentationScope, KeyValue
+from opentelemetry.proto.resource.v1.resource_pb2 import Resource as PbResource
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans
+from opentelemetry.proto.trace.v1.trace_pb2 import Span as PbSpan
+
+from tests.trace_server.helpers import make_project_id
+from weave.trace_server import environment
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.agents import ingest_sampling, ingest_sampling_metrics
+from weave.trace_server.agents.types import (
+    AgentSpansQueryReq,
+    AgentSpanValueRef,
+    GenAIOTelExportReq,
+)
+from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
+from weave.trace_server.opentelemetry.python_spans import Resource as PyResource
+from weave.trace_server.opentelemetry.python_spans import Span as PySpan
+from weave.trace_server.opentelemetry.python_spans import StatusCode
+
+EVAL_MARKER_ATTR = "weave.eval.predict_and_score_call_id"
+STAMP_ATTR = "weave.ingest_sample_rate"
+
+_NOW_NS = int(datetime.datetime(2026, 1, 1).timestamp() * 1_000_000_000)
+
+
+def _proto_span(
+    trace_id: bytes,
+    span_id: bytes,
+    *,
+    parent_span_id: bytes | None = None,
+    attrs: dict[str, str | float] | None = None,
+    name: str = "chat test-model",
+) -> PbSpan:
+    """Build a minimal ended OTel proto span (no parent -> a turn root)."""
+    span = PbSpan()
+    span.name = name
+    span.trace_id = trace_id
+    span.span_id = span_id
+    if parent_span_id is not None:
+        span.parent_span_id = parent_span_id
+    span.start_time_unix_nano = _NOW_NS
+    span.end_time_unix_nano = _NOW_NS + 1_000_000_000
+    span.kind = 1  # CLIENT
+    for key, value in (attrs or {}).items():
+        kv = KeyValue()
+        kv.key = key
+        if isinstance(value, float):
+            kv.value.double_value = value
+        else:
+            kv.value.string_value = value
+        span.attributes.append(kv)
+    span.status.code = StatusCode.OK.value  # type: ignore[assignment]
+    return span
+
+
+def _processed(*spans: PbSpan, run_id: str | None = None) -> tsi.ProcessedResourceSpans:
+    scope = InstrumentationScope()
+    scope.name = "test_instrumentation"
+    scope.version = "1.0.0"
+    scope_spans = ScopeSpans()
+    scope_spans.scope.CopyFrom(scope)
+    scope_spans.spans.extend(spans)
+    resource_spans = ResourceSpans()
+    resource_spans.resource.CopyFrom(PbResource())
+    resource_spans.scope_spans.append(scope_spans)
+    return tsi.ProcessedResourceSpans(
+        entity="test-entity",
+        project="test-project",
+        run_id=run_id,
+        resource_spans=resource_spans,
+    )
+
+
+def _export(ch_server, project_id: str, *spans: PbSpan):
+    return ch_server.genai_otel_export(
+        GenAIOTelExportReq(
+            processed_spans=[_processed(*spans)],
+            project_id=project_id,
+            wb_user_id="test-user",
+        )
+    )
+
+
+def _stored_spans(ch_server, project_id: str):
+    # Custom-attr Maps are returned only for explicitly selected keys, so ask
+    # for the stamp key in both typed maps it could land in.
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(
+            project_id=project_id,
+            custom_attr_columns=[
+                AgentSpanValueRef(source="custom_attrs_float", key=STAMP_ATTR),
+                AgentSpanValueRef(source="custom_attrs_string", key=STAMP_ATTR),
+            ],
+        )
+    )
+    return res.spans
+
+
+def _parse(span: PbSpan) -> PySpan:
+    return PySpan.from_proto(span, PyResource.from_proto(PbResource()))
+
+
+def _tid_with_verdict(rate: float, *, kept: bool, start: int = 1) -> bytes:
+    """First 16-byte trace id (from ``start`` upward) whose verdict matches."""
+    for i in range(start, start + 10_000):
+        tid = i.to_bytes(16, "big")
+        if ingest_sampling.keep_by_hash(tid.hex(), rate) == kept:
+            return tid
+    raise AssertionError(f"no trace id with kept={kept} at rate={rate} in range")
+
+
+@pytest.fixture
+def sampler_metrics(monkeypatch: pytest.MonkeyPatch) -> dict[str, list]:
+    """Record sampler metric emissions instead of sending UDP packets."""
+    calls: dict[str, list] = {
+        "seen": [],
+        "parse_failures": [],
+        "evals_kept": [],
+        "dropped": [],
+    }
+    monkeypatch.setattr(ingest_sampling_metrics, "seen", calls["seen"].append)
+    monkeypatch.setattr(
+        ingest_sampling_metrics, "parse_failures", calls["parse_failures"].append
+    )
+    monkeypatch.setattr(
+        ingest_sampling_metrics, "evals_kept", calls["evals_kept"].append
+    )
+    monkeypatch.setattr(
+        ingest_sampling_metrics,
+        "dropped",
+        lambda c, b, d: calls["dropped"].append((c, b, d)),
+    )
+    return calls
+
+
+# --- pure functions ---------------------------------------------------------
+
+
+def test_keep_by_hash_matches_inline_sha256() -> None:
+    # Pin the exact formula: the calls-model sampler uses the same one, and a
+    # trace living in both data models must get one verdict.
+    for i in range(1, 50):
+        tid = i.to_bytes(16, "big").hex()
+        for rate in (0.0, 0.1, 0.5, 0.9, 1.0):
+            expected = (
+                int(hashlib.sha256(tid.encode("utf-8")).hexdigest(), 16) % 1_000_000
+            ) < rate * 1_000_000
+            assert ingest_sampling.keep_by_hash(tid, rate) is expected
+
+
+def test_keep_by_hash_rate_extremes() -> None:
+    ids = [i.to_bytes(16, "big").hex() for i in range(1, 201)]
+    assert all(ingest_sampling.keep_by_hash(tid, 1.0) for tid in ids)
+    assert not any(ingest_sampling.keep_by_hash(tid, 0.0) for tid in ids)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("0.1", 0.1),  # valid
+        ("0.0", 0.0),  # valid edge (drop all non-eval)
+        ("1.0", 1.0),  # valid edge (off)
+        ("-1", 1.0),  # negative would drop everything -> fall back to off
+        ("2.0", 1.0),  # above range -> off
+        ("nan", 1.0),  # NaN fails the range check -> off
+        ("inf", 1.0),  # inf fails the range check -> off
+        ("abc", 1.0),  # unparseable -> off
+    ],
+)
+def test_sample_rate_env_falls_back_to_off_when_invalid(
+    monkeypatch: pytest.MonkeyPatch, value: str, expected: float
+) -> None:
+    # Validation parity with the calls-model sampler: both read this variable,
+    # so a drift here would give the two models different effective rates.
+    monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", value)
+    assert environment.wf_ingest_sample_rate() == expected
+
+
+@pytest.mark.parametrize(
+    ("trace_id", "usable"),
+    [
+        ("a" * 32, True),
+        ("", False),  # empty proto bytes
+        ("a" * 30, False),  # 15-byte id
+        ("a" * 34, False),  # 17-byte id
+        ("0" * 32, False),  # OTel-invalid zero id
+    ],
+)
+def test_usable_trace_id(trace_id: str, usable: bool) -> None:
+    assert ingest_sampling._usable_trace_id(trace_id) is usable
+
+
+# --- decision ladder (parsed spans, no backend) -----------------------------
+
+
+def test_decide_spans_ladder_at_rate_zero(sampler_metrics: dict[str, list]) -> None:
+    config = ingest_sampling.SamplingConfig(rate=0.0, dry_run=False)
+    eval_tid = (1).to_bytes(16, "big")
+    plain_tid = (2).to_bytes(16, "big")
+    spans = [
+        _parse(_proto_span(b"", b"\x01" * 8)),  # unusable id -> fail open
+        _parse(_proto_span(eval_tid, b"\x02" * 8, attrs={EVAL_MARKER_ATTR: "pas-1"})),
+        # Unmarked child of the eval trace: protected by its marked sibling.
+        _parse(_proto_span(eval_tid, b"\x03" * 8)),
+        _parse(_proto_span(plain_tid, b"\x04" * 8)),
+    ]
+    decisions = ingest_sampling.decide_spans(config, spans, [10, 20, 30, 40])
+    assert decisions == [
+        ingest_sampling.SpanDecision(drop=False),
+        ingest_sampling.SpanDecision(drop=False),
+        ingest_sampling.SpanDecision(drop=False),
+        ingest_sampling.SpanDecision(drop=True),
+    ]
+    assert sampler_metrics["seen"] == [1, 1, 1, 1]
+    assert sampler_metrics["parse_failures"] == [1]
+    assert sampler_metrics["evals_kept"] == [1, 1]
+    assert sampler_metrics["dropped"] == [(1, 40, False)]
+
+
+def test_decide_spans_dry_run_keeps_but_counts(
+    sampler_metrics: dict[str, list],
+) -> None:
+    config = ingest_sampling.SamplingConfig(rate=0.0, dry_run=True)
+    span = _parse(_proto_span((3).to_bytes(16, "big"), b"\x05" * 8))
+    decisions = ingest_sampling.decide_spans(config, [span], [17])
+    # Dry-run never drops, and a dry-run hash winner gets no rate either.
+    assert decisions == [ingest_sampling.SpanDecision(drop=False, sampled_rate=None)]
+    assert sampler_metrics["dropped"] == [(1, 17, True)]
+
+
+def test_decide_spans_rate_stamp_only_on_genuine_hash_keep(
+    sampler_metrics: dict[str, list],
+) -> None:
+    rate = 0.5
+    kept_tid = _tid_with_verdict(rate, kept=True)
+    # A different hash-winning trace id, so the eval trace stays separate.
+    eval_tid = _tid_with_verdict(
+        rate, kept=True, start=int.from_bytes(kept_tid, "big") + 1
+    )
+    assert eval_tid != kept_tid
+    config = ingest_sampling.SamplingConfig(rate=rate, dry_run=False)
+    spans = [
+        _parse(_proto_span(kept_tid, b"\x06" * 8)),
+        # Eval trace with a hash-winning id: kept whole, so no stamp.
+        _parse(_proto_span(eval_tid, b"\x07" * 8, attrs={EVAL_MARKER_ATTR: "pas-2"})),
+    ]
+    decisions = ingest_sampling.decide_spans(config, spans, [1, 1])
+    assert decisions == [
+        ingest_sampling.SpanDecision(drop=False, sampled_rate=0.5),
+        ingest_sampling.SpanDecision(drop=False, sampled_rate=None),
+    ]
+
+
+# --- end-to-end ingest (ClickHouse) -----------------------------------------
+
+# CI ClickHouse occasionally doesn't surface a just-inserted span to the
+# immediate read (same reruns guard as the other genai ingest tests).
+
+
+@pytest.mark.flaky(reruns=3)
+@pytest.mark.parametrize("rate_env", [None, "1.0"], ids=["unset", "explicit-1.0"])
+def test_sampler_off_is_inert(
+    ch_server,
+    sampler_metrics: dict[str, list],
+    monkeypatch: pytest.MonkeyPatch,
+    rate_env: str | None,
+) -> None:
+    """The default config must not change ingest behavior at all."""
+    if rate_env is None:
+        monkeypatch.delenv("WEAVE_INGEST_SAMPLE_RATE", raising=False)
+    else:
+        monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", rate_env)
+    project_id = make_project_id("spans_sampling_off")
+    tid = (10).to_bytes(16, "big")
+    conflict = _proto_span(
+        (11).to_bytes(16, "big"),
+        b"\x13" * 8,
+        # "x" as a leaf and "x.y" under it can't both exist -> parse failure.
+        attrs={"x": "leaf", "x.y": "nested"},
+    )
+    res = _export(
+        ch_server,
+        project_id,
+        _proto_span(tid, b"\x11" * 8),
+        _proto_span(tid, b"\x12" * 8, parent_span_id=b"\x11" * 8),
+        conflict,
+    )
+    assert res.accepted_spans == 2
+    assert res.rejected_spans == 1
+    assert res.error_message != ""
+    assert len(_stored_spans(ch_server, project_id)) == 2
+    # Disabled sampler emits nothing at all.
+    assert sampler_metrics == {
+        "seen": [],
+        "parse_failures": [],
+        "evals_kept": [],
+        "dropped": [],
+    }
+
+
+@pytest.mark.flaky(reruns=3)
+def test_rate_zero_drops_non_eval_trace_whole(
+    ch_server, sampler_metrics: dict[str, list], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", "0.0")
+    project_id = make_project_id("spans_sampling_drop")
+    tid = (20).to_bytes(16, "big")
+    res = _export(
+        ch_server,
+        project_id,
+        _proto_span(tid, b"\x21" * 8),
+        _proto_span(tid, b"\x22" * 8, parent_span_id=b"\x21" * 8),
+    )
+    # Dropped spans still count as accepted: the client sees an ordinary
+    # success, mirroring the calls model.
+    assert res.accepted_spans == 2
+    assert res.rejected_spans == 0
+    assert _stored_spans(ch_server, project_id) == []
+    assert [(c, d) for c, _, d in sampler_metrics["dropped"]] == [
+        (1, False),
+        (1, False),
+    ]
+    assert all(size > 0 for _, size, _ in sampler_metrics["dropped"])
+
+
+@pytest.mark.flaky(reruns=3)
+def test_eval_marked_trace_kept_whole_at_rate_zero(
+    ch_server, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One marked span protects the whole trace -- including unmarked
+    children in the same request, and regardless of which client set the
+    marker (the same rule is the documented opt-in for foreign OTel).
+    """
+    monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", "0.0")
+    project_id = make_project_id("spans_sampling_eval")
+    tid = (30).to_bytes(16, "big")
+    res = _export(
+        ch_server,
+        project_id,
+        _proto_span(tid, b"\x31" * 8, attrs={EVAL_MARKER_ATTR: "pas-3"}),
+        _proto_span(tid, b"\x32" * 8, parent_span_id=b"\x31" * 8),
+    )
+    assert res.accepted_spans == 2
+    assert len(_stored_spans(ch_server, project_id)) == 2
+
+
+@pytest.mark.flaky(reruns=3)
+def test_dry_run_keeps_everything_and_stamps_nothing(
+    ch_server, sampler_metrics: dict[str, list], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", "0.0")
+    monkeypatch.setenv("WEAVE_INGEST_SAMPLE_DRY_RUN", "true")
+    project_id = make_project_id("spans_sampling_dryrun")
+    tid = (40).to_bytes(16, "big")
+    res = _export(ch_server, project_id, _proto_span(tid, b"\x41" * 8))
+    assert res.accepted_spans == 1
+    stored = _stored_spans(ch_server, project_id)
+    assert len(stored) == 1
+    # A dry-run keep is a kept-whole span: no rate stamp, or reconstructed
+    # totals would double-count the hash winners.
+    assert stored[0].custom_attrs_float == {}
+    assert [(c, d) for c, _, d in sampler_metrics["dropped"]] == [(1, True)]
+
+
+@pytest.mark.flaky(reruns=3)
+def test_hash_kept_trace_is_stamped_with_rate(
+    ch_server, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rate = 0.5
+    monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", str(rate))
+    project_id = make_project_id("spans_sampling_stamp")
+    tid = _tid_with_verdict(rate, kept=True)
+    res = _export(
+        ch_server,
+        project_id,
+        # A client-supplied float under the stamp key is overwritten on a
+        # genuine keep; a *string* "0.5" lands in the string map and cannot
+        # touch the float map the weighting consumer reads.
+        _proto_span(tid, b"\x51" * 8, attrs={STAMP_ATTR: 0.9}),
+        _proto_span(
+            tid, b"\x52" * 8, parent_span_id=b"\x51" * 8, attrs={STAMP_ATTR: "0.5"}
+        ),
+    )
+    assert res.accepted_spans == 2
+    stored = sorted(_stored_spans(ch_server, project_id), key=lambda s: s.span_id)
+    assert len(stored) == 2
+    for span in stored:
+        assert span.custom_attrs_float == {STAMP_ATTR: rate}
+    assert stored[1].custom_attrs_string[STAMP_ATTR] == "0.5"
+
+
+@pytest.mark.flaky(reruns=3)
+def test_mixed_request_drops_selectively(
+    ch_server, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rate = 0.5
+    monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", str(rate))
+    project_id = make_project_id("spans_sampling_mixed")
+    kept_tid = _tid_with_verdict(rate, kept=True)
+    dropped_tid = _tid_with_verdict(rate, kept=False)
+    conflict = _proto_span(
+        (60).to_bytes(16, "big"), b"\x63" * 8, attrs={"x": "leaf", "x.y": "nested"}
+    )
+    res = _export(
+        ch_server,
+        project_id,
+        _proto_span(kept_tid, b"\x61" * 8),
+        _proto_span(dropped_tid, b"\x62" * 8),
+        conflict,
+    )
+    # Parse failures stay rejected in the sampled path exactly as today.
+    assert res.accepted_spans == 2
+    assert res.rejected_spans == 1
+    stored = _stored_spans(ch_server, project_id)
+    assert [s.trace_id for s in stored] == [kept_tid.hex()]
+
+
+@pytest.mark.flaky(reruns=3)
+def test_unusable_trace_ids_fail_open(
+    ch_server, sampler_metrics: dict[str, list], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", "0.0")
+    project_id = make_project_id("spans_sampling_failopen")
+    res = _export(
+        ch_server,
+        project_id,
+        _proto_span(b"", b"\x71" * 8),  # empty id
+        _proto_span(b"\xab" * 15, b"\x72" * 8),  # 15-byte id
+        _proto_span(b"\xab" * 17, b"\x73" * 8),  # 17-byte id
+        _proto_span(b"\x00" * 16, b"\x74" * 8),  # OTel-invalid zero id
+    )
+    assert res.accepted_spans == 4
+    assert len(_stored_spans(ch_server, project_id)) == 4
+    assert sampler_metrics["parse_failures"] == [1, 1, 1, 1]
+    assert sampler_metrics["dropped"] == []
+
+
+@pytest.mark.flaky(reruns=3)
+def test_dropped_trace_writes_no_content_files(
+    ch_server, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deciding before blob-strip means a dropped trace leaves no orphaned
+    Content files behind.
+    """
+    b64 = base64.b64encode(b"x" * (AUTO_CONVERSION_MIN_SIZE + 100)).decode("ascii")
+    messages_json = json.dumps(
+        [
+            {
+                "role": "user",
+                "parts": [
+                    {"type": "text", "content": "describe"},
+                    {"type": "image", "url": f"data:image/png;base64,{b64}"},
+                ],
+            }
+        ]
+    )
+    attrs = {"gen_ai.input.messages": messages_json}
+
+    monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", "0.0")
+    dropped_project = make_project_id("spans_sampling_nofiles")
+    _export(
+        ch_server,
+        dropped_project,
+        _proto_span((80).to_bytes(16, "big"), b"\x81" * 8, attrs=attrs),
+    )
+    dropped_stats = ch_server.files_stats(tsi.FilesStatsReq(project_id=dropped_project))
+    assert dropped_stats.total_size_bytes == 0
+
+    # Control: the same payload with the sampler off does write a Content file.
+    monkeypatch.delenv("WEAVE_INGEST_SAMPLE_RATE", raising=False)
+    kept_project = make_project_id("spans_sampling_files")
+    _export(
+        ch_server,
+        kept_project,
+        _proto_span((81).to_bytes(16, "big"), b"\x82" * 8, attrs=attrs),
+    )
+    kept_stats = ch_server.files_stats(tsi.FilesStatsReq(project_id=kept_project))
+    assert kept_stats.total_size_bytes > 0
+
+
+@pytest.mark.flaky(reruns=3)
+def test_dropped_trace_emits_no_scoring_event(
+    ch_server, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drop = not stored AND not scored: the Kafka emit is fed by the same
+    filtered rows, so a dropped turn root never reaches the scoring worker.
+    """
+    monkeypatch.setattr(environment, "wf_enable_online_eval", lambda: True)
+    monkeypatch.setattr(environment, "wf_enable_agent_scoring", lambda: True)
+    producer = MagicMock()
+    monkeypatch.setattr(ch_server, "_kafka_producer", producer)
+    monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", "0.0")
+
+    dropped_project = make_project_id("spans_sampling_nokafka")
+    _export(
+        ch_server,
+        dropped_project,
+        _proto_span((90).to_bytes(16, "big"), b"\x91" * 8),
+    )
+    producer.produce_score_agent_spans.assert_not_called()
+
+    # A kept turn root (eval carve-out) still emits exactly one event.
+    kept_project = make_project_id("spans_sampling_kafka")
+    _export(
+        ch_server,
+        kept_project,
+        _proto_span(
+            (91).to_bytes(16, "big"), b"\x92" * 8, attrs={EVAL_MARKER_ATTR: "pas-4"}
+        ),
+    )
+    producer.produce_score_agent_spans.assert_called_once()

--- a/tests/trace_server/test_spans_ingest_sampling.py
+++ b/tests/trace_server/test_spans_ingest_sampling.py
@@ -225,6 +225,8 @@ def test_unusable_trace_ids_fail_open_in_decisions(
     if usable:
         assert decisions == [ingest_sampling.SpanDecision(drop=True)]
         assert sampler_metrics["parse_failures"] == []
+        assert sampler_metrics["seen"] == [1]
+        assert sampler_metrics["dropped"] == [(1, 5, False)]
     else:
         assert decisions == [ingest_sampling.SpanDecision(drop=False)]
         assert sampler_metrics["parse_failures"] == [1]
@@ -309,10 +311,8 @@ def test_sampler_off_is_inert(
     """The default config must not change ingest behavior at all.
 
     Pins the exact error_message (content and per-span order) on a request
-    mixing good spans with two distinct parse failures. Extraction failures
-    share the same extract_row helper in both branches, but no real OTel
-    payload can make the defensively-guarded extractor raise, so that branch
-    is covered by construction rather than by a fixture.
+    interleaving good spans, two distinct parse failures, and an extraction
+    failure (a message whose `parts` field is not a list).
     """
     if rate_env is None:
         monkeypatch.delenv("WEAVE_INGEST_SAMPLE_RATE", raising=False)
@@ -329,18 +329,29 @@ def test_sampler_off_is_inert(
     conflict_b = _proto_span(
         (12).to_bytes(16, "big"), b"\x14" * 8, attrs={"y": "leaf", "y.z": "nested"}
     )
+    extract_sid = b"\x15" * 8
+    extract_fail = _proto_span(
+        (13).to_bytes(16, "big"),
+        extract_sid,
+        attrs={"gen_ai.output.messages": '[{"parts": 5}]'},
+    )
     res = _export(
         ch_server,
         project_id,
         _proto_span(tid, b"\x11" * 8),
         conflict_a,
         _proto_span(tid, b"\x12" * 8, parent_span_id=b"\x11" * 8),
+        extract_fail,
         conflict_b,
     )
     assert res.accepted_spans == 2
-    assert res.rejected_spans == 2
+    assert res.rejected_spans == 3
     assert res.error_message == "; ".join(
-        _conflict_error(span) for span in (conflict_a, conflict_b)
+        [
+            _conflict_error(conflict_a),
+            f"Extraction failed for span {extract_sid.hex()}: TypeError",
+            _conflict_error(conflict_b),
+        ]
     )
     assert len(_stored_spans(ch_server, project_id)) == 2
     # Disabled sampler emits nothing at all.
@@ -465,6 +476,29 @@ def test_mixed_request_drops_selectively(
     assert res.error_message == _conflict_error(conflict)
     stored = _stored_spans(ch_server, project_id)
     assert [s.trace_id for s in stored] == [kept_tid.hex()]
+
+
+@pytest.mark.flaky(reruns=3)
+def test_extraction_failure_on_kept_trace_stays_rejected(
+    ch_server, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hash-kept span that fails extraction is rejected with the exact
+    type-name-only error, same as with the sampler off (shared helper).
+    """
+    rate = 0.5
+    monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", str(rate))
+    project_id = make_project_id("spans_sampling_extractfail")
+    tid = _tid_with_verdict(rate, kept=True)
+    sid = b"\xa1" * 8
+    res = _export(
+        ch_server,
+        project_id,
+        _proto_span(tid, sid, attrs={"gen_ai.output.messages": '[{"parts": 5}]'}),
+    )
+    assert res.accepted_spans == 0
+    assert res.rejected_spans == 1
+    assert res.error_message == f"Extraction failed for span {sid.hex()}: TypeError"
+    assert _stored_spans(ch_server, project_id) == []
 
 
 @pytest.mark.flaky(reruns=3)

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, TypeVar, cast
 
 from weave.shared import refs_internal as ri
+from weave.trace_server.agents import ingest_sampling
 from weave.trace_server.agents.chat_view import (
     add_optional_cost,
     build_trace_chat,
@@ -829,6 +830,14 @@ class AgentWriteHandler:
 
         The `messages` search table is populated by a ClickHouse
         materialized view off the spans table (migration 030).
+
+        When ingest sampling is enabled (rate < 1.0), spans are parsed first
+        and whole traces are kept or dropped *before* the expensive
+        blob-strip/extraction steps run, so dropped traces never write
+        Content files. Dropped spans are neither stored nor returned (they
+        never reach the scoring Kafka emit) but still count as accepted --
+        the client sees an ordinary success. See agents/ingest_sampling.py
+        (WB-36877).
         """
         span_rows: list[AgentSpanCHInsertable] = []
         accepted = 0
@@ -837,59 +846,102 @@ class AgentWriteHandler:
         failure_counts: dict[str, int] = {}
         failure_examples: list[str] = []
 
-        for processed_span in req.processed_spans:
-            resource = Resource.from_proto(processed_span.resource_spans.resource)
+        # Both branches below run every span through these two helpers, so
+        # parse/extraction failure accounting cannot drift between them.
+        def parse_span(protobuf_span: Any, resource: Resource) -> Span | None:
+            nonlocal rejected
+            try:
+                return Span.from_proto(protobuf_span, resource)
+            except AttributePathConflictError as e:
+                _record_ingest_failure(
+                    failure_counts,
+                    failure_examples,
+                    type(e).__name__,
+                )
+                rejected += 1
+                errors.append(str(e))
+                return None
 
-            for protobuf_scope_spans in processed_span.resource_spans.scope_spans:
-                for protobuf_span in protobuf_scope_spans.spans:
-                    try:
-                        span = Span.from_proto(protobuf_span, resource)
-                    except AttributePathConflictError as e:
-                        _record_ingest_failure(
-                            failure_counts,
-                            failure_examples,
-                            type(e).__name__,
-                        )
-                        rejected += 1
-                        errors.append(str(e))
-                        continue
+        def extract_row(span: Span, run_id: str | None) -> AgentSpanCHInsertable | None:
+            nonlocal accepted, rejected
+            # Strip inline base64/data-URIs into weave refs before the
+            # pure extraction transform runs.
+            if self._trace_server is not None:
+                strip_inline_blobs_from_span(
+                    span,
+                    req.project_id,
+                    self._trace_server,
+                    wb_user_id=req.wb_user_id,
+                )
+            try:
+                genai_row = extract_genai_span(
+                    span,
+                    project_id=req.project_id,
+                    wb_user_id=req.wb_user_id or "",
+                    wb_run_id=run_id or "",
+                )
+            except Exception as e:
+                error_type = type(e).__name__
+                _record_ingest_failure(
+                    failure_counts,
+                    failure_examples,
+                    error_type,
+                    span_id=span.span_id,
+                )
+                rejected += 1
+                # Don't leak raw `str(e)` to the client — it can
+                # contain server-side state. Exception type is
+                # safe and enough for a caller to triage.
+                errors.append(
+                    f"Extraction failed for span {span.span_id}: {error_type}"
+                )
+                return None
+            accepted += 1
+            return genai_row
 
-                    # Strip inline base64/data-URIs into weave refs before the
-                    # pure extraction transform runs.
-                    if self._trace_server is not None:
-                        strip_inline_blobs_from_span(
-                            span,
-                            req.project_id,
-                            self._trace_server,
-                            wb_user_id=req.wb_user_id,
-                        )
+        sampling = ingest_sampling.request_config()
+        if not sampling.enabled:
+            # Sampler off (the default): the unmodified single-pass path.
+            for processed_span in req.processed_spans:
+                resource = Resource.from_proto(processed_span.resource_spans.resource)
+                for protobuf_scope_spans in processed_span.resource_spans.scope_spans:
+                    for protobuf_span in protobuf_scope_spans.spans:
+                        span = parse_span(protobuf_span, resource)
+                        if span is None:
+                            continue
+                        row = extract_row(span, processed_span.run_id)
+                        if row is not None:
+                            span_rows.append(row)
+        else:
+            # Pass 1 (cheap): parse everything, then decide keep/drop per
+            # trace before any blob-strip/extraction work happens.
+            parsed: list[tuple[Span, str | None]] = []
+            byte_sizes: list[int] = []
+            for processed_span in req.processed_spans:
+                resource = Resource.from_proto(processed_span.resource_spans.resource)
+                for protobuf_scope_spans in processed_span.resource_spans.scope_spans:
+                    for protobuf_span in protobuf_scope_spans.spans:
+                        span = parse_span(protobuf_span, resource)
+                        if span is None:
+                            continue
+                        parsed.append((span, processed_span.run_id))
+                        byte_sizes.append(protobuf_span.ByteSize())
 
-                    try:
-                        genai_row = extract_genai_span(
-                            span,
-                            project_id=req.project_id,
-                            wb_user_id=req.wb_user_id or "",
-                            wb_run_id=processed_span.run_id or "",
-                        )
-                    except Exception as e:
-                        error_type = type(e).__name__
-                        _record_ingest_failure(
-                            failure_counts,
-                            failure_examples,
-                            error_type,
-                            span_id=span.span_id,
-                        )
-                        rejected += 1
-                        # Don't leak raw `str(e)` to the client — it can
-                        # contain server-side state. Exception type is
-                        # safe and enough for a caller to triage.
-                        errors.append(
-                            f"Extraction failed for span {span.span_id}: {error_type}"
-                        )
-                        continue
+            decisions = ingest_sampling.decide_spans(
+                sampling, [span for span, _ in parsed], byte_sizes
+            )
 
-                    span_rows.append(genai_row)
+            # Pass 2 (expensive): blob-strip + extraction for kept spans only.
+            for (span, run_id), decision in zip(parsed, decisions, strict=True):
+                if decision.drop:
                     accepted += 1
+                    continue
+                row = extract_row(span, run_id)
+                if row is None:
+                    continue
+                if decision.sampled_rate is not None:
+                    ingest_sampling.stamp_sample_rate(row, decision.sampled_rate)
+                span_rows.append(row)
 
         if span_rows:
             self.insert_spans(span_rows)

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -835,7 +835,7 @@ class AgentWriteHandler:
         and whole traces are kept or dropped *before* the expensive
         blob-strip/extraction steps run, so dropped traces never write
         Content files. Dropped spans are neither stored nor returned (they
-        never reach the scoring Kafka emit) but still count as accepted --
+        never reach the scoring Kafka emit) but still count as accepted —
         the client sees an ordinary success. See agents/ingest_sampling.py
         (WB-36877).
         """
@@ -846,8 +846,8 @@ class AgentWriteHandler:
         failure_counts: dict[str, int] = {}
         failure_examples: list[str] = []
 
-        # Both branches below run every span through these two helpers, so
-        # parse/extraction failure accounting cannot drift between them.
+        # Both branches below account every parse/extraction failure through
+        # these two helpers, so the bookkeeping cannot drift between them.
         def parse_span(protobuf_span: Any, resource: Resource) -> Span | None:
             nonlocal rejected
             try:

--- a/weave/trace_server/agents/ingest_sampling.py
+++ b/weave/trace_server/agents/ingest_sampling.py
@@ -1,0 +1,162 @@
+"""Server-side ingest sampler for the spans (agents) data model.
+
+Drops a deterministic fraction of non-eval traces at OTel ingest -- before
+they reach ClickHouse or the scoring Kafka topic -- so operators can enforce
+one central sampling rate to cut storage cost. Mirrors the calls-model
+sampler in the trace-server service: both read the same
+``WEAVE_INGEST_SAMPLE_RATE`` / ``WEAVE_INGEST_SAMPLE_DRY_RUN`` environment
+variables and share the same hash, so a trace that writes into both data
+models gets one verdict. Off by default (rate 1.0). See WB-36877.
+
+The keep/drop decision is a pure hash of ``trace_id``, so every span of a
+trace gets the same verdict and a trace is kept or dropped whole. A trace is
+always kept when any of its spans in the request carries a ``weave.eval.*``
+attribute (best-effort eval carve-out). Spans kept *by the hash* (sampling
+enabled, not dry-run) get the applied rate stamped into
+``custom_attrs_float["weave.ingest_sample_rate"]`` so downstream consumers
+can weight each kept span as ``1/rate`` originals; spans kept whole (evals,
+sampler off, dry-run, unusable trace_id) carry no stamp and count as
+themselves.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, NamedTuple
+
+from weave.trace_server import environment as wf_env
+from weave.trace_server.agents import ingest_sampling_metrics as metrics
+from weave.trace_server.opentelemetry.helpers import get_attribute
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from weave.trace_server.agents.schema import AgentSpanCHInsertable
+    from weave.trace_server.opentelemetry.python_spans import Span
+
+# Attribute key the applied sample rate is stamped under on kept spans. The
+# flat dotted form is how custom attributes are stored on span rows; the calls
+# model records the same fact as ``attributes["weave"]["ingest_sample_rate"]``.
+INGEST_SAMPLE_RATE_ATTR = "weave.ingest_sample_rate"
+
+# Any non-empty value under this subtree marks a span as belonging to an
+# evaluation. The SDK stamps ``weave.eval.predict_and_score_call_id`` etc. on
+# every span started inside an eval context -- see the ``EVAL_*_SPAN_ATTR``
+# constants in ``weave/trace_server/constants.py``.
+_EVAL_MARKER_KEY = "weave.eval"
+
+# sha256(trace_id) is reduced modulo this many buckets; a trace is kept when
+# its bucket falls below rate * buckets. Must stay byte-identical to the
+# calls-model sampler so a mixed trace gets one verdict across both models.
+_HASH_BUCKETS = 1_000_000
+
+_ZERO_TRACE_ID = "0" * 32
+
+
+@dataclass(frozen=True)
+class SamplingConfig:
+    rate: float
+    dry_run: bool
+
+    @property
+    def enabled(self) -> bool:
+        # rate >= 1.0 keeps everything; treat as fully off so the ingest path
+        # runs its unmodified single-pass loop and emits no metrics.
+        return self.rate < 1.0
+
+
+def request_config() -> SamplingConfig:
+    """Read the sampler config from the environment, once per request."""
+    return SamplingConfig(
+        rate=wf_env.wf_ingest_sample_rate(),
+        dry_run=wf_env.wf_ingest_sample_dry_run(),
+    )
+
+
+def keep_by_hash(trace_id: str, rate: float) -> bool:
+    """Deterministic per-trace keep decision; True means keep.
+
+    Pure function of (trace_id, rate), byte-identical to the calls-model
+    sampler's formula: one trace_id always lands in one bucket, so every span
+    of a trace shares a verdict at a fixed rate.
+    """
+    bucket = (
+        int(hashlib.sha256(trace_id.encode("utf-8")).hexdigest(), 16) % _HASH_BUCKETS
+    )
+    return bucket < rate * _HASH_BUCKETS
+
+
+def _usable_trace_id(trace_id: str) -> bool:
+    """Whether a trace_id can key the hash.
+
+    OTel requires a 16-byte, not-all-zero trace id. ``Span.from_proto``
+    hexlifies whatever bytes arrive, so a malformed id shows up here as a
+    wrong-length string and the spec-invalid zero id as 32 zeros. Those are
+    sentinels shared across broken clients -- hashing them would hand every
+    such client one collective verdict -- so they fail open instead (kept,
+    counted as parse failures).
+    """
+    return len(trace_id) == 32 and trace_id != _ZERO_TRACE_ID
+
+
+class SpanDecision(NamedTuple):
+    """Per-span verdict: whether to drop, and the rate to stamp on a keep.
+
+    ``sampled_rate`` is set only on a genuine hash-keep (sampling enabled, not
+    dry-run); every kept-whole path (see module docstring) leaves it None.
+    """
+
+    drop: bool
+    sampled_rate: float | None = None
+
+
+def decide_spans(
+    config: SamplingConfig,
+    spans: Sequence[Span],
+    byte_sizes: Sequence[int],
+) -> list[SpanDecision]:
+    """Decide keep/drop for every parsed span of one export request.
+
+    The verdict is per trace: a trace is kept whole when any of its spans in
+    this request carries the eval marker, otherwise the trace hash decides.
+    Spans whose trace_id is unusable are kept individually (fail-open).
+    ``byte_sizes`` -- serialized protobuf sizes aligned with ``spans`` -- feed
+    the dropped-bytes counter. Metrics count spans, not traces.
+    """
+    eval_traces: set[str] = set()
+    for span in spans:
+        if _usable_trace_id(span.trace_id) and get_attribute(
+            span.attributes, _EVAL_MARKER_KEY
+        ):
+            eval_traces.add(span.trace_id)
+
+    decisions: list[SpanDecision] = []
+    for span, byte_size in zip(spans, byte_sizes, strict=True):
+        metrics.seen(1)
+        trace_id = span.trace_id
+        if not _usable_trace_id(trace_id):
+            metrics.parse_failures(1)
+            decisions.append(SpanDecision(drop=False))
+        elif trace_id in eval_traces:
+            metrics.evals_kept(1)
+            decisions.append(SpanDecision(drop=False))
+        elif keep_by_hash(trace_id, config.rate):
+            # In dry-run nothing is dropped, so the hash winners don't
+            # represent 1/rate of the population -- report no rate for them.
+            rate = None if config.dry_run else config.rate
+            decisions.append(SpanDecision(drop=False, sampled_rate=rate))
+        else:
+            metrics.dropped(1, byte_size, config.dry_run)
+            decisions.append(SpanDecision(drop=not config.dry_run))
+    return decisions
+
+
+def stamp_sample_rate(row: AgentSpanCHInsertable, rate: float) -> None:
+    """Record the applied rate on a hash-kept span row.
+
+    Runs after custom-attribute extraction, so the stamp cannot be evicted by
+    the per-span attribute cap, and overwrites any client-supplied float under
+    the same key.
+    """
+    row.custom_attrs_float[INGEST_SAMPLE_RATE_ATTR] = rate

--- a/weave/trace_server/agents/ingest_sampling.py
+++ b/weave/trace_server/agents/ingest_sampling.py
@@ -44,10 +44,15 @@ INGEST_SAMPLE_RATE_ATTR = "weave.ingest_sample_rate"
 
 # sha256(trace_id) is reduced modulo this many buckets; a trace is kept when
 # its bucket falls below rate * buckets. Must stay byte-identical to the
-# calls-model sampler so a mixed trace gets one verdict across both models.
+# calls-model sampler in core (services/weave-trace/src/ingest_sampling.py):
+# a trace that writes into both models must get one verdict. There is no shared
+# source yet -- if you change this or keep_by_hash, change that copy too
+# (cross-repo unification is a tracked follow-up).
 _HASH_BUCKETS = 1_000_000
 
-_ZERO_TRACE_ID = "0" * 32
+# OTel's spec-invalid trace id: 16 zero bytes -> 32 hex zeros. Kept fail-open
+# (see _usable_trace_id) rather than hashed, so it is not a shared drop bucket.
+_INVALID_ALL_ZERO_TRACE_ID = "0" * 32
 
 
 @dataclass(frozen=True)
@@ -93,7 +98,7 @@ def _usable_trace_id(trace_id: str) -> bool:
     such client one collective verdict -- so they fail open instead (kept,
     counted as parse failures).
     """
-    return len(trace_id) == 32 and trace_id != _ZERO_TRACE_ID
+    return len(trace_id) == 32 and trace_id != _INVALID_ALL_ZERO_TRACE_ID
 
 
 class SpanDecision(NamedTuple):
@@ -121,6 +126,12 @@ def decide_spans(
     ``spans`` -- feed the dropped-bytes counter. Metrics count spans, not
     traces, and are emitted once per call.
     """
+    # Two passes, not one: the verdict is per trace, but a request carries many
+    # trace_ids and the eval marker can sit on any span of a trace -- including
+    # one that arrives after other spans of the same trace_id. So we must scan
+    # every span to learn which trace_ids are evals BEFORE deciding any span; a
+    # single loop with a bool cannot keep already-seen spans of a trace whose
+    # marker shows up later, nor track multiple trace_ids at once.
     eval_traces: set[str] = set()
     for span in spans:
         if _usable_trace_id(span.trace_id) and get_attribute(

--- a/weave/trace_server/agents/ingest_sampling.py
+++ b/weave/trace_server/agents/ingest_sampling.py
@@ -6,7 +6,8 @@ one central sampling rate to cut storage cost. Mirrors the calls-model
 sampler in the trace-server service: both read the same
 ``WEAVE_INGEST_SAMPLE_RATE`` / ``WEAVE_INGEST_SAMPLE_DRY_RUN`` environment
 variables and share the same hash, so a trace that writes into both data
-models gets one verdict. Off by default (rate 1.0). See WB-36877.
+models gets one verdict — when both models record the same ``trace_id``
+string. Off by default (rate 1.0). See WB-36877.
 
 The keep/drop decision is a pure hash of ``trace_id``, so every span of a
 trace gets the same verdict and a trace is kept or dropped whole. A trace is
@@ -27,6 +28,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 from weave.trace_server import environment as wf_env
 from weave.trace_server.agents import ingest_sampling_metrics as metrics
+from weave.trace_server.constants import EVAL_SPAN_ATTR_PREFIX
 from weave.trace_server.opentelemetry.helpers import get_attribute
 
 if TYPE_CHECKING:
@@ -39,12 +41,6 @@ if TYPE_CHECKING:
 # flat dotted form is how custom attributes are stored on span rows; the calls
 # model records the same fact as ``attributes["weave"]["ingest_sample_rate"]``.
 INGEST_SAMPLE_RATE_ATTR = "weave.ingest_sample_rate"
-
-# Any non-empty value under this subtree marks a span as belonging to an
-# evaluation. The SDK stamps ``weave.eval.predict_and_score_call_id`` etc. on
-# every span started inside an eval context -- see the ``EVAL_*_SPAN_ATTR``
-# constants in ``weave/trace_server/constants.py``.
-_EVAL_MARKER_KEY = "weave.eval"
 
 # sha256(trace_id) is reduced modulo this many buckets; a trace is kept when
 # its bucket falls below rate * buckets. Must stay byte-identical to the
@@ -119,27 +115,34 @@ def decide_spans(
     """Decide keep/drop for every parsed span of one export request.
 
     The verdict is per trace: a trace is kept whole when any of its spans in
-    this request carries the eval marker, otherwise the trace hash decides.
-    Spans whose trace_id is unusable are kept individually (fail-open).
-    ``byte_sizes`` -- serialized protobuf sizes aligned with ``spans`` -- feed
-    the dropped-bytes counter. Metrics count spans, not traces.
+    this request carries a ``weave.eval.*`` marker, otherwise the trace hash
+    decides. Spans whose trace_id is unusable are kept individually
+    (fail-open). ``byte_sizes`` -- serialized protobuf sizes aligned with
+    ``spans`` -- feed the dropped-bytes counter. Metrics count spans, not
+    traces, and are emitted once per call.
     """
     eval_traces: set[str] = set()
     for span in spans:
         if _usable_trace_id(span.trace_id) and get_attribute(
-            span.attributes, _EVAL_MARKER_KEY
+            span.attributes, EVAL_SPAN_ATTR_PREFIX
         ):
             eval_traces.add(span.trace_id)
 
+    # Counters are aggregated and emitted once per request: per-span UDP
+    # packets would triple the syscall count on large exports for no gain.
+    parse_failure_count = 0
+    evals_kept_count = 0
+    dropped_count = 0
+    dropped_bytes = 0
+
     decisions: list[SpanDecision] = []
     for span, byte_size in zip(spans, byte_sizes, strict=True):
-        metrics.seen(1)
         trace_id = span.trace_id
         if not _usable_trace_id(trace_id):
-            metrics.parse_failures(1)
+            parse_failure_count += 1
             decisions.append(SpanDecision(drop=False))
         elif trace_id in eval_traces:
-            metrics.evals_kept(1)
+            evals_kept_count += 1
             decisions.append(SpanDecision(drop=False))
         elif keep_by_hash(trace_id, config.rate):
             # In dry-run nothing is dropped, so the hash winners don't
@@ -147,16 +150,22 @@ def decide_spans(
             rate = None if config.dry_run else config.rate
             decisions.append(SpanDecision(drop=False, sampled_rate=rate))
         else:
-            metrics.dropped(1, byte_size, config.dry_run)
+            dropped_count += 1
+            dropped_bytes += byte_size
             decisions.append(SpanDecision(drop=not config.dry_run))
+
+    metrics.seen(len(spans))
+    if parse_failure_count:
+        metrics.parse_failures(parse_failure_count)
+    if evals_kept_count:
+        metrics.evals_kept(evals_kept_count)
+    if dropped_count:
+        metrics.dropped(dropped_count, dropped_bytes, config.dry_run)
     return decisions
 
 
 def stamp_sample_rate(row: AgentSpanCHInsertable, rate: float) -> None:
-    """Record the applied rate on a hash-kept span row.
-
-    Runs after custom-attribute extraction, so the stamp cannot be evicted by
-    the per-span attribute cap, and overwrites any client-supplied float under
-    the same key.
+    """Stamp the applied rate; runs post-extraction, so the per-span attribute
+    cap can't evict it and a client-supplied float under the key is overwritten.
     """
     row.custom_attrs_float[INGEST_SAMPLE_RATE_ATTR] = rate

--- a/weave/trace_server/agents/ingest_sampling.py
+++ b/weave/trace_server/agents/ingest_sampling.py
@@ -6,7 +6,7 @@ one central sampling rate to cut storage cost. Mirrors the calls-model
 sampler in the trace-server service: both read the same
 ``WEAVE_INGEST_SAMPLE_RATE`` / ``WEAVE_INGEST_SAMPLE_DRY_RUN`` environment
 variables and share the same hash, so a trace that writes into both data
-models gets one verdict — when both models record the same ``trace_id``
+models gets one verdict -- when both models record the same ``trace_id``
 string. Off by default (rate 1.0). See WB-36877.
 
 The keep/drop decision is a pure hash of ``trace_id``, so every span of a
@@ -154,7 +154,10 @@ def decide_spans(
             dropped_bytes += byte_size
             decisions.append(SpanDecision(drop=not config.dry_run))
 
-    metrics.seen(len(spans))
+    # `seen` counts spans that reached the ladder; spans rejected at parse
+    # never get here, so total arrivals = seen + the caller's parse rejects.
+    if spans:
+        metrics.seen(len(spans))
     if parse_failure_count:
         metrics.parse_failures(parse_failure_count)
     if evals_kept_count:

--- a/weave/trace_server/agents/ingest_sampling_metrics.py
+++ b/weave/trace_server/agents/ingest_sampling_metrics.py
@@ -1,0 +1,46 @@
+"""Counters for the spans-model ingest sampler.
+
+Emitted through the DogStatsD helper in ``weave.trace_server.datadog``, the
+only counter transport available to this package. The calls-model sampler's
+counters live in the trace-server service under different metric names; the
+two families deliberately stay separate -- these count *spans* while those
+count ingest messages, so summing them would be meaningless. Every emit is
+best-effort: a metrics failure never breaks ingest.
+"""
+
+from __future__ import annotations
+
+from weave.trace_server.datadog import emit_counter
+
+_METRIC_SEEN = "weave_trace_server.ingest_sampling.spans.seen"
+_METRIC_PARSE_FAILURES = "weave_trace_server.ingest_sampling.spans.parse_failures"
+_METRIC_EVALS_KEPT = "weave_trace_server.ingest_sampling.spans.evals_kept"
+_METRIC_DROPPED = "weave_trace_server.ingest_sampling.spans.dropped"
+_METRIC_DROPPED_BYTES = "weave_trace_server.ingest_sampling.spans.dropped_bytes"
+
+_ROUTE_TAG = "route:agents_otel"
+
+
+def seen(count: int) -> None:
+    """Count spans the sampler inspected (the denominator for the rest)."""
+    emit_counter(_METRIC_SEEN, count, [_ROUTE_TAG])
+
+
+def parse_failures(count: int) -> None:
+    """Count spans kept fail-open because their trace_id cannot key the hash."""
+    emit_counter(_METRIC_PARSE_FAILURES, count, [_ROUTE_TAG])
+
+
+def evals_kept(count: int) -> None:
+    """Count spans kept by the eval carve-out."""
+    emit_counter(_METRIC_EVALS_KEPT, count, [_ROUTE_TAG])
+
+
+def dropped(count: int, byte_size: int, dry_run: bool) -> None:
+    """Count dropped spans and their serialized protobuf size.
+
+    In dry-run the tag marks a would-drop, not a real one.
+    """
+    tags = [_ROUTE_TAG, f"dry_run:{str(dry_run).lower()}"]
+    emit_counter(_METRIC_DROPPED, count, tags)
+    emit_counter(_METRIC_DROPPED_BYTES, byte_size, tags)

--- a/weave/trace_server/agents/ingest_sampling_metrics.py
+++ b/weave/trace_server/agents/ingest_sampling_metrics.py
@@ -12,11 +12,12 @@ from __future__ import annotations
 
 from weave.trace_server.datadog import emit_counter
 
-_METRIC_SEEN = "weave_trace_server.ingest_sampling.spans.seen"
-_METRIC_PARSE_FAILURES = "weave_trace_server.ingest_sampling.spans.parse_failures"
-_METRIC_EVALS_KEPT = "weave_trace_server.ingest_sampling.spans.evals_kept"
-_METRIC_DROPPED = "weave_trace_server.ingest_sampling.spans.dropped"
-_METRIC_DROPPED_BYTES = "weave_trace_server.ingest_sampling.spans.dropped_bytes"
+_PREFIX = "weave_trace_server.ingest_sampling.spans"
+_METRIC_SEEN = f"{_PREFIX}.seen"
+_METRIC_PARSE_FAILURES = f"{_PREFIX}.parse_failures"
+_METRIC_EVALS_KEPT = f"{_PREFIX}.evals_kept"
+_METRIC_DROPPED = f"{_PREFIX}.dropped"
+_METRIC_DROPPED_BYTES = f"{_PREFIX}.dropped_bytes"
 
 _ROUTE_TAG = "route:agents_otel"
 
@@ -39,7 +40,12 @@ def evals_kept(count: int) -> None:
 def dropped(count: int, byte_size: int, dry_run: bool) -> None:
     """Count dropped spans and their serialized protobuf size.
 
-    In dry-run the tag marks a would-drop, not a real one.
+    Emitted in dry-run too (tagged ``dry_run:true``) -- observing would-drops
+    is the whole point of dry-run, whereas the rate stamp is deliberately NOT
+    written in dry-run (nothing was actually sampled). Same metric name for
+    both real and would-drops, so dashboards MUST split this by the ``dry_run``
+    tag; the tag, not a separate metric, is what keeps parity with the
+    calls-model sampler.
     """
     tags = [_ROUTE_TAG, f"dry_run:{str(dry_run).lower()}"]
     emit_counter(_METRIC_DROPPED, count, tags)

--- a/weave/trace_server/constants.py
+++ b/weave/trace_server/constants.py
@@ -48,6 +48,7 @@ SCORE_EVALUATION_RUN_ID_ATTR_KEY = "evaluation_run_id"
 WEAVE_ATTRIBUTES_NAMESPACE = "weave"
 
 # OTel span attribute keys for eval context
+EVAL_SPAN_ATTR_PREFIX = "weave.eval"
 EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR = "weave.eval.predict_and_score_call_id"
 EVAL_PROJECT_ID_SPAN_ATTR = "weave.eval.project_id"
 EVAL_EVALUATION_NAME_SPAN_ATTR = "weave.eval.evaluation_name"

--- a/weave/trace_server/datadog.py
+++ b/weave/trace_server/datadog.py
@@ -1,7 +1,7 @@
 """DogStatsD counter emission + DD-flavored OTel span-tag helpers.
 
-Emits a single counter (`weave_trace_server.db_inserts`) over a UDP socket.
-Wire format: `metric.name:value|c|#tag1:val1,tag2:val2`.
+Emits best-effort counters (the `weave_trace_server.*` family) over a UDP
+socket. Wire format: `metric.name:value|c|#tag1:val1,tag2:val2`.
 """
 
 from __future__ import annotations
@@ -223,6 +223,17 @@ def record_db_insert(*, table: str, count: int, path: str | None = None) -> None
         count,
         [f"table:{table}", f"path:{resolved_path}", *_UNIFIED_TAGS],
     )
+
+
+def emit_counter(metric: str, value: int, tags: list[str]) -> None:
+    """Emit a best-effort counter with the unified service tags appended.
+
+    For counter families owned by other modules (e.g. the spans ingest
+    sampler); `record_db_insert` stays the dedicated DB-insert emitter.
+    """
+    if value <= 0:
+        return
+    _client.emit(metric, value, [*tags, *_UNIFIED_TAGS])
 
 
 def set_current_span_dd_tags(tags: dict[str, str | float | int]) -> None:

--- a/weave/trace_server/datadog.py
+++ b/weave/trace_server/datadog.py
@@ -208,32 +208,25 @@ def tag_db_insert_path(
     return decorator
 
 
-def record_db_insert(*, table: str, count: int, path: str | None = None) -> None:
-    """Emit a counter for rows inserted into the trace-server DB.
-
-    `path` falls back to the current `db_insert_path()` contextvar if
-    not provided; pass explicitly from background flushers where the
-    contextvar may not be set.
-    """
-    if count <= 0:
-        return
-    resolved_path = path if path is not None else _db_insert_path.get()
-    _client.emit(
-        DB_INSERT_METRIC,
-        count,
-        [f"table:{table}", f"path:{resolved_path}", *_UNIFIED_TAGS],
-    )
-
-
 def emit_counter(metric: str, value: int, tags: list[str]) -> None:
-    """Emit a best-effort counter with the unified service tags appended.
-
-    For counter families owned by other modules (e.g. the spans ingest
-    sampler); `record_db_insert` stays the dedicated DB-insert emitter.
+    """Emit one best-effort counter: appends the unified service tags and skips
+    non-positive values. The low-level counter emitter for this module.
     """
     if value <= 0:
         return
     _client.emit(metric, value, [*tags, *_UNIFIED_TAGS])
+
+
+def record_db_insert(*, table: str, count: int, path: str | None = None) -> None:
+    """Emit the DB-rows-inserted counter -- a thin wrapper over `emit_counter`
+    with the fixed metric name and `table`/`path` tags.
+
+    `path` falls back to the current `db_insert_path()` contextvar if not
+    provided; pass explicitly from background flushers where the contextvar
+    may not be set.
+    """
+    resolved_path = path if path is not None else _db_insert_path.get()
+    emit_counter(DB_INSERT_METRIC, count, [f"table:{table}", f"path:{resolved_path}"])
 
 
 def set_current_span_dd_tags(tags: dict[str, str | float | int]) -> None:

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -79,6 +79,33 @@ def wf_enable_agent_scoring() -> bool:
     return os.environ.get("WEAVE_ENABLE_AGENT_SCORING", "false").lower() == "true"
 
 
+# Ingest sampling (spans model) -- shared knobs with the calls-model sampler.
+
+
+def wf_ingest_sample_rate() -> float:
+    """Fraction of non-eval traces to keep at OTel-spans ingest (0.0-1.0).
+
+    The same environment variable also governs the calls-model sampler in the
+    trace-server service, so one operator knob covers both data models.
+    Defaults to 1.0 (sampling off); an unparseable or out-of-range value falls
+    back to 1.0, so a bad config can never start dropping data. Change the
+    rate in a quiet traffic window: an in-flight trace hashed at two different
+    rates can be stored partially.
+    """
+    try:
+        rate = float(os.environ.get("WEAVE_INGEST_SAMPLE_RATE", "1.0"))
+    except ValueError:
+        return 1.0
+    if not 0.0 <= rate <= 1.0:
+        return 1.0
+    return rate
+
+
+def wf_ingest_sample_dry_run() -> bool:
+    """When true, the spans sampler records what it would drop but drops nothing."""
+    return os.environ.get("WEAVE_INGEST_SAMPLE_DRY_RUN", "false").lower() == "true"
+
+
 def wf_scoring_worker_batch_size() -> int:
     """The batch size for the scoring worker."""
     return int(

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -254,22 +254,23 @@ def wf_scoring_worker_remote_scorer_require_structured_result_schema() -> bool:
     )
 
 
-# Ingest sampling -- one shared knob for both data models. The same env vars
-# are read by the calls-model sampler in the trace-server service; these
-# accessors are model-agnostic.
+# Ingest sampling -- shared knobs for both data models. The same env vars are
+# read by the calls-model sampler in the trace-server service; these accessors
+# are model-agnostic.
 
 
 def wf_ingest_sample_rate() -> float:
-    """Fraction of non-eval traces to keep at ingest (0.0-1.0), read per request.
+    """Fraction of non-eval traces to keep at ingest (0.0-1.0).
 
     Governs BOTH data models: the calls-model sampler reads the same variable.
     Defaults to 1.0 (sampling off); an unparseable or out-of-range value falls
     back to 1.0, so a bad config can never start dropping data.
 
-    Read from the process environment, so changing the rate means redeploying /
-    restarting the service with the new value -- it is not a live knob. That
-    redeploy is itself the "quiet window" that avoids the one edge case: a trace
-    hashed at two different rates across the transition can be stored partially.
+    The value comes from the process environment and is not mutated in-process,
+    so changing the rate means redeploying / restarting the service with the new
+    value -- it is not a live knob. A redeploy briefly runs old and new
+    instances at different rates, and a trace whose spans hit both can be stored
+    partially; do rate changes in a low-traffic window to minimize that.
     """
     try:
         rate = float(os.environ.get("WEAVE_INGEST_SAMPLE_RATE", "1.0"))

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -79,33 +79,6 @@ def wf_enable_agent_scoring() -> bool:
     return os.environ.get("WEAVE_ENABLE_AGENT_SCORING", "false").lower() == "true"
 
 
-# Ingest sampling (spans model) -- shared knobs with the calls-model sampler.
-
-
-def wf_ingest_sample_rate() -> float:
-    """Fraction of non-eval traces to keep at OTel-spans ingest (0.0-1.0).
-
-    The same environment variable also governs the calls-model sampler in the
-    trace-server service, so one operator knob covers both data models.
-    Defaults to 1.0 (sampling off); an unparseable or out-of-range value falls
-    back to 1.0, so a bad config can never start dropping data. Change the
-    rate in a quiet traffic window: an in-flight trace hashed at two different
-    rates can be stored partially.
-    """
-    try:
-        rate = float(os.environ.get("WEAVE_INGEST_SAMPLE_RATE", "1.0"))
-    except ValueError:
-        return 1.0
-    if not 0.0 <= rate <= 1.0:
-        return 1.0
-    return rate
-
-
-def wf_ingest_sample_dry_run() -> bool:
-    """When true, the spans sampler records what it would drop but drops nothing."""
-    return os.environ.get("WEAVE_INGEST_SAMPLE_DRY_RUN", "false").lower() == "true"
-
-
 def wf_scoring_worker_batch_size() -> int:
     """The batch size for the scoring worker."""
     return int(
@@ -279,6 +252,33 @@ def wf_scoring_worker_remote_scorer_require_structured_result_schema() -> bool:
         ).lower()
         != "false"
     )
+
+
+# Ingest sampling (spans model) -- shared knobs with the calls-model sampler
+
+
+def wf_ingest_sample_rate() -> float:
+    """Fraction of non-eval traces to keep at OTel-spans ingest (0.0-1.0).
+
+    The same environment variable also governs the calls-model sampler in the
+    trace-server service, so one operator knob covers both data models.
+    Defaults to 1.0 (sampling off); an unparseable or out-of-range value falls
+    back to 1.0, so a bad config can never start dropping data. Change the
+    rate in a quiet traffic window: an in-flight trace hashed at two different
+    rates can be stored partially.
+    """
+    try:
+        rate = float(os.environ.get("WEAVE_INGEST_SAMPLE_RATE", "1.0"))
+    except ValueError:
+        return 1.0
+    if not 0.0 <= rate <= 1.0:
+        return 1.0
+    return rate
+
+
+def wf_ingest_sample_dry_run() -> bool:
+    """When true, the spans sampler records what it would drop but drops nothing."""
+    return os.environ.get("WEAVE_INGEST_SAMPLE_DRY_RUN", "false").lower() == "true"
 
 
 # Clickhouse Settings

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -254,18 +254,22 @@ def wf_scoring_worker_remote_scorer_require_structured_result_schema() -> bool:
     )
 
 
-# Ingest sampling (spans model) -- shared knobs with the calls-model sampler
+# Ingest sampling -- one shared knob for both data models. The same env vars
+# are read by the calls-model sampler in the trace-server service; these
+# accessors are model-agnostic.
 
 
 def wf_ingest_sample_rate() -> float:
-    """Fraction of non-eval traces to keep at OTel-spans ingest (0.0-1.0).
+    """Fraction of non-eval traces to keep at ingest (0.0-1.0), read per request.
 
-    The same environment variable also governs the calls-model sampler in the
-    trace-server service, so one operator knob covers both data models.
+    Governs BOTH data models: the calls-model sampler reads the same variable.
     Defaults to 1.0 (sampling off); an unparseable or out-of-range value falls
-    back to 1.0, so a bad config can never start dropping data. Change the
-    rate in a quiet traffic window: an in-flight trace hashed at two different
-    rates can be stored partially.
+    back to 1.0, so a bad config can never start dropping data.
+
+    Read from the process environment, so changing the rate means redeploying /
+    restarting the service with the new value -- it is not a live knob. That
+    redeploy is itself the "quiet window" that avoids the one edge case: a trace
+    hashed at two different rates across the transition can be stored partially.
     """
     try:
         rate = float(os.environ.get("WEAVE_INGEST_SAMPLE_RATE", "1.0"))
@@ -277,7 +281,10 @@ def wf_ingest_sample_rate() -> float:
 
 
 def wf_ingest_sample_dry_run() -> bool:
-    """When true, the spans sampler records what it would drop but drops nothing."""
+    """When true, the sampler records what it would drop but drops nothing.
+
+    Shadow mode. The same variable also gates the calls-model sampler's dry-run.
+    """
     return os.environ.get("WEAVE_INGEST_SAMPLE_DRY_RUN", "false").lower() == "true"
 
 


### PR DESCRIPTION
## Explainer to save your time

https://github.com/user-attachments/assets/79476387-3c8d-4a26-8294-8fcb684c08b9


## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-36877

## Description

Weave stores traces in two data models. The calls model already has server-side ingest sampling (#46786): set `WEAVE_INGEST_SAMPLE_RATE=0.1` and the server keeps about 10% of non-eval traces, which cuts storage cost. The *spans* model — the agents / OTel ingest path — had nothing: every span sent to it was stored. This PR closes that gap.

Same knob, and pretty much works by same rules. The two existing env vars now govern both models. The verdict is the same hash of the trace id, so a trace is kept or dropped as a whole. If any span of a trace carries a `weave.eval.*` attribute, the whole trace is kept - as it was before in *calls* model - evaluations are too valuable to sample away, and a raw-OTel client can set that attribute to opt into the same protection. A span whose trace id is broken (wrong length, or all zeros) is kept too: when in doubt, keep. One heads-up for operators: a deployment that already runs with a rate below 1.0 starts sampling the spans model when it picks up this change.

The placement is the point. The check runs inside `insert_otel_spans`, right after protobuf parsing and before anything expensive. A dropped trace therefore never writes attachment files, skips extraction entirely, and never reaches the Kafka topic that feeds online scoring — dropped means not stored and not scored. With sampling off (the default) the old single-pass code runs as before; both paths go through the same small parse/extract helpers, so their bookkeeping cannot drift apart. Dropped spans still count as accepted in the response, so clients see an ordinary success. Two fine points: a dropped span that would have failed extraction now counts as accepted (extraction never runs for it), and in sampled requests parse errors come before extraction errors in `error_message`.

Kept traces remember their rate. Every hash-kept span gets `custom_attrs_float["weave.ingest_sample_rate"] = 0.1`, so later anything counting over sampled data can weight each kept span as ten originals. No stamp means the span was kept whole and counts as itself. Dry-run keeps everything and only counts what it would have dropped — and stamps nothing, so the math stays honest. Counters go to DogStatsD (`weave_trace_server.ingest_sampling.spans.*`). No SDK, schema, or API changes.

## Testing

29 tests in `tests/trace_server/test_spans_ingest_sampling.py`. The hash and the env parsing are pinned to the calls sampler's exact behavior. End-to-end against ClickHouse: with the default config nothing changes, down to the exact error messages and their order; at rate 0 a plain trace disappears whole while an eval-marked one survives; the rate stamp lands and a client-supplied fake can't spoof it; a dropped trace leaves no files behind and triggers no scoring event; a span that fails extraction is rejected with the same error as before. A full local `tests/trace_server/` run matches master exactly (the same 5 pre-existing order-dependent failures on both, unrelated); ruff, format, and the repo-pinned mypy are clean.
