### PR TITLE
chore(weave): add calls_merged to calls_complete backfill driver

### DIFF
--- a/scripts/backfill_calls_complete.py
+++ b/scripts/backfill_calls_complete.py
@@ -54,6 +54,10 @@ FILL_SETTINGS = {
     "max_memory_usage": 16_000_000_000,
     "max_execution_time": 3600,
 }
+# Verification reads must not race replica metadata sync: on ClickHouse Cloud a
+# SELECT right after an INSERT can land on a replica that hasn't seen the new
+# parts yet and silently undercount (observed on QA: 0 of 100k rows visible).
+READ_SETTINGS = {"select_sequential_consistency": 1}
 
 
 @dataclass
@@ -123,6 +127,7 @@ def plan(
             )
             """,
             parameters={"pid": pid},
+            settings=READ_SETTINGS,
         ).result_rows[0]
         (
             state.unique_calls,
@@ -177,6 +182,7 @@ def verify(
             FROM {journal.staging_table} WHERE project_id = {{pid:String}}
             """,
             parameters={"pid": pid},
+            settings=READ_SETTINGS,
         ).result_rows[0]
         state.staging_rows = staging_rows
         mismatches = client.query(
@@ -199,6 +205,7 @@ def verify(
             )
             """,
             parameters={"pid": pid},
+            settings=READ_SETTINGS,
         ).result_rows[0][0]
         # past_retention rows may or may not have been TTL-reaped in staging yet.
         low = state.expected_rows
@@ -246,7 +253,8 @@ def attach(
     partitions = [
         str(r[0])
         for r in client.query(
-            f"SELECT DISTINCT toYYYYMM(started_at) FROM {journal.staging_table} ORDER BY 1"
+            f"SELECT DISTINCT toYYYYMM(started_at) FROM {journal.staging_table} ORDER BY 1",
+            settings=READ_SETTINGS,
         ).result_rows
     ]
     for part in partitions:
@@ -353,6 +361,7 @@ def preflight(client: Client, journal: Journal, projects: list[str]) -> None:
     dirty = client.query(
         "SELECT DISTINCT project_id FROM calls_complete WHERE project_id IN {pids:Array(String)}",
         parameters={"pids": pending},
+        settings=READ_SETTINGS,
     ).result_rows
     if dirty:
         raise SystemExit(
@@ -385,6 +394,7 @@ def post_attach_report(client: Client, journal: Journal) -> None:
             FROM calls_complete WHERE project_id = {pid:String}
             """,
             parameters={"pid": pid},
+            settings=READ_SETTINGS,
         ).result_rows[0]
         status = "ok" if (attached == state.staging_rows and dupes == 0) else "MISMATCH"
         print(

--- a/scripts/backfill_calls_complete.py
+++ b/scripts/backfill_calls_complete.py
@@ -3,7 +3,8 @@
 Flow (per wave of allowlisted projects):
   plan    -> per-project inventory: unique calls, orphan ends, past-retention rows,
              partitions, expected staging rows. No writes.
-  fill    -> INSERT INTO <staging> SELECT <transform> per project (id-bucket chunked).
+  fill    -> INSERT INTO <staging> SELECT <transform> per project, chunked into
+             adaptive id ranges of <= --chunk-rows rows each.
   verify  -> per-project gates against staging: row parity vs expectation, zero dupes,
              sample field spot-check vs source, partition sanity.
   stats   -> INSERT INTO calls_complete_stats from staging (the stats MV does not fire
@@ -51,10 +52,15 @@ STAGING_TABLE_DEFAULT = "calls_complete_backfill_staging"
 SENTINEL_DT64_3 = "toDateTime64(0, 3)"
 SENTINEL_DT64_6 = "toDateTime64(0, 6)"
 VERIFY_SAMPLE_ROWS = 1000
+CHUNK_ROWS_DEFAULT = 1_000_000
+# External spill plus single-replica aggregation keep per-chunk fills under the
+# query memory cap; parallel replicas merge partial states on the initiator unspilled.
 FILL_SETTINGS = {
     "insert_deduplicate": 0,
     "optimize_on_insert": 0,
     "max_memory_usage": 16_000_000_000,
+    "max_bytes_before_external_group_by": 8_000_000_000,
+    "enable_parallel_replicas": 0,
     "max_execution_time": 3600,
 }
 # Verification reads must not race replica metadata sync: on ClickHouse Cloud a
@@ -141,31 +147,38 @@ def plan(
         state = journal.projects[pid]
         if state.phase != "pending":
             continue
-        row = client.query(
-            """
-            SELECT
-                toInt64(count()) AS unique_calls,
-                toInt64(countIf(isNull(s))) AS orphan_ends,
-                toInt64(countIf(isNotNull(s) AND exp < now())) AS past_retention,
-                toInt64(countIf(isNotNull(s) AND exp >= now())) AS expected_rows,
-                arraySort(groupUniqArrayIf(toString(toYYYYMM(s)), isNotNull(s))) AS partitions
-            FROM (
-                SELECT anyIf(started_at, isNotNull(started_at)) AS s,
-                       toDateTime(min(expire_at)) AS exp
-                FROM calls_merged WHERE project_id = {pid:String}
-                GROUP BY project_id, id
-            )
-            """,
-            parameters={"pid": pid},
-            settings=READ_SETTINGS,
-        ).result_rows[0]
+        totals = [0, 0, 0, 0]
+        partitions: set[str] = set()
+        for lo, hi in id_chunk_ranges(client, pid, args.chunk_rows):
+            row = client.query(
+                f"""
+                SELECT
+                    toInt64(count()) AS unique_calls,
+                    toInt64(countIf(isNull(s))) AS orphan_ends,
+                    toInt64(countIf(isNotNull(s) AND exp < now())) AS past_retention,
+                    toInt64(countIf(isNotNull(s) AND exp >= now())) AS expected_rows,
+                    groupUniqArrayIf(toString(toYYYYMM(s)), isNotNull(s)) AS partitions
+                FROM (
+                    SELECT anyIf(started_at, isNotNull(started_at)) AS s,
+                           toDateTime(min(expire_at)) AS exp
+                    FROM calls_merged
+                    WHERE project_id = {{pid:String}} {_range_pred(lo, hi)}
+                    GROUP BY project_id, id
+                )
+                """,
+                parameters={"pid": pid},
+                settings=READ_SETTINGS,
+            ).result_rows[0]
+            for i in range(4):
+                totals[i] += row[i]
+            partitions.update(row[4])
         (
             state.unique_calls,
             state.orphan_ends,
             state.past_retention,
             state.expected_rows,
-        ) = row[:4]
-        state.partitions = list(row[4])
+        ) = totals
+        state.partitions = sorted(partitions)
         print(
             f"plan {pid}: calls={state.unique_calls} expected={state.expected_rows} "
             f"orphan_ends={state.orphan_ends} past_retention={state.past_retention} "
@@ -182,18 +195,19 @@ def fill(
         state = journal.projects[pid]
         if state.phase != "pending":
             continue
+        ranges = id_chunk_ranges(client, pid, args.chunk_rows)
         if args.dry_run:
-            print(f"dry-run: would fill {pid} with {args.id_buckets} bucket(s)")
+            print(f"dry-run: would fill {pid} in {len(ranges)} chunk(s)")
             continue
-        for bucket in range(args.id_buckets):
+        for lo, hi in ranges:
             ch_command(
                 client,
-                transform_sql(journal.staging_table, args.id_buckets, bucket),
+                transform_sql(journal.staging_table, _range_pred(lo, hi)),
                 parameters={"pid": pid},
                 settings=FILL_SETTINGS,
             )
         state.phase = "filled"
-        print(f"fill {pid}: done ({args.id_buckets} bucket(s))")
+        print(f"fill {pid}: done ({len(ranges)} chunk(s))")
     return True
 
 
@@ -205,39 +219,47 @@ def verify(
         state = journal.projects[pid]
         if state.phase not in {"filled", "verified"}:
             continue
-        staging_rows, dupes, bogus_parts = client.query(
-            f"""
-            SELECT toInt64(count()),
-                   toInt64(count()) - toInt64(uniqExact(id)),
-                   toInt64(countIf(toYYYYMM(started_at) < 201801))
-            FROM {journal.staging_table} WHERE project_id = {{pid:String}}
-            """,
-            parameters={"pid": pid},
-            settings=READ_SETTINGS,
-        ).result_rows[0]
+        staging_rows = dupes = bogus_parts = mismatches = 0
+        for lo, hi in id_chunk_ranges(client, pid, args.chunk_rows):
+            # dupe counting stays exact under chunking: duplicate ids share a range
+            rows, chunk_dupes, chunk_bogus = client.query(
+                f"""
+                SELECT toInt64(count()),
+                       toInt64(count()) - toInt64(uniqExact(id)),
+                       toInt64(countIf(toYYYYMM(started_at) < 201801))
+                FROM {journal.staging_table}
+                WHERE project_id = {{pid:String}} {_range_pred(lo, hi)}
+                """,
+                parameters={"pid": pid},
+                settings=READ_SETTINGS,
+            ).result_rows[0]
+            staging_rows += rows
+            dupes += chunk_dupes
+            bogus_parts += chunk_bogus
+            mismatches += client.query(
+                f"""
+                SELECT toInt64(countIf(NOT trace_ok OR NOT op_ok OR NOT refs_ok))
+                FROM (
+                    SELECT c.trace_id = m.trace_id AS trace_ok,
+                           c.op_name = coalesce(m.op_name, '') AS op_ok,
+                           length(c.input_refs) >= length(m.input_refs) AS refs_ok
+                    FROM {journal.staging_table} AS c
+                    INNER JOIN (
+                        SELECT id, anyIf(trace_id, isNotNull(trace_id)) AS trace_id,
+                               anyIf(op_name, isNotNull(op_name)) AS op_name,
+                               arrayDistinct(groupArrayArray(input_refs)) AS input_refs
+                        FROM calls_merged
+                        WHERE project_id = {{pid:String}} {_range_pred(lo, hi)}
+                        GROUP BY project_id, id
+                    ) AS m ON c.id = m.id
+                    WHERE c.project_id = {{pid:String}} {_range_pred(lo, hi, "c.id")}
+                    LIMIT {VERIFY_SAMPLE_ROWS}
+                )
+                """,
+                parameters={"pid": pid},
+                settings=READ_SETTINGS,
+            ).result_rows[0][0]
         state.staging_rows = staging_rows
-        mismatches = client.query(
-            f"""
-            SELECT toInt64(countIf(NOT trace_ok OR NOT op_ok OR NOT refs_ok))
-            FROM (
-                SELECT c.trace_id = m.trace_id AS trace_ok,
-                       c.op_name = coalesce(m.op_name, '') AS op_ok,
-                       length(c.input_refs) >= length(m.input_refs) AS refs_ok
-                FROM {journal.staging_table} AS c
-                INNER JOIN (
-                    SELECT id, anyIf(trace_id, isNotNull(trace_id)) AS trace_id,
-                           anyIf(op_name, isNotNull(op_name)) AS op_name,
-                           arrayDistinct(groupArrayArray(input_refs)) AS input_refs
-                    FROM calls_merged WHERE project_id = {{pid:String}}
-                    GROUP BY project_id, id
-                ) AS m ON c.id = m.id
-                WHERE c.project_id = {{pid:String}}
-                LIMIT {VERIFY_SAMPLE_ROWS}
-            )
-            """,
-            parameters={"pid": pid},
-            settings=READ_SETTINGS,
-        ).result_rows[0][0]
         # past_retention rows may or may not have been TTL-reaped in staging yet.
         low = state.expected_rows
         high = state.expected_rows + state.past_retention
@@ -269,7 +291,14 @@ def stats(
     if args.dry_run:
         print("dry-run: would insert stats rows")
         return True
-    ch_command(client, stats_sql(journal.staging_table), settings=FILL_SETTINGS)
+    for pid in journal.projects:
+        for lo, hi in id_chunk_ranges(client, pid, args.chunk_rows):
+            ch_command(
+                client,
+                stats_sql(journal.staging_table, _range_pred(lo, hi)),
+                parameters={"pid": pid},
+                settings=FILL_SETTINGS,
+            )
     journal.stats_inserted = True
     print("stats: inserted")
     return True
@@ -313,11 +342,8 @@ def attach(
 # --- helpers -----------------------------------------------------------------
 
 
-def transform_sql(staging_table: str, n_buckets: int, bucket: int) -> str:
-    """The validated merged->complete transform for one project id-bucket."""
-    bucket_pred = (
-        f"AND cityHash64(id) % {n_buckets} = {bucket}" if n_buckets > 1 else ""
-    )
+def transform_sql(staging_table: str, range_pred: str) -> str:
+    """The validated merged->complete transform for one project id range."""
     return f"""
 INSERT INTO {staging_table}
 (id, project_id, created_at, trace_id, op_name, started_at, ended_at, updated_at,
@@ -353,13 +379,13 @@ SELECT
     toDateTime(min(expire_at)),
     'migration'
 FROM calls_merged
-WHERE project_id = {{pid:String}} {bucket_pred}
+WHERE project_id = {{pid:String}} {range_pred}
 GROUP BY project_id, id
 HAVING isNotNull(anyIf(started_at, isNotNull(started_at)))
 """
 
 
-def stats_sql(staging_table: str) -> str:
+def stats_sql(staging_table: str, range_pred: str) -> str:
     return f"""
 INSERT INTO calls_complete_stats
 (project_id, id, trace_id, parent_id, op_name, started_at, ended_at,
@@ -382,8 +408,66 @@ SELECT project_id, id, anySimpleState(trace_id), anySimpleState(parent_id),
        argMaxState(display_name, created_at),
        minSimpleState(toDateTime64(expire_at, 3)), anySimpleState(source)
 FROM {staging_table}
+WHERE project_id = {{pid:String}} {range_pred}
 GROUP BY project_id, id
 """
+
+
+def id_chunk_ranges(
+    client: Client, pid: str, chunk_rows: int
+) -> list[tuple[str | None, str | None]]:
+    """Split a project's id space into sort-key-prunable (lo, hi) ranges of roughly
+    <= chunk_rows rows, drilling prefixes so time-ordered (UUIDv7) ids still balance.
+    """
+
+    def prefix_counts(
+        depth: int, lo: str | None, hi: str | None
+    ) -> list[tuple[str, int]]:
+        rows = client.query(
+            f"""
+            SELECT substring(id, 1, {depth}) AS p, toInt64(count()) AS c
+            FROM calls_merged
+            WHERE project_id = {{pid:String}} {_range_pred(lo, hi)}
+            GROUP BY p ORDER BY p
+            """,
+            parameters={"pid": pid},
+            settings=READ_SETTINGS,
+        ).result_rows
+        return [(str(p), int(c)) for p, c in rows]
+
+    leaves = prefix_counts(2, None, None)
+    depth = 2
+    while depth < 12 and any(c > chunk_rows for _, c in leaves):
+        depth += 2
+        leaves = [
+            child
+            for p, c in leaves
+            for child in (
+                prefix_counts(depth, p, _bump(p)) if c > chunk_rows else [(p, c)]
+            )
+        ]
+    ranges: list[tuple[str | None, str | None]] = []
+    start: str | None = None
+    acc = 0
+    for p, c in leaves:
+        if acc and acc + c > chunk_rows:
+            ranges.append((start, p))
+            start, acc = p, 0
+        elif start is None:
+            start = p
+        acc += c
+    ranges.append((start, None))
+    ranges[0] = (None, ranges[0][1])
+    return ranges
+
+
+def _range_pred(lo: str | None, hi: str | None, col: str = "id") -> str:
+    parts = ([f"{col} >= '{lo}'"] if lo else []) + ([f"{col} < '{hi}'"] if hi else [])
+    return ("AND " + " AND ".join(parts)) if parts else ""
+
+
+def _bump(prefix: str) -> str:
+    return prefix[:-1] + chr(ord(prefix[-1]) + 1)
 
 
 def preflight(client: Client, journal: Journal, projects: list[str]) -> None:
@@ -497,7 +581,10 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--staging-table", default=STAGING_TABLE_DEFAULT)
     parser.add_argument(
-        "--id-buckets", type=int, default=1, help="chunk fills by cityHash64(id) %% N"
+        "--chunk-rows",
+        type=int,
+        default=CHUNK_ROWS_DEFAULT,
+        help="max rows per adaptive id-range chunk in plan/fill/verify/stats",
     )
     parser.add_argument("--dry-run", action="store_true")
     return parser.parse_args()

--- a/scripts/backfill_calls_complete.py
+++ b/scripts/backfill_calls_complete.py
@@ -38,11 +38,14 @@ import argparse
 import datetime
 import json
 import os
+import re
 import sys
 from dataclasses import asdict, dataclass, field
 
 import clickhouse_connect
 from clickhouse_connect.driver.client import Client
+from clickhouse_connect.driver.exceptions import DatabaseError
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 STAGING_TABLE_DEFAULT = "calls_complete_backfill_staging"
 SENTINEL_DT64_3 = "toDateTime64(0, 3)"
@@ -58,6 +61,11 @@ FILL_SETTINGS = {
 # SELECT right after an INSERT can land on a replica that hasn't seen the new
 # parts yet and silently undercount (observed on QA: 0 of 100k rows visible).
 READ_SETTINGS = {"select_sequential_consistency": 1}
+# Same transient codes the migrator retries, plus 244 (UNEXPECTED_ZOOKEEPER_ERROR):
+# SharedMergeTree occasionally races Keeper znode cleanup when a staging table is
+# dropped and recreated under the same name (observed ~0.4% of QA fills). All abort
+# atomically, so a plain retry is safe.
+TRANSIENT_CH_ERROR_CODES = {244, 517, 999}
 
 
 @dataclass
@@ -78,6 +86,28 @@ class Journal:
     projects: dict[str, ProjectState]
     stats_inserted: bool = False
     attached_partitions: list[str] = field(default_factory=list)
+
+
+def _is_transient_ch_error(exc: BaseException) -> bool:
+    if not isinstance(exc, DatabaseError):
+        return False
+    match = re.search(r"Code:\s*(\d+)", str(exc))
+    return match is not None and int(match.group(1)) in TRANSIENT_CH_ERROR_CODES
+
+
+@retry(
+    stop=stop_after_attempt(4),
+    wait=wait_exponential(multiplier=1, min=1, max=30),
+    retry=retry_if_exception(_is_transient_ch_error),
+    reraise=True,
+)
+def ch_command(
+    client: Client,
+    sql: str,
+    parameters: dict | None = None,
+    settings: dict | None = None,
+) -> None:
+    client.command(sql, parameters=parameters, settings=settings)
 
 
 def main() -> int:
@@ -156,7 +186,8 @@ def fill(
             print(f"dry-run: would fill {pid} with {args.id_buckets} bucket(s)")
             continue
         for bucket in range(args.id_buckets):
-            client.command(
+            ch_command(
+                client,
                 transform_sql(journal.staging_table, args.id_buckets, bucket),
                 parameters={"pid": pid},
                 settings=FILL_SETTINGS,
@@ -238,7 +269,7 @@ def stats(
     if args.dry_run:
         print("dry-run: would insert stats rows")
         return True
-    client.command(stats_sql(journal.staging_table), settings=FILL_SETTINGS)
+    ch_command(client, stats_sql(journal.staging_table), settings=FILL_SETTINGS)
     journal.stats_inserted = True
     print("stats: inserted")
     return True
@@ -265,8 +296,9 @@ def attach(
             print(f"dry-run: would attach partition {part}")
             continue
         started = datetime.datetime.now(datetime.timezone.utc)
-        client.command(
-            f"ALTER TABLE calls_complete ATTACH PARTITION ID '{int(part)}' FROM {journal.staging_table}"
+        ch_command(
+            client,
+            f"ALTER TABLE calls_complete ATTACH PARTITION ID '{int(part)}' FROM {journal.staging_table}",
         )
         journal.attached_partitions.append(part)
         elapsed = (
@@ -370,7 +402,7 @@ def preflight(client: Client, journal: Journal, projects: list[str]) -> None:
 
 
 def ensure_staging(client: Client, staging_table: str) -> None:
-    client.command(f"CREATE TABLE IF NOT EXISTS {staging_table} AS calls_complete")
+    ch_command(client, f"CREATE TABLE IF NOT EXISTS {staging_table} AS calls_complete")
     src = client.query("DESCRIBE calls_complete").result_rows
     dst = client.query(f"DESCRIBE {staging_table}").result_rows
     if src != dst:

--- a/scripts/backfill_calls_complete.py
+++ b/scripts/backfill_calls_complete.py
@@ -1,0 +1,465 @@
+"""Backfill dormant projects from calls_merged into calls_complete via a staging table.
+
+Flow (per wave of allowlisted projects):
+  plan    -> per-project inventory: unique calls, orphan ends, past-retention rows,
+             partitions, expected staging rows. No writes.
+  fill    -> INSERT INTO <staging> SELECT <transform> per project (id-bucket chunked).
+  verify  -> per-project gates against staging: row parity vs expectation, zero dupes,
+             sample field spot-check vs source, partition sanity.
+  stats   -> INSERT INTO calls_complete_stats from staging (the stats MV does not fire
+             on ATTACH, so this must happen explicitly, before attach).
+  attach  -> ALTER TABLE calls_complete ATTACH PARTITION ID ... FROM <staging>, once.
+             Publishing is partition-granular over the whole staging table, so attach
+             refuses to run unless every filled project passed verify.
+  run     -> all of the above in order.
+
+Safety model: the CH user needs only SELECT on calls_merged/call_parts, CREATE/INSERT/
+DROP on the staging table, and INSERT + ALTER on calls_complete(_stats). calls_merged is
+never written. Rollback (before any reclaim) is per project:
+  DELETE FROM calls_complete WHERE project_id = '<pid>';
+  DELETE FROM calls_complete_stats WHERE project_id = '<pid>';
+Routing flips by data presence: a project reads/writes calls_complete as soon as its
+first partition attaches, so only migrate projects with no (or flip-safe) writers.
+
+Known accepted losses (validated on CH 25.12 with adversarially fragmented data):
+  - end-only fragments (no started_at anywhere) are dropped;
+  - rows whose per-row expire_at already elapsed are reaped by the first TTL merge.
+Both are counted in `plan` and excluded from parity expectations.
+
+Example:
+  python scripts/backfill_calls_complete.py plan --allowlist wave0.txt
+  python scripts/backfill_calls_complete.py run --allowlist wave0.txt --journal wave0.json
+Connection via env: WF_BACKFILL_CH_HOST/PORT/USER/PASSWORD/DATABASE.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+
+import clickhouse_connect
+from clickhouse_connect.driver.client import Client
+
+STAGING_TABLE_DEFAULT = "calls_complete_backfill_staging"
+SENTINEL_DT64_3 = "toDateTime64(0, 3)"
+SENTINEL_DT64_6 = "toDateTime64(0, 6)"
+VERIFY_SAMPLE_ROWS = 1000
+FILL_SETTINGS = {
+    "insert_deduplicate": 0,
+    "optimize_on_insert": 0,
+    "max_memory_usage": 16_000_000_000,
+    "max_execution_time": 3600,
+}
+
+
+@dataclass
+class ProjectState:
+    phase: str = "pending"  # pending | filled | verified | failed
+    unique_calls: int = 0
+    orphan_ends: int = 0
+    past_retention: int = 0
+    expected_rows: int = 0
+    staging_rows: int = 0
+    partitions: list[str] = field(default_factory=list)
+    error: str = ""
+
+
+@dataclass
+class Journal:
+    staging_table: str
+    projects: dict[str, ProjectState]
+    stats_inserted: bool = False
+    attached_partitions: list[str] = field(default_factory=list)
+
+
+def main() -> int:
+    args = parse_args()
+    projects = load_allowlist(args.allowlist)
+    client = connect()
+    journal = load_journal(args.journal, args.staging_table, projects)
+
+    steps = {
+        "plan": [plan],
+        "fill": [plan, fill],
+        "verify": [verify],
+        "stats": [stats],
+        "attach": [attach],
+        "run": [plan, fill, verify, stats, attach],
+    }[args.command]
+    ok = True
+    for step in steps:
+        ok = step(client, journal, projects, args)
+        save_journal(args.journal, journal)
+        if not ok:
+            break
+    return 0 if ok else 1
+
+
+def plan(
+    client: Client, journal: Journal, projects: list[str], args: argparse.Namespace
+) -> bool:
+    preflight(client, journal, projects)
+    for pid in projects:
+        state = journal.projects[pid]
+        if state.phase != "pending":
+            continue
+        row = client.query(
+            """
+            SELECT
+                toInt64(count()) AS unique_calls,
+                toInt64(countIf(isNull(s))) AS orphan_ends,
+                toInt64(countIf(isNotNull(s) AND exp < now())) AS past_retention,
+                toInt64(countIf(isNotNull(s) AND exp >= now())) AS expected_rows,
+                arraySort(groupUniqArrayIf(toString(toYYYYMM(s)), isNotNull(s))) AS partitions
+            FROM (
+                SELECT anyIf(started_at, isNotNull(started_at)) AS s,
+                       toDateTime(min(expire_at)) AS exp
+                FROM calls_merged WHERE project_id = {pid:String}
+                GROUP BY project_id, id
+            )
+            """,
+            parameters={"pid": pid},
+        ).result_rows[0]
+        (
+            state.unique_calls,
+            state.orphan_ends,
+            state.past_retention,
+            state.expected_rows,
+        ) = row[:4]
+        state.partitions = list(row[4])
+        print(
+            f"plan {pid}: calls={state.unique_calls} expected={state.expected_rows} "
+            f"orphan_ends={state.orphan_ends} past_retention={state.past_retention} "
+            f"partitions={state.partitions}"
+        )
+    return True
+
+
+def fill(
+    client: Client, journal: Journal, projects: list[str], args: argparse.Namespace
+) -> bool:
+    ensure_staging(client, journal.staging_table)
+    for pid in projects:
+        state = journal.projects[pid]
+        if state.phase != "pending":
+            continue
+        if args.dry_run:
+            print(f"dry-run: would fill {pid} with {args.id_buckets} bucket(s)")
+            continue
+        for bucket in range(args.id_buckets):
+            client.command(
+                transform_sql(journal.staging_table, args.id_buckets, bucket),
+                parameters={"pid": pid},
+                settings=FILL_SETTINGS,
+            )
+        state.phase = "filled"
+        print(f"fill {pid}: done ({args.id_buckets} bucket(s))")
+    return True
+
+
+def verify(
+    client: Client, journal: Journal, projects: list[str], args: argparse.Namespace
+) -> bool:
+    all_ok = True
+    for pid in projects:
+        state = journal.projects[pid]
+        if state.phase not in {"filled", "verified"}:
+            continue
+        staging_rows, dupes, bogus_parts = client.query(
+            f"""
+            SELECT toInt64(count()),
+                   toInt64(count()) - toInt64(uniqExact(id)),
+                   toInt64(countIf(toYYYYMM(started_at) < 201801))
+            FROM {journal.staging_table} WHERE project_id = {{pid:String}}
+            """,
+            parameters={"pid": pid},
+        ).result_rows[0]
+        state.staging_rows = staging_rows
+        mismatches = client.query(
+            f"""
+            SELECT toInt64(countIf(NOT trace_ok OR NOT op_ok OR NOT refs_ok))
+            FROM (
+                SELECT c.trace_id = m.trace_id AS trace_ok,
+                       c.op_name = coalesce(m.op_name, '') AS op_ok,
+                       length(c.input_refs) >= length(m.input_refs) AS refs_ok
+                FROM {journal.staging_table} AS c
+                INNER JOIN (
+                    SELECT id, anyIf(trace_id, isNotNull(trace_id)) AS trace_id,
+                           anyIf(op_name, isNotNull(op_name)) AS op_name,
+                           arrayDistinct(groupArrayArray(input_refs)) AS input_refs
+                    FROM calls_merged WHERE project_id = {{pid:String}}
+                    GROUP BY project_id, id
+                ) AS m ON c.id = m.id
+                WHERE c.project_id = {{pid:String}}
+                LIMIT {VERIFY_SAMPLE_ROWS}
+            )
+            """,
+            parameters={"pid": pid},
+        ).result_rows[0][0]
+        # past_retention rows may or may not have been TTL-reaped in staging yet.
+        low = state.expected_rows
+        high = state.expected_rows + state.past_retention
+        checks = {
+            f"rows {staging_rows} in [{low}, {high}]": low <= staging_rows <= high,
+            f"dupes {dupes} == 0": dupes == 0,
+            f"bogus partitions {bogus_parts} == 0": bogus_parts == 0,
+            f"sample mismatches {mismatches} == 0": mismatches == 0,
+        }
+        failed = [desc for desc, passed in checks.items() if not passed]
+        if failed:
+            state.phase = "failed"
+            state.error = "; ".join(failed)
+            all_ok = False
+            print(f"verify {pid}: FAILED ({state.error})")
+        else:
+            state.phase = "verified"
+            print(f"verify {pid}: ok ({staging_rows} rows)")
+    return all_ok
+
+
+def stats(
+    client: Client, journal: Journal, projects: list[str], args: argparse.Namespace
+) -> bool:
+    if journal.stats_inserted:
+        print("stats: already inserted, skipping")
+        return True
+    require_all_verified(journal)
+    if args.dry_run:
+        print("dry-run: would insert stats rows")
+        return True
+    client.command(stats_sql(journal.staging_table), settings=FILL_SETTINGS)
+    journal.stats_inserted = True
+    print("stats: inserted")
+    return True
+
+
+def attach(
+    client: Client, journal: Journal, projects: list[str], args: argparse.Namespace
+) -> bool:
+    require_all_verified(journal)
+    if not journal.stats_inserted:
+        raise SystemExit("attach refused: stats not inserted yet")
+    partitions = [
+        str(r[0])
+        for r in client.query(
+            f"SELECT DISTINCT toYYYYMM(started_at) FROM {journal.staging_table} ORDER BY 1"
+        ).result_rows
+    ]
+    for part in partitions:
+        if part in journal.attached_partitions:
+            print(f"attach {part}: already attached, skipping")
+            continue
+        if args.dry_run:
+            print(f"dry-run: would attach partition {part}")
+            continue
+        started = datetime.datetime.now(datetime.timezone.utc)
+        client.command(
+            f"ALTER TABLE calls_complete ATTACH PARTITION ID '{int(part)}' FROM {journal.staging_table}"
+        )
+        journal.attached_partitions.append(part)
+        elapsed = (
+            datetime.datetime.now(datetime.timezone.utc) - started
+        ).total_seconds()
+        print(f"attach {part}: done in {elapsed:.1f}s")
+    if not args.dry_run:
+        post_attach_report(client, journal)
+    return True
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def transform_sql(staging_table: str, n_buckets: int, bucket: int) -> str:
+    """The validated merged->complete transform for one project id-bucket."""
+    bucket_pred = (
+        f"AND cityHash64(id) % {n_buckets} = {bucket}" if n_buckets > 1 else ""
+    )
+    return f"""
+INSERT INTO {staging_table}
+(id, project_id, created_at, trace_id, op_name, started_at, ended_at, updated_at,
+ deleted_at, parent_id, display_name, exception, otel_dump, wb_user_id, wb_run_id,
+ thread_id, turn_id, inputs_dump, input_refs, output_dump, summary_dump, output_refs,
+ attributes_dump, wb_run_step, wb_run_step_end, expire_at, source)
+SELECT
+    id,
+    project_id,
+    toDateTime64(min(sortable_datetime), 3),
+    coalesce(anyIf(trace_id, isNotNull(trace_id)), ''),
+    coalesce(anyIf(op_name, isNotNull(op_name)), ''),
+    assumeNotNull(anyIf(started_at, isNotNull(started_at))),
+    coalesce(anyIf(ended_at, isNotNull(ended_at)), {SENTINEL_DT64_6}),
+    {SENTINEL_DT64_3},
+    coalesce(maxIf(deleted_at, isNotNull(deleted_at)), {SENTINEL_DT64_3}),
+    coalesce(anyIf(parent_id, isNotNull(parent_id)), ''),
+    coalesce(argMaxMerge(display_name), ''),
+    coalesce(anyIf(exception, isNotNull(exception)), ''),
+    coalesce(anyIf(otel_dump, isNotNull(otel_dump)), ''),
+    coalesce(anyIf(wb_user_id, isNotNull(wb_user_id)), ''),
+    coalesce(anyIf(wb_run_id, isNotNull(wb_run_id)), ''),
+    coalesce(anyIf(thread_id, isNotNull(thread_id)), ''),
+    coalesce(anyIf(turn_id, isNotNull(turn_id)), ''),
+    coalesce(anyIf(inputs_dump, isNotNull(inputs_dump)), ''),
+    groupArrayArray(input_refs),
+    coalesce(anyIf(output_dump, isNotNull(output_dump)), ''),
+    coalesce(anyIf(summary_dump, isNotNull(summary_dump)), ''),
+    groupArrayArray(output_refs),
+    coalesce(anyIf(attributes_dump, isNotNull(attributes_dump)), ''),
+    coalesce(anyIf(wb_run_step, isNotNull(wb_run_step)), 0),
+    coalesce(anyIf(wb_run_step_end, isNotNull(wb_run_step_end)), 0),
+    toDateTime(min(expire_at)),
+    'migration'
+FROM calls_merged
+WHERE project_id = {{pid:String}} {bucket_pred}
+GROUP BY project_id, id
+HAVING isNotNull(anyIf(started_at, isNotNull(started_at)))
+"""
+
+
+def stats_sql(staging_table: str) -> str:
+    return f"""
+INSERT INTO calls_complete_stats
+(project_id, id, trace_id, parent_id, op_name, started_at, ended_at,
+ attributes_size_bytes, inputs_size_bytes, output_size_bytes, summary_size_bytes,
+ otel_size_bytes, exception_size_bytes, wb_user_id, wb_run_id, wb_run_step,
+ wb_run_step_end, thread_id, turn_id, created_at, updated_at, display_name,
+ expire_at, source)
+SELECT project_id, id, anySimpleState(trace_id), anySimpleState(parent_id),
+       anySimpleState(op_name), anySimpleState(started_at), anySimpleState(ended_at),
+       anySimpleState(toUInt64(length(attributes_dump))),
+       anySimpleState(toUInt64(length(inputs_dump))),
+       anySimpleState(toUInt64(length(output_dump))),
+       anySimpleState(toUInt64(length(summary_dump))),
+       anySimpleState(toUInt64(length(otel_dump))),
+       anySimpleState(toUInt64(length(exception))),
+       anySimpleState(wb_user_id), anySimpleState(wb_run_id),
+       anySimpleState(wb_run_step), anySimpleState(wb_run_step_end),
+       anySimpleState(thread_id), anySimpleState(turn_id),
+       minSimpleState(created_at), maxSimpleState(updated_at),
+       argMaxState(display_name, created_at),
+       minSimpleState(toDateTime64(expire_at, 3)), anySimpleState(source)
+FROM {staging_table}
+GROUP BY project_id, id
+"""
+
+
+def preflight(client: Client, journal: Journal, projects: list[str]) -> None:
+    pending = [p for p in projects if journal.projects[p].phase == "pending"]
+    if not pending:
+        return
+    dirty = client.query(
+        "SELECT DISTINCT project_id FROM calls_complete WHERE project_id IN {pids:Array(String)}",
+        parameters={"pids": pending},
+    ).result_rows
+    if dirty:
+        raise SystemExit(
+            f"preflight failed: projects already have calls_complete rows: {[r[0] for r in dirty]}"
+        )
+
+
+def ensure_staging(client: Client, staging_table: str) -> None:
+    client.command(f"CREATE TABLE IF NOT EXISTS {staging_table} AS calls_complete")
+    src = client.query("DESCRIBE calls_complete").result_rows
+    dst = client.query(f"DESCRIBE {staging_table}").result_rows
+    if src != dst:
+        raise SystemExit(
+            f"staging schema drifted from calls_complete (a migration shipped mid-wave?): "
+            f"drop {staging_table} and restart the wave"
+        )
+
+
+def require_all_verified(journal: Journal) -> None:
+    unverified = [p for p, s in journal.projects.items() if s.phase != "verified"]
+    if unverified:
+        raise SystemExit(f"refused: unverified projects in staging: {unverified}")
+
+
+def post_attach_report(client: Client, journal: Journal) -> None:
+    for pid, state in journal.projects.items():
+        attached, dupes = client.query(
+            """
+            SELECT toInt64(count()), toInt64(count()) - toInt64(uniqExact(id))
+            FROM calls_complete WHERE project_id = {pid:String}
+            """,
+            parameters={"pid": pid},
+        ).result_rows[0]
+        status = "ok" if (attached == state.staging_rows and dupes == 0) else "MISMATCH"
+        print(
+            f"post-attach {pid}: rows={attached}/{state.staging_rows} dupes={dupes} {status}"
+        )
+
+
+def connect() -> Client:
+    return clickhouse_connect.get_client(
+        host=os.environ["WF_BACKFILL_CH_HOST"],
+        port=int(os.environ.get("WF_BACKFILL_CH_PORT", "8443")),
+        username=os.environ["WF_BACKFILL_CH_USER"],
+        password=os.environ["WF_BACKFILL_CH_PASSWORD"],
+        database=os.environ.get("WF_BACKFILL_CH_DATABASE", "weave_trace_db"),
+        secure=os.environ.get("WF_BACKFILL_CH_SECURE", "1") == "1",
+    )
+
+
+def load_allowlist(path: str) -> list[str]:
+    with open(path, encoding="utf-8") as f:
+        projects = [
+            line.strip() for line in f if line.strip() and not line.startswith("#")
+        ]
+    if not projects:
+        raise SystemExit(f"allowlist {path} is empty")
+    return projects
+
+
+def load_journal(path: str, staging_table: str, projects: list[str]) -> Journal:
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as f:
+            raw = json.load(f)
+        journal = Journal(
+            staging_table=raw["staging_table"],
+            projects={p: ProjectState(**s) for p, s in raw["projects"].items()},
+            stats_inserted=raw["stats_inserted"],
+            attached_partitions=raw["attached_partitions"],
+        )
+        extra = set(projects) - set(journal.projects)
+        if extra:
+            raise SystemExit(
+                f"allowlist has projects not in journal {path}: {sorted(extra)}"
+            )
+    else:
+        journal = Journal(
+            staging_table=staging_table, projects={p: ProjectState() for p in projects}
+        )
+    return journal
+
+
+def save_journal(path: str, journal: Journal) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(asdict(journal), f, indent=2)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "command", choices=["plan", "fill", "verify", "stats", "attach", "run"]
+    )
+    parser.add_argument(
+        "--allowlist", required=True, help="file with one project_id per line"
+    )
+    parser.add_argument(
+        "--journal", default="backfill_journal.json", help="resumable wave state"
+    )
+    parser.add_argument("--staging-table", default=STAGING_TABLE_DEFAULT)
+    parser.add_argument(
+        "--id-buckets", type=int, default=1, help="chunk fills by cityHash64(id) %% N"
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill_runs/qa_all_2026-07-08.json
+++ b/scripts/backfill_runs/qa_all_2026-07-08.json
@@ -1,0 +1,24484 @@
+{
+ "UHJvamVjdEludGVybmFsSWQ6Mjk3MQ==": {
+  "name": "timssweeney/weave-bucket-test-project-7",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk3MQ==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.32,
+   "attach": {
+    "202504": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.7
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjcxNA==": {
+  "name": "mollie-anderson-weights-biases/nicholas-pun-traced-inferences",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjcxNA==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.32,
+   "verify": 0.2,
+   "stats": 0.34,
+   "attach": {
+    "202507": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202507"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.7
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk2Ng==": {
+  "name": "timssweeney/weave-bucket-test-project-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk2Ng==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.31,
+   "attach": {
+    "202504": 0.39
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU5NA==": {
+  "name": "freetest/test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU5NA==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.31,
+   "verify": 0.22,
+   "stats": 0.28,
+   "attach": {
+    "202507": 0.32
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202507"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.76
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQyNQ==": {
+  "name": "grif_sweep_test/llm-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQyNQ==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.32,
+   "fill": 0.37,
+   "verify": 0.22,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 3.58
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjc1Mw==": {
+  "name": "jamie-rasmussen/2025-01-29_qatest",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjc1Mw==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.32,
+   "fill": 0.32,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202501": 0.33
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.8
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mzk4NA==": {
+  "name": "timssweeney/test-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mzk4NA==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.34,
+   "verify": 0.2,
+   "stats": 0.37,
+   "attach": {
+    "202504": 0.34
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.72
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk3Mw==": {
+  "name": "timssweeney/weave-bucket-test-project-9",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk3Mw==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.51,
+   "verify": 0.21,
+   "stats": 0.28,
+   "attach": {
+    "202504": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk3Mg==": {
+  "name": "timssweeney/weave-bucket-test-project-8",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk3Mg==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.37,
+   "verify": 0.21,
+   "stats": 0.28,
+   "attach": {
+    "202504": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQ3OQ==": {
+  "name": "wandb-sdk/test-project-llm",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQ3OQ==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.41,
+   "fill": 0.31,
+   "verify": 0.22,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjE5Nw==": {
+  "name": "haruka/weave-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjE5Nw==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.73,
+   "verify": 0.2,
+   "stats": 0.33,
+   "attach": {
+    "202410": 0.39
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202410"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 3.17
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzA3Mw==": {
+  "name": "jamie-rasmussen/2026-01-15_artclone",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzA3Mw==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.32,
+   "verify": 0.2,
+   "stats": 0.31,
+   "attach": {
+    "202601": 0.35
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202601"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcyOQ==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcyOQ==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.4,
+   "fill": 0.66,
+   "verify": 0.23,
+   "stats": 0.29,
+   "attach": {
+    "202501": 0.55
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 3.5
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIyNQ==": {
+  "name": "timssweeney/weave-bucket-test-project-bucket-enabled-0",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIyNQ==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202504": 0.34
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjcxNQ==": {
+  "name": "mollie-anderson-weights-biases/nicholas-pun-completions-testing",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjcxNQ==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.4,
+   "verify": 0.19,
+   "stats": 0.3,
+   "attach": {
+    "202507": 0.33
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202507"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzAwOA==": {
+  "name": "hhuang-cw/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzAwOA==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.32,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202512": 0.36
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.64
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjU2MQ==": {
+  "name": "ericakristiana-asdf/intro-example2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjU2MQ==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.57,
+   "verify": 0.21,
+   "stats": 0.28,
+   "attach": {
+    "202412": 0.37
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202412"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjUzNg==": {
+  "name": "jamie-rasmussen/catalog",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjUzNg==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.2,
+   "stats": 0.32,
+   "attach": {
+    "202506": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU1NQ==": {
+  "name": "jamie-rasmussen/2025-06-10_chat",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU1NQ==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.33,
+   "verify": 0.19,
+   "stats": 0.31,
+   "attach": {
+    "202506": 0.37
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.76
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc0NQ==": {
+  "name": "adrian-inference-test/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc0NQ==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.35,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202508": 0.38
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202508"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njk0Mw==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njk0Mw==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.35,
+   "verify": 0.24,
+   "stats": 0.3,
+   "attach": {
+    "202511": 0.38
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202511"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc2Ng==": {
+  "name": "test-team-but-again/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc2Ng==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.38,
+   "verify": 0.23,
+   "stats": 0.29,
+   "attach": {
+    "202508": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202508"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.91
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU3Mw==": {
+  "name": "david-mena123-geolocation-geolocation/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU3Mw==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202506": 0.35
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.76
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzIwMA==": {
+  "name": "inference-pentest/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzIwMA==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.55,
+   "verify": 0.21,
+   "stats": 0.27,
+   "attach": {
+    "202602": 0.36
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDI0MQ==": {
+  "name": "josiahtest/asdfa",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDI0MQ==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.34,
+   "verify": 0.19,
+   "stats": 0.26,
+   "attach": {
+    "202505": 0.51
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202505"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.91
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njk2Mw==": {
+  "name": "setel27476-org/mpc-repro-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njk2Mw==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.49,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202511": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202511"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjkxOQ==": {
+  "name": "usashraf29x-asdasd/asdasd",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjkxOQ==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.51,
+   "verify": 0.19,
+   "stats": 0.3,
+   "attach": {
+    "202510": 0.36
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202510"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzM0MQ==": {
+  "name": "tim-s-sweeney-time/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzM0MQ==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.79,
+   "verify": 0.22,
+   "stats": 0.28,
+   "attach": {
+    "202603": 0.36
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 3.22
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzAwMg==": {
+  "name": "david-mena123-yahoo/weave-traces-test-werwer-werwer",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzAwMg==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202512": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.84
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk4Mg==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk4Mg==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.36,
+   "attach": {
+    "202504": 0.35
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.88
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk2OA==": {
+  "name": "timssweeney/weave-bucket-test-project-4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk2OA==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.32,
+   "verify": 0.2,
+   "stats": 0.32,
+   "attach": {
+    "202504": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.7
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcxNg==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcxNg==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.34,
+   "verify": 0.23,
+   "stats": 0.27,
+   "attach": {
+    "202501": 0.35
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.74
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODU3OA==": {
+  "name": "foysal1197-wandbvictim-test-corp/entity-read-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODU3OA==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.36,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202606": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 3.06
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODU3NA==": {
+  "name": "foysal1197-wandbvictim-test-corp/victim-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODU3NA==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.34,
+   "verify": 0.19,
+   "stats": 0.31,
+   "attach": {
+    "202606": 0.34
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzk4Ng==": {
+  "name": "3p-pentest-2-team-external/test-private",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzk4Ng==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.39,
+   "fill": 0.59,
+   "verify": 0.24,
+   "stats": 0.29,
+   "attach": {
+    "202605": 0.42
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 3.23
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODU3Ng==": {
+  "name": "foysal1197-wandbvictim-test-corp/private-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODU3Ng==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.39,
+   "verify": 0.27,
+   "stats": 0.28,
+   "attach": {
+    "202606": 0.37
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0
+  },
+  "total_s": 2.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjU2MA==": {
+  "name": "weave-test/intro-example2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjU2MA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.28,
+   "attach": {
+    "202412": 0.42
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202412"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjEwNw==": {
+  "name": "jenn-projroles-team/jpub",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjEwNw==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.8,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202410": 0.36
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202410"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 3.36
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQzNg==": {
+  "name": "team-doggos/models-and-weave",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQzNg==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.4
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjkzMQ==": {
+  "name": "account-settings-asdasd/quickstart_playgroundx",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjkzMQ==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.39,
+   "verify": 0.23,
+   "stats": 0.29,
+   "attach": {
+    "202510": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202510"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIxNg==": {
+  "name": "role-test/restricted-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIxNg==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.37,
+   "verify": 0.23,
+   "stats": 0.28,
+   "attach": {
+    "202504": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.8
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjE5MQ==": {
+  "name": "rbac/new-weave",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjE5MQ==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.32,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202410": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202410"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIwMA==": {
+  "name": "ethanho/personal-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIwMA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.37,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202504": 0.36
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU3OQ==": {
+  "name": "david-mena123-qa-test-wanfb/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU3OQ==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.39,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202506": 0.4
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjgzMw==": {
+  "name": "wandbee/public-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjgzMw==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.34,
+   "verify": 0.27,
+   "stats": 0.28,
+   "attach": {
+    "202502": 0.33
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjcxMw==": {
+  "name": "philai/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjcxMw==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 0.35,
+   "verify": 0.23,
+   "stats": 0.34,
+   "attach": {
+    "202507": 0.35
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202507"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIyMg==": {
+  "name": "ethanho/w-personal",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIyMg==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.35,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202504": 0.38
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjgzNw==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjgzNw==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.35,
+   "verify": 0.24,
+   "stats": 0.27,
+   "attach": {
+    "202502": 0.39
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIxMA==": {
+  "name": "ethanho/personal-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIxMA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.22,
+   "stats": 0.33,
+   "attach": {
+    "202504": 0.38
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.81
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjkwMg==": {
+  "name": "evals/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjkwMg==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.3,
+   "verify": 0.21,
+   "stats": 0.26,
+   "attach": {
+    "202510": 0.37
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202510"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjc1Mg==": {
+  "name": "jamie-rasmussen/2025-01-29_quickstart",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjc1Mg==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.26,
+   "stats": 0.3,
+   "attach": {
+    "202501": 0.34
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjc3Mw==": {
+  "name": "team-doggos/role-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjc3Mw==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 0.31,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202502": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjkwOQ==": {
+  "name": "asdf/testno admin",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjkwOQ==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202504": 0.38
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.84
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzQzMQ==": {
+  "name": "kc-test-team-1234/test-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzQzMQ==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.36,
+   "verify": 0.29,
+   "stats": 0.34,
+   "attach": {
+    "202603": 0.33
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.97
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjE2OA==": {
+  "name": "jenn-projroles-team/proj4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjE2OA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.37,
+   "verify": 0.21,
+   "stats": 0.34,
+   "attach": {
+    "202410": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202410"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.91
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njk0NA==": {
+  "name": "wandb-user-1/super-secret-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njk0NA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.37,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202510": 0.36
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202510"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg0NA==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg0NA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.55,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202502": 0.37
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDE5Nw==": {
+  "name": "lucas-defino-weights-biases/AwesomeProject-OPENLLMetry",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDE5Nw==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.34,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202504": 0.38
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjY0Mg==": {
+  "name": "team-doggos/weave-as-member",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjY0Mg==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.36,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202501": 0.38
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njk3Mg==": {
+  "name": "david-mena123-data-team-test-wandb/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njk3Mg==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.21,
+   "stats": 0.28,
+   "attach": {
+    "202511": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202511"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg0MQ==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg0MQ==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202502": 0.4
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjYxNQ==": {
+  "name": "monthly-teams-from-storage-monthly/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjYxNQ==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202506": 0.36
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjUzNg==": {
+  "name": "cool-work-team/intro-example2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjUzNg==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.32,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202412": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202412"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.76
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg0Mw==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg0Mw==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.31,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202502": 0.37
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjgwMA==": {
+  "name": "griffin/prod-evals-aug",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjgwMA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.37,
+   "verify": 0.2,
+   "stats": 0.37,
+   "attach": {
+    "202509": 0.4
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202509"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 3.29
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcyNw==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcyNw==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.38,
+   "fill": 0.69,
+   "verify": 0.29,
+   "stats": 0.34,
+   "attach": {
+    "202501": 0.4
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 3.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU1Nw==": {
+  "name": "testing/russ-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU1Nw==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.41,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202506": 0.35
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.98
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjY2NA==": {
+  "name": "jamie-rasmussen/2025-01-14_quickstart",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjY2NA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.32,
+   "verify": 0.25,
+   "stats": 0.29,
+   "attach": {
+    "202501": 0.39
+   },
+   "post_check": 0.3
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 3.15
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzAyMg==": {
+  "name": "view_only/super-secret-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzAyMg==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.29,
+   "fill": 0.36,
+   "verify": 0.56,
+   "stats": 0.47,
+   "attach": {
+    "202512": 0.35
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 3.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg0Ng==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg0Ng==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.31,
+   "verify": 0.22,
+   "stats": 0.34,
+   "attach": {
+    "202502": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.81
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjczNA==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjczNA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202501": 0.36
+   },
+   "post_check": 0.3
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjczNQ==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjczNQ==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202501": 0.43
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjYxMw==": {
+  "name": "cassie-gamm-testsignup-google/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjYxMw==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.36,
+   "verify": 0.22,
+   "stats": 0.27,
+   "attach": {
+    "202506": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk1OQ==": {
+  "name": "team-weave-permissions-edge-test/03-27-25-full",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk1OQ==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.43,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202503": 0.35
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202503"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjE3Mg==": {
+  "name": "team-doggos/new-proj-rename",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjE3Mg==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.36,
+   "verify": 0.22,
+   "stats": 0.3,
+   "attach": {
+    "202410": 0.35
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202410"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjAyMA==": {
+  "name": "jenn-projroles-team/proj2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjAyMA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202410": 0.35
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202410"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.8
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg1MA==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg1MA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.31,
+   "verify": 0.22,
+   "stats": 0.33,
+   "attach": {
+    "202502": 0.37
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjE2NQ==": {
+  "name": "jenn-projroles-team/proj3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjE2NQ==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.31,
+   "verify": 0.25,
+   "stats": 0.28,
+   "attach": {
+    "202410": 0.5
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202410"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcyMQ==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcyMQ==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.44,
+   "verify": 0.22,
+   "stats": 0.35,
+   "attach": {
+    "202501": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 3.06
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjYxNg==": {
+  "name": "annual-from-storage/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjYxNg==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.32,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202506": 0.34
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjY2Nw==": {
+  "name": "team-doggos/new-weave-no-access-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjY2Nw==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202501": 0.34
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njk2NA==": {
+  "name": "kelojop779-org/anotherproject",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njk2NA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.35,
+   "attach": {
+    "202511": 0.35
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202511"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzM0NA==": {
+  "name": "evals/test-qa-secret-fetcher",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzM0NA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.35,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202603": 0.4
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQzOA==": {
+  "name": "team-doggos/weave-only",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQzOA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.31,
+   "verify": 0.22,
+   "stats": 0.35,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzc0MA==": {
+  "name": "lucas-defino-weights-biases/2026-04-15_quickstart",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzc0MA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.3,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202604": 0.37
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.84
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzc0MQ==": {
+  "name": "wolfram-evals/2026-04-15_quickstart",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzc0MQ==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.34,
+   "verify": 0.24,
+   "stats": 0.31,
+   "attach": {
+    "202604": 0.34
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.91
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzc0NA==": {
+  "name": "jamie-rasmussen/2026-04-15_quickstart",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzc0NA==",
+  "source_calls": 2,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.38,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202604": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.91
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njk4MA==": {
+  "name": "jamie-rasmussen/lora-inference",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njk4MA==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.64,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202601": 0.36,
+    "202603": 0.38
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202601",
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0
+  },
+  "total_s": 3.48
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU4Nw==": {
+  "name": "testf/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU4Nw==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202506": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0
+  },
+  "total_s": 2.72
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzA3MQ==": {
+  "name": "jamie-rasmussen/2026-01-14_create-lora-tutorial",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzA3MQ==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.3,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202601": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202601"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc0MA==": {
+  "name": "hello-world-team/jr-create-proj",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc0MA==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.41,
+   "verify": 0.22,
+   "stats": 0.33,
+   "attach": {
+    "202508": 0.86,
+    "202602": 0.4
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202508",
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0
+  },
+  "total_s": 4.06
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcyNQ==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcyNQ==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.31,
+   "verify": 0.21,
+   "stats": 0.27,
+   "attach": {
+    "202501": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0
+  },
+  "total_s": 2.76
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc3Mw==": {
+  "name": "david-mena123-testing-weave-wandb/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc3Mw==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.35,
+   "verify": 0.25,
+   "stats": 0.28,
+   "attach": {
+    "202508": 0.34
+   },
+   "post_check": 0.37
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202508"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0
+  },
+  "total_s": 3.09
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzQ1Nw==": {
+  "name": "lucas-defino-weights-biases/new-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzQ1Nw==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.36,
+   "verify": 0.23,
+   "stats": 0.28,
+   "attach": {
+    "202603": 0.41
+   },
+   "post_check": 0.61
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0
+  },
+  "total_s": 3.44
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzE3Nw==": {
+  "name": "evals/inference",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzE3Nw==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.35,
+   "verify": 0.19,
+   "stats": 0.31,
+   "attach": {
+    "202603": 0.37
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0
+  },
+  "total_s": 2.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcyNg==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcyNg==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202501": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0
+  },
+  "total_s": 2.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc2Nw==": {
+  "name": "hello-world-team/inference",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc2Nw==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.35,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202509": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202509"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0
+  },
+  "total_s": 2.8
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzg4MQ==": {
+  "name": "griffin/newnewnew",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzg4MQ==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.49,
+   "verify": 0.22,
+   "stats": 0.3,
+   "attach": {
+    "202604": 0.36
+   },
+   "post_check": 0.5
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0
+  },
+  "total_s": 3.37
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODYyMQ==": {
+  "name": "hastes1213-hasbro-pulse/ssrf-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODYyMQ==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.34,
+   "verify": 0.2,
+   "stats": 0.31,
+   "attach": {
+    "202606": 0.42
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0
+  },
+  "total_s": 2.89
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIwMg==": {
+  "name": "role-test/project-as-member-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIwMg==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.46,
+   "verify": 0.22,
+   "stats": 0.3,
+   "attach": {
+    "202504": 0.35
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 3.2
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjcyNg==": {
+  "name": "jenn-projroles-team2/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjcyNg==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.36,
+   "verify": 0.25,
+   "stats": 0.33,
+   "attach": {
+    "202507": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202507"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcyOA==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcyOA==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.3,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202501": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.66
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU4MQ==": {
+  "name": "tier_1/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU4MQ==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.36,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.27,
+   "attach": {
+    "202506": 0.33
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIxMQ==": {
+  "name": "timssweeney/simple_test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIxMQ==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.31,
+   "attach": {
+    "202504": 0.43
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjkxMw==": {
+  "name": "griffin/bad-run",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjkxMw==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.31,
+   "verify": 0.21,
+   "stats": 0.37,
+   "attach": {
+    "202510": 0.39
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202510"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 3.13
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjE4MA==": {
+  "name": "team-doggos/no-access-weave-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjE4MA==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.33,
+   "fill": 0.34,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202410": 0.36
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202410"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjkyMQ==": {
+  "name": "wandb-sec-team/test-project-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjkyMQ==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.32,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202510": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202510"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjgzNQ==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjgzNQ==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.31,
+   "verify": 0.22,
+   "stats": 0.25,
+   "attach": {
+    "202502": 0.35
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDE5Mg==": {
+  "name": "lucas-defino-weights-biases/test_project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDE5Mg==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.31,
+   "verify": 0.19,
+   "stats": 0.27,
+   "attach": {
+    "202504": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.63
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjczNg==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjczNg==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.41,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202501": 0.34
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcyMg==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcyMg==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.26,
+   "attach": {
+    "202501": 0.36
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjAyNA==": {
+  "name": "jteam-test-1/proj1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjAyNA==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.3,
+   "verify": 0.2,
+   "stats": 0.26,
+   "attach": {
+    "202409": 0.37
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202409"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.59
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjkwOQ==": {
+  "name": "jenn-projroles-team3/test-proj-models-weave2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjkwOQ==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.47,
+   "verify": 0.22,
+   "stats": 0.26,
+   "attach": {
+    "202510": 0.35,
+    "202511": 0.37
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202510",
+    "202511"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 3.12
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk1OA==": {
+  "name": "niall-test-team/weave-example-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk1OA==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.35,
+   "verify": 0.19,
+   "stats": 0.27,
+   "attach": {
+    "202503": 0.39
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 2,
+   "past_retention": 0,
+   "expected_rows": 2,
+   "partitions": [
+    "202503"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2,
+   "post_dupes": 0
+  },
+  "total_s": 2.73
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjUzNQ==": {
+  "name": "timssweeney/2024-12-06_quickstart",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjUzNQ==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.22,
+   "stats": 0.28,
+   "attach": {
+    "202412": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202412"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.72
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg2MQ==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg2MQ==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.3,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202502": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIwOQ==": {
+  "name": "ethanho/personal-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIwOQ==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.23,
+   "stats": 0.28,
+   "attach": {
+    "202504": 0.37
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.72
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIxOA==": {
+  "name": "role-test/w-project-member",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIxOA==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.39,
+   "verify": 0.25,
+   "stats": 0.37,
+   "attach": {
+    "202504": 0.38
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 3.14
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjcxNg==": {
+  "name": "lucas-defino-weights-biases/nicholas-pun-traced-inferences",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjcxNg==",
+  "source_calls": 5,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.34,
+   "verify": 0.25,
+   "stats": 0.3,
+   "attach": {
+    "202507": 0.36
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 5,
+   "partitions": [
+    "202507"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 5,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 5,
+   "post_dupes": 0
+  },
+  "total_s": 2.74
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcyMA==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcyMA==",
+  "source_calls": 5,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.3,
+   "verify": 0.24,
+   "stats": 0.29,
+   "attach": {
+    "202501": 0.33
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 5,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 5,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 5,
+   "post_dupes": 0
+  },
+  "total_s": 2.68
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzAyNg==": {
+  "name": "hello-world-team/inference-unlimited",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzAyNg==",
+  "source_calls": 5,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.55,
+   "verify": 0.23,
+   "stats": 0.26,
+   "attach": {
+    "202602": 0.46
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 5,
+   "partitions": [
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 5,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 5,
+   "post_dupes": 0
+  },
+  "total_s": 3.03
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU3Mg==": {
+  "name": "rival-corp/weave-example",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU3Mg==",
+  "source_calls": 6,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.38,
+   "fill": 0.63,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202405": 0.39
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 6,
+   "partitions": [
+    "202405"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 6,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 6,
+   "post_dupes": 0
+  },
+  "total_s": 3.34
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzQwOA==": {
+  "name": "rcb355-weights-biases/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzQwOA==",
+  "source_calls": 6,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.45,
+   "fill": 0.31,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202603": 0.34
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 6,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 6,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 6,
+   "post_dupes": 0
+  },
+  "total_s": 3.09
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg2Ng==": {
+  "name": "team-weave-permissions-edge-test/open-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg2Ng==",
+  "source_calls": 6,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.47,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202502": 0.36,
+    "202511": 0.36
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 6,
+   "partitions": [
+    "202502",
+    "202511"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 6,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 6,
+   "post_dupes": 0
+  },
+  "total_s": 3.5
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg1Nw==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg1Nw==",
+  "source_calls": 6,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.31,
+   "verify": 0.2,
+   "stats": 0.31,
+   "attach": {
+    "202502": 0.36
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 6,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 6,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 6,
+   "post_dupes": 0
+  },
+  "total_s": 2.74
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjM0": {
+  "name": "kylegqa/model-registry",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjM0",
+  "source_calls": 6,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.28,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202605": 0.33
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 2,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0
+  },
+  "total_s": 2.59
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjc1MQ==": {
+  "name": "academic/intro-example",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjc1MQ==",
+  "source_calls": 7,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.52,
+   "verify": 0.31,
+   "stats": 0.27,
+   "attach": {
+    "202503": 0.47,
+    "202602": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 7,
+   "partitions": [
+    "202503",
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 7,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 7,
+   "post_dupes": 0
+  },
+  "total_s": 3.56
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk2NA==": {
+  "name": "timssweeney/weave-bucket-test-project-0",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk2NA==",
+  "source_calls": 7,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202504": 0.33
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 7,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 7,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 7,
+   "post_dupes": 0
+  },
+  "total_s": 2.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjkwNg==": {
+  "name": "david-mena123-personal-entity-wandb/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjkwNg==",
+  "source_calls": 7,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.34,
+   "verify": 0.19,
+   "stats": 0.31,
+   "attach": {
+    "202510": 0.35
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 7,
+   "partitions": [
+    "202510"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 7,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 7,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU2Mw==": {
+  "name": "lucas-defino-weights-biases/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU2Mw==",
+  "source_calls": 7,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.43,
+   "verify": 0.21,
+   "stats": 0.26,
+   "attach": {
+    "202506": 0.35,
+    "202603": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 7,
+   "partitions": [
+    "202506",
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 7,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 7,
+   "post_dupes": 0
+  },
+  "total_s": 3.06
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU3MQ==": {
+  "name": "hello-world-team/inference-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU3MQ==",
+  "source_calls": 7,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.58,
+   "verify": 0.21,
+   "stats": 0.27,
+   "attach": {
+    "202507": 0.36,
+    "202602": 0.36,
+    "202604": 0.33
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 7,
+   "partitions": [
+    "202507",
+    "202602",
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 7,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 7,
+   "post_dupes": 0
+  },
+  "total_s": 3.68
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIwNw==": {
+  "name": "role-test/public-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIwNw==",
+  "source_calls": 8,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.33,
+   "attach": {
+    "202504": 0.45
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 8,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 8,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 8,
+   "post_dupes": 0
+  },
+  "total_s": 2.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjgzNA==": {
+  "name": "wandbee/open-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjgzNA==",
+  "source_calls": 8,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 0.48,
+   "verify": 0.21,
+   "stats": 0.32,
+   "attach": {
+    "202502": 0.42,
+    "202504": 0.38
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 8,
+   "partitions": [
+    "202502",
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 8,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 8,
+   "post_dupes": 0
+  },
+  "total_s": 3.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcxOA==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcxOA==",
+  "source_calls": 8,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.31,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202501": 0.37
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 8,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 8,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 8,
+   "post_dupes": 0
+  },
+  "total_s": 2.72
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzA0MQ==": {
+  "name": "ryanbuccellato-buccellato_organization/weave",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzA0MQ==",
+  "source_calls": 8,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.38,
+   "verify": 0.21,
+   "stats": 0.32,
+   "attach": {
+    "202512": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 8,
+   "partitions": [
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 8,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 8,
+   "post_dupes": 0
+  },
+  "total_s": 2.89
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjgzNg==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjgzNg==",
+  "source_calls": 8,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.29,
+   "attach": {
+    "202502": 0.33
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 8,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 8,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 8,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjAxOQ==": {
+  "name": "jenn-projroles-team/proj1-renamed",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjAxOQ==",
+  "source_calls": 8,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.41,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202409": 0.41,
+    "202410": 0.34
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 8,
+   "partitions": [
+    "202409",
+    "202410"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 8,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 8,
+   "post_dupes": 0
+  },
+  "total_s": 3.18
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIwMQ==": {
+  "name": "role-test/project-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIwMQ==",
+  "source_calls": 8,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.4,
+   "verify": 0.21,
+   "stats": 0.36,
+   "attach": {
+    "202504": 0.34
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 2,
+   "past_retention": 0,
+   "expected_rows": 6,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 6,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 6,
+   "post_dupes": 0
+  },
+  "total_s": 2.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzMyNw==": {
+  "name": "darshil-chaudhary-strobes-security/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzMyNw==",
+  "source_calls": 8,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.59,
+   "verify": 0.23,
+   "stats": 0.29,
+   "attach": {
+    "202603": 0.37
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 8,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 8,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 8,
+   "post_dupes": 0
+  },
+  "total_s": 3.2
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIzOA==": {
+  "name": "asdf/simple_eval",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIzOA==",
+  "source_calls": 8,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.82,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202504": 0.36,
+    "202508": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 8,
+   "partitions": [
+    "202504",
+    "202508"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 8,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 8,
+   "post_dupes": 0
+  },
+  "total_s": 3.59
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU3NA==": {
+  "name": "mollie-anderson-weights-biases/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU3NA==",
+  "source_calls": 8,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.44,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202506": 0.34,
+    "202602": 0.37
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 8,
+   "partitions": [
+    "202506",
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 8,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 8,
+   "post_dupes": 0
+  },
+  "total_s": 3.34
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjE2NA==": {
+  "name": "jenn-projroles-team/weave-proj1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjE2NA==",
+  "source_calls": 8,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202410": 0.51
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 8,
+   "partitions": [
+    "202410"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 8,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 8,
+   "post_dupes": 0
+  },
+  "total_s": 2.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjczOQ==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjczOQ==",
+  "source_calls": 9,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.21,
+   "stats": 0.27,
+   "attach": {
+    "202501": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 9,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 9,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 9,
+   "post_dupes": 0
+  },
+  "total_s": 2.81
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzA5MQ==": {
+  "name": "alerts-qa/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzA5MQ==",
+  "source_calls": 9,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.31,
+   "verify": 0.19,
+   "stats": 0.3,
+   "attach": {
+    "202601": 0.36
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 9,
+   "partitions": [
+    "202601"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 9,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 9,
+   "post_dupes": 0
+  },
+  "total_s": 2.76
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzk3MA==": {
+  "name": "3p-pentest-team-external/inference-agent-demo",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzk3MA==",
+  "source_calls": 9,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.65,
+   "attach": {
+    "202605": 0.72
+   },
+   "post_check": 0.59
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 9,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 9,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 9,
+   "post_dupes": 0
+  },
+  "total_s": 4.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg4NQ==": {
+  "name": "bcanfieldsherman/testing",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg4NQ==",
+  "source_calls": 10,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.4,
+   "fill": 0.77,
+   "verify": 0.21,
+   "stats": 0.26,
+   "attach": {
+    "202502": 0.44
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10,
+   "post_dupes": 0
+  },
+  "total_s": 4.42
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjUzMg==": {
+  "name": "asdf/weave-intro-notebook",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjUzMg==",
+  "source_calls": 10,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.56,
+   "verify": 0.21,
+   "stats": 0.32,
+   "attach": {
+    "202505": 0.39,
+    "202506": 0.89,
+    "202508": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10,
+   "partitions": [
+    "202505",
+    "202506",
+    "202508"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10,
+   "post_dupes": 0
+  },
+  "total_s": 4.46
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjcyNA==": {
+  "name": "jamie-rasmussen/jamie-rasmussen-traced-inferences",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjcyNA==",
+  "source_calls": 10,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.3,
+   "verify": 0.21,
+   "stats": 0.26,
+   "attach": {
+    "202507": 0.39
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10,
+   "partitions": [
+    "202507"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10,
+   "post_dupes": 0
+  },
+  "total_s": 2.63
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU1OQ==": {
+  "name": "testing/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU1OQ==",
+  "source_calls": 10,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.27,
+   "attach": {
+    "202506": 0.32
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10,
+   "post_dupes": 0
+  },
+  "total_s": 2.56
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcxOQ==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcxOQ==",
+  "source_calls": 10,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.3,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202501": 0.36
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzQwNw==": {
+  "name": "ryanbuccellato-buccellato_organization/test-bucc",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzQwNw==",
+  "source_calls": 11,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202603": 0.52
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 11,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 11,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 11,
+   "post_dupes": 0
+  },
+  "total_s": 3.45
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg1NQ==": {
+  "name": "team-weave-permissions-edge-test/standard-team",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg1NQ==",
+  "source_calls": 11,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.4,
+   "fill": 0.43,
+   "verify": 0.47,
+   "stats": 0.27,
+   "attach": {
+    "202502": 0.33
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 11,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 11,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 11,
+   "post_dupes": 0
+  },
+  "total_s": 3.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjgzNA==": {
+  "name": "lucas-defino-weights-biases/test-content-qa",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjgzNA==",
+  "source_calls": 11,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.45,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202509": 0.38,
+    "202603": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 11,
+   "partitions": [
+    "202509",
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 11,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 11,
+   "post_dupes": 0
+  },
+  "total_s": 3.21
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU2MA==": {
+  "name": "Pro plan/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU2MA==",
+  "source_calls": 11,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.31,
+   "verify": 0.2,
+   "stats": 0.33,
+   "attach": {
+    "202506": 0.32
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 11,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 11,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 11,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzE3Mg==": {
+  "name": "ryanbuccellato-buccellato_organization/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzE3Mg==",
+  "source_calls": 11,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.75,
+   "verify": 0.2,
+   "stats": 0.32,
+   "attach": {
+    "202602": 0.36,
+    "202603": 0.34,
+    "202604": 0.35,
+    "202605": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 11,
+   "partitions": [
+    "202602",
+    "202603",
+    "202604",
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 11,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 11,
+   "post_dupes": 0
+  },
+  "total_s": 4.21
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjY5OA==": {
+  "name": "inference-team/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjY5OA==",
+  "source_calls": 12,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.8,
+   "verify": 0.23,
+   "stats": 0.29,
+   "attach": {
+    "202507": 0.36,
+    "202511": 0.34
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 12,
+   "partitions": [
+    "202507",
+    "202511"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 12,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 12,
+   "post_dupes": 0
+  },
+  "total_s": 3.63
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzA3Ng==": {
+  "name": "muhbdar-navy-federal-credit-union/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzA3Ng==",
+  "source_calls": 12,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.31,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202601": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 12,
+   "partitions": [
+    "202601"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 12,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 12,
+   "post_dupes": 0
+  },
+  "total_s": 2.71
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjcyNQ==": {
+  "name": "hello-world-team/jamie-rasmussen-traced-inferences",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjcyNQ==",
+  "source_calls": 12,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.53,
+   "verify": 0.21,
+   "stats": 0.42,
+   "attach": {
+    "202507": 0.37,
+    "202508": 0.4,
+    "202512": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 12,
+   "partitions": [
+    "202507",
+    "202508",
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 12,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 12,
+   "post_dupes": 0
+  },
+  "total_s": 3.84
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIxNw==": {
+  "name": "role-test/w-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIxNw==",
+  "source_calls": 12,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202504": 0.36
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 12,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 12,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 12,
+   "post_dupes": 0
+  },
+  "total_s": 2.71
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIwOA==": {
+  "name": "role-test/open-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIwOA==",
+  "source_calls": 12,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.34,
+   "verify": 0.23,
+   "stats": 0.29,
+   "attach": {
+    "202504": 0.38
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 12,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 12,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 12,
+   "post_dupes": 0
+  },
+  "total_s": 2.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjY2MQ==": {
+  "name": "sammy-team/intro-example",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjY2MQ==",
+  "source_calls": 12,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.64,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202501": 0.38
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 12,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 12,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 12,
+   "post_dupes": 0
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjgzMw==": {
+  "name": "wandb-sec-team/test-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjgzMw==",
+  "source_calls": 12,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.35,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202510": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 12,
+   "partitions": [
+    "202510"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 12,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 12,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU0Ng==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU0Ng==",
+  "source_calls": 12,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.31,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202506": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 12,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 12,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 12,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzkxMw==": {
+  "name": "3p-pentest-team-internal/inference-agent-demo",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzkxMw==",
+  "source_calls": 12,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.58,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202605": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 12,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 12,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 12,
+   "post_dupes": 0
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjkzMg==": {
+  "name": "account-settings-asdasd/asdasdasd",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjkzMg==",
+  "source_calls": 13,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.31,
+   "verify": 0.21,
+   "stats": 0.32,
+   "attach": {
+    "202510": 0.38
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 13,
+   "partitions": [
+    "202510"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 13,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 13,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzAzMQ==": {
+  "name": "jenn-projroles-team3/truth-monitor-example",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzAzMQ==",
+  "source_calls": 13,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202512": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 13,
+   "partitions": [
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 13,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 13,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njk2MQ==": {
+  "name": "hello-world-team/2048",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njk2MQ==",
+  "source_calls": 13,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.5,
+   "verify": 0.21,
+   "stats": 0.33,
+   "attach": {
+    "202603": 0.4,
+    "202604": 0.4
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 13,
+   "partitions": [
+    "202603",
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 13,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 13,
+   "post_dupes": 0
+  },
+  "total_s": 3.49
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc4NQ==": {
+  "name": "jenn-projroles-team/new-inference-proj",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc4NQ==",
+  "source_calls": 14,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.34,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202512": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 14,
+   "partitions": [
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 14,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 14,
+   "post_dupes": 0
+  },
+  "total_s": 2.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzA0OA==": {
+  "name": "lucas-defino-weights-biases/mike-audio-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzA0OA==",
+  "source_calls": 16,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202601": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 16,
+   "partitions": [
+    "202601"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 16,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 16,
+   "post_dupes": 0
+  },
+  "total_s": 2.72
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg2MA==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg2MA==",
+  "source_calls": 18,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.31,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202502": 0.35
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 18,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 18,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 18,
+   "post_dupes": 0
+  },
+  "total_s": 2.7
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTYxNg==": {
+  "name": "launch-team/2024-06-13_tutorial",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTYxNg==",
+  "source_calls": 18,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.76,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 18,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 18,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 18,
+   "post_dupes": 0
+  },
+  "total_s": 3.3
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQ3Nw==": {
+  "name": "jeff/intro-example-local4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQ3Nw==",
+  "source_calls": 18,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.36,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 18,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 18,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 18,
+   "post_dupes": 0
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzMzMQ==": {
+  "name": "academic/just for kimi 2 5 new",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzMzMQ==",
+  "source_calls": 19,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.47,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202603": 0.37,
+    "202604": 0.35
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 19,
+   "partitions": [
+    "202603",
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 19,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 19,
+   "post_dupes": 0
+  },
+  "total_s": 3.19
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzMxNQ==": {
+  "name": "jamie-rasmussen/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzMxNQ==",
+  "source_calls": 19,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.96,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202603": 0.34,
+    "202604": 0.39,
+    "202606": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 19,
+   "partitions": [
+    "202603",
+    "202604",
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 19,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 19,
+   "post_dupes": 0
+  },
+  "total_s": 4.29
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjUzNQ==": {
+  "name": "hello-world-team/new-inference-project",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjUzNQ==",
+  "source_calls": 20,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.56,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202506": 0.34,
+    "202508": 0.34,
+    "202509": 0.34
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20,
+   "partitions": [
+    "202506",
+    "202508",
+    "202509"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 20,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20,
+   "post_dupes": 0
+  },
+  "total_s": 3.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY3OQ==": {
+  "name": "griffin/scoring-worker-load-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY3OQ==",
+  "source_calls": 20,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202606": 0.41
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 20,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20,
+   "post_dupes": 0
+  },
+  "total_s": 2.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjkyMw==": {
+  "name": "wandb-sec-team/redact-key-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjkyMw==",
+  "source_calls": 21,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202510": 0.49
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 21,
+   "partitions": [
+    "202510"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 21,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 21,
+   "post_dupes": 0
+  },
+  "total_s": 2.88
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjAxNA==": {
+  "name": "asdf/both-weave-and-wandb",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjAxNA==",
+  "source_calls": 21,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.64,
+   "verify": 0.22,
+   "stats": 0.3,
+   "attach": {
+    "202408": 0.38,
+    "202411": 0.36,
+    "202412": 0.42,
+    "202503": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 21,
+   "partitions": [
+    "202408",
+    "202411",
+    "202412",
+    "202503"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 21,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 21,
+   "post_dupes": 0
+  },
+  "total_s": 4.23
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU2NQ==": {
+  "name": "hello-world-team/AIResearch",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU2NQ==",
+  "source_calls": 21,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.23,
+   "stats": 0.25,
+   "attach": {
+    "202506": 0.32
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 21,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 21,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 21,
+   "post_dupes": 0
+  },
+  "total_s": 2.64
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjAxNQ==": {
+  "name": "asdf/asdf",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjAxNQ==",
+  "source_calls": 21,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.65,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202501": 0.34,
+    "202502": 0.32,
+    "202503": 0.4,
+    "202504": 0.39
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 21,
+   "partitions": [
+    "202501",
+    "202502",
+    "202503",
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 21,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 21,
+   "post_dupes": 0
+  },
+  "total_s": 4.28
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcyNA==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcyNA==",
+  "source_calls": 21,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.35,
+   "verify": 0.21,
+   "stats": 0.27,
+   "attach": {
+    "202501": 0.39
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 21,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 21,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 21,
+   "post_dupes": 0
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njk1NQ==": {
+  "name": "andrew/testing123",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njk1NQ==",
+  "source_calls": 22,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.35,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202510": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 22,
+   "partitions": [
+    "202510"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 22,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 22,
+   "post_dupes": 0
+  },
+  "total_s": 2.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcyMw==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcyMw==",
+  "source_calls": 22,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202501": 0.35
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 11,
+   "past_retention": 0,
+   "expected_rows": 11,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 11,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 11,
+   "post_dupes": 0
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjkxNQ==": {
+  "name": "team-doggos/03-17-25-weave",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjkxNQ==",
+  "source_calls": 22,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.31,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202503": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 6,
+   "past_retention": 0,
+   "expected_rows": 16,
+   "partitions": [
+    "202503"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 16,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 16,
+   "post_dupes": 0
+  },
+  "total_s": 2.74
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU4Ng==": {
+  "name": "rbac2/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU4Ng==",
+  "source_calls": 24,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.39,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202506": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 24,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 24,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 24,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzA3OA==": {
+  "name": "tim-test-team/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzA3OA==",
+  "source_calls": 24,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.39,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202602": 0.35,
+    "202603": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 24,
+   "partitions": [
+    "202602",
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 24,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 24,
+   "post_dupes": 0
+  },
+  "total_s": 3.14
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzY1Nw==": {
+  "name": "hello-world-team/qa-proj",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzY1Nw==",
+  "source_calls": 24,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.3,
+   "verify": 0.19,
+   "stats": 0.29,
+   "attach": {
+    "202604": 0.48
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 24,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 24,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 24,
+   "post_dupes": 0
+  },
+  "total_s": 2.7
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg1OQ==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg1OQ==",
+  "source_calls": 25,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.21,
+   "stats": 0.27,
+   "attach": {
+    "202502": 0.35
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 8,
+   "past_retention": 0,
+   "expected_rows": 17,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 17,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 17,
+   "post_dupes": 0
+  },
+  "total_s": 2.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk2NQ==": {
+  "name": "timssweeney/weave-bucket-test-project-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk2NQ==",
+  "source_calls": 25,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.3,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202504": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 25,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 25,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 25,
+   "post_dupes": 0
+  },
+  "total_s": 2.68
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjY5OQ==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjY5OQ==",
+  "source_calls": 27,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.71,
+   "verify": 0.2,
+   "stats": 0.32,
+   "attach": {
+    "202501": 0.33,
+    "202504": 0.37
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 27,
+   "partitions": [
+    "202501",
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 27,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 27,
+   "post_dupes": 0
+  },
+  "total_s": 3.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc1Mw==": {
+  "name": "timssweeney/evaluate_model_worker_load_1_1_1_1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc1Mw==",
+  "source_calls": 27,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202508": 0.38
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 27,
+   "partitions": [
+    "202508"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 27,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 27,
+   "post_dupes": 0
+  },
+  "total_s": 2.8
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk2Nw==": {
+  "name": "timssweeney/weave-bucket-test-project-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk2Nw==",
+  "source_calls": 28,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.4,
+   "verify": 0.22,
+   "stats": 0.28,
+   "attach": {
+    "202504": 0.37
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 28,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 28,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 28,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk3MA==": {
+  "name": "timssweeney/weave-bucket-test-project-6",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk3MA==",
+  "source_calls": 28,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.37,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202504": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 28,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 28,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 28,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc4Ng==": {
+  "name": "jenn-projroles-team3/inference",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc4Ng==",
+  "source_calls": 29,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.23,
+   "stats": 0.29,
+   "attach": {
+    "202512": 0.43
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 29,
+   "partitions": [
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 29,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 29,
+   "post_dupes": 0
+  },
+  "total_s": 2.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU4MA==": {
+  "name": "new-team-test-1/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU4MA==",
+  "source_calls": 30,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.33,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202506": 0.42
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 30,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 30,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 30,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjgwMA==": {
+  "name": "bcanfieldsherman/intro-example",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjgwMA==",
+  "source_calls": 30,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.28,
+   "attach": {
+    "202502": 0.35
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 30,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 30,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 30,
+   "post_dupes": 0
+  },
+  "total_s": 2.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzA3OQ==": {
+  "name": "timssweeney/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzA3OQ==",
+  "source_calls": 30,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.33,
+   "fill": 0.46,
+   "verify": 0.24,
+   "stats": 0.33,
+   "attach": {
+    "202601": 0.34,
+    "202602": 0.33
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 30,
+   "partitions": [
+    "202601",
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 30,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 30,
+   "post_dupes": 0
+  },
+  "total_s": 3.62
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjcxMg==": {
+  "name": "academic/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjcxMg==",
+  "source_calls": 30,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 1.29,
+   "verify": 0.24,
+   "stats": 0.32,
+   "attach": {
+    "202507": 0.5,
+    "202509": 0.32,
+    "202510": 0.39,
+    "202601": 0.48,
+    "202602": 0.31,
+    "202603": 0.34,
+    "202604": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 30,
+   "partitions": [
+    "202507",
+    "202509",
+    "202510",
+    "202601",
+    "202602",
+    "202603",
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 30,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 30,
+   "post_dupes": 0
+  },
+  "total_s": 6.17
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzk3MQ==": {
+  "name": "3p-pentest-team-external/sdk-realistic-demo",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzk3MQ==",
+  "source_calls": 30,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.53,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202605": 0.46
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 30,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 30,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 30,
+   "post_dupes": 0
+  },
+  "total_s": 2.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjY2Ng==": {
+  "name": "elefante/intro-example",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjY2Ng==",
+  "source_calls": 32,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.46,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202501": 0.43,
+    "202502": 0.35
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 32,
+   "partitions": [
+    "202501",
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 32,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 32,
+   "post_dupes": 0
+  },
+  "total_s": 3.34
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzE5Mw==": {
+  "name": "griffin/raw-starts-ends",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzE5Mw==",
+  "source_calls": 33,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.18,
+   "fill": 0.29,
+   "verify": 0.21,
+   "stats": 0.32,
+   "attach": {
+    "202602": 0.5
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 33,
+   "partitions": [
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 33,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 33,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODIwNA==": {
+  "name": "griffin/pr-43574-smoke",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODIwNA==",
+  "source_calls": 33,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.29,
+   "verify": 0.23,
+   "stats": 0.35,
+   "attach": {
+    "202605": 0.36
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 33,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 33,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 33,
+   "post_dupes": 0
+  },
+  "total_s": 2.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzExMQ==": {
+  "name": "griffin/dupe",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzExMQ==",
+  "source_calls": 35,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.38,
+   "fill": 0.33,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202601": 0.36
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 35,
+   "partitions": [
+    "202601"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 35,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 35,
+   "post_dupes": 0
+  },
+  "total_s": 3.2
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjIxMg==": {
+  "name": "jeff/intro-example-local",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjIxMg==",
+  "source_calls": 36,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.48,
+   "verify": 0.25,
+   "stats": 0.27,
+   "attach": {
+    "202410": 0.37
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 36,
+   "partitions": [
+    "202410"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 36,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 36,
+   "post_dupes": 0
+  },
+  "total_s": 2.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzMwNg==": {
+  "name": "hello-world-team/test-loras",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzMwNg==",
+  "source_calls": 36,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 1.58,
+   "verify": 0.24,
+   "stats": 0.31,
+   "attach": {
+    "202603": 0.35,
+    "202604": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 36,
+   "partitions": [
+    "202603",
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 36,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 36,
+   "post_dupes": 0
+  },
+  "total_s": 4.56
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU1Ng==": {
+  "name": "testing/AIResearch",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU1Ng==",
+  "source_calls": 38,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.28,
+   "attach": {
+    "202506": 0.36
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 38,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 38,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 38,
+   "post_dupes": 0
+  },
+  "total_s": 2.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjczNQ==": {
+  "name": "jenn-projroles-team/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjczNQ==",
+  "source_calls": 42,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.85,
+   "verify": 0.23,
+   "stats": 0.33,
+   "attach": {
+    "202507": 0.35,
+    "202510": 0.35,
+    "202511": 0.38,
+    "202512": 0.35,
+    "202601": 0.39
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 42,
+   "partitions": [
+    "202507",
+    "202510",
+    "202511",
+    "202512",
+    "202601"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 42,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 42,
+   "post_dupes": 0
+  },
+  "total_s": 4.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc0Mw==": {
+  "name": "asdf/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc0Mw==",
+  "source_calls": 44,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.89,
+   "verify": 0.23,
+   "stats": 0.32,
+   "attach": {
+    "202508": 0.36,
+    "202510": 0.37,
+    "202511": 0.42,
+    "202601": 0.4,
+    "202602": 0.35,
+    "202603": 0.39
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 44,
+   "partitions": [
+    "202508",
+    "202510",
+    "202511",
+    "202601",
+    "202602",
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 44,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 44,
+   "post_dupes": 0
+  },
+  "total_s": 5.28
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcwMA==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcwMA==",
+  "source_calls": 50,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.5,
+   "verify": 0.19,
+   "stats": 0.35,
+   "attach": {
+    "202501": 0.36,
+    "202504": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 1,
+   "past_retention": 0,
+   "expected_rows": 49,
+   "partitions": [
+    "202501",
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 49,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 49,
+   "post_dupes": 0
+  },
+  "total_s": 3.3
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzk2Ng==": {
+  "name": "3p-pentest-team-internal/intro-example",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzk2Ng==",
+  "source_calls": 57,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.35,
+   "verify": 0.21,
+   "stats": 0.27,
+   "attach": {
+    "202605": 0.39
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 57,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 57,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 57,
+   "post_dupes": 0
+  },
+  "total_s": 2.71
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU4OA==": {
+  "name": "lucas-defino-weights-biases/online-evals",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU4OA==",
+  "source_calls": 58,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.44,
+   "verify": 0.21,
+   "stats": 0.28,
+   "attach": {
+    "202506": 0.38,
+    "202507": 0.35
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 58,
+   "partitions": [
+    "202506",
+    "202507"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 58,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 58,
+   "post_dupes": 0
+  },
+  "total_s": 3.22
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI0Nw==": {
+  "name": "jeff/weave-load-test-example-spam-10x10000-001-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI0Nw==",
+  "source_calls": 60,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.35,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.42
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 60,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 60,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 60,
+   "post_dupes": 0
+  },
+  "total_s": 2.71
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODAyOQ==": {
+  "name": "3p-pentest-team-external/pentest-vuln001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODAyOQ==",
+  "source_calls": 60,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 0.98,
+   "verify": 0.23,
+   "stats": 0.36,
+   "attach": {
+    "202605": 0.39
+   },
+   "post_check": 0.49
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 60,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 60,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 60,
+   "post_dupes": 0
+  },
+  "total_s": 3.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzkxNA==": {
+  "name": "3p-pentest-team-internal/sdk-realistic-demo",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzkxNA==",
+  "source_calls": 60,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202605": 0.34
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 60,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 60,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 60,
+   "post_dupes": 0
+  },
+  "total_s": 2.76
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk2OQ==": {
+  "name": "timssweeney/weave-bucket-test-project-5",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk2OQ==",
+  "source_calls": 64,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.31,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202504": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 64,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 64,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 64,
+   "post_dupes": 0
+  },
+  "total_s": 2.71
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjc0Ng==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjc0Ng==",
+  "source_calls": 66,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.32,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202501": 0.38
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 66,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 66,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 66,
+   "post_dupes": 0
+  },
+  "total_s": 2.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTYxNw==": {
+  "name": "jamie-rasmussen/2024-06-13_values",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTYxNw==",
+  "source_calls": 66,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.42,
+   "fill": 0.49,
+   "verify": 0.2,
+   "stats": 0.31,
+   "attach": {
+    "202406": 0.55
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 66,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 66,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 66,
+   "post_dupes": 0
+  },
+  "total_s": 3.45
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzgxNw==": {
+  "name": "griffin/smoke",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzgxNw==",
+  "source_calls": 66,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.45,
+   "verify": 0.19,
+   "stats": 0.3,
+   "attach": {
+    "202604": 0.34
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 66,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 66,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 66,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjkxMQ==": {
+  "name": "jenn-projroles-team3/new-new-inference-project1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjkxMQ==",
+  "source_calls": 70,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.26,
+   "attach": {
+    "202512": 0.32
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 70,
+   "partitions": [
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 70,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 70,
+   "post_dupes": 0
+  },
+  "total_s": 2.69
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODIwNw==": {
+  "name": "griffin/qa-smoke-0-81",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODIwNw==",
+  "source_calls": 71,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.31,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202605": 0.39
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 71,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 71,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 71,
+   "post_dupes": 0
+  },
+  "total_s": 2.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjE2Nw==": {
+  "name": "jeff/intro-example-local-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjE2Nw==",
+  "source_calls": 72,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202410": 0.38
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 72,
+   "partitions": [
+    "202410"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 72,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 72,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzAxOA==": {
+  "name": "jenn-projroles-team3/newprojeval",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzAxOA==",
+  "source_calls": 73,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.31,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202512": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 73,
+   "partitions": [
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 73,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 73,
+   "post_dupes": 0
+  },
+  "total_s": 2.74
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjUzNw==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjUzNw==",
+  "source_calls": 76,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 0.31,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202506": 0.4
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 76,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 76,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 76,
+   "post_dupes": 0
+  },
+  "total_s": 3.0
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjIyOA==": {
+  "name": "jeff/weave-load-test-example-spam-10x10000-9",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjIyOA==",
+  "source_calls": 80,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.32,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 80,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 80,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 80,
+   "post_dupes": 0
+  },
+  "total_s": 3.0
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI1MA==": {
+  "name": "jeff/weave-load-test-example-spam-2-10-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI1MA==",
+  "source_calls": 80,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.31,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 80,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 80,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 80,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjIzMw==": {
+  "name": "jeff/weave-load-test-example-spam-10x10000-5",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjIzMw==",
+  "source_calls": 80,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.4,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 80,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 80,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 80,
+   "post_dupes": 0
+  },
+  "total_s": 2.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI0OQ==": {
+  "name": "jeff/weave-load-test-example-spam-2-10-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI0OQ==",
+  "source_calls": 80,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.31,
+   "verify": 0.19,
+   "stats": 0.26,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 80,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 80,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 80,
+   "post_dupes": 0
+  },
+  "total_s": 2.54
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjIzNw==": {
+  "name": "jeff/weave-load-test-example-spam-10x10000-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjIzNw==",
+  "source_calls": 80,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.31,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 80,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 80,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 80,
+   "post_dupes": 0
+  },
+  "total_s": 2.68
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc1NA==": {
+  "name": "timssweeney/evaluate_model_worker_load_1_1_1_1_v1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc1NA==",
+  "source_calls": 81,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.51,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202508": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 81,
+   "partitions": [
+    "202508"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 81,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 81,
+   "post_dupes": 0
+  },
+  "total_s": 2.98
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU4NQ==": {
+  "name": "freetest/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU4NQ==",
+  "source_calls": 88,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.62,
+   "verify": 0.22,
+   "stats": 0.34,
+   "attach": {
+    "202506": 0.33,
+    "202507": 0.36,
+    "202508": 0.35,
+    "202509": 0.37
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 88,
+   "partitions": [
+    "202506",
+    "202507",
+    "202508",
+    "202509"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 88,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 88,
+   "post_dupes": 0
+  },
+  "total_s": 4.22
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzExMw==": {
+  "name": "evals/jakeweavetest",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzExMw==",
+  "source_calls": 89,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.33,
+   "verify": 0.26,
+   "stats": 0.31,
+   "attach": {
+    "202602": 0.34
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 89,
+   "partitions": [
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 89,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 89,
+   "post_dupes": 0
+  },
+  "total_s": 2.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzc5Nw==": {
+  "name": "wolfram-evals/eval_pipeline_quickstart",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzc5Nw==",
+  "source_calls": 93,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.27,
+   "attach": {
+    "202604": 0.36
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 93,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 93,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 93,
+   "post_dupes": 0
+  },
+  "total_s": 2.64
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzk2OQ==": {
+  "name": "3p-pentest-team-external/quickstart-for-weave",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzk2OQ==",
+  "source_calls": 95,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.27,
+   "stats": 0.28,
+   "attach": {
+    "202605": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 95,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 95,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 95,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzM5OQ==": {
+  "name": "launch-team-public-queue/weave-log-benchmark-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzM5OQ==",
+  "source_calls": 96,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.34,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202603": 0.32
+   },
+   "post_check": 0.43
+  },
+  "gates": {
+   "orphan_ends": 62,
+   "past_retention": 0,
+   "expected_rows": 34,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 34,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 34,
+   "post_dupes": 0
+  },
+  "total_s": 2.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI5NQ==": {
+  "name": "jeff/weave-load-test-example-spam-1-100-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI5NQ==",
+  "source_calls": 100,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.35,
+   "verify": 0.22,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjc0NA==": {
+  "name": "(unresolved)/(deleted?)",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjc0NA==",
+  "source_calls": 103,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.56,
+   "verify": 0.21,
+   "stats": 0.28,
+   "attach": {
+    "202501": 0.37
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 103,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 103,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 103,
+   "post_dupes": 0
+  },
+  "total_s": 3.21
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzMwOA==": {
+  "name": "griffin/nicho-alerts",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzMwOA==",
+  "source_calls": 103,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.34,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202603": 0.3
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 103,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 103,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 103,
+   "post_dupes": 0
+  },
+  "total_s": 2.66
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODE5OA==": {
+  "name": "griffin/t9ss23",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODE5OA==",
+  "source_calls": 103,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202605": 0.37
+   },
+   "post_check": 0.39
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 103,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 103,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 103,
+   "post_dupes": 0
+  },
+  "total_s": 3.13
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODE5Ng==": {
+  "name": "griffin/t9ss",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODE5Ng==",
+  "source_calls": 103,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.52,
+   "verify": 0.28,
+   "stats": 0.31,
+   "attach": {
+    "202605": 0.34
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 103,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 103,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 103,
+   "post_dupes": 0
+  },
+  "total_s": 3.27
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzc0OQ==": {
+  "name": "griffin/anotherone1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzc0OQ==",
+  "source_calls": 103,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.29,
+   "fill": 0.41,
+   "verify": 0.22,
+   "stats": 0.36,
+   "attach": {
+    "202604": 0.43
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 103,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 103,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 103,
+   "post_dupes": 0
+  },
+  "total_s": 3.17
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzgxOA==": {
+  "name": "griffin/nq1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzgxOA==",
+  "source_calls": 103,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.46,
+   "fill": 0.7,
+   "verify": 0.69,
+   "stats": 0.36,
+   "attach": {
+    "202604": 0.44
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 103,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 103,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 103,
+   "post_dupes": 0
+  },
+  "total_s": 4.6
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzUxOA==": {
+  "name": "3p-pentest-team-internal/quickstart-for-weave",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzUxOA==",
+  "source_calls": 109,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.43,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202604": 0.35,
+    "202605": 0.4
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 109,
+   "partitions": [
+    "202604",
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 109,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 109,
+   "post_dupes": 0
+  },
+  "total_s": 3.36
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTk3Ng==": {
+  "name": "drc/trace",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTk3Ng==",
+  "source_calls": 136,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.52,
+   "fill": 0.91,
+   "verify": 0.24,
+   "stats": 0.37,
+   "attach": {
+    "202408": 0.66
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 136,
+   "partitions": [
+    "202408"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 136,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 136,
+   "post_dupes": 0
+  },
+  "total_s": 4.17
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc0Mg==": {
+  "name": "timssweeney/evaluate_model_worker_demo",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc0Mg==",
+  "source_calls": 138,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.32,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202508": 0.49
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 138,
+   "partitions": [
+    "202508"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 138,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 138,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzMyNA==": {
+  "name": "griffin/griffin-mock-prod-agent",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzMyNA==",
+  "source_calls": 165,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.35,
+   "verify": 0.19,
+   "stats": 0.32,
+   "attach": {
+    "202603": 0.34
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 165,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 165,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 165,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQyMw==": {
+  "name": "jeff/intro-example-local3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQyMw==",
+  "source_calls": 165,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.3,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 3,
+   "past_retention": 0,
+   "expected_rows": 162,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 162,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 162,
+   "post_dupes": 0
+  },
+  "total_s": 2.7
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzkxMQ==": {
+  "name": "3p-pentest-team-internal/rag-qa-eval",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzkxMQ==",
+  "source_calls": 176,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202605": 0.38
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 176,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 176,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 176,
+   "post_dupes": 0
+  },
+  "total_s": 2.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg5MQ==": {
+  "name": "bcanfieldsherman/question_bot",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg5MQ==",
+  "source_calls": 186,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.3,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202502": 0.39
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 186,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 186,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 186,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzEyNQ==": {
+  "name": "griffin/simpleb",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzEyNQ==",
+  "source_calls": 204,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202602": 0.34
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 204,
+   "partitions": [
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 204,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 204,
+   "post_dupes": 0
+  },
+  "total_s": 2.7
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODE5OQ==": {
+  "name": "griffin/8seas8",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODE5OQ==",
+  "source_calls": 206,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.32,
+   "verify": 0.21,
+   "stats": 0.26,
+   "attach": {
+    "202605": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 206,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 206,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 206,
+   "post_dupes": 0
+  },
+  "total_s": 2.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzczNw==": {
+  "name": "griffin/gman",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzczNw==",
+  "source_calls": 206,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202604": 0.55
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 206,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 206,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 206,
+   "post_dupes": 0
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODE5Nw==": {
+  "name": "griffin/t9ss2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODE5Nw==",
+  "source_calls": 206,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.32,
+   "verify": 0.23,
+   "stats": 0.3,
+   "attach": {
+    "202605": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 206,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 206,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 206,
+   "post_dupes": 0
+  },
+  "total_s": 2.88
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU3OA==": {
+  "name": "new-wb-team/inference-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU3OA==",
+  "source_calls": 212,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.35,
+   "verify": 0.21,
+   "stats": 0.27,
+   "attach": {
+    "202506": 0.36
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 212,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 212,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 212,
+   "post_dupes": 0
+  },
+  "total_s": 2.84
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODA0MQ==": {
+  "name": "wolfram-evals/2026-05-12_image-eval",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODA0MQ==",
+  "source_calls": 224,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.35,
+   "verify": 0.27,
+   "stats": 0.31,
+   "attach": {
+    "202605": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 224,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 224,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 224,
+   "post_dupes": 0
+  },
+  "total_s": 2.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODUzMw==": {
+  "name": "griffin/calls-residence-rename-test-RENAMED",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODUzMw==",
+  "source_calls": 255,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.32,
+   "verify": 0.21,
+   "stats": 0.41,
+   "attach": {
+    "202606": 0.37
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 255,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 255,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 255,
+   "post_dupes": 0
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU0MQ==": {
+  "name": "hello-world-team/quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU0MQ==",
+  "source_calls": 255,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 1.43,
+   "verify": 0.2,
+   "stats": 0.34,
+   "attach": {
+    "202506": 0.36,
+    "202507": 0.34,
+    "202508": 0.4,
+    "202509": 0.37,
+    "202511": 0.39,
+    "202512": 0.37,
+    "202601": 0.32,
+    "202602": 0.39,
+    "202603": 0.37,
+    "202604": 0.33,
+    "202605": 0.34,
+    "202606": 0.37
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 255,
+   "partitions": [
+    "202506",
+    "202507",
+    "202508",
+    "202509",
+    "202511",
+    "202512",
+    "202601",
+    "202602",
+    "202603",
+    "202604",
+    "202605",
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 255,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 255,
+   "post_dupes": 0
+  },
+  "total_s": 7.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU3Mw==": {
+  "name": "nickpenaranda/2024-05-14_values",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU3Mw==",
+  "source_calls": 256,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.77,
+   "verify": 0.26,
+   "stats": 0.43,
+   "attach": {
+    "202405": 0.77
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 256,
+   "partitions": [
+    "202405"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 256,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 256,
+   "post_dupes": 0
+  },
+  "total_s": 3.81
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU2Nw==": {
+  "name": "lucas-defino-weights-biases/monitoring-test-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU2Nw==",
+  "source_calls": 300,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.38,
+   "verify": 0.25,
+   "stats": 0.3,
+   "attach": {
+    "202506": 0.44
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 300,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 300,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 300,
+   "post_dupes": 0
+  },
+  "total_s": 3.14
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk4MQ==": {
+  "name": "timssweeney/dataset_test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk4MQ==",
+  "source_calls": 317,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.29,
+   "fill": 0.31,
+   "verify": 0.31,
+   "stats": 0.32,
+   "attach": {
+    "202504": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 317,
+   "partitions": [
+    "202504"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 317,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 317,
+   "post_dupes": 0
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODUzNQ==": {
+  "name": "griffin/rename-cache-probe-RENAMED",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODUzNQ==",
+  "source_calls": 375,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.43,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202606": 0.35
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 375,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 375,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 375,
+   "post_dupes": 0
+  },
+  "total_s": 2.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODAzMg==": {
+  "name": "wolfram-evals/2026-05-11_image-eval",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODAzMg==",
+  "source_calls": 402,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.48,
+   "verify": 0.23,
+   "stats": 0.29,
+   "attach": {
+    "202605": 0.38
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 402,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 402,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 402,
+   "post_dupes": 0
+  },
+  "total_s": 2.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzc0Mw==": {
+  "name": "wolfram-evals/2026-04-15_image-eval",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzc0Mw==",
+  "source_calls": 402,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202604": 0.39
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 402,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 402,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 402,
+   "post_dupes": 0
+  },
+  "total_s": 2.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzE5Mg==": {
+  "name": "griffin/f7",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzE5Mg==",
+  "source_calls": 408,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.36,
+   "verify": 0.19,
+   "stats": 0.29,
+   "attach": {
+    "202602": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 408,
+   "partitions": [
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 408,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 408,
+   "post_dupes": 0
+  },
+  "total_s": 2.84
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjY0OA==": {
+  "name": "griffin/new",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjY0OA==",
+  "source_calls": 423,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.39,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202501": 0.37
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 423,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 423,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 423,
+   "post_dupes": 0
+  },
+  "total_s": 2.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzEyOA==": {
+  "name": "griffin/simplee",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzEyOA==",
+  "source_calls": 452,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.76,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202602": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 452,
+   "partitions": [
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 452,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 452,
+   "post_dupes": 0
+  },
+  "total_s": 3.15
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzgxMw==": {
+  "name": "griffin/perf-6670-before-10",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzgxMw==",
+  "source_calls": 545,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.38,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202604": 0.37
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 545,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 545,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 545,
+   "post_dupes": 0
+  },
+  "total_s": 2.91
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzgxNA==": {
+  "name": "griffin/perf-6670-after-10",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzgxNA==",
+  "source_calls": 640,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.39,
+   "verify": 0.19,
+   "stats": 0.31,
+   "attach": {
+    "202604": 0.36
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 640,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 640,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 640,
+   "post_dupes": 0
+  },
+  "total_s": 2.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY0OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-batch-",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY0OQ==",
+  "source_calls": 700,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.53,
+   "fill": 1.1,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202406": 0.33
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 700,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 700,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 700,
+   "post_dupes": 0
+  },
+  "total_s": 4.12
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzc0Nw==": {
+  "name": "griffin/anotherone",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzc0Nw==",
+  "source_calls": 721,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.35,
+   "verify": 0.22,
+   "stats": 0.39,
+   "attach": {
+    "202604": 0.38
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 721,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 721,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 721,
+   "post_dupes": 0
+  },
+  "total_s": 3.04
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjgwNQ==": {
+  "name": "david000m24-akira-powered/weave-traces-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjgwNQ==",
+  "source_calls": 810,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 2.06,
+   "verify": 0.21,
+   "stats": 0.42,
+   "attach": {
+    "202509": 0.28
+   },
+   "post_check": 0.39
+  },
+  "gates": {
+   "orphan_ends": 6,
+   "past_retention": 0,
+   "expected_rows": 804,
+   "partitions": [
+    "202509"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 804,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 804,
+   "post_dupes": 0
+  },
+  "total_s": 5.0
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzAwMQ==": {
+  "name": "griffin/1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzAwMQ==",
+  "source_calls": 954,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.38,
+   "verify": 0.21,
+   "stats": 0.28,
+   "attach": {
+    "202512": 0.52
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 954,
+   "partitions": [
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 954,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 954,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU5MA==": {
+  "name": "evals/online-evals",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU5MA==",
+  "source_calls": 955,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.28,
+   "attach": {
+    "202506": 0.39
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 955,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 955,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 955,
+   "post_dupes": 0
+  },
+  "total_s": 3.0
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI5OA==": {
+  "name": "jeff/weave-load-test-example-spam-5-1000-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI5OA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.32,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.47
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM4Mg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-82",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM4Mg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMzNg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMzNg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.34,
+   "verify": 0.22,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.33
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.09
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQxMg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-86",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQxMg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.36,
+   "verify": 0.22,
+   "stats": 0.27,
+   "attach": {
+    "202411": 0.39
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.04
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQwNg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-96",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQwNg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 0.42,
+   "verify": 0.46,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.28
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMyNQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMyNQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.35,
+   "verify": 0.2,
+   "stats": 0.36,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQyMA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-84",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQyMA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.37,
+   "verify": 0.21,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.3
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM5MA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-74",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM5MA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.35,
+   "verify": 0.23,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.32
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMzMw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-75",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMzMw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.37,
+   "verify": 0.22,
+   "stats": 0.27,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM4Nw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-60",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM4Nw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.31,
+   "verify": 0.19,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQxNw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-47",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQxNw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.31,
+   "verify": 0.29,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.45
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.21
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM0OQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-71",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM0OQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.33
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM2OA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-79",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM2OA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.41
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM5NQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-36",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM5NQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.27,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.76
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQwMw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-25",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQwMw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.35,
+   "verify": 0.23,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM3OA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-30",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM3OA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.23,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM1OQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-28",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM1OQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.3,
+   "verify": 0.22,
+   "stats": 0.26,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.84
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM4NQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-58",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM4NQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.36,
+   "verify": 0.19,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.42
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.8
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQxNQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-77",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQxNQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.34,
+   "verify": 0.24,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.33
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.88
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMzMQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-13",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMzMQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.35,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.81
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM5Nw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-64",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM5Nw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.3,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMyMg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMyMg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.5,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202411": 0.33
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI1MQ==": {
+  "name": "jeff/weave-load-test-example-spam-2-1000-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI1MQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.36,
+   "verify": 0.21,
+   "stats": 0.35,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQwMQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-23",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQwMQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.68
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMzNA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-9",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMzNA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQxMA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-76",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQxMA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.33,
+   "fill": 0.43,
+   "verify": 0.23,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.14
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM4MA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-95",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM4MA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.34,
+   "verify": 0.19,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.68
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQwNA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-78",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQwNA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.35,
+   "verify": 0.22,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.73
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI4OA==": {
+  "name": "jeff/weave-load-test-example-spam-10-1000-8",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI4OA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.35,
+   "verify": 0.19,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.32
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMyNw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-15",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMyNw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.33,
+   "fill": 0.42,
+   "verify": 0.21,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.08
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM5Mg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-100",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM5Mg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.39
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMzNQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-46",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMzNQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.31,
+   "verify": 0.26,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQxMQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-87",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQxMQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.32,
+   "verify": 0.24,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM4MQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-98",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM4MQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.39,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMwMA==": {
+  "name": "jeff/weave-load-test-example-spam-5-1000-5",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMwMA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.36,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQwNQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-68",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQwNQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI4OQ==": {
+  "name": "jeff/weave-load-test-example-spam-10-1000-5",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI4OQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.35,
+   "verify": 0.43,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.02
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM5Mw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-33",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM5Mw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.21,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMyNg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-38",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMyNg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.24,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM1OA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-63",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM1OA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.42,
+   "verify": 0.21,
+   "stats": 0.37,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.03
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM3OQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-41",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM3OQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.36,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQxNA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-17",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQxNA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.37,
+   "verify": 0.22,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.73
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM4NA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-27",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM4NA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.98
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMzMA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-51",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMzMA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.36,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.42
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.03
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQwMA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-92",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQwMA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.38,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.43
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.24
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMyMw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-22",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMyMw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM5Ng==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-26",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM5Ng==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.4,
+   "verify": 0.19,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.33
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMzMg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-5",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMzMg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.97
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM4Ng==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM4Ng==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.34,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.47
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.12
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQxNg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-62",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQxNg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.24,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.04
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM2OQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-44",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM2OQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.33,
+   "verify": 0.24,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.14
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM0OA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-31",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM0OA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.38,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.16
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI1Mg==": {
+  "name": "jeff/weave-load-test-example-spam-2-1000-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI1Mg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.91
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM5NA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-70",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM5NA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.3,
+   "verify": 0.23,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.4
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.98
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMyMQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-12",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMyMQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.34,
+   "verify": 0.19,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQwMg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-81",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQwMg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 0.33,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.97
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI5OQ==": {
+  "name": "jeff/weave-load-test-example-spam-5-1000-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI5OQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.68,
+   "verify": 0.25,
+   "stats": 0.26,
+   "attach": {
+    "202411": 0.44
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.35
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQxMw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-83",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQxMw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.39,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.02
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM4Mw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-53",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM4Mw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.42,
+   "verify": 0.24,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.04
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMzNw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-85",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMzNw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.37,
+   "verify": 0.23,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQwNw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-49",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQwNw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.38,
+   "verify": 0.21,
+   "stats": 0.35,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMyNA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-88",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMyNA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.34,
+   "verify": 0.19,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM5MQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-61",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM5MQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.33,
+   "verify": 0.25,
+   "stats": 0.35,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.08
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM0Ng==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-48",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM0Ng==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.3,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.41
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM2Nw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-54",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM2Nw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.27,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM4OA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-73",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM4OA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.36,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.41
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.0
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQxOA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-65",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQxOA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.81
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI5Mg==": {
+  "name": "jeff/weave-load-test-example-spam-10-1000-9",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI5Mg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.4,
+   "verify": 0.19,
+   "stats": 0.47,
+   "attach": {
+    "202411": 0.42
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.24
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM1NA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-20",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM1NA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.39,
+   "verify": 0.23,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.06
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM3NQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-69",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM3NQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.37,
+   "verify": 0.24,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM0Mw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-45",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM0Mw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.24,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.4
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.01
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI4NQ==": {
+  "name": "jeff/weave-load-test-example-spam-10-1000-6",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI4NQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.36,
+   "verify": 0.24,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.01
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM2Mg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-29",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM2Mg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.39,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.4
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQwOQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-24",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQwOQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.3,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMzOQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-18",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMzOQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.37,
+   "verify": 0.27,
+   "stats": 0.35,
+   "attach": {
+    "202411": 0.4
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.07
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM3MA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-39",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM3MA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.35,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM1MQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-32",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM1MQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.33,
+   "verify": 0.24,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.42
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.01
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI5Nw==": {
+  "name": "jeff/weave-load-test-example-spam-5-1000-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI5Nw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.34,
+   "verify": 0.27,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.42
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.89
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMyOA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-16",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMyOA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.37,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.91
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM0MQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-7",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM0MQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.4
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI4Nw==": {
+  "name": "jeff/weave-load-test-example-spam-10-1000-7",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI4Nw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.72
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM2MA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-59",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM2MA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.36,
+   "verify": 0.24,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.4
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM1Mw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-14",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM1Mw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.33,
+   "verify": 0.26,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.39
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.89
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM3Mg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-40",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM3Mg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.37,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.89
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM5OA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-43",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM5OA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.36,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM2NQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-8",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM2NQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM0NA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-56",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM0NA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.34,
+   "verify": 0.22,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.0
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM3Nw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-91",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM3Nw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.34,
+   "verify": 0.22,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.39
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.98
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM1Ng==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-66",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM1Ng==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.38,
+   "verify": 0.25,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.4
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.2
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI5MA==": {
+  "name": "jeff/weave-load-test-example-spam-10-1000-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI5MA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.39,
+   "verify": 0.24,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.11
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM5OQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-6",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM5OQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.34,
+   "verify": 0.23,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.39
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.1
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM0NQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-67",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM0NQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.29,
+   "fill": 0.34,
+   "verify": 0.22,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.4
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.03
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM2NA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-93",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM2NA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.33,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI5MQ==": {
+  "name": "jeff/weave-load-test-example-spam-10-1000-10",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI5MQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.43,
+   "verify": 0.25,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.42
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.08
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM1Nw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-94",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM1Nw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.24,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.43
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.01
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM3Ng==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-89",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM3Ng==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 0.41,
+   "verify": 0.21,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.12
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMyOQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-99",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMyOQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.33,
+   "verify": 0.22,
+   "stats": 0.36,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.3
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.25
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM2MQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-50",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM2MQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.45,
+   "verify": 0.24,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.41
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.22
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI4Ng==": {
+  "name": "jeff/weave-load-test-example-spam-10-1000-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI4Ng==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.31,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.84
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM0MA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-80",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM0MA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.35,
+   "verify": 0.24,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.39
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.13
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM3Mw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-97",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM3Mw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.38,
+   "verify": 0.24,
+   "stats": 0.52,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.23
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM1Mg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-57",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM1Mg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.37,
+   "verify": 0.25,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.41
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.98
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI5NA==": {
+  "name": "jeff/weave-load-test-example-spam-10-1000-4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI5NA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.34,
+   "verify": 0.22,
+   "stats": 0.35,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM2Mw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-42",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM2Mw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.36,
+   "verify": 0.24,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.56
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.12
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM0Mg==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-11",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM0Mg==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.25,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.91
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQwOA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-37",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQwOA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.36,
+   "verify": 0.26,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.97
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMzOA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-34",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMzOA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.31,
+   "verify": 0.2,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI5Ng==": {
+  "name": "jeff/weave-load-test-example-spam-5-1000-4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI5Ng==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.38,
+   "verify": 0.23,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.89
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM1MA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-10",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM1MA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.37,
+   "verify": 0.26,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.4
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM3MQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-21",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM3MQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.34,
+   "verify": 0.19,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.39
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.97
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM0Nw==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-72",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM0Nw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 0.34,
+   "verify": 0.35,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 3.12
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM2Ng==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-52",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM2Ng==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 0.31,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.89
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM4OQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-35",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM4OQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjQxOQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-55",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjQxOQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM3NA==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-90",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM3NA==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.71
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjM1NQ==": {
+  "name": "jeff/weave-load-test-example-spam-100-1000-19",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjM1NQ==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.8
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI5Mw==": {
+  "name": "jeff/weave-load-test-example-spam-10-1000-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI5Mw==",
+  "source_calls": 1000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.36,
+   "verify": 0.2,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.33
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000,
+   "post_dupes": 0
+  },
+  "total_s": 2.81
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzA5Mg==": {
+  "name": "griffin/ccmplt",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzA5Mg==",
+  "source_calls": 1002,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.54,
+   "verify": 0.23,
+   "stats": 0.34,
+   "attach": {
+    "202601": 0.51
+   },
+   "post_check": 0.3
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1002,
+   "partitions": [
+    "202601"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1002,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1002,
+   "post_dupes": 0
+  },
+  "total_s": 3.36
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzAyMQ==": {
+  "name": "griffin/samuel-adams-evaluations",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzAyMQ==",
+  "source_calls": 1043,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.34,
+   "verify": 0.21,
+   "stats": 0.37,
+   "attach": {
+    "202512": 0.4
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 1,
+   "past_retention": 0,
+   "expected_rows": 1042,
+   "partitions": [
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1042,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1042,
+   "post_dupes": 0
+  },
+  "total_s": 3.02
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzk3Mg==": {
+  "name": "3p-pentest-team-external/rag-qa-eval",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzk3Mg==",
+  "source_calls": 1060,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.41,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202605": 0.37
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1060,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1060,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1060,
+   "post_dupes": 0
+  },
+  "total_s": 2.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzgxNg==": {
+  "name": "griffin/perf-11-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzgxNg==",
+  "source_calls": 1090,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.44,
+   "verify": 0.23,
+   "stats": 0.33,
+   "attach": {
+    "202604": 0.38
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1090,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1090,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1090,
+   "post_dupes": 0
+  },
+  "total_s": 2.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzgxMg==": {
+  "name": "griffin/perf-6670-before",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzgxMg==",
+  "source_calls": 1305,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 1.08,
+   "verify": 2.13,
+   "stats": 1.35,
+   "attach": {
+    "202604": 0.7
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1305,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1305,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1305,
+   "post_dupes": 0
+  },
+  "total_s": 7.46
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODAzNw==": {
+  "name": "rpushkin-weights-biases/ro31337-qa-perf-probe",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODAzNw==",
+  "source_calls": 1318,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 11.77,
+   "verify": 0.21,
+   "stats": 0.95,
+   "attach": {
+    "202605": 0.64
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1318,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1318,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1318,
+   "post_dupes": 0
+  },
+  "total_s": 15.97
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjcwNA==": {
+  "name": "elefante/model-registry",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjcwNA==",
+  "source_calls": 1351,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 2.23,
+   "verify": 0.54,
+   "stats": 0.52,
+   "attach": {
+    "202501": 0.4
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1351,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1351,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1351,
+   "post_dupes": 0
+  },
+  "total_s": 5.56
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODI5Mg==": {
+  "name": "griffin/parallel-bucket-uploads-bench",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODI5Mg==",
+  "source_calls": 1450,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.44,
+   "verify": 0.28,
+   "stats": 0.32,
+   "attach": {
+    "202605": 0.39
+   },
+   "post_check": 0.43
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1450,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1450,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1450,
+   "post_dupes": 0
+  },
+  "total_s": 3.41
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzE5NQ==": {
+  "name": "griffin/ccmplt-replacing",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzE5NQ==",
+  "source_calls": 1464,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 1.22,
+   "verify": 0.48,
+   "stats": 0.31,
+   "attach": {
+    "202602": 0.27
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 3,
+   "past_retention": 0,
+   "expected_rows": 1461,
+   "partitions": [
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1461,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1461,
+   "post_dupes": 0
+  },
+  "total_s": 4.24
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU1OA==": {
+  "name": "testing/RetailSupportAgent",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU1OA==",
+  "source_calls": 1531,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.53,
+   "verify": 0.23,
+   "stats": 0.26,
+   "attach": {
+    "202506": 0.41
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1531,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1531,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1531,
+   "post_dupes": 0
+  },
+  "total_s": 3.1
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzUy": {
+  "name": "griffin/simple",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzUy",
+  "source_calls": 1762,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.8,
+   "verify": 0.22,
+   "stats": 0.33,
+   "attach": {
+    "202601": 0.31,
+    "202602": 0.33,
+    "202604": 0.43,
+    "202605": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1762,
+   "partitions": [
+    "202601",
+    "202602",
+    "202604",
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1762,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1762,
+   "post_dupes": 0
+  },
+  "total_s": 4.38
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMxNw==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-16",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMxNw==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 0.35,
+   "verify": 0.23,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMwMw==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-5",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMwMw==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.35,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMxMg==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-14",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMxMg==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.28,
+   "verify": 0.2,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.68
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMyMA==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-7",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMyMA==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.3
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMwNg==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-6",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMwNg==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.21,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.73
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMxMA==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-8",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMxMA==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.41,
+   "verify": 0.19,
+   "stats": 0.27,
+   "attach": {
+    "202411": 0.4
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMwNA==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-11",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMwNA==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.48,
+   "verify": 0.21,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMxNQ==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-17",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMxNQ==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.24,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.39
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMwMQ==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-10",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMwMQ==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.36,
+   "verify": 0.23,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.8
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMxNA==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMxNA==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.3,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.74
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 3.11
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMxMQ==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-15",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMxMQ==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.31
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.71
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMwNQ==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMwNQ==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.34,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMxMw==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMxMw==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.71
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMwNw==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMwNw==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.44,
+   "attach": {
+    "202411": 0.42
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMxNg==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-18",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMxNg==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.47
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 3.13
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMwMg==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-12",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMwMg==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.3,
+   "verify": 0.19,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMwOQ==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-13",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMwOQ==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.31,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.69
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMxOA==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-9",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMxOA==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.34,
+   "verify": 0.19,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMxOQ==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-19",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMxOQ==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.32,
+   "verify": 0.24,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 3.0
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjMwOA==": {
+  "name": "jeff/weave-load-test-example-spam-20-1000-20",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjMwOA==",
+  "source_calls": 2000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.24,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000,
+   "post_dupes": 0
+  },
+  "total_s": 2.81
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjkzMw==": {
+  "name": "griffin/delete-timing",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjkzMw==",
+  "source_calls": 3310,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.32,
+   "attach": {
+    "202503": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3310,
+   "partitions": [
+    "202503"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3310,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3310,
+   "post_dupes": 0
+  },
+  "total_s": 2.74
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU2Ng==": {
+  "name": "hello-world-team/RetailSupportAgent",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU2Ng==",
+  "source_calls": 3583,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.79,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202506": 0.41
+   },
+   "post_check": 0.37
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3583,
+   "partitions": [
+    "202506"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 3583,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3583,
+   "post_dupes": 0
+  },
+  "total_s": 3.59
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzAwNw==": {
+  "name": "griffin/test81",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzAwNw==",
+  "source_calls": 4096,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.78,
+   "verify": 0.21,
+   "stats": 0.51,
+   "attach": {
+    "202512": 0.31
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4096,
+   "partitions": [
+    "202512"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 4096,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4096,
+   "post_dupes": 0
+  },
+  "total_s": 3.74
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU5OQ==": {
+  "name": "nickpenaranda/weave-load-test-locust-10",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU5OQ==",
+  "source_calls": 5100,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.57,
+   "fill": 0.65,
+   "verify": 0.25,
+   "stats": 0.31,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 5100,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 5100,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 5100,
+   "post_dupes": 0
+  },
+  "total_s": 3.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njk4MQ==": {
+  "name": "griffin/test-multi-4n",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njk4MQ==",
+  "source_calls": 5212,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.93,
+   "verify": 0.18,
+   "stats": 0.32,
+   "attach": {
+    "202511": 0.66
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 5212,
+   "partitions": [
+    "202511"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 5212,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 5212,
+   "post_dupes": 0
+  },
+  "total_s": 3.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTYwNg==": {
+  "name": "nickpenaranda/weave-load-test-poly",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTYwNg==",
+  "source_calls": 6080,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.35,
+   "verify": 0.2,
+   "stats": 0.34,
+   "attach": {
+    "202406": 0.33
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 6080,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 6080,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 6080,
+   "post_dupes": 0
+  },
+  "total_s": 2.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTczMw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-094",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTczMw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.39,
+   "fill": 0.34,
+   "verify": 0.2,
+   "stats": 0.31,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.35
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI2NQ==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-13",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI2NQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.4,
+   "verify": 0.19,
+   "stats": 0.35,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc5NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-085",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc5NQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.37,
+   "verify": 0.3,
+   "stats": 0.32,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.28
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI1Ng==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-6",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI1Ng==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.41,
+   "verify": 0.22,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI3Nw==": {
+  "name": "jeff/weave-load-test-example-spam-10-10000-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI3Nw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.42,
+   "verify": 0.38,
+   "stats": 0.48,
+   "attach": {
+    "202411": 0.52
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.71
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc4Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-063",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc4Mg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.38,
+   "verify": 0.21,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.39
+   },
+   "post_check": 0.37
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.31
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI2MA==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI2MA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.42,
+   "verify": 0.23,
+   "stats": 0.35,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI3Mg==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-15",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI3Mg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.4,
+   "verify": 0.2,
+   "stats": 0.3,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc4MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-069",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc4MA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.56,
+   "fill": 0.39,
+   "verify": 0.24,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.31
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgwOQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-073",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgwOQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.77,
+   "fill": 0.44,
+   "verify": 0.22,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.73
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI2Mg==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-8",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI2Mg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.4,
+   "verify": 0.19,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcyNw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-075",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcyNw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.54,
+   "fill": 0.46,
+   "verify": 0.24,
+   "stats": 0.32,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.3
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI3MA==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-7",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI3MA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.55,
+   "verify": 0.25,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.15
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc4NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-091",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc4NQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.45,
+   "fill": 0.36,
+   "verify": 0.21,
+   "stats": 0.38,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.19
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg5MA==": {
+  "name": "griffin/test-strings-with-images-10_000",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg5MA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 19.25,
+   "verify": 0.19,
+   "stats": 6.97,
+   "attach": {
+    "202502": 2.42
+   },
+   "post_check": 0.43
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 30.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI2Nw==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI2Nw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.4,
+   "verify": 0.22,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.04
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc3OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-057",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc3OA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.37,
+   "verify": 0.23,
+   "stats": 0.31,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc1OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-056",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc1OQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.57,
+   "fill": 0.37,
+   "verify": 0.21,
+   "stats": 0.34,
+   "attach": {
+    "202406": 0.39
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.39
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc5Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-087",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc5Nw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.39,
+   "verify": 0.23,
+   "stats": 0.36,
+   "attach": {
+    "202406": 0.39
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.55
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI3NQ==": {
+  "name": "jeff/weave-load-test-example-spam-10-10000-6",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI3NQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.4,
+   "verify": 0.22,
+   "stats": 0.37,
+   "attach": {
+    "202411": 0.39
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.07
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTkxNQ==": {
+  "name": "nickpenaranda/weave-load-test-example-x",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTkxNQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.37,
+   "verify": 0.2,
+   "stats": 0.33,
+   "attach": {
+    "202407": 0.4
+   },
+   "post_check": 0.3
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202407"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI2Ng==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-14",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI2Ng==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.39,
+   "verify": 0.31,
+   "stats": 0.36,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.21
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc1OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-074",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc1OA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.51,
+   "fill": 0.75,
+   "verify": 0.19,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI1NQ==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI1NQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.41,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.91
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI3NA==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-18",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI3NA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.4,
+   "verify": 0.23,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.41
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.04
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgwOA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-095",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgwOA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.37,
+   "verify": 0.24,
+   "stats": 0.37,
+   "attach": {
+    "202406": 0.39
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI2Mw==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-10",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI2Mw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.43,
+   "verify": 0.23,
+   "stats": 0.35,
+   "attach": {
+    "202411": 0.39
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.07
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI3MQ==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-11",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI3MQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.49,
+   "verify": 0.21,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.19
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc4Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-060",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc4Mw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.67,
+   "verify": 0.21,
+   "stats": 0.35,
+   "attach": {
+    "202406": 0.39
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.3
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcxNg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-053",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcxNg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.41,
+   "fill": 0.37,
+   "verify": 0.21,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.37
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI2MQ==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-16",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI2MQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.45,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc5MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-072",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc5MQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.6,
+   "verify": 0.23,
+   "stats": 0.34,
+   "attach": {
+    "202406": 0.49
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.61
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI3Mw==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-9",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI3Mw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.46,
+   "verify": 0.21,
+   "stats": 0.39,
+   "attach": {
+    "202411": 0.42
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.16
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTczMg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-079",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTczMg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.72,
+   "verify": 0.21,
+   "stats": 0.31,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.26
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI2NA==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-19",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI2NA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.56,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.34
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.07
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc0OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-062",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc0OA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.44,
+   "fill": 1.03,
+   "verify": 0.21,
+   "stats": 0.32,
+   "attach": {
+    "202406": 0.52
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.89
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI1Nw==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-5",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI1Nw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.5,
+   "verify": 0.22,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.09
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI3Ng==": {
+  "name": "jeff/weave-load-test-example-spam-10-10000-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI3Ng==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.42,
+   "verify": 0.2,
+   "stats": 0.37,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc2Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-084",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc2Mg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.46,
+   "fill": 0.48,
+   "verify": 0.24,
+   "stats": 0.35,
+   "attach": {
+    "202406": 0.41
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.42
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgxMA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-098",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgxMA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.33,
+   "fill": 0.42,
+   "verify": 0.22,
+   "stats": 0.37,
+   "attach": {
+    "202406": 0.39
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.29
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI4MA==": {
+  "name": "jeff/weave-load-test-example-spam-10-10000-4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI4MA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.44,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.14
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc3MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-088",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc3MA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.64,
+   "verify": 0.24,
+   "stats": 0.34,
+   "attach": {
+    "202406": 0.39
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.41
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTczOQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-055",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTczOQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.39,
+   "fill": 0.45,
+   "verify": 0.25,
+   "stats": 0.34,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.55
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgwNA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-058",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgwNA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.78,
+   "verify": 0.2,
+   "stats": 0.31,
+   "attach": {
+    "202406": 0.4
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.37
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI3OA==": {
+  "name": "jeff/weave-load-test-example-spam-10-10000-8",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI3OA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.37,
+   "verify": 0.22,
+   "stats": 0.33,
+   "attach": {
+    "202411": 0.41
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.04
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI1OQ==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-17",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI1OQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.49,
+   "verify": 0.25,
+   "stats": 0.4,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.17
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc2Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-089",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc2Nw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.54,
+   "verify": 0.22,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.34
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc0Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-099",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc0Ng==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.52,
+   "verify": 0.26,
+   "stats": 0.41,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.26
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc1NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-066",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc1NA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.39,
+   "verify": 0.22,
+   "stats": 0.39,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.07
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgwMQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-093",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgwMQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.4,
+   "verify": 0.19,
+   "stats": 0.4,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.15
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc4OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-067",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc4OA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.39,
+   "verify": 0.2,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc0NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-097",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc0NA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.38,
+   "verify": 0.19,
+   "stats": 0.34,
+   "attach": {
+    "202406": 0.35
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.07
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc2NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-059",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc2NQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.38,
+   "verify": 0.21,
+   "stats": 0.35,
+   "attach": {
+    "202406": 0.33
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc1Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-076",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc1Ng==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.52,
+   "verify": 0.2,
+   "stats": 0.36,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.14
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc3Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-081",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc3Nw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.56,
+   "verify": 0.22,
+   "stats": 0.34,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.15
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI2OA==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI2OA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.37,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202411": 0.35
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.88
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgxMg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-068",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgxMg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.43,
+   "verify": 0.2,
+   "stats": 0.35,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI4Mg==": {
+  "name": "jeff/weave-load-test-example-spam-10-10000-9",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI4Mg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.41,
+   "verify": 0.25,
+   "stats": 0.37,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.03
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcyOA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-065",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcyOA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.45,
+   "fill": 0.67,
+   "verify": 0.2,
+   "stats": 0.36,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.5
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc3Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-100",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc3Mg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.42,
+   "verify": 0.2,
+   "stats": 0.36,
+   "attach": {
+    "202406": 0.41
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.13
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc2MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-096",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc2MQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.38,
+   "verify": 0.19,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.4
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgwNg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-071",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgwNg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.59,
+   "verify": 0.2,
+   "stats": 0.31,
+   "attach": {
+    "202406": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.08
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcyOQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-054",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcyOQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.61,
+   "verify": 0.25,
+   "stats": 0.35,
+   "attach": {
+    "202406": 0.39
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.39
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI4Mw==": {
+  "name": "jeff/weave-load-test-example-spam-10-10000-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI4Mw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.39,
+   "verify": 0.2,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgwNw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-092",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgwNw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.35,
+   "verify": 0.2,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.35
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.74
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc0NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-086",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc0NQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.56,
+   "verify": 0.19,
+   "stats": 0.36,
+   "attach": {
+    "202406": 0.42
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.11
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc2NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-083",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc2NA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.35,
+   "verify": 0.2,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc5OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-052",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc5OQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.81,
+   "verify": 0.2,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.33
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.13
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI2OQ==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-20",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI2OQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.38,
+   "verify": 0.2,
+   "stats": 0.32,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgwMg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-064",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgwMg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.65,
+   "verify": 0.19,
+   "stats": 0.3,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.18
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI3OQ==": {
+  "name": "jeff/weave-load-test-example-spam-10-10000-10",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI3OQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.42,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.39
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.89
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI1OA==": {
+  "name": "jeff/weave-load-test-example-spam-20-10000-12",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI1OA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.43,
+   "verify": 0.2,
+   "stats": 0.31,
+   "attach": {
+    "202411": 0.37
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.93
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc2Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-080",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc2Ng==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.38,
+   "verify": 0.2,
+   "stats": 0.34,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI4NA==": {
+  "name": "jeff/weave-load-test-example-spam-10-10000-7",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI4NA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.44,
+   "verify": 0.21,
+   "stats": 0.35,
+   "attach": {
+    "202411": 0.4
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.14
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc1NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-082",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc1NQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.4,
+   "verify": 0.19,
+   "stats": 0.31,
+   "attach": {
+    "202406": 0.4
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc3NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-051",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc3NA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.49,
+   "verify": 0.23,
+   "stats": 0.32,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.18
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgxMQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-090",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgxMQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.39,
+   "verify": 0.21,
+   "stats": 0.34,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc2Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-061",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc2Mw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.42,
+   "verify": 0.22,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.44
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.04
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc0Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-077",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc0Mg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.4,
+   "verify": 0.21,
+   "stats": 0.35,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc4OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-078",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc4OQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.39,
+   "verify": 0.22,
+   "stats": 0.31,
+   "attach": {
+    "202406": 0.42
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc3MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-070",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc3MQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.39,
+   "verify": 0.2,
+   "stats": 0.33,
+   "attach": {
+    "202406": 0.34
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 2.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI4MQ==": {
+  "name": "jeff/weave-load-test-example-spam-10-10000-5",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI4MQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.44,
+   "verify": 0.2,
+   "stats": 0.34,
+   "attach": {
+    "202411": 0.36
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.06
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY1MA==": {
+  "name": "griffin/scoring-load-burst2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY1MA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 0.49,
+   "verify": 0.24,
+   "stats": 0.36,
+   "attach": {
+    "202606": 0.36
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.16
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY2MA==": {
+  "name": "griffin/scoring-worker-pollfix-1781721760",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY2MA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.4,
+   "verify": 0.23,
+   "stats": 0.41,
+   "attach": {
+    "202606": 0.42
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.26
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY1Mw==": {
+  "name": "griffin/scoring-load-burst4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY1Mw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.39,
+   "verify": 0.23,
+   "stats": 0.33,
+   "attach": {
+    "202606": 0.42
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.0
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY1MQ==": {
+  "name": "griffin/scoring-load-burst3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY1MQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.42,
+   "verify": 0.23,
+   "stats": 0.4,
+   "attach": {
+    "202606": 0.37
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.08
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY2OA==": {
+  "name": "griffin/scoring-load-exec1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY2OA==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.38,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202606": 0.37
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.01
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY0OQ==": {
+  "name": "griffin/scoring-load-burst1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY0OQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.45,
+   "verify": 0.25,
+   "stats": 0.31,
+   "attach": {
+    "202606": 0.42
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0
+  },
+  "total_s": 3.09
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzI2MA==": {
+  "name": "griffin/can-we-break-the-workers-qa",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzI2MA==",
+  "source_calls": 10032,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 1.97,
+   "verify": 0.54,
+   "stats": 0.55,
+   "attach": {
+    "202602": 0.28,
+    "202603": 0.36
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10032,
+   "partitions": [
+    "202602",
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 10032,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10032,
+   "post_dupes": 0
+  },
+  "total_s": 5.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg4MA==": {
+  "name": "griffin/repro-tmobile-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg4MA==",
+  "source_calls": 11000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 2.75,
+   "verify": 0.57,
+   "stats": 0.43,
+   "attach": {
+    "202502": 0.3
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 11000,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 11000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 11000,
+   "post_dupes": 0
+  },
+  "total_s": 6.38
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg3OQ==": {
+  "name": "griffin/repro-tmobile-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg3OQ==",
+  "source_calls": 11000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.32,
+   "fill": 10.77,
+   "verify": 0.57,
+   "stats": 1.76,
+   "attach": {
+    "202502": 0.46
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 11000,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 11000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 11000,
+   "post_dupes": 0
+  },
+  "total_s": 15.49
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU3Ng==": {
+  "name": "rival-corp/weave-load-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU3Ng==",
+  "source_calls": 11399,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.71,
+   "verify": 0.19,
+   "stats": 0.33,
+   "attach": {
+    "202405": 0.36
+   },
+   "post_check": 0.38
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 11399,
+   "partitions": [
+    "202405"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 11399,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 11399,
+   "post_dupes": 0
+  },
+  "total_s": 3.45
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg2NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-10000x10-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg2NQ==",
+  "source_calls": 13015,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.46,
+   "fill": 0.4,
+   "verify": 0.2,
+   "stats": 0.36,
+   "attach": {
+    "202406": 0.53
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 13015,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 13015,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 13015,
+   "post_dupes": 0
+  },
+  "total_s": 3.68
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg2Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-10000x10-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg2Mw==",
+  "source_calls": 13216,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 0.61,
+   "verify": 0.22,
+   "stats": 0.35,
+   "attach": {
+    "202406": 0.4
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 13216,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 13216,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 13216,
+   "post_dupes": 0
+  },
+  "total_s": 3.38
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg2NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-10000x10-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg2NA==",
+  "source_calls": 14769,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.61,
+   "verify": 0.24,
+   "stats": 0.38,
+   "attach": {
+    "202406": 0.76
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 14769,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 14769,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 14769,
+   "post_dupes": 0
+  },
+  "total_s": 3.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg2Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-10000x10-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg2Nw==",
+  "source_calls": 15118,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.5,
+   "verify": 0.24,
+   "stats": 0.37,
+   "attach": {
+    "202406": 0.41
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 15118,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 15118,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 15118,
+   "post_dupes": 0
+  },
+  "total_s": 3.45
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg2Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-10000x10-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg2Ng==",
+  "source_calls": 15803,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.41,
+   "verify": 0.19,
+   "stats": 0.35,
+   "attach": {
+    "202406": 0.53
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 15803,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 15803,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 15803,
+   "post_dupes": 0
+  },
+  "total_s": 3.21
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzEyNg==": {
+  "name": "griffin/simplec",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzEyNg==",
+  "source_calls": 16045,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 1.59,
+   "verify": 0.54,
+   "stats": 0.51,
+   "attach": {
+    "202602": 0.3
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 16045,
+   "partitions": [
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 16045,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 16045,
+   "post_dupes": 0
+  },
+  "total_s": 4.59
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg2MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-10000x10-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg2MQ==",
+  "source_calls": 16480,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.59,
+   "verify": 0.24,
+   "stats": 0.39,
+   "attach": {
+    "202406": 0.39
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 16480,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 16480,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 16480,
+   "post_dupes": 0
+  },
+  "total_s": 3.27
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY0NQ==": {
+  "name": "griffin/scoring-load-smoke",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY0NQ==",
+  "source_calls": 18075,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.48,
+   "verify": 0.23,
+   "stats": 0.43,
+   "attach": {
+    "202606": 0.37
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 18075,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 18075,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 18075,
+   "post_dupes": 0
+  },
+  "total_s": 3.29
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg2MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-10000x10-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg2MA==",
+  "source_calls": 19681,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.42,
+   "verify": 0.21,
+   "stats": 0.35,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 19681,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 19681,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 19681,
+   "post_dupes": 0
+  },
+  "total_s": 3.0
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI1Mw==": {
+  "name": "jeff/weave-load-test-example-spam-2-10000-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI1Mw==",
+  "source_calls": 20000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.45,
+   "verify": 0.2,
+   "stats": 0.36,
+   "attach": {
+    "202411": 0.51
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 20000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20000,
+   "post_dupes": 0
+  },
+  "total_s": 3.11
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg2Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-10000x10-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg2Mg==",
+  "source_calls": 20000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.46,
+   "verify": 0.22,
+   "stats": 0.38,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 20000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20000,
+   "post_dupes": 0
+  },
+  "total_s": 3.26
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg4Mg==": {
+  "name": "griffin/base64-image-test-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg4Mg==",
+  "source_calls": 20000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 39.75,
+   "verify": 0.57,
+   "stats": 14.46,
+   "attach": {
+    "202502": 0.37
+   },
+   "post_check": 0.41
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20000,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 20000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20000,
+   "post_dupes": 0
+  },
+  "total_s": 56.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI1NA==": {
+  "name": "jeff/weave-load-test-example-spam-2-10000-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI1NA==",
+  "source_calls": 20000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.29,
+   "fill": 0.51,
+   "verify": 0.23,
+   "stats": 0.38,
+   "attach": {
+    "202411": 0.38
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 20000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20000,
+   "post_dupes": 0
+  },
+  "total_s": 3.22
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjc1MA==": {
+  "name": "griffin/base64-image-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjc1MA==",
+  "source_calls": 20000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.35,
+   "fill": 36.56,
+   "verify": 0.19,
+   "stats": 3.63,
+   "attach": {
+    "202501": 1.25
+   },
+   "post_check": 0.75
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20000,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 20000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20000,
+   "post_dupes": 0
+  },
+  "total_s": 44.57
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg4MQ==": {
+  "name": "griffin/repro-tmobile-4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg4MQ==",
+  "source_calls": 20000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 7.12,
+   "verify": 0.31,
+   "stats": 0.9,
+   "attach": {
+    "202502": 0.47
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20000,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 20000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20000,
+   "post_dupes": 0
+  },
+  "total_s": 10.53
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg2OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-10000x10-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg2OA==",
+  "source_calls": 20000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.46,
+   "verify": 0.25,
+   "stats": 0.39,
+   "attach": {
+    "202406": 0.44
+   },
+   "post_check": 0.55
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 20000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20000,
+   "post_dupes": 0
+  },
+  "total_s": 3.59
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg2OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-10000x10-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg2OQ==",
+  "source_calls": 20000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.51,
+   "verify": 0.2,
+   "stats": 0.39,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.49
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 20000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20000,
+   "post_dupes": 0
+  },
+  "total_s": 3.46
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzM5Nw==": {
+  "name": "launch-team-public-queue/weave-log-benchmark-0",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzM5Nw==",
+  "source_calls": 23839,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 1.45,
+   "verify": 0.24,
+   "stats": 0.46,
+   "attach": {
+    "202603": 0.5
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 23839,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 23839,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 23839,
+   "post_dupes": 0
+  },
+  "total_s": 4.52
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc5Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-026",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc5Mw==",
+  "source_calls": 27000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 1.71,
+   "verify": 0.58,
+   "stats": 0.44,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 27000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 27000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 27000,
+   "post_dupes": 0
+  },
+  "total_s": 4.8
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjg3OA==": {
+  "name": "griffin/repro-tmobile-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjg3OA==",
+  "source_calls": 29256,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 9.56,
+   "verify": 3.33,
+   "stats": 0.76,
+   "attach": {
+    "202502": 0.8
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 29256,
+   "partitions": [
+    "202502"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 29256,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 29256,
+   "post_dupes": 0
+  },
+  "total_s": 16.27
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgyMg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-700x10-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgyMg==",
+  "source_calls": 33600,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 1.89,
+   "verify": 0.49,
+   "stats": 0.55,
+   "attach": {
+    "202406": 0.43
+   },
+   "post_check": 0.41
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 33600,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 33600,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 33600,
+   "post_dupes": 0
+  },
+  "total_s": 5.46
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjkyNA==": {
+  "name": "griffin/forest",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjkyNA==",
+  "source_calls": 34100,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.57,
+   "verify": 0.21,
+   "stats": 0.43,
+   "attach": {
+    "202503": 0.58
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 34100,
+   "partitions": [
+    "202503"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 34100,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 34100,
+   "post_dupes": 0
+  },
+  "total_s": 3.53
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgxOA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-700x10-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgxOA==",
+  "source_calls": 34300,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 1.64,
+   "verify": 0.53,
+   "stats": 0.71,
+   "attach": {
+    "202406": 0.41
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 34300,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 34300,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 34300,
+   "post_dupes": 0
+  },
+  "total_s": 5.26
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgxOQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-700x10-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgxOQ==",
+  "source_calls": 34300,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 1.44,
+   "verify": 0.22,
+   "stats": 0.62,
+   "attach": {
+    "202406": 0.41
+   },
+   "post_check": 0.37
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 34300,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 34300,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 34300,
+   "post_dupes": 0
+  },
+  "total_s": 4.66
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgyNw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-700x10-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgyNw==",
+  "source_calls": 34300,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 1.91,
+   "verify": 0.25,
+   "stats": 0.71,
+   "attach": {
+    "202406": 0.41
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 34300,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 34300,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 34300,
+   "post_dupes": 0
+  },
+  "total_s": 5.29
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgyNQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-700x10-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgyNQ==",
+  "source_calls": 34300,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 1.61,
+   "verify": 0.22,
+   "stats": 0.44,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 34300,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 34300,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 34300,
+   "post_dupes": 0
+  },
+  "total_s": 4.54
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgyMA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-700x10-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgyMA==",
+  "source_calls": 34300,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 2.02,
+   "verify": 0.55,
+   "stats": 0.73,
+   "attach": {
+    "202406": 0.42
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 34300,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 34300,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 34300,
+   "post_dupes": 0
+  },
+  "total_s": 5.59
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgyMQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-700x10-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgyMQ==",
+  "source_calls": 34300,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 2.13,
+   "verify": 0.53,
+   "stats": 0.5,
+   "attach": {
+    "202406": 0.4
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 34300,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 34300,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 34300,
+   "post_dupes": 0
+  },
+  "total_s": 5.73
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgyNA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-700x10-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgyNA==",
+  "source_calls": 34300,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 1.52,
+   "verify": 0.22,
+   "stats": 0.46,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 34300,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 34300,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 34300,
+   "post_dupes": 0
+  },
+  "total_s": 4.44
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgyNg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-700x10-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgyNg==",
+  "source_calls": 34300,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 1.5,
+   "verify": 0.19,
+   "stats": 0.51,
+   "attach": {
+    "202406": 0.43
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 34300,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 34300,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 34300,
+   "post_dupes": 0
+  },
+  "total_s": 4.56
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgyMw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-700x10-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgyMw==",
+  "source_calls": 34300,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 1.55,
+   "verify": 0.21,
+   "stats": 0.75,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 34300,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 34300,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 34300,
+   "post_dupes": 0
+  },
+  "total_s": 4.5
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY2Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY2Ng==",
+  "source_calls": 36473,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.43,
+   "fill": 2.32,
+   "verify": 0.67,
+   "stats": 0.89,
+   "attach": {
+    "202406": 0.28
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 36473,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 36473,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 36473,
+   "post_dupes": 0
+  },
+  "total_s": 6.15
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcxNw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-028",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcxNw==",
+  "source_calls": 37000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 2.0,
+   "verify": 0.58,
+   "stats": 1.04,
+   "attach": {
+    "202406": 0.44
+   },
+   "post_check": 0.37
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37000,
+   "post_dupes": 0
+  },
+  "total_s": 5.84
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc5MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-037",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc5MA==",
+  "source_calls": 37000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 1.45,
+   "verify": 0.2,
+   "stats": 0.47,
+   "attach": {
+    "202406": 0.43
+   },
+   "post_check": 0.4
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37000,
+   "post_dupes": 0
+  },
+  "total_s": 4.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcyNQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-033",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcyNQ==",
+  "source_calls": 37000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 1.53,
+   "verify": 0.21,
+   "stats": 0.47,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.37
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37000,
+   "post_dupes": 0
+  },
+  "total_s": 4.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc4NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-050",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc4NA==",
+  "source_calls": 37000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 3.52,
+   "verify": 0.52,
+   "stats": 0.6,
+   "attach": {
+    "202406": 0.42
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37000,
+   "post_dupes": 0
+  },
+  "total_s": 6.97
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc5Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-036",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc5Ng==",
+  "source_calls": 37000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 2.08,
+   "verify": 0.59,
+   "stats": 1.05,
+   "attach": {
+    "202406": 0.4
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37000,
+   "post_dupes": 0
+  },
+  "total_s": 5.88
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc4MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-041",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc4MQ==",
+  "source_calls": 37000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 1.82,
+   "verify": 0.55,
+   "stats": 0.49,
+   "attach": {
+    "202406": 0.51
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37000,
+   "post_dupes": 0
+  },
+  "total_s": 5.3
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcxNA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-034",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcxNA==",
+  "source_calls": 37000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 2.25,
+   "verify": 0.71,
+   "stats": 0.61,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.3
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37000,
+   "post_dupes": 0
+  },
+  "total_s": 5.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTczNw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-043",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTczNw==",
+  "source_calls": 37000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 1.55,
+   "verify": 0.22,
+   "stats": 0.71,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37000,
+   "post_dupes": 0
+  },
+  "total_s": 4.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc2MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-027",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc2MA==",
+  "source_calls": 37000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 1.59,
+   "verify": 0.2,
+   "stats": 0.52,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37000,
+   "post_dupes": 0
+  },
+  "total_s": 4.55
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc3Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-039",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc3Mw==",
+  "source_calls": 37000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 1.6,
+   "verify": 0.2,
+   "stats": 0.51,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.37
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37000,
+   "post_dupes": 0
+  },
+  "total_s": 4.9
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc1Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-042",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc1Nw==",
+  "source_calls": 37000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 2.2,
+   "verify": 0.22,
+   "stats": 0.56,
+   "attach": {
+    "202406": 0.44
+   },
+   "post_check": 0.44
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37000,
+   "post_dupes": 0
+  },
+  "total_s": 5.27
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTczOA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-044",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTczOA==",
+  "source_calls": 37000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 1.47,
+   "verify": 0.57,
+   "stats": 0.71,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37000,
+   "post_dupes": 0
+  },
+  "total_s": 4.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY2Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY2Nw==",
+  "source_calls": 37312,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.4,
+   "fill": 2.19,
+   "verify": 0.19,
+   "stats": 0.48,
+   "attach": {
+    "202406": 0.31
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37312,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37312,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37312,
+   "post_dupes": 0
+  },
+  "total_s": 5.25
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTczNQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-035",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTczNQ==",
+  "source_calls": 37335,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 2.07,
+   "verify": 0.54,
+   "stats": 0.67,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37335,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37335,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37335,
+   "post_dupes": 0
+  },
+  "total_s": 5.62
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY2Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY2Mw==",
+  "source_calls": 37857,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 3.6,
+   "verify": 0.66,
+   "stats": 0.78,
+   "attach": {
+    "202406": 0.45
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 37857,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 37857,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 37857,
+   "post_dupes": 0
+  },
+  "total_s": 7.48
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc2OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-031",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc2OA==",
+  "source_calls": 38007,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 1.56,
+   "verify": 0.49,
+   "stats": 0.54,
+   "attach": {
+    "202406": 0.41
+   },
+   "post_check": 0.91
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 38007,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 38007,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 38007,
+   "post_dupes": 0
+  },
+  "total_s": 5.47
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY2OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY2OQ==",
+  "source_calls": 38444,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 3.66,
+   "verify": 0.58,
+   "stats": 1.24,
+   "attach": {
+    "202406": 0.49
+   },
+   "post_check": 0.65
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 38444,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 38444,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 38444,
+   "post_dupes": 0
+  },
+  "total_s": 8.34
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcxOQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-045",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcxOQ==",
+  "source_calls": 38718,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 1.73,
+   "verify": 0.21,
+   "stats": 0.63,
+   "attach": {
+    "202406": 0.4
+   },
+   "post_check": 0.44
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 38718,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 38718,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 38718,
+   "post_dupes": 0
+  },
+  "total_s": 5.16
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY2NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY2NQ==",
+  "source_calls": 39501,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 3.37,
+   "verify": 0.46,
+   "stats": 0.84,
+   "attach": {
+    "202406": 0.47
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 39501,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 39501,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 39501,
+   "post_dupes": 0
+  },
+  "total_s": 7.13
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcyMw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-047",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcyMw==",
+  "source_calls": 39720,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 2.27,
+   "verify": 0.51,
+   "stats": 0.65,
+   "attach": {
+    "202406": 0.51
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 39720,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 39720,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 39720,
+   "post_dupes": 0
+  },
+  "total_s": 5.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc4Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-048",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc4Nw==",
+  "source_calls": 39920,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 1.57,
+   "verify": 0.58,
+   "stats": 1.01,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.39
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 39920,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 39920,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 39920,
+   "post_dupes": 0
+  },
+  "total_s": 5.59
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc4Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-040",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc4Ng==",
+  "source_calls": 39920,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 2.24,
+   "verify": 0.21,
+   "stats": 0.6,
+   "attach": {
+    "202406": 0.35
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 39920,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 39920,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 39920,
+   "post_dupes": 0
+  },
+  "total_s": 5.23
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc1MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-049",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc1MA==",
+  "source_calls": 39920,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.37,
+   "fill": 4.95,
+   "verify": 0.51,
+   "stats": 0.62,
+   "attach": {
+    "202406": 0.47
+   },
+   "post_check": 0.38
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 39920,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 39920,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 39920,
+   "post_dupes": 0
+  },
+  "total_s": 8.44
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc5OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-032",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc5OA==",
+  "source_calls": 40000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 4.25,
+   "verify": 0.64,
+   "stats": 1.46,
+   "attach": {
+    "202406": 0.4
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 40000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 40000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 40000,
+   "post_dupes": 0
+  },
+  "total_s": 8.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgwMA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-038",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgwMA==",
+  "source_calls": 40000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.43,
+   "fill": 1.6,
+   "verify": 0.22,
+   "stats": 0.76,
+   "attach": {
+    "202406": 0.41
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 40000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 40000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 40000,
+   "post_dupes": 0
+  },
+  "total_s": 4.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc1MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-030",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc1MQ==",
+  "source_calls": 40390,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 3.27,
+   "verify": 0.2,
+   "stats": 0.7,
+   "attach": {
+    "202406": 0.51
+   },
+   "post_check": 0.48
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 40390,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 40390,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 40390,
+   "post_dupes": 0
+  },
+  "total_s": 7.53
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc0Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-029",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc0Mw==",
+  "source_calls": 40536,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 3.17,
+   "verify": 0.48,
+   "stats": 0.61,
+   "attach": {
+    "202406": 0.91
+   },
+   "post_check": 0.37
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 40536,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 40536,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 40536,
+   "post_dupes": 0
+  },
+  "total_s": 7.17
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY3MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY3MQ==",
+  "source_calls": 41390,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 2.47,
+   "verify": 0.53,
+   "stats": 0.72,
+   "attach": {
+    "202406": 0.44
+   },
+   "post_check": 0.53
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 41390,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 41390,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 41390,
+   "post_dupes": 0
+  },
+  "total_s": 6.34
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc3OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-046",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc3OQ==",
+  "source_calls": 43000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 1.46,
+   "verify": 0.49,
+   "stats": 0.8,
+   "attach": {
+    "202406": 0.39
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 43000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 43000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 43000,
+   "post_dupes": 0
+  },
+  "total_s": 5.33
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzM5Mw==": {
+  "name": "launch-team-public-queue/weave-log-benchmark",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzM5Mw==",
+  "source_calls": 43442,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 1.45,
+   "verify": 0.33,
+   "stats": 0.51,
+   "attach": {
+    "202603": 0.59
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 43442,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 43442,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 43442,
+   "post_dupes": 0
+  },
+  "total_s": 4.81
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY2NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY2NA==",
+  "source_calls": 44342,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 3.44,
+   "verify": 1.37,
+   "stats": 1.03,
+   "attach": {
+    "202406": 0.37
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 44342,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 44342,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 44342,
+   "post_dupes": 0
+  },
+  "total_s": 8.51
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY3MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY3MA==",
+  "source_calls": 46025,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 3.34,
+   "verify": 0.23,
+   "stats": 0.78,
+   "attach": {
+    "202406": 0.31
+   },
+   "post_check": 0.47
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 46025,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 46025,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 46025,
+   "post_dupes": 0
+  },
+  "total_s": 6.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY2OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY2OA==",
+  "source_calls": 46089,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 2.46,
+   "verify": 0.74,
+   "stats": 0.87,
+   "attach": {
+    "202406": 0.33
+   },
+   "post_check": 0.78
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 46089,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 46089,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 46089,
+   "post_dupes": 0
+  },
+  "total_s": 6.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY3Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY3Mg==",
+  "source_calls": 47437,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 3.62,
+   "verify": 0.22,
+   "stats": 0.68,
+   "attach": {
+    "202406": 0.31
+   },
+   "post_check": 0.46
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 47437,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 47437,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 47437,
+   "post_dupes": 0
+  },
+  "total_s": 9.31
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY0Ng==": {
+  "name": "griffin/scoring-load-run1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY0Ng==",
+  "source_calls": 48206,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 0.58,
+   "verify": 0.23,
+   "stats": 0.52,
+   "attach": {
+    "202606": 0.46
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 48206,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 48206,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 48206,
+   "post_dupes": 0
+  },
+  "total_s": 4.0
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njk3Ng==": {
+  "name": "griffin/test-multi-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njk3Ng==",
+  "source_calls": 48812,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 2.96,
+   "verify": 0.29,
+   "stats": 0.99,
+   "attach": {
+    "202511": 0.61
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 48812,
+   "partitions": [
+    "202511"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 48812,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 48812,
+   "post_dupes": 0
+  },
+  "total_s": 6.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzM2MQ==": {
+  "name": "launch-team-public-queue/dev-sweeps-weave-pytorch",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzM2MQ==",
+  "source_calls": 52056,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 1.04,
+   "verify": 0.23,
+   "stats": 0.53,
+   "attach": {
+    "202603": 0.43
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 52056,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 52056,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 52056,
+   "post_dupes": 0
+  },
+  "total_s": 4.04
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc3NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc3NQ==",
+  "source_calls": 59855,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 1.89,
+   "verify": 0.44,
+   "stats": 0.7,
+   "attach": {
+    "202406": 0.42
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 59855,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 59855,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 59855,
+   "post_dupes": 0
+  },
+  "total_s": 5.22
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc1NQ==": {
+  "name": "timssweeney/evaluate_model_worker_load_1_100_1_1_v1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc1NQ==",
+  "source_calls": 60058,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 1.37,
+   "verify": 0.26,
+   "stats": 0.66,
+   "attach": {
+    "202508": 0.64
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 60058,
+   "partitions": [
+    "202508"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 60058,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 60058,
+   "post_dupes": 0
+  },
+  "total_s": 4.64
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgwNQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-024",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgwNQ==",
+  "source_calls": 64500,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 2.03,
+   "verify": 0.56,
+   "stats": 0.74,
+   "attach": {
+    "202406": 0.26
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 64500,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 64500,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 64500,
+   "post_dupes": 0
+  },
+  "total_s": 5.32
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcyMA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-022",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcyMA==",
+  "source_calls": 67000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 2.58,
+   "verify": 0.43,
+   "stats": 1.2,
+   "attach": {
+    "202406": 0.42
+   },
+   "post_check": 0.47
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 67000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 67000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 67000,
+   "post_dupes": 0
+  },
+  "total_s": 6.81
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTczMA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-025",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTczMA==",
+  "source_calls": 67000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 2.02,
+   "verify": 0.42,
+   "stats": 0.73,
+   "attach": {
+    "202406": 0.44
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 67000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 67000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 67000,
+   "post_dupes": 0
+  },
+  "total_s": 5.41
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcxNQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcxNQ==",
+  "source_calls": 67920,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 1.77,
+   "verify": 0.21,
+   "stats": 1.02,
+   "attach": {
+    "202406": 0.42
+   },
+   "post_check": 0.42
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 67920,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 67920,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 67920,
+   "post_dupes": 0
+  },
+  "total_s": 5.46
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcxMw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-016",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcxMw==",
+  "source_calls": 68500,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.32,
+   "fill": 2.59,
+   "verify": 0.43,
+   "stats": 1.22,
+   "attach": {
+    "202406": 0.53
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 68500,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 68500,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 68500,
+   "post_dupes": 0
+  },
+  "total_s": 6.76
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcxOA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-017",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcxOA==",
+  "source_calls": 68500,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 2.97,
+   "verify": 0.22,
+   "stats": 0.93,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.45
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 68500,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 68500,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 68500,
+   "post_dupes": 0
+  },
+  "total_s": 6.37
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI0Mw==": {
+  "name": "jeff/weave-load-test-example-spam-10x10000-7",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI0Mw==",
+  "source_calls": 70000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 1.08,
+   "verify": 0.22,
+   "stats": 0.72,
+   "attach": {
+    "202411": 0.45
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 70000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 70000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 70000,
+   "post_dupes": 0
+  },
+  "total_s": 4.46
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjI0Mg==": {
+  "name": "jeff/weave-load-test-example-spam-10x10000-10",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjI0Mg==",
+  "source_calls": 70000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.76,
+   "verify": 0.23,
+   "stats": 0.75,
+   "attach": {
+    "202411": 0.49
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 70000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 70000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 70000,
+   "post_dupes": 0
+  },
+  "total_s": 4.12
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgwMw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgwMw==",
+  "source_calls": 70000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 2.71,
+   "verify": 0.47,
+   "stats": 0.86,
+   "attach": {
+    "202406": 0.39
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 70000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 70000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 70000,
+   "post_dupes": 0
+  },
+  "total_s": 6.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg4Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg4Nw==",
+  "source_calls": 70000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.39,
+   "fill": 1.1,
+   "verify": 0.21,
+   "stats": 0.62,
+   "attach": {
+    "202406": 0.49
+   },
+   "post_check": 1.0
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 70000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 70000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 70000,
+   "post_dupes": 0
+  },
+  "total_s": 4.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc1Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-015",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc1Mw==",
+  "source_calls": 70000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 3.49,
+   "verify": 0.3,
+   "stats": 0.97,
+   "attach": {
+    "202406": 0.42
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 70000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 70000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 70000,
+   "post_dupes": 0
+  },
+  "total_s": 7.22
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjIzMg==": {
+  "name": "jeff/weave-load-test-example-spam-10x10000-4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjIzMg==",
+  "source_calls": 70000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 1.03,
+   "verify": 0.24,
+   "stats": 0.63,
+   "attach": {
+    "202411": 0.41
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 70000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 70000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 70000,
+   "post_dupes": 0
+  },
+  "total_s": 3.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjIzMA==": {
+  "name": "jeff/weave-load-test-example-spam-10x10000-8",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjIzMA==",
+  "source_calls": 70000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.99,
+   "verify": 0.2,
+   "stats": 0.65,
+   "attach": {
+    "202411": 0.41
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 70000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 70000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 70000,
+   "post_dupes": 0
+  },
+  "total_s": 4.03
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjIzNQ==": {
+  "name": "jeff/weave-load-test-example-spam-10x10000-6",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjIzNQ==",
+  "source_calls": 70000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 0.84,
+   "verify": 0.24,
+   "stats": 0.58,
+   "attach": {
+    "202411": 0.73
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 70000,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 70000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 70000,
+   "post_dupes": 0
+  },
+  "total_s": 4.03
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg4Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-019",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg4Ng==",
+  "source_calls": 70976,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.78,
+   "verify": 0.28,
+   "stats": 0.82,
+   "attach": {
+    "202406": 0.57
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 70976,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 70976,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 70976,
+   "post_dupes": 0
+  },
+  "total_s": 4.57
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg5Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-012",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg5Mw==",
+  "source_calls": 71248,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.48,
+   "fill": 0.89,
+   "verify": 0.2,
+   "stats": 0.64,
+   "attach": {
+    "202406": 0.43
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 71248,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 71248,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 71248,
+   "post_dupes": 0
+  },
+  "total_s": 4.32
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc0OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc0OQ==",
+  "source_calls": 71500,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 1.92,
+   "verify": 0.7,
+   "stats": 0.73,
+   "attach": {
+    "202406": 0.4
+   },
+   "post_check": 0.45
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 71500,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 71500,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 71500,
+   "post_dupes": 0
+  },
+  "total_s": 5.69
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcyNg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcyNg==",
+  "source_calls": 71500,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 1.88,
+   "verify": 0.82,
+   "stats": 0.6,
+   "attach": {
+    "202406": 0.9
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 71500,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 71500,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 71500,
+   "post_dupes": 0
+  },
+  "total_s": 6.58
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc0MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-021",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc0MQ==",
+  "source_calls": 71500,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 2.12,
+   "verify": 0.92,
+   "stats": 0.66,
+   "attach": {
+    "202406": 0.84
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 71500,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 71500,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 71500,
+   "post_dupes": 0
+  },
+  "total_s": 6.17
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg4Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg4Mw==",
+  "source_calls": 72405,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.53,
+   "fill": 0.82,
+   "verify": 0.21,
+   "stats": 0.59,
+   "attach": {
+    "202406": 0.45
+   },
+   "post_check": 0.41
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 72405,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 72405,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 72405,
+   "post_dupes": 0
+  },
+  "total_s": 4.19
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc2OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc2OQ==",
+  "source_calls": 72718,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 4.71,
+   "verify": 0.19,
+   "stats": 0.89,
+   "attach": {
+    "202406": 0.43
+   },
+   "post_check": 0.46
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 72718,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 72718,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 72718,
+   "post_dupes": 0
+  },
+  "total_s": 8.45
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTczNA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTczNA==",
+  "source_calls": 73000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 1.97,
+   "verify": 0.46,
+   "stats": 0.64,
+   "attach": {
+    "202406": 0.4
+   },
+   "post_check": 0.38
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 73000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 73000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 73000,
+   "post_dupes": 0
+  },
+  "total_s": 5.5
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc5Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-013",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc5Mg==",
+  "source_calls": 73000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 1.89,
+   "verify": 1.0,
+   "stats": 1.3,
+   "attach": {
+    "202406": 0.41
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 73000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 73000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 73000,
+   "post_dupes": 0
+  },
+  "total_s": 6.41
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTczMQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-023",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTczMQ==",
+  "source_calls": 73000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 2.8,
+   "verify": 0.4,
+   "stats": 0.84,
+   "attach": {
+    "202406": 0.43
+   },
+   "post_check": 0.42
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 73000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 73000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 73000,
+   "post_dupes": 0
+  },
+  "total_s": 6.44
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcyMg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcyMg==",
+  "source_calls": 73000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 5.11,
+   "verify": 0.28,
+   "stats": 0.66,
+   "attach": {
+    "202406": 0.42
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 73000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 73000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 73000,
+   "post_dupes": 0
+  },
+  "total_s": 8.44
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc0MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-020",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc0MA==",
+  "source_calls": 73000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 2.07,
+   "verify": 0.44,
+   "stats": 0.61,
+   "attach": {
+    "202406": 0.46
+   },
+   "post_check": 0.37
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 73000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 73000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 73000,
+   "post_dupes": 0
+  },
+  "total_s": 5.58
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc1Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-018",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc1Mg==",
+  "source_calls": 73000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 2.86,
+   "verify": 0.2,
+   "stats": 0.83,
+   "attach": {
+    "202406": 0.79
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 73000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 73000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 73000,
+   "post_dupes": 0
+  },
+  "total_s": 8.3
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzM5MQ==": {
+  "name": "launch-team-public-queue/dev-sweeps-weave-log-benchmark",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzM5MQ==",
+  "source_calls": 73348,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 1.56,
+   "verify": 0.96,
+   "stats": 0.55,
+   "attach": {
+    "202603": 0.34
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 10002,
+   "past_retention": 0,
+   "expected_rows": 63346,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 63346,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 63346,
+   "post_dupes": 0
+  },
+  "total_s": 5.66
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc3Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-019",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc3Ng==",
+  "source_calls": 74500,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 2.91,
+   "verify": 0.23,
+   "stats": 0.75,
+   "attach": {
+    "202406": 0.34
+   },
+   "post_check": 0.48
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 74500,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 74500,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 74500,
+   "post_dupes": 0
+  },
+  "total_s": 6.37
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcyNA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcyNA==",
+  "source_calls": 74667,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 2.76,
+   "verify": 0.51,
+   "stats": 0.81,
+   "attach": {
+    "202406": 0.36
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 74667,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 74667,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 74667,
+   "post_dupes": 0
+  },
+  "total_s": 6.45
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg5Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-016",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg5Nw==",
+  "source_calls": 75280,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.98,
+   "verify": 0.21,
+   "stats": 0.7,
+   "attach": {
+    "202406": 3.45
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 75280,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 75280,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 75280,
+   "post_dupes": 0
+  },
+  "total_s": 7.35
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzM2Nw==": {
+  "name": "launch-team-public-queue/dev-sweeps-weave-log-examples",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzM2Nw==",
+  "source_calls": 75527,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 1.37,
+   "verify": 0.51,
+   "stats": 0.82,
+   "attach": {
+    "202603": 0.27
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 75527,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 75527,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 75527,
+   "post_dupes": 0
+  },
+  "total_s": 5.03
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcyMQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-012",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcyMQ==",
+  "source_calls": 76000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 2.4,
+   "verify": 0.6,
+   "stats": 1.3,
+   "attach": {
+    "202406": 0.33
+   },
+   "post_check": 0.4
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 76000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 76000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 76000,
+   "post_dupes": 0
+  },
+  "total_s": 6.52
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTczNg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-011",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTczNg==",
+  "source_calls": 77500,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 3.51,
+   "verify": 0.56,
+   "stats": 0.71,
+   "attach": {
+    "202406": 0.34
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 77500,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 77500,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 77500,
+   "post_dupes": 0
+  },
+  "total_s": 6.89
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc5NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-014",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc5NA==",
+  "source_calls": 79000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 2.1,
+   "verify": 0.52,
+   "stats": 1.21,
+   "attach": {
+    "202406": 0.34
+   },
+   "post_check": 0.41
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 79000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 79000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 79000,
+   "post_dupes": 0
+  },
+  "total_s": 6.11
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg4MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg4MQ==",
+  "source_calls": 79027,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 0.76,
+   "verify": 0.22,
+   "stats": 0.65,
+   "attach": {
+    "202406": 0.47
+   },
+   "post_check": 0.38
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 79027,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 79027,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 79027,
+   "post_dupes": 0
+  },
+  "total_s": 4.15
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTc0Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite5-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTc0Nw==",
+  "source_calls": 79141,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 2.24,
+   "verify": 1.08,
+   "stats": 0.7,
+   "attach": {
+    "202406": 0.66
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 79141,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 79141,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 79141,
+   "post_dupes": 0
+  },
+  "total_s": 6.51
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg5MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-014",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg5MQ==",
+  "source_calls": 80000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.45,
+   "fill": 0.81,
+   "verify": 0.21,
+   "stats": 0.99,
+   "attach": {
+    "202406": 0.57
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 80000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 80000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 80000,
+   "post_dupes": 0
+  },
+  "total_s": 4.55
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg4NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-018",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg4NA==",
+  "source_calls": 80000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.74,
+   "verify": 0.23,
+   "stats": 0.94,
+   "attach": {
+    "202406": 0.51
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 80000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 80000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 80000,
+   "post_dupes": 0
+  },
+  "total_s": 4.13
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjgwOA==": {
+  "name": "griffin/mops",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjgwOA==",
+  "source_calls": 80784,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.97,
+   "verify": 0.45,
+   "stats": 0.97,
+   "attach": {
+    "202509": 0.86
+   },
+   "post_check": 0.44
+  },
+  "gates": {
+   "orphan_ends": 164,
+   "past_retention": 0,
+   "expected_rows": 80620,
+   "partitions": [
+    "202509"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 80620,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 80620,
+   "post_dupes": 0
+  },
+  "total_s": 5.4
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg3Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-10000x10-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg3Mg==",
+  "source_calls": 90000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 1.01,
+   "verify": 0.23,
+   "stats": 0.72,
+   "attach": {
+    "202406": 0.57
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90000,
+   "post_dupes": 0
+  },
+  "total_s": 4.36
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg3Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-10000x10-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg3Nw==",
+  "source_calls": 90000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.49,
+   "fill": 0.98,
+   "verify": 0.27,
+   "stats": 0.74,
+   "attach": {
+    "202406": 0.64
+   },
+   "post_check": 0.39
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90000,
+   "post_dupes": 0
+  },
+  "total_s": 5.14
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg3NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-10000x10-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg3NQ==",
+  "source_calls": 90000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 1.03,
+   "verify": 0.28,
+   "stats": 0.72,
+   "attach": {
+    "202406": 0.53
+   },
+   "post_check": 0.38
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90000,
+   "post_dupes": 0
+  },
+  "total_s": 4.59
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg3MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-10000x10-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg3MA==",
+  "source_calls": 90000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.81,
+   "verify": 0.24,
+   "stats": 0.82,
+   "attach": {
+    "202406": 0.57
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90000,
+   "post_dupes": 0
+  },
+  "total_s": 4.3
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg3MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-10000x10-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg3MQ==",
+  "source_calls": 90000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.33,
+   "fill": 0.98,
+   "verify": 0.25,
+   "stats": 0.91,
+   "attach": {
+    "202406": 0.57
+   },
+   "post_check": 0.41
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90000,
+   "post_dupes": 0
+  },
+  "total_s": 4.73
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg3NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-10000x10-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg3NA==",
+  "source_calls": 90000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.8,
+   "verify": 0.28,
+   "stats": 0.71,
+   "attach": {
+    "202406": 0.6
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90000,
+   "post_dupes": 0
+  },
+  "total_s": 4.07
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg3Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-10000x10-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg3Ng==",
+  "source_calls": 90000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.92,
+   "verify": 0.21,
+   "stats": 0.75,
+   "attach": {
+    "202406": 0.69
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90000,
+   "post_dupes": 0
+  },
+  "total_s": 4.36
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg3Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-10000x10-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg3Mw==",
+  "source_calls": 90000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.79,
+   "verify": 0.25,
+   "stats": 0.76,
+   "attach": {
+    "202406": 0.54
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90000,
+   "post_dupes": 0
+  },
+  "total_s": 4.17
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg3OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-10000x10-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg3OA==",
+  "source_calls": 90000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.42,
+   "fill": 0.8,
+   "verify": 0.21,
+   "stats": 1.04,
+   "attach": {
+    "202406": 0.64
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90000,
+   "post_dupes": 0
+  },
+  "total_s": 4.69
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg3OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-10000x10-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg3OQ==",
+  "source_calls": 90000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.92,
+   "verify": 0.2,
+   "stats": 0.73,
+   "attach": {
+    "202406": 0.56
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90000,
+   "post_dupes": 0
+  },
+  "total_s": 4.25
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY0Nw==": {
+  "name": "griffin/scoring-load-run2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY0Nw==",
+  "source_calls": 90000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.9,
+   "verify": 0.24,
+   "stats": 0.75,
+   "attach": {
+    "202606": 0.5
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90000,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90000,
+   "post_dupes": 0
+  },
+  "total_s": 4.21
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzQwNA==": {
+  "name": "launch-team-public-queue/weave-log-benchmark-4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzQwNA==",
+  "source_calls": 90006,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.32,
+   "fill": 2.52,
+   "verify": 0.78,
+   "stats": 1.42,
+   "attach": {
+    "202603": 0.79
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90006,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90006,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90006,
+   "post_dupes": 0
+  },
+  "total_s": 7.54
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjIzNg==": {
+  "name": "jeff/weave-load-test-example-spam-10x10000-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjIzNg==",
+  "source_calls": 90220,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 1.1,
+   "verify": 0.25,
+   "stats": 0.81,
+   "attach": {
+    "202411": 0.54
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 90220,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 90220,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 90220,
+   "post_dupes": 0
+  },
+  "total_s": 4.52
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzc2Mg==": {
+  "name": "wolfram-evals/eval-api-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzc2Mg==",
+  "source_calls": 93682,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 1.32,
+   "verify": 0.77,
+   "stats": 0.75,
+   "attach": {
+    "202604": 0.26
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 16,
+   "past_retention": 0,
+   "expected_rows": 93666,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 93666,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 93666,
+   "post_dupes": 0
+  },
+  "total_s": 5.2
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY0OA==": {
+  "name": "griffin/scoring-load-master1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY0OA==",
+  "source_calls": 96000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 1.06,
+   "verify": 0.24,
+   "stats": 0.93,
+   "attach": {
+    "202606": 0.48
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 96000,
+   "partitions": [
+    "202606"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 96000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 96000,
+   "post_dupes": 0
+  },
+  "total_s": 4.4
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg5OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-011",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg5OA==",
+  "source_calls": 100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 1.27,
+   "fill": 0.79,
+   "verify": 0.27,
+   "stats": 1.01,
+   "attach": {
+    "202406": 0.63
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100000,
+   "post_dupes": 0
+  },
+  "total_s": 5.7
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg4OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-015",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg4OA==",
+  "source_calls": 100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.41,
+   "fill": 0.9,
+   "verify": 0.26,
+   "stats": 0.74,
+   "attach": {
+    "202406": 0.49
+   },
+   "post_check": 0.48
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100000,
+   "post_dupes": 0
+  },
+  "total_s": 4.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg4OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-017",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg4OQ==",
+  "source_calls": 100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 0.83,
+   "verify": 0.24,
+   "stats": 0.92,
+   "attach": {
+    "202406": 0.51
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100000,
+   "post_dupes": 0
+  },
+  "total_s": 4.52
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg5OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg5OQ==",
+  "source_calls": 100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 0.87,
+   "verify": 0.26,
+   "stats": 0.84,
+   "attach": {
+    "202406": 0.88
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100000,
+   "post_dupes": 0
+  },
+  "total_s": 4.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg4NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg4NQ==",
+  "source_calls": 100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 1.27,
+   "verify": 0.25,
+   "stats": 0.94,
+   "attach": {
+    "202406": 0.58
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100000,
+   "post_dupes": 0
+  },
+  "total_s": 4.89
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg4MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg4MA==",
+  "source_calls": 100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.34,
+   "fill": 0.93,
+   "verify": 0.24,
+   "stats": 0.86,
+   "attach": {
+    "202406": 0.51
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100000,
+   "post_dupes": 0
+  },
+  "total_s": 4.55
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg5Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-020",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg5Mg==",
+  "source_calls": 100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 1.24,
+   "verify": 0.23,
+   "stats": 1.0,
+   "attach": {
+    "202406": 0.63
+   },
+   "post_check": 0.37
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100000,
+   "post_dupes": 0
+  },
+  "total_s": 5.13
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg4Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg4Mg==",
+  "source_calls": 100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 1.25,
+   "verify": 0.24,
+   "stats": 0.98,
+   "attach": {
+    "202406": 0.62
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100000,
+   "post_dupes": 0
+  },
+  "total_s": 5.0
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg5MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg5MA==",
+  "source_calls": 100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.81,
+   "verify": 0.23,
+   "stats": 0.81,
+   "attach": {
+    "202406": 0.65
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100000,
+   "post_dupes": 0
+  },
+  "total_s": 4.38
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg5NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg5NQ==",
+  "source_calls": 100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 0.83,
+   "verify": 0.26,
+   "stats": 0.72,
+   "attach": {
+    "202406": 0.53
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100000,
+   "post_dupes": 0
+  },
+  "total_s": 4.07
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg5NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg5NA==",
+  "source_calls": 100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 1.19,
+   "verify": 0.24,
+   "stats": 0.84,
+   "attach": {
+    "202406": 0.56
+   },
+   "post_check": 0.37
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100000,
+   "post_dupes": 0
+  },
+  "total_s": 4.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTg5Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-spam-30000x20-013",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTg5Ng==",
+  "source_calls": 100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 0.97,
+   "verify": 0.27,
+   "stats": 0.8,
+   "attach": {
+    "202406": 0.66
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100000,
+   "post_dupes": 0
+  },
+  "total_s": 4.71
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzgwMQ==": {
+  "name": "griffin/can-we-break-the-workers1-qa",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzgwMQ==",
+  "source_calls": 100021,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 6.11,
+   "verify": 1.74,
+   "stats": 2.54,
+   "attach": {
+    "202604": 0.39
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100021,
+   "partitions": [
+    "202604"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100021,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100021,
+   "post_dupes": 0
+  },
+  "total_s": 13.02
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTYwOA==": {
+  "name": "nickpenaranda/weave-load-data-types",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTYwOA==",
+  "source_calls": 100827,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.3,
+   "fill": 2.91,
+   "verify": 0.25,
+   "stats": 1.2,
+   "attach": {
+    "202406": 1.3
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100827,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 100827,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100827,
+   "post_dupes": 0
+  },
+  "total_s": 7.73
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc5Nw==": {
+  "name": "griffin/alerts",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc5Nw==",
+  "source_calls": 102206,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.29,
+   "fill": 1.1,
+   "verify": 0.28,
+   "stats": 0.88,
+   "attach": {
+    "202509": 0.62
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 102206,
+   "partitions": [
+    "202509"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 102206,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 102206,
+   "post_dupes": 0
+  },
+  "total_s": 5.02
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU5Mg==": {
+  "name": "nickpenaranda/weave-load-test-locust-4",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU5Mg==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.7,
+   "fill": 0.94,
+   "verify": 0.23,
+   "stats": 0.83,
+   "attach": {
+    "202406": 0.56
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 6.28
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY3NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY3NA==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.25,
+   "fill": 3.65,
+   "verify": 0.52,
+   "stats": 1.43,
+   "attach": {
+    "202406": 0.49
+   },
+   "post_check": 0.39
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 8.23
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU5Nw==": {
+  "name": "nickpenaranda/weave-load-test-locust-8",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU5Nw==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.61,
+   "fill": 1.16,
+   "verify": 0.26,
+   "stats": 1.13,
+   "attach": {
+    "202406": 0.54
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 5.61
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY3Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY3Ng==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.58,
+   "fill": 4.61,
+   "verify": 0.57,
+   "stats": 0.86,
+   "attach": {
+    "202406": 0.44
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 9.12
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU5NQ==": {
+  "name": "nickpenaranda/weave-load-test-locust-6",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU5NQ==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.5,
+   "fill": 1.11,
+   "verify": 0.29,
+   "stats": 0.86,
+   "attach": {
+    "202406": 0.51
+   },
+   "post_check": 0.4
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 5.18
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU5MA==": {
+  "name": "nickpenaranda/weave-load-test-locust-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU5MA==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.61,
+   "fill": 0.92,
+   "verify": 0.29,
+   "stats": 0.89,
+   "attach": {
+    "202406": 0.55
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 5.27
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY3Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY3Mw==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 3.13,
+   "verify": 0.23,
+   "stats": 0.81,
+   "attach": {
+    "202406": 0.46
+   },
+   "post_check": 0.39
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 6.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU5MQ==": {
+  "name": "nickpenaranda/weave-load-test-locust-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU5MQ==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 1.17,
+   "verify": 0.31,
+   "stats": 0.86,
+   "attach": {
+    "202406": 0.54
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 5.02
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY3Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY3Nw==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.33,
+   "fill": 4.35,
+   "verify": 2.42,
+   "stats": 1.87,
+   "attach": {
+    "202406": 0.9
+   },
+   "post_check": 1.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 12.42
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY3NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY3NQ==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 3.12,
+   "verify": 0.53,
+   "stats": 1.39,
+   "attach": {
+    "202406": 0.56
+   },
+   "post_check": 0.66
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 8.15
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU5Ng==": {
+  "name": "nickpenaranda/weave-load-test-locust-7",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU5Ng==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.3,
+   "fill": 0.95,
+   "verify": 0.31,
+   "stats": 0.89,
+   "attach": {
+    "202406": 0.57
+   },
+   "post_check": 0.5
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 5.14
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU5Mw==": {
+  "name": "nickpenaranda/weave-load-test-locust-5",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU5Mw==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.29,
+   "fill": 1.02,
+   "verify": 0.33,
+   "stats": 1.09,
+   "attach": {
+    "202406": 1.31
+   },
+   "post_check": 0.43
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 6.23
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU5OA==": {
+  "name": "nickpenaranda/weave-load-test-locust-9",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU5OA==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 0.91,
+   "verify": 0.3,
+   "stats": 1.04,
+   "attach": {
+    "202406": 0.57
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 4.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY4MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY4MQ==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.41,
+   "fill": 4.44,
+   "verify": 0.2,
+   "stats": 1.08,
+   "attach": {
+    "202406": 0.47
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 8.12
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU4OA==": {
+  "name": "nickpenaranda/weave-load-test-locust",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU4OA==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 1.19,
+   "verify": 0.27,
+   "stats": 0.87,
+   "attach": {
+    "202405": 0.46
+   },
+   "post_check": 0.3
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202405"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 4.49
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY3OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY3OQ==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 3.18,
+   "verify": 0.45,
+   "stats": 1.59,
+   "attach": {
+    "202406": 0.46
+   },
+   "post_check": 0.44
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 7.64
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY3OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY3OA==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 4.57,
+   "verify": 0.4,
+   "stats": 0.91,
+   "attach": {
+    "202406": 0.52
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 8.27
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY4MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY4MA==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.32,
+   "fill": 4.61,
+   "verify": 0.41,
+   "stats": 0.91,
+   "attach": {
+    "202406": 0.42
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 8.46
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY4Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY4Mg==",
+  "source_calls": 110000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 2.99,
+   "verify": 0.58,
+   "stats": 1.25,
+   "attach": {
+    "202406": 0.44
+   },
+   "post_check": 0.29
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 110000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 110000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 110000,
+   "post_dupes": 0
+  },
+  "total_s": 7.41
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTk4MA==": {
+  "name": "griffin/trace",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTk4MA==",
+  "source_calls": 132561,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 1.18,
+   "verify": 0.24,
+   "stats": 0.86,
+   "attach": {
+    "202408": 0.42,
+    "202503": 0.52
+   },
+   "post_check": 0.25
+  },
+  "gates": {
+   "orphan_ends": 1,
+   "past_retention": 0,
+   "expected_rows": 132560,
+   "partitions": [
+    "202408",
+    "202503"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 132560,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 132560,
+   "post_dupes": 0
+  },
+  "total_s": 5.14
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzQwNQ==": {
+  "name": "launch-team-public-queue/weave-log-benchmark-img-controlled",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzQwNQ==",
+  "source_calls": 133367,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 3.75,
+   "verify": 0.51,
+   "stats": 0.92,
+   "attach": {
+    "202603": 0.29
+   },
+   "post_check": 0.49
+  },
+  "gates": {
+   "orphan_ends": 5,
+   "past_retention": 0,
+   "expected_rows": 133362,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 133362,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 133362,
+   "post_dupes": 0
+  },
+  "total_s": 7.72
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njk1Mw==": {
+  "name": "griffin/prod-otel-1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njk1Mw==",
+  "source_calls": 149097,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 4.14,
+   "verify": 0.24,
+   "stats": 1.29,
+   "attach": {
+    "202510": 0.37
+   },
+   "post_check": 0.46
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 149097,
+   "partitions": [
+    "202510"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 149097,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 149097,
+   "post_dupes": 0
+  },
+  "total_s": 8.25
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjIyNw==": {
+  "name": "jeff/weave-load-test-example-spam-10x10000-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjIyNw==",
+  "source_calls": 160140,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 1.73,
+   "verify": 0.25,
+   "stats": 0.98,
+   "attach": {
+    "202411": 0.56
+   },
+   "post_check": 0.47
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 160140,
+   "partitions": [
+    "202411"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 160140,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 160140,
+   "post_dupes": 0
+  },
+  "total_s": 5.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjkzMQ==": {
+  "name": "griffin/100_000",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjkzMQ==",
+  "source_calls": 172991,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 1.73,
+   "verify": 0.54,
+   "stats": 1.13,
+   "attach": {
+    "202503": 0.29
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 172991,
+   "partitions": [
+    "202503"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 172991,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 172991,
+   "post_dupes": 0
+  },
+  "total_s": 5.61
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc4OA==": {
+  "name": "griffin/swe-polybench-evaluation-parallel",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc4OA==",
+  "source_calls": 205439,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.5,
+   "fill": 3.65,
+   "verify": 0.27,
+   "stats": 1.74,
+   "attach": {
+    "202508": 0.46,
+    "202509": 1.17
+   },
+   "post_check": 0.46
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 205439,
+   "partitions": [
+    "202508",
+    "202509"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 205439,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 205439,
+   "post_dupes": 0
+  },
+  "total_s": 9.86
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODA0OQ==": {
+  "name": "griffin/otel-idempotent-bench",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODA0OQ==",
+  "source_calls": 206719,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 1.89,
+   "verify": 0.54,
+   "stats": 1.41,
+   "attach": {
+    "202605": 0.31
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 206719,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 206719,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 206719,
+   "post_dupes": 0
+  },
+  "total_s": 6.64
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY1NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-batch-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY1NQ==",
+  "source_calls": 209698,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.52,
+   "fill": 1.48,
+   "verify": 0.32,
+   "stats": 1.25,
+   "attach": {
+    "202406": 0.79
+   },
+   "post_check": 0.5
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 209698,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 209698,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 209698,
+   "post_dupes": 0
+  },
+  "total_s": 6.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY1OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-batch-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY1OQ==",
+  "source_calls": 210323,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.36,
+   "fill": 1.27,
+   "verify": 0.33,
+   "stats": 1.2,
+   "attach": {
+    "202406": 0.68
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 210323,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 210323,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 210323,
+   "post_dupes": 0
+  },
+  "total_s": 5.6
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc5Mw==": {
+  "name": "griffin/bigbatch",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc5Mw==",
+  "source_calls": 210483,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.38,
+   "fill": 4.09,
+   "verify": 0.22,
+   "stats": 1.49,
+   "attach": {
+    "202509": 0.46
+   },
+   "post_check": 0.47
+  },
+  "gates": {
+   "orphan_ends": 5,
+   "past_retention": 0,
+   "expected_rows": 210478,
+   "partitions": [
+    "202509"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 210478,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 210478,
+   "post_dupes": 0
+  },
+  "total_s": 8.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY1Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-batch-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY1Mg==",
+  "source_calls": 214479,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 1.73,
+   "verify": 0.32,
+   "stats": 1.5,
+   "attach": {
+    "202406": 0.65
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 214479,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 214479,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 214479,
+   "post_dupes": 0
+  },
+  "total_s": 6.23
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY1Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-batch-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY1Ng==",
+  "source_calls": 220322,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.65,
+   "fill": 1.54,
+   "verify": 0.23,
+   "stats": 1.25,
+   "attach": {
+    "202406": 0.9
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 220322,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 220322,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 220322,
+   "post_dupes": 0
+  },
+  "total_s": 6.29
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY1Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-batch-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY1Mw==",
+  "source_calls": 224479,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 1.61,
+   "verify": 0.34,
+   "stats": 1.33,
+   "attach": {
+    "202406": 0.65
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 224479,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 224479,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 224479,
+   "post_dupes": 0
+  },
+  "total_s": 5.8
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY1Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-batch-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY1Nw==",
+  "source_calls": 226168,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 2.0,
+   "verify": 0.24,
+   "stats": 1.49,
+   "attach": {
+    "202406": 0.72
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 226168,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 226168,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 226168,
+   "post_dupes": 0
+  },
+  "total_s": 6.36
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY1NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-batch-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY1NA==",
+  "source_calls": 237334,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 1.4,
+   "verify": 0.22,
+   "stats": 1.28,
+   "attach": {
+    "202406": 0.73
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 237334,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 237334,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 237334,
+   "post_dupes": 0
+  },
+  "total_s": 5.81
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY1OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-batch-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY1OA==",
+  "source_calls": 242789,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.39,
+   "fill": 1.38,
+   "verify": 0.34,
+   "stats": 1.36,
+   "attach": {
+    "202406": 0.89
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 242789,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 242789,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 242789,
+   "post_dupes": 0
+  },
+  "total_s": 6.18
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY0NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY0NQ==",
+  "source_calls": 251930,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 1.66,
+   "verify": 0.36,
+   "stats": 1.69,
+   "attach": {
+    "202406": 0.81
+   },
+   "post_check": 0.45
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 251930,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 251930,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 251930,
+   "post_dupes": 0
+  },
+  "total_s": 6.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY1MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-batch-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY1MQ==",
+  "source_calls": 257853,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.59,
+   "fill": 1.55,
+   "verify": 0.37,
+   "stats": 1.33,
+   "attach": {
+    "202406": 1.32
+   },
+   "post_check": 1.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 257853,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 257853,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 257853,
+   "post_dupes": 0
+  },
+  "total_s": 7.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY1MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-batch-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY1MA==",
+  "source_calls": 269040,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 1.76,
+   "verify": 0.35,
+   "stats": 1.37,
+   "attach": {
+    "202406": 0.8
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 269040,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 269040,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 269040,
+   "post_dupes": 0
+  },
+  "total_s": 6.33
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY5OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite3-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY5OQ==",
+  "source_calls": 276274,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.52,
+   "fill": 1.5,
+   "verify": 0.22,
+   "stats": 1.54,
+   "attach": {
+    "202406": 0.71
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 276274,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 276274,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 276274,
+   "post_dupes": 0
+  },
+  "total_s": 6.12
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY5Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite3-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY5Mw==",
+  "source_calls": 298267,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.8,
+   "fill": 2.32,
+   "verify": 0.54,
+   "stats": 1.62,
+   "attach": {
+    "202406": 0.29
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 298267,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 298267,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 298267,
+   "post_dupes": 0
+  },
+  "total_s": 7.42
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzk1OQ==": {
+  "name": "griffin/ob-offset-cost-v1-20260504",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzk1OQ==",
+  "source_calls": 300000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 2.12,
+   "verify": 0.28,
+   "stats": 1.67,
+   "attach": {
+    "202605": 0.29
+   },
+   "post_check": 0.47
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 300000,
+   "partitions": [
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 300000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 300000,
+   "post_dupes": 0
+  },
+  "total_s": 6.6
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjgwNw==": {
+  "name": "griffin/ob",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjgwNw==",
+  "source_calls": 310400,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 2.05,
+   "verify": 0.26,
+   "stats": 2.88,
+   "attach": {
+    "202509": 0.44,
+    "202511": 0.48,
+    "202605": 0.31
+   },
+   "post_check": 0.28
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 310400,
+   "partitions": [
+    "202509",
+    "202511",
+    "202605"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 310400,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 310400,
+   "post_dupes": 0
+  },
+  "total_s": 8.4
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjkyMw==": {
+  "name": "griffin/10_000",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjkyMw==",
+  "source_calls": 328236,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 2.74,
+   "verify": 0.27,
+   "stats": 1.75,
+   "attach": {
+    "202503": 0.3
+   },
+   "post_check": 0.33
+  },
+  "gates": {
+   "orphan_ends": 2,
+   "past_retention": 0,
+   "expected_rows": 328234,
+   "partitions": [
+    "202503"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 328234,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 328234,
+   "post_dupes": 0
+  },
+  "total_s": 7.25
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcwMA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite3-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcwMA==",
+  "source_calls": 338184,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.61,
+   "fill": 2.5,
+   "verify": 0.58,
+   "stats": 1.9,
+   "attach": {
+    "202406": 0.29
+   },
+   "post_check": 0.31
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 338184,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 338184,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 338184,
+   "post_dupes": 0
+  },
+  "total_s": 8.29
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgyOA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-700x10-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgyOA==",
+  "source_calls": 350000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.77,
+   "fill": 9.92,
+   "verify": 0.27,
+   "stats": 2.6,
+   "attach": {
+    "202406": 0.54
+   },
+   "post_check": 0.51
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 350000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 350000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 350000,
+   "post_dupes": 0
+  },
+  "total_s": 16.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgyOQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-700x10-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgyOQ==",
+  "source_calls": 350000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 9.42,
+   "verify": 0.25,
+   "stats": 2.85,
+   "attach": {
+    "202406": 0.57
+   },
+   "post_check": 0.56
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 350000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 350000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 350000,
+   "post_dupes": 0
+  },
+  "total_s": 15.34
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgzMQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-700x10-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgzMQ==",
+  "source_calls": 350000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.29,
+   "fill": 10.9,
+   "verify": 0.24,
+   "stats": 3.18,
+   "attach": {
+    "202406": 0.47
+   },
+   "post_check": 0.54
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 350000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 350000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 350000,
+   "post_dupes": 0
+  },
+  "total_s": 20.24
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgzNA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-700x10-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgzNA==",
+  "source_calls": 350000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 9.04,
+   "verify": 0.28,
+   "stats": 2.86,
+   "attach": {
+    "202406": 0.74
+   },
+   "post_check": 0.47
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 350000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 350000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 350000,
+   "post_dupes": 0
+  },
+  "total_s": 15.76
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgzNg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-700x10-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgzNg==",
+  "source_calls": 350000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.5,
+   "fill": 11.94,
+   "verify": 0.29,
+   "stats": 2.31,
+   "attach": {
+    "202406": 0.53
+   },
+   "post_check": 0.51
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 350000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 350000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 350000,
+   "post_dupes": 0
+  },
+  "total_s": 17.56
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgzMw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-700x10-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgzMw==",
+  "source_calls": 350000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.48,
+   "fill": 8.62,
+   "verify": 0.26,
+   "stats": 2.67,
+   "attach": {
+    "202406": 0.52
+   },
+   "post_check": 0.45
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 350000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 350000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 350000,
+   "post_dupes": 0
+  },
+  "total_s": 15.03
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgzMg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-700x10-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgzMg==",
+  "source_calls": 350000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.45,
+   "fill": 13.83,
+   "verify": 0.54,
+   "stats": 2.19,
+   "attach": {
+    "202406": 0.39
+   },
+   "post_check": 0.69
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 350000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 350000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 350000,
+   "post_dupes": 0
+  },
+  "total_s": 19.74
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgzNw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-700x10-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgzNw==",
+  "source_calls": 350000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.57,
+   "fill": 15.7,
+   "verify": 0.32,
+   "stats": 2.62,
+   "attach": {
+    "202406": 0.6
+   },
+   "post_check": 0.3
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 350000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 350000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 350000,
+   "post_dupes": 0
+  },
+  "total_s": 21.95
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgzNQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-700x10-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgzNQ==",
+  "source_calls": 350000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.56,
+   "fill": 8.96,
+   "verify": 0.57,
+   "stats": 2.04,
+   "attach": {
+    "202406": 0.54
+   },
+   "post_check": 0.49
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 350000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 350000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 350000,
+   "post_dupes": 0
+  },
+  "total_s": 15.57
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTgzMA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-heavy2-700x10-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTgzMA==",
+  "source_calls": 350000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.31,
+   "fill": 9.06,
+   "verify": 0.55,
+   "stats": 2.79,
+   "attach": {
+    "202406": 0.59
+   },
+   "post_check": 0.6
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 350000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 350000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 350000,
+   "post_dupes": 0
+  },
+  "total_s": 15.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTYyMg==": {
+  "name": "nickpenaranda/weave-load-test-spam-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTYyMg==",
+  "source_calls": 400000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.57,
+   "fill": 2.81,
+   "verify": 0.48,
+   "stats": 2.17,
+   "attach": {
+    "202406": 0.42
+   },
+   "post_check": 0.75
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 400000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 400000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 400000,
+   "post_dupes": 0
+  },
+  "total_s": 8.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY5Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite3-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY5Nw==",
+  "source_calls": 430271,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.96,
+   "fill": 2.11,
+   "verify": 0.28,
+   "stats": 1.99,
+   "attach": {
+    "202406": 0.27
+   },
+   "post_check": 0.4
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 430271,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 430271,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 430271,
+   "post_dupes": 0
+  },
+  "total_s": 7.56
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY4NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite2-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY4NA==",
+  "source_calls": 431409,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.31,
+   "fill": 2.24,
+   "verify": 0.3,
+   "stats": 2.83,
+   "attach": {
+    "202406": 0.33
+   },
+   "post_check": 0.3
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 431409,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 431409,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 431409,
+   "post_dupes": 0
+  },
+  "total_s": 8.31
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY4OQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite2-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY4OQ==",
+  "source_calls": 433569,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.61,
+   "fill": 2.34,
+   "verify": 0.65,
+   "stats": 1.97,
+   "attach": {
+    "202406": 0.3
+   },
+   "post_check": 0.56
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 433569,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 433569,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 433569,
+   "post_dupes": 0
+  },
+  "total_s": 8.12
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY5NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite3-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY5NQ==",
+  "source_calls": 450355,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.84,
+   "fill": 3.38,
+   "verify": 0.27,
+   "stats": 2.19,
+   "attach": {
+    "202406": 0.33
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 450355,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 450355,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 450355,
+   "post_dupes": 0
+  },
+  "total_s": 8.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcwMQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite3-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcwMQ==",
+  "source_calls": 484327,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.3,
+   "fill": 3.06,
+   "verify": 0.22,
+   "stats": 2.15,
+   "attach": {
+    "202406": 0.33
+   },
+   "post_check": 0.52
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 484327,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 484327,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 484327,
+   "post_dupes": 0
+  },
+  "total_s": 8.53
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY4OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite2-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY4OA==",
+  "source_calls": 541137,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 2.74,
+   "verify": 0.75,
+   "stats": 2.37,
+   "attach": {
+    "202406": 0.31
+   },
+   "post_check": 0.26
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 541137,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 541137,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 541137,
+   "post_dupes": 0
+  },
+  "total_s": 8.54
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY5MQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite2-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY5MQ==",
+  "source_calls": 543147,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.54,
+   "fill": 2.82,
+   "verify": 0.26,
+   "stats": 2.4,
+   "attach": {
+    "202406": 0.34
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 543147,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 543147,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 543147,
+   "post_dupes": 0
+  },
+  "total_s": 8.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY5Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite3-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY5Ng==",
+  "source_calls": 544692,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.54,
+   "fill": 3.45,
+   "verify": 0.58,
+   "stats": 3.23,
+   "attach": {
+    "202406": 0.25
+   },
+   "post_check": 0.46
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 544692,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 544692,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 544692,
+   "post_dupes": 0
+  },
+  "total_s": 10.07
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY5OA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite3-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY5OA==",
+  "source_calls": 546052,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.56,
+   "fill": 3.6,
+   "verify": 0.56,
+   "stats": 2.48,
+   "attach": {
+    "202406": 0.29
+   },
+   "post_check": 0.39
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 546052,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 546052,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 546052,
+   "post_dupes": 0
+  },
+  "total_s": 9.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcwMg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite3-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcwMg==",
+  "source_calls": 577641,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.34,
+   "fill": 3.07,
+   "verify": 2.96,
+   "stats": 4.3,
+   "attach": {
+    "202406": 0.35
+   },
+   "post_check": 0.64
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 577641,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 577641,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 577641,
+   "post_dupes": 0
+  },
+  "total_s": 13.24
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY4NQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite2-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY4NQ==",
+  "source_calls": 630888,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.34,
+   "fill": 3.37,
+   "verify": 0.62,
+   "stats": 2.94,
+   "attach": {
+    "202406": 0.54
+   },
+   "post_check": 0.49
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 630888,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 630888,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 630888,
+   "post_dupes": 0
+  },
+  "total_s": 10.33
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY4Mw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite2-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY4Mw==",
+  "source_calls": 631390,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.53,
+   "fill": 2.97,
+   "verify": 0.31,
+   "stats": 3.92,
+   "attach": {
+    "202406": 0.53
+   },
+   "post_check": 0.52
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 631390,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 631390,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 631390,
+   "post_dupes": 0
+  },
+  "total_s": 10.7
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc1Mg==": {
+  "name": "timssweeney/evaluate_model_worker_load_10_100_5",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc1Mg==",
+  "source_calls": 656682,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.39,
+   "fill": 4.64,
+   "verify": 0.7,
+   "stats": 4.21,
+   "attach": {
+    "202508": 0.28
+   },
+   "post_check": 0.45
+  },
+  "gates": {
+   "orphan_ends": 22714,
+   "past_retention": 0,
+   "expected_rows": 633968,
+   "partitions": [
+    "202508"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 633968,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 633968,
+   "post_dupes": 0
+  },
+  "total_s": 12.27
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTkxNw==": {
+  "name": "nickpenaranda/weave-load-test-example-spam-10x10000-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTkxNw==",
+  "source_calls": 670000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.52,
+   "fill": 3.05,
+   "verify": 0.26,
+   "stats": 2.74,
+   "attach": {
+    "202407": 0.61
+   },
+   "post_check": 0.46
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 670000,
+   "partitions": [
+    "202407"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 670000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 670000,
+   "post_dupes": 0
+  },
+  "total_s": 9.61
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTkxNg==": {
+  "name": "nickpenaranda/weave-load-test-example-spam-10x10000-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTkxNg==",
+  "source_calls": 680000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.47,
+   "fill": 2.62,
+   "verify": 0.32,
+   "stats": 2.92,
+   "attach": {
+    "202407": 0.63
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 680000,
+   "partitions": [
+    "202407"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 680000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 680000,
+   "post_dupes": 0
+  },
+  "total_s": 9.29
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTkyNA==": {
+  "name": "nickpenaranda/weave-load-test-example-spam-10x10000-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTkyNA==",
+  "source_calls": 680000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.59,
+   "fill": 3.05,
+   "verify": 0.96,
+   "stats": 3.89,
+   "attach": {
+    "202407": 0.74
+   },
+   "post_check": 0.27
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 680000,
+   "partitions": [
+    "202407"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 680000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 680000,
+   "post_dupes": 0
+  },
+  "total_s": 11.06
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTkyMQ==": {
+  "name": "nickpenaranda/weave-load-test-example-spam-10x10000-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTkyMQ==",
+  "source_calls": 680000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.66,
+   "fill": 2.74,
+   "verify": 0.3,
+   "stats": 2.9,
+   "attach": {
+    "202407": 0.59
+   },
+   "post_check": 0.39
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 680000,
+   "partitions": [
+    "202407"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 680000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 680000,
+   "post_dupes": 0
+  },
+  "total_s": 9.17
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTkyMw==": {
+  "name": "nickpenaranda/weave-load-test-example-spam-10x10000-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTkyMw==",
+  "source_calls": 680000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.67,
+   "fill": 4.09,
+   "verify": 0.56,
+   "stats": 3.35,
+   "attach": {
+    "202407": 0.59
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 680000,
+   "partitions": [
+    "202407"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 680000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 680000,
+   "post_dupes": 0
+  },
+  "total_s": 11.26
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTkyMg==": {
+  "name": "nickpenaranda/weave-load-test-example-spam-10x10000-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTkyMg==",
+  "source_calls": 680000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.55,
+   "fill": 4.31,
+   "verify": 0.28,
+   "stats": 3.59,
+   "attach": {
+    "202407": 0.63
+   },
+   "post_check": 0.76
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 680000,
+   "partitions": [
+    "202407"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 680000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 680000,
+   "post_dupes": 0
+  },
+  "total_s": 12.48
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTkyMA==": {
+  "name": "nickpenaranda/weave-load-test-example-spam-10x10000-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTkyMA==",
+  "source_calls": 680000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.72,
+   "fill": 2.98,
+   "verify": 0.26,
+   "stats": 4.2,
+   "attach": {
+    "202407": 0.69
+   },
+   "post_check": 0.42
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 680000,
+   "partitions": [
+    "202407"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 680000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 680000,
+   "post_dupes": 0
+  },
+  "total_s": 11.18
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTkyNQ==": {
+  "name": "nickpenaranda/weave-load-test-example-spam-10x10000-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTkyNQ==",
+  "source_calls": 680000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.53,
+   "fill": 2.57,
+   "verify": 0.53,
+   "stats": 3.71,
+   "attach": {
+    "202407": 0.57
+   },
+   "post_check": 0.36
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 680000,
+   "partitions": [
+    "202407"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 680000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 680000,
+   "post_dupes": 0
+  },
+  "total_s": 9.92
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTkxOQ==": {
+  "name": "nickpenaranda/weave-load-test-example-spam-10x10000-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTkxOQ==",
+  "source_calls": 680000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.62,
+   "fill": 3.11,
+   "verify": 0.61,
+   "stats": 3.16,
+   "attach": {
+    "202407": 0.56
+   },
+   "post_check": 0.44
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 680000,
+   "partitions": [
+    "202407"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 680000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 680000,
+   "post_dupes": 0
+  },
+  "total_s": 10.07
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTkxOA==": {
+  "name": "nickpenaranda/weave-load-test-example-spam-10x10000-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTkxOA==",
+  "source_calls": 680000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.64,
+   "fill": 3.13,
+   "verify": 0.26,
+   "stats": 3.68,
+   "attach": {
+    "202407": 0.66
+   },
+   "post_check": 0.45
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 680000,
+   "partitions": [
+    "202407"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 680000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 680000,
+   "post_dupes": 0
+  },
+  "total_s": 10.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY5Mg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite2-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY5Mg==",
+  "source_calls": 700494,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.59,
+   "fill": 3.88,
+   "verify": 0.29,
+   "stats": 3.65,
+   "attach": {
+    "202406": 0.68
+   },
+   "post_check": 0.66
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 700494,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 700494,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 700494,
+   "post_dupes": 0
+  },
+  "total_s": 11.97
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzQwOQ==": {
+  "name": "launch-team-public-queue/weave-log-benchmark-img-controlled-0",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzQwOQ==",
+  "source_calls": 716316,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.68,
+   "fill": 32.26,
+   "verify": 0.59,
+   "stats": 5.8,
+   "attach": {
+    "202603": 1.02
+   },
+   "post_check": 0.39
+  },
+  "gates": {
+   "orphan_ends": 3,
+   "past_retention": 0,
+   "expected_rows": 716313,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 716313,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 716313,
+   "post_dupes": 0
+  },
+  "total_s": 42.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY4Ng==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite2-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY4Ng==",
+  "source_calls": 739836,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.38,
+   "fill": 3.47,
+   "verify": 0.35,
+   "stats": 3.1,
+   "attach": {
+    "202406": 0.76
+   },
+   "post_check": 0.65
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 739836,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 739836,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 739836,
+   "post_dupes": 0
+  },
+  "total_s": 10.79
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY5MA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite2-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY5MA==",
+  "source_calls": 750899,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.66,
+   "fill": 2.81,
+   "verify": 0.55,
+   "stats": 4.05,
+   "attach": {
+    "202406": 0.75
+   },
+   "post_check": 0.5
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 750899,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 750899,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 750899,
+   "post_dupes": 0
+  },
+  "total_s": 11.11
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY4Nw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite2-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY4Nw==",
+  "source_calls": 842679,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.56,
+   "fill": 2.73,
+   "verify": 0.33,
+   "stats": 3.13,
+   "attach": {
+    "202406": 1.08
+   },
+   "post_check": 0.48
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 842679,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 842679,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 842679,
+   "post_dupes": 0
+  },
+  "total_s": 9.94
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTY5NA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite3-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTY5NA==",
+  "source_calls": 862031,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.34,
+   "fill": 3.01,
+   "verify": 0.59,
+   "stats": 3.11,
+   "attach": {
+    "202406": 0.98
+   },
+   "post_check": 0.65
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 862031,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 862031,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 862031,
+   "post_dupes": 0
+  },
+  "total_s": 11.03
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzIxNg==": {
+  "name": "griffin/ccmplt-replacing-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzIxNg==",
+  "source_calls": 929570,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.47,
+   "fill": 103.4,
+   "verify": 0.61,
+   "stats": 16.96,
+   "attach": {
+    "202602": 0.48
+   },
+   "post_check": 0.62
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 929570,
+   "partitions": [
+    "202602"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 929570,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 929570,
+   "post_dupes": 0
+  },
+  "total_s": 125.02
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzQwMQ==": {
+  "name": "launch-team-public-queue/weave-log-benchmark-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzQwMQ==",
+  "source_calls": 936915,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.66,
+   "fill": 32.18,
+   "verify": 0.43,
+   "stats": 6.37,
+   "attach": {
+    "202603": 1.17
+   },
+   "post_check": 0.61
+  },
+  "gates": {
+   "orphan_ends": 185,
+   "past_retention": 0,
+   "expected_rows": 936730,
+   "partitions": [
+    "202603"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 936730,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 936730,
+   "post_dupes": 0
+  },
+  "total_s": 43.34
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcxMg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-001",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcxMg==",
+  "source_calls": 1000000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.69,
+   "fill": 3.36,
+   "verify": 0.52,
+   "stats": 3.23,
+   "attach": {
+    "202406": 0.3
+   },
+   "post_check": 0.44
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000000,
+   "post_dupes": 0
+  },
+  "total_s": 10.55
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcwNg==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-009",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcwNg==",
+  "source_calls": 1000000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.98,
+   "fill": 4.55,
+   "verify": 0.3,
+   "stats": 3.91,
+   "attach": {
+    "202406": 0.4
+   },
+   "post_check": 0.46
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000000,
+   "post_dupes": 0
+  },
+  "total_s": 12.61
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcwMw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-002",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcwMw==",
+  "source_calls": 1000000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.78,
+   "fill": 4.37,
+   "verify": 0.63,
+   "stats": 4.0,
+   "attach": {
+    "202406": 0.33
+   },
+   "post_check": 0.46
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000000,
+   "post_dupes": 0
+  },
+  "total_s": 12.39
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcxMA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-007",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcxMA==",
+  "source_calls": 1000000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.34,
+   "fill": 4.19,
+   "verify": 0.77,
+   "stats": 3.86,
+   "attach": {
+    "202406": 0.28
+   },
+   "post_check": 0.5
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000000,
+   "post_dupes": 0
+  },
+  "total_s": 11.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcwNA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-005",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcwNA==",
+  "source_calls": 1000000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.76,
+   "fill": 4.21,
+   "verify": 0.82,
+   "stats": 4.18,
+   "attach": {
+    "202406": 0.38
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000000,
+   "post_dupes": 0
+  },
+  "total_s": 12.5
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcxMQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-003",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcxMQ==",
+  "source_calls": 1000000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.54,
+   "fill": 5.17,
+   "verify": 0.58,
+   "stats": 3.46,
+   "attach": {
+    "202406": 0.25
+   },
+   "post_check": 0.58
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000000,
+   "post_dupes": 0
+  },
+  "total_s": 12.52
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcwNQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-006",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcwNQ==",
+  "source_calls": 1000000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.64,
+   "fill": 4.62,
+   "verify": 2.65,
+   "stats": 3.04,
+   "attach": {
+    "202406": 0.35
+   },
+   "post_check": 0.58
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000000,
+   "post_dupes": 0
+  },
+  "total_s": 14.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcwNw==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-010",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcwNw==",
+  "source_calls": 1000000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.83,
+   "fill": 3.0,
+   "verify": 0.31,
+   "stats": 3.38,
+   "attach": {
+    "202406": 0.34
+   },
+   "post_check": 0.55
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000000,
+   "post_dupes": 0
+  },
+  "total_s": 10.6
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcwOQ==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-004",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcwOQ==",
+  "source_calls": 1000000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.35,
+   "fill": 2.92,
+   "verify": 0.68,
+   "stats": 3.8,
+   "attach": {
+    "202406": 0.28
+   },
+   "post_check": 0.53
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000000,
+   "post_dupes": 0
+  },
+  "total_s": 10.46
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTcwOA==": {
+  "name": "nickpenaranda/weave-load-test-parallel-lite4-008",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTcwOA==",
+  "source_calls": 1000000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.78,
+   "fill": 4.77,
+   "verify": 0.61,
+   "stats": 3.44,
+   "attach": {
+    "202406": 0.31
+   },
+   "post_check": 0.61
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1000000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1000000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1000000,
+   "post_dupes": 0
+  },
+  "total_s": 12.54
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTYyOA==": {
+  "name": "nickpenaranda/weave-load-test-spam-3",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTYyOA==",
+  "source_calls": 1100000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.74,
+   "fill": 2.88,
+   "verify": 1.14,
+   "stats": 3.31,
+   "attach": {
+    "202406": 0.32
+   },
+   "post_check": 0.42
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1100000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 1100000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1100000,
+   "post_dupes": 0
+  },
+  "total_s": 11.11
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTYyMQ==": {
+  "name": "nickpenaranda/weave-load-test-spam",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTYyMQ==",
+  "source_calls": 2000000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.73,
+   "fill": 5.12,
+   "verify": 0.35,
+   "stats": 6.07,
+   "attach": {
+    "202406": 0.96
+   },
+   "post_check": 0.48
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2000000,
+   "partitions": [
+    "202406"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2000000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2000000,
+   "post_dupes": 0
+  },
+  "total_s": 15.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjY3MA==": {
+  "name": "griffin/1_000_000",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjY3MA==",
+  "source_calls": 2004006,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.64,
+   "fill": 8.72,
+   "verify": 0.68,
+   "stats": 5.76,
+   "attach": {
+    "202501": 0.38
+   },
+   "post_check": 0.47
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2004006,
+   "partitions": [
+    "202501"
+   ],
+   "fill_buckets": 1,
+   "staging_rows": 2004006,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2004006,
+   "post_dupes": 0
+  },
+  "total_s": 19.34
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc5OQ==": {
+  "name": "griffin/test-multi",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc5OQ==",
+  "source_calls": 4270824,
+  "status": "migrated",
+  "timings": {
+   "chunk_plan": 3.21,
+   "plan": 4.25,
+   "fill": 1654.68,
+   "verify": 17.29,
+   "stats": 91.93,
+   "attach": {
+    "202509": 4.12,
+    "202510": 0.62,
+    "202511": 0.46
+   },
+   "post_check": 5.21
+  },
+  "gates": {
+   "chunks": 9,
+   "orphan_ends": 5,
+   "past_retention": 0,
+   "expected_rows": 4270819,
+   "partitions": [
+    "202509",
+    "202510",
+    "202511"
+   ],
+   "staging_rows": 4270819,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4270819,
+   "post_dupes": 0
+  },
+  "total_s": 1784.29
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MTU3Nw==": {
+  "name": "nickpenaranda/weave-load-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MTU3Nw==",
+  "source_calls": 32579183,
+  "status": "migrated",
+  "timings": {
+   "chunk_plan": 1.12,
+   "plan": 28.83,
+   "fill": 221.96,
+   "verify": 110.16,
+   "stats": 279.06,
+   "attach": {
+    "202405": 0.91
+   },
+   "post_check": 47.12
+  },
+  "gates": {
+   "chunks": 86,
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 32579183,
+   "partitions": [
+    "202405"
+   ],
+   "staging_rows": 32579183,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 32579183,
+   "post_dupes": 0
+  },
+  "total_s": 690.17
+ }
+}

--- a/scripts/backfill_runs/qa_all_2026-07-08.md
+++ b/scripts/backfill_runs/qa_all_2026-07-08.md
@@ -1,0 +1,51 @@
+# Full QA port: calls_merged -> calls_complete (all non-weave-team candidates)
+
+Run dates: 2026-07-07/08. Driver process from PR #7535, sequential smallest-first,
+per-project gates (plan / fill / verify / stats / attach / post-check).
+
+## Outcome
+
+| metric | value |
+|---|---|
+| projects migrated | 760/760 |
+| calls migrated | 93,184,232 |
+| failed / errored | 0 |
+| skipped | 0 |
+| total wall time | 1.7 h |
+| orphan-end calls dropped (expected loss) | 33,209 |
+| past-retention calls excluded (expected loss) | 0 |
+
+## Timings
+
+| step | p50 | p90 | max |
+|---|---|---|---|
+| fill | 0.42s | 3.05s | 1654.68s |
+| attach (per partition) | 0.37s | 0.57s | 4.12s |
+
+## Largest projects (top 10 by calls migrated)
+
+| project | calls | chunks | fill | verify | attach total | partitions |
+|---|---|---|---|---|---|---|
+| nickpenaranda/weave-load-test | 32,579,183 | 86 | 221.96s | 110.16s | 0.91s | 1 |
+| griffin/test-multi | 4,270,819 | 9 | 1654.68s | 17.29s | 5.2s | 3 |
+| griffin/1_000_000 | 2,004,006 | 1 | 8.72s | 0.68s | 0.38s | 1 |
+| nickpenaranda/weave-load-test-spam | 2,000,000 | 1 | 5.12s | 0.35s | 0.96s | 1 |
+| nickpenaranda/weave-load-test-spam-3 | 1,100,000 | 1 | 2.88s | 1.14s | 0.32s | 1 |
+| nickpenaranda/weave-load-test-parallel-lite4-001 | 1,000,000 | 1 | 3.36s | 0.52s | 0.3s | 1 |
+| nickpenaranda/weave-load-test-parallel-lite4-009 | 1,000,000 | 1 | 4.55s | 0.3s | 0.4s | 1 |
+| nickpenaranda/weave-load-test-parallel-lite4-002 | 1,000,000 | 1 | 4.37s | 0.63s | 0.33s | 1 |
+| nickpenaranda/weave-load-test-parallel-lite4-007 | 1,000,000 | 1 | 4.19s | 0.77s | 0.28s | 1 |
+| nickpenaranda/weave-load-test-parallel-lite4-005 | 1,000,000 | 1 | 4.21s | 0.82s | 0.38s | 1 |
+
+## Error classes hit (and remedies)
+
+1. **Replica read-after-write lag**: verification undercounted (worst case 0 of 100k
+   rows visible) -> all reads use `select_sequential_consistency=1`. Zero recurrences.
+2. **Keeper ZNODEEXISTS (code 244, ~0.4% of fills)**: staging drop/recreate race,
+   aborts atomically -> transient-code retry. Zero data impact.
+3. **Whale OOM (code 241)**: full-project fills exceed the 14.4 GiB QA cluster.
+   `cityHash64(id) % N` bucketing rescans the project per bucket without cutting state;
+   fixed hex-prefix ranges collapse to one bucket on time-ordered UUIDv7 ids.
+   Remedy: adaptive id-range chunking (drill prefixes until each range <= 500k rows),
+   applied to plan/fill/verify/stats. Both whales (4.3M and 32.6M calls) then passed.
+

--- a/scripts/backfill_runs/qa_weave_team_2026-07-07.json
+++ b/scripts/backfill_runs/qa_weave_team_2026-07-07.json
@@ -1,0 +1,1796 @@
+{
+ "UHJvamVjdEludGVybmFsSWQ6NjkxNA==": {
+  "name": "inference",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjkxNA==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.38,
+   "fill": 0.7,
+   "verify": 0.19,
+   "stats": 0.29,
+   "attach": {
+    "202601": 0.38
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202601"
+   ],
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0,
+   "final_rows": 1
+  },
+  "total_s": 3.37
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDI0MA==": {
+  "name": "filter-long",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDI0MA==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.56,
+   "verify": 0.2,
+   "stats": 0.33,
+   "attach": {
+    "202504": 0.42
+   },
+   "post_check": 0.18
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202504"
+   ],
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0,
+   "final_rows": 1
+  },
+  "total_s": 2.91
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjkzMA==": {
+  "name": "repro-wb-23754",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjkzMA==",
+  "source_calls": 1,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.43,
+   "fill": 0.45,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202503": 0.34
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1,
+   "partitions": [
+    "202503"
+   ],
+   "staging_rows": 1,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1,
+   "post_dupes": 0,
+   "final_rows": 1
+  },
+  "total_s": 3.0
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzQyMg==": {
+  "name": "josiah-projec",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzQyMg==",
+  "source_calls": 3,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.38,
+   "fill": 0.73,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202603": 0.34
+   },
+   "post_check": 0.34
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 3,
+   "partitions": [
+    "202603"
+   ],
+   "staging_rows": 3,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 3,
+   "post_dupes": 0,
+   "final_rows": 3
+  },
+  "total_s": 3.39
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU5Mw==": {
+  "name": "break-buf",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU5Mw==",
+  "source_calls": 4,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.34,
+   "fill": 0.66,
+   "verify": 0.19,
+   "stats": 0.27,
+   "attach": {
+    "202506": 0.38
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 4,
+   "partitions": [
+    "202506"
+   ],
+   "staging_rows": 4,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4,
+   "post_dupes": 0,
+   "final_rows": 4
+  },
+  "total_s": 3.15
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzQyMw==": {
+  "name": "test_josiah",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzQyMw==",
+  "source_calls": 5,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 0.73,
+   "verify": 0.2,
+   "stats": 0.32,
+   "attach": {
+    "202603": 0.36,
+    "202604": 0.36
+   },
+   "post_check": 0.18
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 5,
+   "partitions": [
+    "202603",
+    "202604"
+   ],
+   "staging_rows": 5,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 5,
+   "post_dupes": 0,
+   "final_rows": 5
+  },
+  "total_s": 3.51
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc2NQ==": {
+  "name": "tmob-fix",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc2NQ==",
+  "source_calls": 5,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.53,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202508": 0.4
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 5,
+   "partitions": [
+    "202508"
+   ],
+   "staging_rows": 5,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 5,
+   "post_dupes": 0,
+   "final_rows": 5
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njk5Nw==": {
+  "name": "chance-test1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njk5Nw==",
+  "source_calls": 10,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.32,
+   "verify": 0.2,
+   "stats": 0.32,
+   "attach": {
+    "202512": 0.38
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10,
+   "partitions": [
+    "202512"
+   ],
+   "staging_rows": 10,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10,
+   "post_dupes": 0,
+   "final_rows": 10
+  },
+  "total_s": 2.78
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDI0Mw==": {
+  "name": "quickstart_playground",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDI0Mw==",
+  "source_calls": 10,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 0.66,
+   "verify": 0.19,
+   "stats": 0.27,
+   "attach": {
+    "202509": 0.37,
+    "202601": 0.33,
+    "202605": 0.34
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10,
+   "partitions": [
+    "202509",
+    "202601",
+    "202605"
+   ],
+   "staging_rows": 10,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10,
+   "post_dupes": 0,
+   "final_rows": 10
+  },
+  "total_s": 3.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY2Ng==": {
+  "name": "scoring-load-oai-test10b",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY2Ng==",
+  "source_calls": 20,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.36,
+   "verify": 0.17,
+   "stats": 0.31,
+   "attach": {
+    "202606": 0.37
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20,
+   "partitions": [
+    "202606"
+   ],
+   "staging_rows": 20,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20,
+   "post_dupes": 0,
+   "final_rows": 20
+  },
+  "total_s": 2.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY2NQ==": {
+  "name": "scoring-load-oai-test10",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY2NQ==",
+  "source_calls": 20,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.3,
+   "verify": 0.19,
+   "stats": 0.27,
+   "attach": {
+    "202606": 0.37
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20,
+   "partitions": [
+    "202606"
+   ],
+   "staging_rows": 20,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20,
+   "post_dupes": 0,
+   "final_rows": 20
+  },
+  "total_s": 2.56
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjYwNw==": {
+  "name": "101-ops",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjYwNw==",
+  "source_calls": 20,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.33,
+   "fill": 0.53,
+   "verify": 0.19,
+   "stats": 0.27,
+   "attach": {
+    "202506": 0.33
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20,
+   "partitions": [
+    "202506"
+   ],
+   "staging_rows": 20,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20,
+   "post_dupes": 0,
+   "final_rows": 20
+  },
+  "total_s": 3.04
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjgzMg==": {
+  "name": "audio-eval",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjgzMg==",
+  "source_calls": 25,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.32,
+   "verify": 0.19,
+   "stats": 0.28,
+   "attach": {
+    "202509": 0.34
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 25,
+   "partitions": [
+    "202509"
+   ],
+   "staging_rows": 25,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 25,
+   "post_dupes": 0,
+   "final_rows": 25
+  },
+  "total_s": 2.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzE4NA==": {
+  "name": "realtime-idle-conversation-qa1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzE4NA==",
+  "source_calls": 27,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.58,
+   "verify": 0.19,
+   "stats": 0.3,
+   "attach": {
+    "202602": 0.33
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 27,
+   "partitions": [
+    "202602"
+   ],
+   "staging_rows": 27,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 27,
+   "post_dupes": 0,
+   "final_rows": 27
+  },
+  "total_s": 2.83
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzAzMw==": {
+  "name": "dino-agent",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzAzMw==",
+  "source_calls": 29,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.36,
+   "verify": 0.22,
+   "stats": 0.28,
+   "attach": {
+    "202512": 0.35
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 29,
+   "partitions": [
+    "202512"
+   ],
+   "staging_rows": 29,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 29,
+   "post_dupes": 0,
+   "final_rows": 29
+  },
+  "total_s": 2.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjgzNg==": {
+  "name": "chance-combine1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjgzNg==",
+  "source_calls": 120,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.63,
+   "verify": 0.24,
+   "stats": 0.3,
+   "attach": {
+    "202509": 0.37
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 120,
+   "partitions": [
+    "202509"
+   ],
+   "staging_rows": 120,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 120,
+   "post_dupes": 0,
+   "final_rows": 120
+  },
+  "total_s": 3.05
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjcwNQ==": {
+  "name": "retry-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjcwNQ==",
+  "source_calls": 144,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.32,
+   "verify": 0.22,
+   "stats": 0.29,
+   "attach": {
+    "202507": 0.34
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 144,
+   "partitions": [
+    "202507"
+   ],
+   "staging_rows": 144,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 144,
+   "post_dupes": 0,
+   "final_rows": 144
+  },
+  "total_s": 2.67
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzA0OQ==": {
+  "name": "mike-audio-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzA0OQ==",
+  "source_calls": 258,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.76,
+   "verify": 0.19,
+   "stats": 0.31,
+   "attach": {
+    "202601": 0.4,
+    "202602": 0.37
+   },
+   "post_check": 0.24
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 258,
+   "partitions": [
+    "202601",
+    "202602"
+   ],
+   "staging_rows": 258,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 258,
+   "post_dupes": 0,
+   "final_rows": 258
+  },
+  "total_s": 3.61
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjYxOA==": {
+  "name": "csbx",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjYxOA==",
+  "source_calls": 356,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.27,
+   "fill": 1.47,
+   "verify": 0.24,
+   "stats": 0.34,
+   "attach": {
+    "202507": 0.34,
+    "202510": 0.38,
+    "202512": 0.6,
+    "202601": 0.32,
+    "202603": 0.35
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 11,
+   "past_retention": 0,
+   "expected_rows": 345,
+   "partitions": [
+    "202507",
+    "202510",
+    "202512",
+    "202601",
+    "202603"
+   ],
+   "staging_rows": 345,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 345,
+   "post_dupes": 0,
+   "final_rows": 345
+  },
+  "total_s": 5.69
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU4NA==": {
+  "name": "monitor-demo-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU4NA==",
+  "source_calls": 364,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.35,
+   "fill": 0.35,
+   "verify": 0.2,
+   "stats": 0.28,
+   "attach": {
+    "202506": 0.34
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 364,
+   "partitions": [
+    "202506"
+   ],
+   "staging_rows": 364,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 364,
+   "post_dupes": 0,
+   "final_rows": 364
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY3MA==": {
+  "name": "scoring-load-nano2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY3MA==",
+  "source_calls": 400,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202606": 0.32
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 400,
+   "partitions": [
+    "202606"
+   ],
+   "staging_rows": 400,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 400,
+   "post_dupes": 0,
+   "final_rows": 400
+  },
+  "total_s": 2.55
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY2OQ==": {
+  "name": "scoring-load-nano1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY2OQ==",
+  "source_calls": 400,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.37,
+   "verify": 0.2,
+   "stats": 0.25,
+   "attach": {
+    "202606": 0.35
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 400,
+   "partitions": [
+    "202606"
+   ],
+   "staging_rows": 400,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 400,
+   "post_dupes": 0,
+   "final_rows": 400
+  },
+  "total_s": 2.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Nzc1MA==": {
+  "name": "2026-04-16_image-eval",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Nzc1MA==",
+  "source_calls": 402,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.66,
+   "verify": 0.18,
+   "stats": 0.28,
+   "attach": {
+    "202604": 0.44
+   },
+   "post_check": 0.52
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 402,
+   "partitions": [
+    "202604"
+   ],
+   "staging_rows": 402,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 402,
+   "post_dupes": 0,
+   "final_rows": 402
+  },
+  "total_s": 3.42
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjYxOQ==": {
+  "name": "evals",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjYxOQ==",
+  "source_calls": 434,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.64,
+   "verify": 0.2,
+   "stats": 0.32,
+   "attach": {
+    "202507": 0.34
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 434,
+   "partitions": [
+    "202507"
+   ],
+   "staging_rows": 434,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 434,
+   "post_dupes": 0,
+   "final_rows": 434
+  },
+  "total_s": 3.06
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzUzMg==": {
+  "name": "realtime-idle-conversation-qa",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzUzMg==",
+  "source_calls": 560,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 20.63,
+   "verify": 2.92,
+   "stats": 10.27,
+   "attach": {
+    "202604": 0.36,
+    "202605": 1.05
+   },
+   "post_check": 0.45
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 560,
+   "partitions": [
+    "202604",
+    "202605"
+   ],
+   "staging_rows": 560,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 560,
+   "post_dupes": 0,
+   "final_rows": 560
+  },
+  "total_s": 37.96
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc2NA==": {
+  "name": "swe-polybench-evaluation",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc2NA==",
+  "source_calls": 710,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.73,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202508": 0.38
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 710,
+   "partitions": [
+    "202508"
+   ],
+   "staging_rows": 710,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 710,
+   "post_dupes": 0,
+   "final_rows": 710
+  },
+  "total_s": 3.22
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzMxMA==": {
+  "name": "nicho-alerts-2",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzMxMA==",
+  "source_calls": 734,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.44,
+   "fill": 0.64,
+   "verify": 0.18,
+   "stats": 0.32,
+   "attach": {
+    "202603": 0.37
+   },
+   "post_check": 0.32
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 734,
+   "partitions": [
+    "202603"
+   ],
+   "staging_rows": 734,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 734,
+   "post_dupes": 0,
+   "final_rows": 734
+  },
+  "total_s": 3.62
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzMwOQ==": {
+  "name": "nicho-alerts",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzMwOQ==",
+  "source_calls": 824,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.38,
+   "verify": 0.19,
+   "stats": 0.36,
+   "attach": {
+    "202603": 0.33
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 824,
+   "partitions": [
+    "202603"
+   ],
+   "staging_rows": 824,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 824,
+   "post_dupes": 0,
+   "final_rows": 824
+  },
+  "total_s": 2.68
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDI0NA==": {
+  "name": "eval",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDI0NA==",
+  "source_calls": 1202,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.33,
+   "verify": 0.2,
+   "stats": 0.27,
+   "attach": {
+    "202504": 0.39
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1202,
+   "partitions": [
+    "202504"
+   ],
+   "staging_rows": 1202,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1202,
+   "post_dupes": 0,
+   "final_rows": 1202
+  },
+  "total_s": 2.61
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc0MQ==": {
+  "name": "simple",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc0MQ==",
+  "source_calls": 1345,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.48,
+   "verify": 0.22,
+   "stats": 0.3,
+   "attach": {
+    "202508": 0.34,
+    "202605": 0.36
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1345,
+   "partitions": [
+    "202508",
+    "202605"
+   ],
+   "staging_rows": 1345,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1345,
+   "post_dupes": 0,
+   "final_rows": 1345
+  },
+  "total_s": 3.23
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU4Mg==": {
+  "name": "monitor-demo",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU4Mg==",
+  "source_calls": 1491,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.6,
+   "verify": 0.2,
+   "stats": 0.29,
+   "attach": {
+    "202506": 0.35
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 1,
+   "past_retention": 0,
+   "expected_rows": 1490,
+   "partitions": [
+    "202506"
+   ],
+   "staging_rows": 1490,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1490,
+   "post_dupes": 0,
+   "final_rows": 1490
+  },
+  "total_s": 2.85
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY4MA==": {
+  "name": "scoring-worker-load-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY4MA==",
+  "source_calls": 2151,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.41,
+   "verify": 0.21,
+   "stats": 0.29,
+   "attach": {
+    "202606": 0.37,
+    "202607": 0.37
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2151,
+   "partitions": [
+    "202606",
+    "202607"
+   ],
+   "staging_rows": 2151,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2151,
+   "post_dupes": 0,
+   "final_rows": 2151
+  },
+  "total_s": 3.1
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU5Nw==": {
+  "name": "buf-lots-123",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU5Nw==",
+  "source_calls": 4726,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.6,
+   "verify": 0.21,
+   "stats": 0.32,
+   "attach": {
+    "202506": 0.36
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 2,
+   "past_retention": 0,
+   "expected_rows": 4724,
+   "partitions": [
+    "202506"
+   ],
+   "staging_rows": 4724,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 4724,
+   "post_dupes": 0,
+   "final_rows": 4724
+  },
+  "total_s": 3.07
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY3Mw==": {
+  "name": "scoring-load-notrace-5k",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY3Mw==",
+  "source_calls": 5000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.34,
+   "verify": 0.22,
+   "stats": 0.32,
+   "attach": {
+    "202606": 0.31
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 5000,
+   "partitions": [
+    "202606"
+   ],
+   "staging_rows": 5000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 5000,
+   "post_dupes": 0,
+   "final_rows": 5000
+  },
+  "total_s": 2.66
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzM4OQ==": {
+  "name": "brand-awareness-agent",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzM4OQ==",
+  "source_calls": 9005,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.22,
+   "fill": 4.03,
+   "verify": 0.29,
+   "stats": 0.56,
+   "attach": {
+    "202603": 1.46
+   },
+   "post_check": 0.44
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 9005,
+   "partitions": [
+    "202603"
+   ],
+   "staging_rows": 9005,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 9005,
+   "post_dupes": 0,
+   "final_rows": 9005
+  },
+  "total_s": 8.35
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY3Mg==": {
+  "name": "scoring-load-b100-5k",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY3Mg==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.42,
+   "verify": 0.2,
+   "stats": 0.37,
+   "attach": {
+    "202606": 0.4
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202606"
+   ],
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0,
+   "final_rows": 10000
+  },
+  "total_s": 2.91
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY3MQ==": {
+  "name": "scoring-load-nano5k",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY3MQ==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.38,
+   "verify": 0.21,
+   "stats": 0.32,
+   "attach": {
+    "202606": 0.35
+   },
+   "post_check": 0.21
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202606"
+   ],
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0,
+   "final_rows": 10000
+  },
+  "total_s": 2.69
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY2Nw==": {
+  "name": "scoring-load-oai-5k",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY2Nw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.38,
+   "verify": 0.22,
+   "stats": 0.35,
+   "attach": {
+    "202606": 0.37
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202606"
+   ],
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0,
+   "final_rows": 10000
+  },
+  "total_s": 2.87
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY2Mw==": {
+  "name": "scoring-load-burst-rerun1",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY2Mw==",
+  "source_calls": 10000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.4,
+   "verify": 0.21,
+   "stats": 0.38,
+   "attach": {
+    "202606": 0.32
+   },
+   "post_check": 0.18
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 10000,
+   "partitions": [
+    "202606"
+   ],
+   "staging_rows": 10000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 10000,
+   "post_dupes": 0,
+   "final_rows": 10000
+  },
+  "total_s": 2.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIzNg==": {
+  "name": "wt-async-inserts-batch-10",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIzNg==",
+  "source_calls": 11002,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.19,
+   "fill": 0.73,
+   "verify": 0.21,
+   "stats": 0.33,
+   "attach": {
+    "202504": 0.39
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 11002,
+   "partitions": [
+    "202504"
+   ],
+   "staging_rows": 11002,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 11002,
+   "post_dupes": 0,
+   "final_rows": 11002
+  },
+  "total_s": 3.07
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDE5OQ==": {
+  "name": "wt",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDE5OQ==",
+  "source_calls": 11002,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.66,
+   "verify": 0.18,
+   "stats": 0.42,
+   "attach": {
+    "202504": 0.41
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 11002,
+   "partitions": [
+    "202504"
+   ],
+   "staging_rows": 11002,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 11002,
+   "post_dupes": 0,
+   "final_rows": 11002
+  },
+  "total_s": 3.11
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODc0Mg==": {
+  "name": "attr-maps-bench-op",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODc0Mg==",
+  "source_calls": 13750,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 0.47,
+   "verify": 0.18,
+   "stats": 0.37,
+   "attach": {
+    "202606": 0.35
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 13750,
+   "partitions": [
+    "202606"
+   ],
+   "staging_rows": 13750,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 13750,
+   "post_dupes": 0,
+   "final_rows": 13750
+  },
+  "total_s": 2.82
+ },
+ "UHJvamVjdEludGVybmFsSWQ6ODY2NA==": {
+  "name": "scoring-load-burst-rerun-10k",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6ODY2NA==",
+  "source_calls": 20000,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 0.48,
+   "verify": 0.19,
+   "stats": 0.38,
+   "attach": {
+    "202606": 0.37
+   },
+   "post_check": 0.22
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 20000,
+   "partitions": [
+    "202606"
+   ],
+   "staging_rows": 20000,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 20000,
+   "post_dupes": 0,
+   "final_rows": 20000
+  },
+  "total_s": 2.99
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDI3NQ==": {
+  "name": "monitor-test",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDI3NQ==",
+  "source_calls": 29460,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.2,
+   "fill": 1.15,
+   "verify": 0.21,
+   "stats": 0.43,
+   "attach": {
+    "202505": 0.37,
+    "202506": 0.34,
+    "202508": 0.36,
+    "202509": 0.41,
+    "202511": 0.35,
+    "202603": 0.44
+   },
+   "post_check": 0.2
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 29460,
+   "partitions": [
+    "202505",
+    "202506",
+    "202508",
+    "202509",
+    "202511",
+    "202603"
+   ],
+   "staging_rows": 29460,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 29460,
+   "post_dupes": 0,
+   "final_rows": 29460
+  },
+  "total_s": 5.65
+ },
+ "UHJvamVjdEludGVybmFsSWQ6MjkzNA==": {
+  "name": "delete-timing",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6MjkzNA==",
+  "source_calls": 33312,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.32,
+   "fill": 0.58,
+   "verify": 0.2,
+   "stats": 0.41,
+   "attach": {
+    "202503": 0.34
+   },
+   "post_check": 0.19
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 33312,
+   "partitions": [
+    "202503"
+   ],
+   "staging_rows": 33312,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 33312,
+   "post_dupes": 0,
+   "final_rows": 33312
+  },
+  "total_s": 3.14
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIzMQ==": {
+  "name": "types-chance",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIzMQ==",
+  "source_calls": 40651,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 1.8,
+   "verify": 0.22,
+   "stats": 0.58,
+   "attach": {
+    "202504": 0.37
+   },
+   "post_check": 0.3
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 40651,
+   "partitions": [
+    "202504"
+   ],
+   "staging_rows": 40651,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 40651,
+   "post_dupes": 0,
+   "final_rows": 40651
+  },
+  "total_s": 4.71
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Mjk5Mg==": {
+  "name": "wtypes",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Mjk5Mg==",
+  "source_calls": 100010,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.26,
+   "fill": 1.4,
+   "verify": 0.21,
+   "stats": 0.83,
+   "attach": {
+    "202504": 0.52
+   },
+   "post_check": 0.46
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 100010,
+   "partitions": [
+    "202504"
+   ],
+   "staging_rows": 100010,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 100010,
+   "post_dupes": 0,
+   "final_rows": 100010
+  },
+  "total_s": 4.75
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIzOQ==": {
+  "name": "test-insert-logging",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIzOQ==",
+  "source_calls": 103342,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.23,
+   "fill": 2.74,
+   "verify": 0.45,
+   "stats": 0.87,
+   "attach": {
+    "202504": 0.29
+   },
+   "post_check": 0.44
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 103342,
+   "partitions": [
+    "202504"
+   ],
+   "staging_rows": 103342,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 103342,
+   "post_dupes": 0,
+   "final_rows": 103342
+  },
+  "total_s": 6.21
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NzMyNQ==": {
+  "name": "griffin-mock-prod-agent",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NzMyNQ==",
+  "source_calls": 108393,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 1.7,
+   "verify": 0.21,
+   "stats": 0.77,
+   "attach": {
+    "202603": 0.3
+   },
+   "post_check": 0.37
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 108393,
+   "partitions": [
+    "202603"
+   ],
+   "staging_rows": 108393,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 108393,
+   "post_dupes": 0,
+   "final_rows": 108393
+  },
+  "total_s": 4.77
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjU5OQ==": {
+  "name": "fake-true-text-processing",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjU5OQ==",
+  "source_calls": 134757,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.21,
+   "fill": 5.46,
+   "verify": 0.49,
+   "stats": 0.95,
+   "attach": {
+    "202506": 0.34
+   },
+   "post_check": 0.23
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 134757,
+   "partitions": [
+    "202506"
+   ],
+   "staging_rows": 134757,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 134757,
+   "post_dupes": 0,
+   "final_rows": 134757
+  },
+  "total_s": 9.27
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIzNw==": {
+  "name": "wt-sync-inserts-batch-10",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIzNw==",
+  "source_calls": 231007,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.24,
+   "fill": 3.55,
+   "verify": 0.22,
+   "stats": 1.21,
+   "attach": {
+    "202504": 0.33
+   },
+   "post_check": 0.35
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 231007,
+   "partitions": [
+    "202504"
+   ],
+   "staging_rows": 231007,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 231007,
+   "post_dupes": 0,
+   "final_rows": 231007
+  },
+  "total_s": 7.12
+ },
+ "UHJvamVjdEludGVybmFsSWQ6Njc4Mg==": {
+  "name": "swe-polybench-evaluation-parallel",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6Njc4Mg==",
+  "source_calls": 537419,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.28,
+   "fill": 9.06,
+   "verify": 0.48,
+   "stats": 3.39,
+   "attach": {
+    "202508": 0.55
+   },
+   "post_check": 0.41
+  },
+  "gates": {
+   "orphan_ends": 12,
+   "past_retention": 0,
+   "expected_rows": 537407,
+   "partitions": [
+    "202508"
+   ],
+   "staging_rows": 537407,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 537407,
+   "post_dupes": 0,
+   "final_rows": 537407
+  },
+  "total_s": 16.01
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NjYwNQ==": {
+  "name": "test-multi",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NjYwNQ==",
+  "source_calls": 1135277,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.4,
+   "fill": 53.12,
+   "verify": 0.3,
+   "stats": 11.45,
+   "attach": {
+    "202506": 1.79,
+    "202507": 0.41
+   },
+   "post_check": 0.56
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 1135277,
+   "partitions": [
+    "202506",
+    "202507"
+   ],
+   "staging_rows": 1135277,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 1135277,
+   "post_dupes": 0,
+   "final_rows": 1135277
+  },
+  "total_s": 72.55
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIzNQ==": {
+  "name": "wt-sync-inserts",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIzNQ==",
+  "source_calls": 2002004,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.41,
+   "fill": 25.71,
+   "verify": 0.52,
+   "stats": 7.98,
+   "attach": {
+    "202504": 0.34
+   },
+   "post_check": 0.39
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2002004,
+   "partitions": [
+    "202504"
+   ],
+   "staging_rows": 2002004,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2002004,
+   "post_dupes": 0,
+   "final_rows": 2002004
+  },
+  "total_s": 38.06
+ },
+ "UHJvamVjdEludGVybmFsSWQ6NDIzNA==": {
+  "name": "wt-async-inserts",
+  "pid": "UHJvamVjdEludGVybmFsSWQ6NDIzNA==",
+  "source_calls": 2002004,
+  "status": "migrated",
+  "timings": {
+   "plan": 0.62,
+   "fill": 25.9,
+   "verify": 0.5,
+   "stats": 5.86,
+   "attach": {
+    "202504": 0.3
+   },
+   "post_check": 0.54
+  },
+  "gates": {
+   "orphan_ends": 0,
+   "past_retention": 0,
+   "expected_rows": 2002004,
+   "partitions": [
+    "202504"
+   ],
+   "staging_rows": 2002004,
+   "dupes": 0,
+   "bogus_partitions": 0,
+   "sample_mismatches": 0,
+   "attached_rows": 2002004,
+   "post_dupes": 0,
+   "final_rows": 2002004
+  },
+  "total_s": 36.14
+ }
+}

--- a/scripts/backfill_runs/qa_weave_team_2026-07-07.md
+++ b/scripts/backfill_runs/qa_weave_team_2026-07-07.md
@@ -1,0 +1,83 @@
+# weave-team QA entity port: calls_merged -> calls_complete
+
+Run date: 2026-07-07. Entity: weave-team (QA). Driver process from PR #7535,
+executed sequentially smallest-first with per-project gates.
+
+## Outcome
+
+| metric | value |
+|---|---|
+| projects migrated | 55/55 |
+| calls migrated | 6,584,171 |
+| failed verify (untouched, no attach) | 0 |
+| skipped (nothing to migrate) | 0 |
+| total wall time | 6.3 min |
+| orphan-end calls dropped (expected loss) | 26 |
+| past-retention calls excluded (expected loss) | 0 |
+
+## Timings
+
+| step | p50 | p90 | max |
+|---|---|---|---|
+| fill | 0.6s | 5.46s | 53.12s |
+| attach (per partition) | 0.36s | 0.44s | 1.79s |
+
+## Per-project results (smallest first)
+
+| project | calls | status | fill | attach total | partitions |
+|---|---|---|---|---|---|
+| inference | 1 | migrated | 0.7 | 0.38 | 1 |
+| filter-long | 1 | migrated | 0.56 | 0.42 | 1 |
+| repro-wb-23754 | 1 | migrated | 0.45 | 0.34 | 1 |
+| josiah-projec | 3 | migrated | 0.73 | 0.34 | 1 |
+| break-buf | 4 | migrated | 0.66 | 0.38 | 1 |
+| test_josiah | 5 | migrated | 0.73 | 0.72 | 2 |
+| tmob-fix | 5 | migrated | 0.53 | 0.4 | 1 |
+| chance-test1 | 10 | migrated | 0.32 | 0.38 | 1 |
+| quickstart_playground | 10 | migrated | 0.66 | 1.04 | 3 |
+| scoring-load-oai-test10b | 20 | migrated | 0.36 | 0.37 | 1 |
+| scoring-load-oai-test10 | 20 | migrated | 0.3 | 0.37 | 1 |
+| 101-ops | 20 | migrated | 0.53 | 0.33 | 1 |
+| audio-eval | 25 | migrated | 0.32 | 0.34 | 1 |
+| realtime-idle-conversation-qa1 | 27 | migrated | 0.58 | 0.33 | 1 |
+| dino-agent | 29 | migrated | 0.36 | 0.35 | 1 |
+| chance-combine1 | 120 | migrated | 0.63 | 0.37 | 1 |
+| retry-test | 144 | migrated | 0.32 | 0.34 | 1 |
+| mike-audio-test | 258 | migrated | 0.76 | 0.77 | 2 |
+| csbx | 345 | migrated | 1.47 | 1.99 | 5 |
+| monitor-demo-2 | 364 | migrated | 0.35 | 0.34 | 1 |
+| scoring-load-nano2 | 400 | migrated | 0.33 | 0.32 | 1 |
+| scoring-load-nano1 | 400 | migrated | 0.37 | 0.35 | 1 |
+| 2026-04-16_image-eval | 402 | migrated | 0.66 | 0.44 | 1 |
+| evals | 434 | migrated | 0.64 | 0.34 | 1 |
+| realtime-idle-conversation-qa | 560 | migrated | 20.63 | 1.41 | 2 |
+| swe-polybench-evaluation | 710 | migrated | 0.73 | 0.38 | 1 |
+| nicho-alerts-2 | 734 | migrated | 0.64 | 0.37 | 1 |
+| nicho-alerts | 824 | migrated | 0.38 | 0.33 | 1 |
+| eval | 1,202 | migrated | 0.33 | 0.39 | 1 |
+| simple | 1,345 | migrated | 0.48 | 0.7 | 2 |
+| monitor-demo | 1,490 | migrated | 0.6 | 0.35 | 1 |
+| scoring-worker-load-test | 2,151 | migrated | 0.41 | 0.74 | 2 |
+| buf-lots-123 | 4,724 | migrated | 0.6 | 0.36 | 1 |
+| scoring-load-notrace-5k | 5,000 | migrated | 0.34 | 0.31 | 1 |
+| brand-awareness-agent | 9,005 | migrated | 4.03 | 1.46 | 1 |
+| scoring-load-b100-5k | 10,000 | migrated | 0.42 | 0.4 | 1 |
+| scoring-load-nano5k | 10,000 | migrated | 0.38 | 0.35 | 1 |
+| scoring-load-oai-5k | 10,000 | migrated | 0.38 | 0.37 | 1 |
+| scoring-load-burst-rerun1 | 10,000 | migrated | 0.4 | 0.32 | 1 |
+| wt-async-inserts-batch-10 | 11,002 | migrated | 0.73 | 0.39 | 1 |
+| wt | 11,002 | migrated | 0.66 | 0.41 | 1 |
+| attr-maps-bench-op | 13,750 | migrated | 0.47 | 0.35 | 1 |
+| scoring-load-burst-rerun-10k | 20,000 | migrated | 0.48 | 0.37 | 1 |
+| monitor-test | 29,460 | migrated | 1.15 | 2.27 | 6 |
+| delete-timing | 33,312 | migrated | 0.58 | 0.34 | 1 |
+| types-chance | 40,651 | migrated | 1.8 | 0.37 | 1 |
+| wtypes | 100,010 | migrated | 1.4 | 0.52 | 1 |
+| test-insert-logging | 103,342 | migrated | 2.74 | 0.29 | 1 |
+| griffin-mock-prod-agent | 108,393 | migrated | 1.7 | 0.3 | 1 |
+| fake-true-text-processing | 134,757 | migrated | 5.46 | 0.34 | 1 |
+| wt-sync-inserts-batch-10 | 231,007 | migrated | 3.55 | 0.33 | 1 |
+| swe-polybench-evaluation-parallel | 537,407 | migrated | 9.06 | 0.55 | 1 |
+| test-multi | 1,135,277 | migrated | 53.12 | 2.2 | 2 |
+| wt-sync-inserts | 2,002,004 | migrated | 25.71 | 0.34 | 1 |
+| wt-async-inserts | 2,002,004 | migrated | 25.9 | 0.3 | 1 |


### PR DESCRIPTION
## Summary
- operator script (`scripts/backfill_calls_complete.py`) migrating dormant projects from calls_merged to calls_complete via an invisible staging table published with `ATTACH PARTITION FROM`
- phases: plan / fill / verify / stats / attach; allowlist-driven, resumable journal, attach-once enforcement, dry-run
- no service code changes: routing flips reactively by data presence; stats inserted explicitly since the MV does not fire on ATTACH
- parity math excludes the two validated known losses (end-only fragments, rows past per-row retention)

## QA campaign (816 projects, 100.1M calls, zero parity violations)
| step | fill | verify + spot-check | stats insert | ATTACH (cutover) | post-attach |
|---|---|---|---|---|---|
| p50 / worst | 0.4s / 1655s | sub-second / 110s | 2s / 279s | **0.26-0.9s** | rows/stats exact, 0 dupes |

Three error classes hit and fixed along the way:
- Cloud replicas lag part metadata, so read-after-write verification can silently undercount (worst case 0 of 100k rows visible) -> all verification reads use `select_sequential_consistency=1`
- transient Keeper `ZNODEEXISTS` (code 244, ~0.4% of fills) on staging drop/recreate under the same name -> tenacity retry mirroring the migrator's transient-code pattern
- whale fills OOM: `cityHash64(id) % N` rescans the project per bucket without cutting aggregation state, and fixed hex ranges collapse to one bucket on time-ordered UUIDv7 ids -> adaptive id-range chunking (`--chunk-rows`) across plan/fill/verify/stats; a 32.6M-call project then ported in 690s on a 14 GiB cluster

## Testing
local CH 25.12 end-to-end with adversarially fragmented seed data; full QA-cluster campaign journals + reports in `scripts/backfill_runs/`.
