### PR TITLE
chore(weave): update costs

### DIFF
--- a/weave/trace_server/costs/cost_checkpoint.json
+++ b/weave/trace_server/costs/cost_checkpoint.json
@@ -26683,6 +26683,14 @@
       "cache_read_input": 3e-07,
       "cache_creation_input": 3.75e-06,
       "created_at": "2026-07-01 09:59:23"
+    },
+    {
+      "provider": "bedrock_converse",
+      "input": 2e-06,
+      "output": 1e-05,
+      "cache_read_input": 2e-07,
+      "cache_creation_input": 2.5e-06,
+      "created_at": "2026-07-07 13:24:02"
     }
   ],
   "global.anthropic.claude-sonnet-5": [
@@ -26693,6 +26701,14 @@
       "cache_read_input": 3e-07,
       "cache_creation_input": 3.75e-06,
       "created_at": "2026-07-01 09:59:23"
+    },
+    {
+      "provider": "bedrock_converse",
+      "input": 2e-06,
+      "output": 1e-05,
+      "cache_read_input": 2e-07,
+      "cache_creation_input": 2.5e-06,
+      "created_at": "2026-07-07 13:24:02"
     }
   ],
   "us.anthropic.claude-sonnet-5": [
@@ -26703,6 +26719,14 @@
       "cache_read_input": 3.3e-07,
       "cache_creation_input": 4.125e-06,
       "created_at": "2026-07-01 09:59:23"
+    },
+    {
+      "provider": "bedrock_converse",
+      "input": 2.2e-06,
+      "output": 1.1e-05,
+      "cache_read_input": 2.2e-07,
+      "cache_creation_input": 2.75e-06,
+      "created_at": "2026-07-07 13:24:02"
     }
   ],
   "eu.anthropic.claude-sonnet-5": [
@@ -26713,6 +26737,14 @@
       "cache_read_input": 3.3e-07,
       "cache_creation_input": 4.125e-06,
       "created_at": "2026-07-01 09:59:23"
+    },
+    {
+      "provider": "bedrock_converse",
+      "input": 2.2e-06,
+      "output": 1.1e-05,
+      "cache_read_input": 2.2e-07,
+      "cache_creation_input": 2.75e-06,
+      "created_at": "2026-07-07 13:24:02"
     }
   ],
   "au.anthropic.claude-sonnet-5": [
@@ -26723,6 +26755,14 @@
       "cache_read_input": 3.3e-07,
       "cache_creation_input": 4.125e-06,
       "created_at": "2026-07-01 09:59:23"
+    },
+    {
+      "provider": "bedrock_converse",
+      "input": 2.2e-06,
+      "output": 1.1e-05,
+      "cache_read_input": 2.2e-07,
+      "cache_creation_input": 2.75e-06,
+      "created_at": "2026-07-07 13:24:02"
     }
   ],
   "jp.anthropic.claude-sonnet-5": [
@@ -26733,6 +26773,14 @@
       "cache_read_input": 3.3e-07,
       "cache_creation_input": 4.125e-06,
       "created_at": "2026-07-01 09:59:23"
+    },
+    {
+      "provider": "bedrock_converse",
+      "input": 2.2e-06,
+      "output": 1.1e-05,
+      "cache_read_input": 2.2e-07,
+      "cache_creation_input": 2.75e-06,
+      "created_at": "2026-07-07 13:24:02"
     }
   ],
   "azure_ai/claude-sonnet-5": [
@@ -26743,6 +26791,14 @@
       "cache_read_input": 3e-07,
       "cache_creation_input": 3.75e-06,
       "created_at": "2026-07-01 09:59:23"
+    },
+    {
+      "provider": "azure_ai",
+      "input": 2e-06,
+      "output": 1e-05,
+      "cache_read_input": 2e-07,
+      "cache_creation_input": 2.5e-06,
+      "created_at": "2026-07-07 13:24:02"
     }
   ],
   "azure_ai/gpt-5.5": [
@@ -26803,6 +26859,14 @@
       "cache_read_input": 3e-07,
       "cache_creation_input": 3.75e-06,
       "created_at": "2026-07-01 09:59:23"
+    },
+    {
+      "provider": "anthropic",
+      "input": 2e-06,
+      "output": 1e-05,
+      "cache_read_input": 2e-07,
+      "cache_creation_input": 2.5e-06,
+      "created_at": "2026-07-07 13:24:02"
     }
   ],
   "cloudflare/@cf/openai/gpt-oss-120b": [
@@ -27393,6 +27457,14 @@
       "cache_read_input": 3e-07,
       "cache_creation_input": 3.75e-06,
       "created_at": "2026-07-01 09:59:23"
+    },
+    {
+      "provider": "vertex_ai-anthropic_models",
+      "input": 2e-06,
+      "output": 1e-05,
+      "cache_read_input": 2e-07,
+      "cache_creation_input": 2.5e-06,
+      "created_at": "2026-07-07 13:24:02"
     }
   ],
   "vertex_ai/gemini-3-pro-image": [
@@ -27763,6 +27835,14 @@
       "cache_read_input": 3e-07,
       "cache_creation_input": 3.75e-06,
       "created_at": "2026-07-01 09:59:23"
+    },
+    {
+      "provider": "vertex_ai-anthropic_models",
+      "input": 2e-06,
+      "output": 1e-05,
+      "cache_read_input": 2e-07,
+      "cache_creation_input": 2.5e-06,
+      "created_at": "2026-07-07 13:24:02"
     }
   ],
   "bedrock_mantle/google.gemma-4-31b": [
@@ -28013,6 +28093,36 @@
       "cache_read_input": 0.0,
       "cache_creation_input": 0.0,
       "created_at": "2026-07-01 09:59:23"
+    }
+  ],
+  "bedrock_mantle/xai.grok-4.3": [
+    {
+      "provider": "bedrock_mantle",
+      "input": 1.25e-06,
+      "output": 2.5e-06,
+      "cache_read_input": 2e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-07 13:24:02"
+    }
+  ],
+  "tencent/deepseek-v4-pro": [
+    {
+      "provider": "tencent",
+      "input": 4.35e-07,
+      "output": 8.7e-07,
+      "cache_read_input": 3.625e-09,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-07 13:24:02"
+    }
+  ],
+  "tencent/deepseek-v4-flash": [
+    {
+      "provider": "tencent",
+      "input": 1.4e-07,
+      "output": 2.8e-07,
+      "cache_read_input": 2.8e-09,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-07 13:24:02"
     }
   ]
 }


### PR DESCRIPTION
Ran `make update_costs` to pull the latest model pricing from litellm.

Adds 10 new cost entries — `bedrock_converse` pricing for the `claude-sonnet-5` regional variants (global/us/eu/au/jp/azure).