### PR TITLE
chore(weave_ts): Add remarks to weave.startFoo fns

### DIFF
--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -33,8 +33,9 @@ export function startConversation(opts: ConversationInit = {}): Conversation {
 export const startSession = startConversation;
 
 /**
- * Start a new Turn. If a Conversation is active, the turn inherits its
- * `conversationId`; otherwise the turn has no conversation id.
+ * Start a `Turn` as a child of the current `Conversation`.
+ *
+ * Starts without a `conversation_id` if no `Conversation` is active.
  *
  * @example
  * weave.startTurn();
@@ -50,6 +51,12 @@ export const startSession = startConversation;
  *   systemInstructions: ['You are a helpful weather bot.'],
  *   startTime: new Date('2026-05-29T10:00:00.000Z'),
  * });
+ *
+ * @remarks
+ * Prefer `conversation.startTurn(...)` when you have a handle on the parent.
+ * `weave.startTurn(...)` may be helpful when it is impractical for the
+ * code that starts the span to receive the parent handle directly.
+ *
  */
 export function startTurn(opts: TurnInit = {}): Turn {
   const conversation = getGenaiState().conversation;
@@ -60,8 +67,9 @@ export function startTurn(opts: TurnInit = {}): Turn {
 }
 
 /**
- * Start an LLM span as a child of the current Turn. Throws if no Turn is
- * active.
+ * Start an `LLM` span as a child of the current `Turn`.
+ *
+ * Throws if no `Turn` is active.
  *
  * @example
  * weave.startLLM({model: 'gpt-4o-mini', providerName: 'openai'});
@@ -73,6 +81,13 @@ export function startTurn(opts: TurnInit = {}): Turn {
  *   systemInstructions: ['You are a helpful weather bot.'],
  *   startTime: new Date('2026-05-29T10:00:00.000Z'),
  * });
+ *
+ * @remarks
+ * Prefer `turn.startLLM(...)` or `subagent.startLLM(...)` when you have
+ * a handle on the parent. `weave.startLLM(...)` may be helpful when it is
+ * impractical for the code that starts the span to receive the parent
+ * handle directly.
+ *
  */
 export function startLLM(opts: LLMInit): LLM {
   const turn = getGenaiState().turn;
@@ -85,12 +100,9 @@ export function startLLM(opts: LLMInit): LLM {
 }
 
 /**
- * Start a Tool span. Parent resolution (matches the design's "flat by
- * default, hierarchical if you nest"):
- * - If an LLM is active, the Tool nests under it.
- * - Otherwise, the Tool is a sibling under the current Turn.
+ * Start a `Tool` span as a child of the current `LLM` or `Turn`.
  *
- * Throws if neither a Turn nor an LLM is active.
+ * Throws if neither an `LLM` nor `Turn` is active.
  *
  * @example
  * weave.startTool({
@@ -106,6 +118,13 @@ export function startLLM(opts: LLMInit): LLM {
  *   toolCallId: 'call_t1',
  *   startTime: new Date('2026-05-29T10:00:00.800Z'),
  * });
+ *
+ * @remarks
+ * Prefer `llm.startTool(...)`, `turn.startTool(...)`, or
+ * `subagent.startTool(...)` when you have a handle on the parent.
+ * `weave.startTool(...)` may be helpful when it is impractical for
+ * the code that starts the span to receive the parent handle directly.
+ *
  */
 export function startTool(opts: ToolInit): Tool {
   const state = getGenaiState();
@@ -121,7 +140,9 @@ export function startTool(opts: ToolInit): Tool {
 }
 
 /**
- * Start a SubAgent span. Same parent-resolution rules as `startTool`.
+ * Start a `SubAgent` span as a child of the current `LLM` or `Turn`.
+ *
+ * Throws if neither an `LLM` nor `Turn` is active.
  *
  * @example
  * weave.startSubagent({name: 'critic'});
@@ -133,6 +154,13 @@ export function startTool(opts: ToolInit): Tool {
  *   systemInstructions: ['Critique the proposed plan.'],
  *   startTime: new Date('2026-05-29T10:00:00.000Z'),
  * });
+ *
+ * @remarks
+ * Prefer `llm.startSubagent(...)`, `turn.startSubagent(...)`, or
+ * `subagent.startSubagent(...)` when you have a handle on the parent.
+ * `weave.startSubagent(...)` may be helpful when it is impractical for
+ * the code that starts the span to receive the parent handle directly.
+ *
  */
 export function startSubagent(opts: SubAgentInit): SubAgent {
   const state = getGenaiState();

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -33,17 +33,24 @@ export interface SubAgentInit extends SpanInitBase {
   agentVersion?: string;
 }
 
+type Opts = {
+  span: Span;
+  context: Context;
+  conversationId: string;
+} & Required<Omit<SubAgentInit, 'startTime'>>;
+
 /**
  * A nested agent invocation — used when the current agent hands work to
  * another named agent (e.g. a planner calling a researcher). Emits an
  * `invoke_agent` span tagged with the subagent's name and (optionally)
  * its model.
  *
- * Created by `weave.startSubagent()` (or `turn.startSubagent()`, or
- * `llm.startSubagent()`) and terminated with `end()`. Children (LLM, Tool,
- * SubAgent) attach via the `startLLM`, `startTool`, `startSubagent` methods,
- * so a subagent's own model calls and tools nest under its `invoke_agent`
- * span rather than flattening onto the parent Turn.
+ * Created by `weave.startSubagent()` (or `turn.startSubagent()`,
+ * `llm.startSubagent()`, or `subagent.startSubagent()`) and terminated with
+ * `end()`. Children (LLM, Tool, SubAgent) attach via the `startLLM`,
+ * `startTool`, `startSubagent` methods, so a subagent's own model calls and
+ * tools nest under its `invoke_agent` span rather than flattening onto the
+ * parent Turn.
  *
  * @example
  * const subagent = weave.startSubagent({name: 'researcher'});
@@ -72,12 +79,6 @@ export interface SubAgentInit extends SpanInitBase {
  *   subagent.end();
  * }
  */
-type Opts = {
-  span: Span;
-  context: Context;
-  conversationId: string;
-} & Required<Omit<SubAgentInit, 'startTime'>>;
-
 export class SubAgent extends SpanBase {
   private _context: Context;
   private _conversationId: string;


### PR DESCRIPTION
## Description

* We'd like to update https://docs.wandb.ai/ to use the more explicit `startFoo` forms. Starting with the jsdocs here so these remarks are present in SDK reference pages as well.
