### PR TITLE
feat(weave): add persisted agent dashboard object type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,13 @@ _Important:_ For OpenAI Codex agents (most likely you!), your environment does n
 
 Note: the scripts read `modelsBegin.json`/`modelsFinal.json`, which are symlinks into wandb/core and only resolve when this repo is checked out as the submodule inside wandb/core (`services/weave-trace/weave-python/weave-public`).
 
+Persisted `AgentDashboard` objects intentionally use a closed, discriminated
+schema. Supported panel variants and their configuration fields must be added
+to `builtin_object_classes/agent_dashboard.py`; do not replace panel settings
+with an untyped dictionary. After changing the model, run
+`make synchronize-base-object-schemas` from the repository root so the Python
+schema and the dependent Core frontend types stay aligned.
+
 ### Trace Server API / Node SDK Schema
 
 When trace-server request/response models or route schemas change, refresh the API schema used by the Node SDK:

--- a/tests/trace/test_agent_dashboard.py
+++ b/tests/trace/test_agent_dashboard.py
@@ -1,0 +1,164 @@
+import pytest
+from pydantic import ValidationError
+
+from weave.trace_server.interface.builtin_object_classes.agent_dashboard import (
+    AgentDashboard,
+)
+
+
+def dashboard_value(panels: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "label": "Agent reliability",
+        "definition": {"panels": panels},
+    }
+
+
+def panel_value(
+    panel_type: str,
+    query: dict[str, object],
+    *,
+    settings_extra: dict[str, object] | None = None,
+    layout: dict[str, int] | None = None,
+) -> dict[str, object]:
+    return {
+        "id": f"{panel_type}-panel",
+        "panel_type": panel_type,
+        "layout": layout or {"x": 0, "y": 0, "w": 6, "h": 4},
+        "settings": {
+            "title": "Panel title",
+            "query": query,
+            **(settings_extra or {}),
+        },
+    }
+
+
+def test_agent_dashboard_validates_supported_panel_variants() -> None:
+    dashboard = AgentDashboard.model_validate(
+        dashboard_value(
+            [
+                panel_value(
+                    "kpi",
+                    {
+                        "version": 1,
+                        "metric": "count_distinct(conversation.id)",
+                        "filter": "",
+                        "format": "number",
+                    },
+                ),
+                panel_value(
+                    "timeline",
+                    {
+                        "version": 1,
+                        "metric": "avg(span.duration_ms)",
+                        "filter": 'span.provider_name = "openai"',
+                        "groupBy": "custom_attrs_string.customer.tier",
+                        "limit": 8,
+                        "format": "duration",
+                    },
+                ),
+                panel_value(
+                    "breakdown",
+                    {
+                        "version": 1,
+                        "metric": "error_rate(turn.id)",
+                        "filter": "",
+                        "groupBy": "agent_version",
+                        "limit": 6,
+                        "format": "percent",
+                    },
+                ),
+            ]
+        )
+    )
+
+    assert dashboard.model_dump(mode="json", by_alias=True, exclude_none=True) == {
+        "label": "Agent reliability",
+        "definition": {
+            "panels": [
+                panel_value(
+                    "kpi",
+                    {
+                        "version": 1,
+                        "metric": "count_distinct(conversation.id)",
+                        "filter": "",
+                        "format": "number",
+                    },
+                ),
+                panel_value(
+                    "timeline",
+                    {
+                        "version": 1,
+                        "metric": "avg(span.duration_ms)",
+                        "filter": 'span.provider_name = "openai"',
+                        "groupBy": "custom_attrs_string.customer.tier",
+                        "limit": 8,
+                        "format": "duration",
+                    },
+                ),
+                panel_value(
+                    "breakdown",
+                    {
+                        "version": 1,
+                        "metric": "error_rate(turn.id)",
+                        "filter": "",
+                        "groupBy": "agent_version",
+                        "limit": 6,
+                        "format": "percent",
+                    },
+                ),
+            ]
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "panel",
+    [
+        panel_value("heatmap", {"version": 1, "metric": "count()", "filter": ""}),
+        panel_value(
+            "kpi",
+            {"version": 1, "metric": "count()", "filter": "", "groupBy": "tool_name"},
+        ),
+        panel_value(
+            "timeline",
+            {"version": 1, "metric": "count()", "filter": "", "limit": 51},
+        ),
+        panel_value(
+            "timeline",
+            {"version": 1, "metric": "count()", "filter": "", "format": "bytes"},
+        ),
+        panel_value(
+            "breakdown",
+            {"version": 1, "metric": "count()", "filter": ""},
+        ),
+        panel_value(
+            "timeline",
+            {"version": 1, "metric": "count()", "filter": ""},
+            settings_extra={"color": "purple"},
+        ),
+        panel_value(
+            "timeline",
+            {"version": 1, "metric": "count()", "filter": "", "color": "purple"},
+        ),
+        panel_value(
+            "timeline",
+            {"version": 1, "metric": "count()", "filter": ""},
+            layout={"x": 20, "y": 0, "w": 6, "h": 4},
+        ),
+    ],
+    ids=[
+        "unsupported-panel-type",
+        "kpi-grouping",
+        "limit-out-of-range",
+        "unsupported-format",
+        "breakdown-without-grouping",
+        "unknown-settings-option",
+        "unknown-query-option",
+        "layout-out-of-bounds",
+    ],
+)
+def test_agent_dashboard_rejects_unsupported_configuration(
+    panel: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        AgentDashboard.model_validate(dashboard_value([panel]))

--- a/weave/trace_server/interface/builtin_object_classes/agent_dashboard.py
+++ b/weave/trace_server/interface/builtin_object_classes/agent_dashboard.py
@@ -1,0 +1,144 @@
+"""Validated builtin object models for persisted agent dashboards."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from weave.trace_server.interface.builtin_object_classes import base_object_def
+
+DASHBOARD_GRID_COLUMNS = 24
+PanelValueFormat = Literal["number", "percent", "cost", "duration"]
+
+
+class DashboardConfigModel(BaseModel):
+    """Closed configuration model used by persisted dashboard components."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class PanelGridLayout(DashboardConfigModel):
+    """Position and size of a panel in the dashboard's 24-column grid."""
+
+    x: int = Field(ge=0, lt=DASHBOARD_GRID_COLUMNS)
+    y: int = Field(ge=0)
+    w: int = Field(ge=1, le=DASHBOARD_GRID_COLUMNS)
+    h: int = Field(ge=1)
+
+    @model_validator(mode="after")
+    def validate_horizontal_bounds(self) -> PanelGridLayout:
+        if self.x + self.w > DASHBOARD_GRID_COLUMNS:
+            raise ValueError("panel layout extends beyond the dashboard grid")
+        return self
+
+
+class PanelQueryConfig(DashboardConfigModel):
+    """Options shared by all supported dashboard panel queries."""
+
+    version: int = Field(default=1, ge=1, le=1)
+    metric: str = Field(min_length=1)
+    filter: str = ""
+    format: PanelValueFormat | None = None
+
+
+class KpiPanelQueryConfig(PanelQueryConfig):
+    """A scalar query; KPI panels do not support grouping or Top-N."""
+
+
+class TimelinePanelQueryConfig(PanelQueryConfig):
+    """A time-bucketed query with optional series grouping."""
+
+    group_by: str | None = Field(default=None, alias="groupBy")
+    limit: int | None = Field(default=None, ge=1, le=50)
+
+
+class BreakdownPanelQueryConfig(PanelQueryConfig):
+    """A grouped Top-N query used by breakdown panels."""
+
+    group_by: str = Field(min_length=1, alias="groupBy")
+    limit: int = Field(default=6, ge=1, le=50)
+
+
+class KpiPanelSettings(DashboardConfigModel):
+    """Supported configuration for a KPI panel."""
+
+    query: KpiPanelQueryConfig
+    title: str | None = None
+
+
+class TimelinePanelSettings(DashboardConfigModel):
+    """Supported configuration for a timeline panel."""
+
+    query: TimelinePanelQueryConfig
+    title: str | None = None
+
+
+class BreakdownPanelSettings(DashboardConfigModel):
+    """Supported configuration for a breakdown panel."""
+
+    query: BreakdownPanelQueryConfig
+    title: str | None = None
+
+
+class DashboardPanelBase(DashboardConfigModel):
+    """Fields shared by every supported dashboard panel."""
+
+    id: str = Field(min_length=1)
+    layout: PanelGridLayout
+
+
+class KpiDashboardPanel(DashboardPanelBase):
+    """A single-value KPI tile."""
+
+    panel_type: Literal["kpi"]
+    settings: KpiPanelSettings
+
+
+class TimelineDashboardPanel(DashboardPanelBase):
+    """A metric plotted over time."""
+
+    panel_type: Literal["timeline"]
+    settings: TimelinePanelSettings
+
+
+class BreakdownDashboardPanel(DashboardPanelBase):
+    """A metric grouped into ranked categorical rows."""
+
+    panel_type: Literal["breakdown"]
+    settings: BreakdownPanelSettings
+
+
+DashboardPanel = KpiDashboardPanel | TimelineDashboardPanel | BreakdownDashboardPanel
+
+
+class AgentDashboardDefinition(DashboardConfigModel):
+    """The validated panels and grid layouts in an agent dashboard."""
+
+    panels: list[DashboardPanel]
+
+
+class AgentDashboard(base_object_def.BaseObject):
+    """A saved agent dashboard configuration."""
+
+    label: str
+    definition: AgentDashboardDefinition
+
+
+__all__ = [
+    "AgentDashboard",
+    "AgentDashboardDefinition",
+    "BreakdownDashboardPanel",
+    "BreakdownPanelQueryConfig",
+    "BreakdownPanelSettings",
+    "DashboardPanel",
+    "KpiDashboardPanel",
+    "KpiPanelQueryConfig",
+    "KpiPanelSettings",
+    "PanelGridLayout",
+    "PanelQueryConfig",
+    "PanelValueFormat",
+    "TimelineDashboardPanel",
+    "TimelinePanelQueryConfig",
+    "TimelinePanelSettings",
+]

--- a/weave/trace_server/interface/builtin_object_classes/builtin_object_registry.py
+++ b/weave/trace_server/interface/builtin_object_classes/builtin_object_registry.py
@@ -1,3 +1,6 @@
+from weave.trace_server.interface.builtin_object_classes.agent_dashboard import (
+    AgentDashboard,
+)
 from weave.trace_server.interface.builtin_object_classes.alert_spec import AlertSpec
 from weave.trace_server.interface.builtin_object_classes.annotation_spec import (
     AnnotationSpec,
@@ -50,3 +53,4 @@ register_base_object(SavedView)
 register_base_object(ComparisonView)
 register_base_object(LLMStructuredCompletionModel)
 register_base_object(ChartConfig)
+register_base_object(AgentDashboard)

--- a/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
+++ b/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
@@ -1,5 +1,75 @@
 {
   "$defs": {
+    "AgentDashboard": {
+      "description": "A saved agent dashboard configuration.",
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "label": {
+          "title": "Label",
+          "type": "string"
+        },
+        "definition": {
+          "$ref": "#/$defs/AgentDashboardDefinition"
+        }
+      },
+      "required": [
+        "label",
+        "definition"
+      ],
+      "title": "AgentDashboard",
+      "type": "object"
+    },
+    "AgentDashboardDefinition": {
+      "additionalProperties": false,
+      "description": "The validated panels and grid layouts in an agent dashboard.",
+      "properties": {
+        "panels": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/KpiDashboardPanel"
+              },
+              {
+                "$ref": "#/$defs/TimelineDashboardPanel"
+              },
+              {
+                "$ref": "#/$defs/BreakdownDashboardPanel"
+              }
+            ]
+          },
+          "title": "Panels",
+          "type": "array"
+        }
+      },
+      "required": [
+        "panels"
+      ],
+      "title": "AgentDashboardDefinition",
+      "type": "object"
+    },
     "AlertSpec": {
       "properties": {
         "name": {
@@ -207,6 +277,121 @@
         }
       },
       "title": "AnnotationSpec",
+      "type": "object"
+    },
+    "BreakdownDashboardPanel": {
+      "additionalProperties": false,
+      "description": "A metric grouped into ranked categorical rows.",
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "layout": {
+          "$ref": "#/$defs/PanelGridLayout"
+        },
+        "panel_type": {
+          "const": "breakdown",
+          "title": "Panel Type",
+          "type": "string"
+        },
+        "settings": {
+          "$ref": "#/$defs/BreakdownPanelSettings"
+        }
+      },
+      "required": [
+        "id",
+        "layout",
+        "panel_type",
+        "settings"
+      ],
+      "title": "BreakdownDashboardPanel",
+      "type": "object"
+    },
+    "BreakdownPanelQueryConfig": {
+      "additionalProperties": false,
+      "description": "A grouped Top-N query used by breakdown panels.",
+      "properties": {
+        "version": {
+          "default": 1,
+          "maximum": 1,
+          "minimum": 1,
+          "title": "Version",
+          "type": "integer"
+        },
+        "metric": {
+          "minLength": 1,
+          "title": "Metric",
+          "type": "string"
+        },
+        "filter": {
+          "default": "",
+          "title": "Filter",
+          "type": "string"
+        },
+        "format": {
+          "anyOf": [
+            {
+              "enum": [
+                "number",
+                "percent",
+                "cost",
+                "duration"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Format"
+        },
+        "groupBy": {
+          "minLength": 1,
+          "title": "Groupby",
+          "type": "string"
+        },
+        "limit": {
+          "default": 6,
+          "maximum": 50,
+          "minimum": 1,
+          "title": "Limit",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "metric",
+        "groupBy"
+      ],
+      "title": "BreakdownPanelQueryConfig",
+      "type": "object"
+    },
+    "BreakdownPanelSettings": {
+      "additionalProperties": false,
+      "description": "Supported configuration for a breakdown panel.",
+      "properties": {
+        "query": {
+          "$ref": "#/$defs/BreakdownPanelQueryConfig"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "title": "BreakdownPanelSettings",
       "type": "object"
     },
     "CallsFilter": {
@@ -1402,6 +1587,108 @@
       "title": "InOperation",
       "type": "object"
     },
+    "KpiDashboardPanel": {
+      "additionalProperties": false,
+      "description": "A single-value KPI tile.",
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "layout": {
+          "$ref": "#/$defs/PanelGridLayout"
+        },
+        "panel_type": {
+          "const": "kpi",
+          "title": "Panel Type",
+          "type": "string"
+        },
+        "settings": {
+          "$ref": "#/$defs/KpiPanelSettings"
+        }
+      },
+      "required": [
+        "id",
+        "layout",
+        "panel_type",
+        "settings"
+      ],
+      "title": "KpiDashboardPanel",
+      "type": "object"
+    },
+    "KpiPanelQueryConfig": {
+      "additionalProperties": false,
+      "description": "A scalar query; KPI panels do not support grouping or Top-N.",
+      "properties": {
+        "version": {
+          "default": 1,
+          "maximum": 1,
+          "minimum": 1,
+          "title": "Version",
+          "type": "integer"
+        },
+        "metric": {
+          "minLength": 1,
+          "title": "Metric",
+          "type": "string"
+        },
+        "filter": {
+          "default": "",
+          "title": "Filter",
+          "type": "string"
+        },
+        "format": {
+          "anyOf": [
+            {
+              "enum": [
+                "number",
+                "percent",
+                "cost",
+                "duration"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Format"
+        }
+      },
+      "required": [
+        "metric"
+      ],
+      "title": "KpiPanelQueryConfig",
+      "type": "object"
+    },
+    "KpiPanelSettings": {
+      "additionalProperties": false,
+      "description": "Supported configuration for a KPI panel.",
+      "properties": {
+        "query": {
+          "$ref": "#/$defs/KpiPanelQueryConfig"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "title": "KpiPanelSettings",
+      "type": "object"
+    },
     "LLMStructuredCompletionModel": {
       "additionalProperties": false,
       "properties": {
@@ -2265,6 +2552,42 @@
       "title": "OrOperation",
       "type": "object"
     },
+    "PanelGridLayout": {
+      "additionalProperties": false,
+      "description": "Position and size of a panel in the dashboard's 24-column grid.",
+      "properties": {
+        "x": {
+          "exclusiveMaximum": 24,
+          "minimum": 0,
+          "title": "X",
+          "type": "integer"
+        },
+        "y": {
+          "minimum": 0,
+          "title": "Y",
+          "type": "integer"
+        },
+        "w": {
+          "maximum": 24,
+          "minimum": 1,
+          "title": "W",
+          "type": "integer"
+        },
+        "h": {
+          "minimum": 1,
+          "title": "H",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "w",
+        "h"
+      ],
+      "title": "PanelGridLayout",
+      "type": "object"
+    },
     "Pin": {
       "properties": {
         "left": {
@@ -2911,6 +3234,134 @@
       "title": "TestOnlyNestedBaseObject",
       "type": "object"
     },
+    "TimelineDashboardPanel": {
+      "additionalProperties": false,
+      "description": "A metric plotted over time.",
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "layout": {
+          "$ref": "#/$defs/PanelGridLayout"
+        },
+        "panel_type": {
+          "const": "timeline",
+          "title": "Panel Type",
+          "type": "string"
+        },
+        "settings": {
+          "$ref": "#/$defs/TimelinePanelSettings"
+        }
+      },
+      "required": [
+        "id",
+        "layout",
+        "panel_type",
+        "settings"
+      ],
+      "title": "TimelineDashboardPanel",
+      "type": "object"
+    },
+    "TimelinePanelQueryConfig": {
+      "additionalProperties": false,
+      "description": "A time-bucketed query with optional series grouping.",
+      "properties": {
+        "version": {
+          "default": 1,
+          "maximum": 1,
+          "minimum": 1,
+          "title": "Version",
+          "type": "integer"
+        },
+        "metric": {
+          "minLength": 1,
+          "title": "Metric",
+          "type": "string"
+        },
+        "filter": {
+          "default": "",
+          "title": "Filter",
+          "type": "string"
+        },
+        "format": {
+          "anyOf": [
+            {
+              "enum": [
+                "number",
+                "percent",
+                "cost",
+                "duration"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Format"
+        },
+        "groupBy": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Groupby"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "maximum": 50,
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
+        }
+      },
+      "required": [
+        "metric"
+      ],
+      "title": "TimelinePanelQueryConfig",
+      "type": "object"
+    },
+    "TimelinePanelSettings": {
+      "additionalProperties": false,
+      "description": "Supported configuration for a timeline panel.",
+      "properties": {
+        "query": {
+          "$ref": "#/$defs/TimelinePanelQueryConfig"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "title": "TimelinePanelSettings",
+      "type": "object"
+    },
     "WeaveMetricThresholdSpec": {
       "additionalProperties": true,
       "description": "Alert specification for weave metric threshold alerts.\n\nFields align with gorilla's WeaveMetricThresholdFilter and the\nalert_worker's WeaveMetricFilter.  Extra keys are permitted so that\nthe schema can evolve without breaking existing stored objects.",
@@ -3081,6 +3532,9 @@
     },
     "ChartConfig": {
       "$ref": "#/$defs/ChartConfig"
+    },
+    "AgentDashboard": {
+      "$ref": "#/$defs/AgentDashboard"
     }
   },
   "required": [
@@ -3095,7 +3549,8 @@
     "SavedView",
     "ComparisonView",
     "LLMStructuredCompletionModel",
-    "ChartConfig"
+    "ChartConfig",
+    "AgentDashboard"
   ],
   "title": "CompositeBaseObject",
   "type": "object"


### PR DESCRIPTION
## Summary

- Adds `AgentDashboard` as a persisted Weave builtin object for saving, loading, and forking Agent Dashboard configurations.
- Defines a closed, validated contract for the three supported visualizations: KPI, timeline, and breakdown panels.
- Registers the builtin object and regenerates the composite builtin-object JSON schema so the trace server and generated clients share the same contract.

## Design

- `panel_type` is restricted to `kpi`, `timeline`, or `breakdown`; unsupported visualization types are rejected.
- Each visualization has an explicit settings model instead of a free-form dictionary:
  - KPI queries cannot contain grouping or Top-N options.
  - Timeline queries may contain `groupBy` and `limit`.
  - Breakdown queries require `groupBy` and have a bounded `limit`.
- Query configuration explicitly enumerates `version`, `metric`, `filter`, and the supported value formats (`number`, `percent`, `cost`, `duration`). Unknown settings and query keys are rejected.
- Grid coordinates are validated as positive integer units within the dashboard's 24-column layout.
- This uses the existing builtin-object persistence path; it does not add a storage system, endpoint, or migration.

Adding a new panel type or persisted option is intentionally a schema change: define its typed model here, regenerate the builtin-object schemas, and update the generated consumer bindings.

## UI

No standalone UI change. This PR is the persistence contract consumed by [wandb/core#48596](https://github.com/wandb/core/pull/48596); the user-facing preset, editor, layout, and expression screenshots live on the corresponding Core PRs.

## Testing

- `uvx ruff check` passes for the model and focused test.
- 9 focused Agent Dashboard model tests pass, including rejection cases for unsupported types, invalid per-panel options, unknown keys, invalid formats, and out-of-grid layouts.
- The composite builtin-object schema and Core Zod bindings were regenerated from the Pydantic source models.

## Related PRs

- Primary UI consumer: [wandb/core#48596](https://github.com/wandb/core/pull/48596)
- Core dashboard stack: [#48593](https://github.com/wandb/core/pull/48593) → [#48594](https://github.com/wandb/core/pull/48594) → [#48595](https://github.com/wandb/core/pull/48595) → [#48596](https://github.com/wandb/core/pull/48596) → [#48597](https://github.com/wandb/core/pull/48597) → [#48598](https://github.com/wandb/core/pull/48598)
