### PR TITLE
perf(weave): narrow eval cost pricing to predict calls

### DIFF
--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -1273,6 +1273,200 @@ def test_eval_results_summary_predict_total_cost_none_when_absent(client):
     assert res.summary.evaluations[0].predict_total_cost is None
 
 
+def test_eval_results_rows_trial_total_cost_predict_only(client):
+    """Per-trial total_cost in rows: predict-only, filled without a summary.
+
+    include_summary=False pins that the cost fill is not tied to the summary
+    path. The judge's (differently priced) usage must not leak into the trial,
+    and a trial without a predict call reports None, not the judge's cost.
+    """
+    project_id = client.project_id
+    client.server.cost_create(
+        CostCreateReq(
+            project_id=project_id,
+            costs={"predict-llm": _PREDICT_PRICE, "judge-llm": _JUDGE_PRICE},
+            wb_user_id="VXNlcjo0NTI1NDQ=",
+        )
+    )
+    eval_id = _create_eval_run_with_cost_trials(
+        client,
+        [
+            ({"predict-llm": _PREDICT_USAGE}, {"judge-llm": _JUDGE_USAGE}),
+            (None, {"judge-llm": _JUDGE_USAGE}),
+        ],
+        eval_name="row-cost",
+    )
+    res = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=project_id,
+            evaluation_call_ids=[eval_id],
+            include_rows=True,
+            include_summary=False,
+            include_predict_and_score_children=True,
+            include_costs=True,
+        )
+    )
+    trial_costs = [
+        trial.total_cost
+        for row in res.rows
+        for evaluation in row.evaluations
+        for trial in evaluation.trials
+    ]
+    assert len(trial_costs) == 2
+    assert trial_costs.count(None) == 1
+    assert [c for c in trial_costs if c is not None] == [
+        pytest.approx(_PREDICT_COST_PER_TRIAL)
+    ]
+
+
+def test_eval_results_sorted_rows_trial_total_cost(client):
+    """Costs fill on the sorted path too, and land on the right trial.
+
+    Sorting takes a separate branch on the in-memory backend; two trials with
+    different predict usage pin that each sorted row keeps its own cost.
+    """
+    project_id = client.project_id
+    client.server.cost_create(
+        CostCreateReq(
+            project_id=project_id,
+            costs={"predict-llm": _PREDICT_PRICE},
+            wb_user_id="VXNlcjo0NTI1NDQ=",
+        )
+    )
+    double_usage = {"prompt_tokens": 200, "completion_tokens": 100, "total_tokens": 300}
+    eval_id = _create_eval_run_with_cost_trials(
+        client,
+        [
+            ({"predict-llm": _PREDICT_USAGE}, None),
+            ({"predict-llm": double_usage}, None),
+        ],
+        eval_name="sorted-cost",
+    )
+    res = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=project_id,
+            evaluation_call_ids=[eval_id],
+            include_rows=True,
+            include_summary=False,
+            include_predict_and_score_children=True,
+            include_costs=True,
+            sort_by=[EvalResultsSortBy(field="output.output", direction="desc")],
+        )
+    )
+    trial_costs = [
+        trial.total_cost
+        for row in res.rows
+        for evaluation in row.evaluations
+        for trial in evaluation.trials
+    ]
+    # Descending by output: "answer_1" (the double-usage trial) sorts first.
+    assert trial_costs == [
+        pytest.approx(2 * _PREDICT_COST_PER_TRIAL),
+        pytest.approx(_PREDICT_COST_PER_TRIAL),
+    ]
+
+
+def test_eval_results_trial_genai_span_ref_preserved_with_costs(client):
+    """A summary-carried genai_span_ref survives include_costs=True.
+
+    Regression pin: the ClickHouse cost enrichment used to rebuild the child
+    summary and drop summary.weave.genai_span_ref. With costs now read via a
+    separate predict-only query, the children keep their raw summary, so the
+    ref reaches the trial alongside the cost.
+    """
+    project_id = client.project_id
+    client.server.cost_create(
+        CostCreateReq(
+            project_id=project_id,
+            costs={"predict-llm": _PREDICT_PRICE},
+            wb_user_id="VXNlcjo0NTI1NDQ=",
+        )
+    )
+    model_ref = "model://genai-cost"
+    run = client.server.evaluation_run_create(
+        EvaluationRunCreateReq(
+            project_id=project_id,
+            evaluation="eval://genai-cost",
+            model=model_ref,
+        )
+    )
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    pas_id = generate_id()
+    client.server.call_start(
+        CallStartReq(
+            start=StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=pas_id,
+                trace_id=run.evaluation_run_id,
+                parent_id=run.evaluation_run_id,
+                op_name="Evaluation.predict_and_score",
+                started_at=now,
+                attributes={},
+                inputs={"example": {"idx": 0}, "model": model_ref},
+            )
+        )
+    )
+    predict_id = generate_id()
+    client.server.call_start(
+        CallStartReq(
+            start=StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=predict_id,
+                trace_id=run.evaluation_run_id,
+                parent_id=pas_id,
+                op_name="Model.predict",
+                started_at=now,
+                attributes={},
+                inputs={"self": model_ref, "example": {"idx": 0}},
+            )
+        )
+    )
+    client.server.call_end(
+        CallEndReq(
+            end=EndedCallSchemaForInsert(
+                project_id=project_id,
+                id=predict_id,
+                ended_at=now + datetime.timedelta(seconds=1),
+                output="answer",
+                summary={
+                    "usage": {"predict-llm": _PREDICT_USAGE},
+                    "weave": {
+                        "genai_span_ref": [
+                            {"trace_id": "agent-trace-1", "span_id": "span-1"}
+                        ]
+                    },
+                },
+            )
+        )
+    )
+    client.server.call_end(
+        CallEndReq(
+            end=EndedCallSchemaForInsert(
+                project_id=project_id,
+                id=pas_id,
+                ended_at=now + datetime.timedelta(seconds=2),
+                output={"output": "answer", "scores": {}},
+                summary={},
+            )
+        )
+    )
+    res = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=project_id,
+            evaluation_call_ids=[run.evaluation_run_id],
+            include_rows=True,
+            include_summary=False,
+            include_predict_and_score_children=True,
+            include_costs=True,
+        )
+    )
+    trial = res.rows[0].evaluations[0].trials[0]
+    assert trial.genai_span_ref == [
+        GenAISpanRef(trace_id="agent-trace-1", span_id="span-1")
+    ]
+    assert trial.total_cost == pytest.approx(_PREDICT_COST_PER_TRIAL)
+
+
 def test_eval_results_resolved_inputs_inline(client):
     """Inline inputs should be available as dicts in raw_data_row."""
     project_id = client.project_id

--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -1455,16 +1455,22 @@ def test_eval_results_trial_genai_span_ref_preserved_with_costs(client):
             project_id=project_id,
             evaluation_call_ids=[run.evaluation_run_id],
             include_rows=True,
-            include_summary=False,
+            include_summary=True,
             include_predict_and_score_children=True,
             include_costs=True,
         )
     )
+    assert res.total_rows == 1
     trial = res.rows[0].evaluations[0].trials[0]
     assert trial.genai_span_ref == [
         GenAISpanRef(trace_id="agent-trace-1", span_id="span-1")
     ]
+    # Rows and summary of the same response carry the same predict-only cost.
     assert trial.total_cost == pytest.approx(_PREDICT_COST_PER_TRIAL)
+    assert res.summary is not None
+    assert res.summary.evaluations[0].predict_total_cost == pytest.approx(
+        _PREDICT_COST_PER_TRIAL
+    )
 
 
 def test_eval_results_resolved_inputs_inline(client):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5735,7 +5735,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     filter=tsi.CallsFilter(parent_ids=batch),
                     columns=child_columns,
                     sort_by=[tsi.SortBy(field="started_at", direction="asc")],
-                    include_costs=req.include_costs,
                 )
                 page_calls.extend(self.calls_query_stream(child_req))
 
@@ -5746,6 +5745,15 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             req.include_raw_data_rows if req.include_rows else False,
             req.include_predict_and_score_children,
         )
+
+        # Cost is read from the predict call only (see _build_trial), so the
+        # children above are fetched without cost enrichment and only the
+        # predict calls are priced here — before compute_summary_from_rows,
+        # which sums trial.total_cost.
+        if req.include_costs:
+            eval_helpers.apply_predict_costs(
+                all_rows, req.project_id, self.calls_query_stream
+            )
 
         summary: tsi.EvalResultsSummaryRes | None = None
         if req.include_summary:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5746,10 +5746,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             req.include_predict_and_score_children,
         )
 
-        # Cost is read from the predict call only (see _build_trial), so the
-        # children above are fetched without cost enrichment and only the
-        # predict calls are priced here — before compute_summary_from_rows,
-        # which sums trial.total_cost.
+        # children above are fetched without costs; price only the predict calls
         if req.include_costs:
             eval_helpers.apply_predict_costs(
                 all_rows, req.project_id, self.calls_query_stream

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -279,6 +279,7 @@ def extract_total_cost(
     return total_cost if found_any else None
 
 
+@traced(name="eval_results_helpers.apply_predict_costs")
 def apply_predict_costs(
     rows: list[tsi.EvalResultsRow],
     project_id: str,

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -285,7 +285,7 @@ def apply_predict_costs(
     project_id: str,
     fetch_calls: Callable[[tsi.CallsQueryReq], Iterable[tsi.CallSchema]],
 ) -> None:
-    """Fill each trial's total_cost from its predict call, in place.
+    """Fill each trial's total_cost from its predict call in-place.
 
     Trial children are fetched without cost enrichment (pricing every scorer
     child just to read the predict cost is wasted work), so trials start with
@@ -448,10 +448,11 @@ def _build_trial(
         total_tokens=extract_total_tokens(
             predict_call.summary if predict_call else predict_and_score_call.summary
         ),
-        # Predict-only: read cost from the predict call alone. Unlike tokens, do
-        # not fall back to the predict_and_score summary, whose cost rollup would
-        # include the LLM-as-a-judge scorer.
-        total_cost=extract_total_cost(predict_call.summary) if predict_call else None,
+        # Cost is filled afterwards by apply_predict_costs: children arrive
+        # without cost enrichment, and only the predict calls get priced —
+        # never the predict_and_score rollup, which would include the
+        # LLM-as-a-judge scorer.
+        total_cost=None,
         scorer_call_ids=best_effort_scorer_call_ids(scores, trial_children),
         genai_span_ref=_combine_genai_span_refs(predict_call, predict_and_score_call),
     )

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -279,6 +279,51 @@ def extract_total_cost(
     return total_cost if found_any else None
 
 
+def apply_predict_costs(
+    rows: list[tsi.EvalResultsRow],
+    project_id: str,
+    fetch_calls: Callable[[tsi.CallsQueryReq], Iterable[tsi.CallSchema]],
+) -> None:
+    """Fill each trial's total_cost from its predict call, in place.
+
+    Trial children are fetched without cost enrichment (pricing every scorer
+    child just to read the predict cost is wasted work), so trials start with
+    total_cost=None. This re-reads only the predict calls by id with
+    include_costs=True and copies their cost onto the trials. Must run before
+    compute_summary_from_rows, which sums trial.total_cost.
+    """
+    predict_call_ids = sorted(
+        {
+            trial.predict_call_id
+            for row in rows
+            for evaluation in row.evaluations
+            for trial in evaluation.trials
+            if trial.predict_call_id is not None
+        }
+    )
+    if not predict_call_ids:
+        return
+    cost_by_call_id: dict[str, float] = {}
+    for i in range(0, len(predict_call_ids), tsc.MAX_FILTER_LENGTH):
+        batch = predict_call_ids[i : i + tsc.MAX_FILTER_LENGTH]
+        cost_req = tsi.CallsQueryReq(
+            project_id=project_id,
+            filter=tsi.CallsFilter(call_ids=batch),
+            columns=["id"],
+            sort_by=[],
+            include_costs=True,
+        )
+        for call in fetch_calls(cost_req):
+            cost = extract_total_cost(call.summary)
+            if cost is not None:
+                cost_by_call_id[call.id] = cost
+    for row in rows:
+        for evaluation in row.evaluations:
+            for trial in evaluation.trials:
+                if trial.predict_call_id is not None:
+                    trial.total_cost = cost_by_call_id.get(trial.predict_call_id)
+
+
 def best_effort_scorer_call_ids(
     scores: dict[str, Any], child_calls: list[tsi.CallSchema]
 ) -> dict[str, str]:
@@ -685,6 +730,9 @@ def eval_results_query(
         offset=0,
     )
     all_rows, _ = eval_results_grouped_rows(all_rows_req, eval_root_ids, all_calls)
+
+    if req.include_costs:
+        apply_predict_costs(all_rows, req.project_id, server.calls_query_stream)
 
     rows: list[tsi.EvalResultsRow] = []
     total_rows = 0

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -2461,7 +2461,6 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
         project_id: str,
         eval_root_ids: list[str],
         include_children: bool = True,
-        include_costs: bool = False,
     ) -> Iterator[tsi.CallSchema]:
         columns = [
             "id",
@@ -2494,7 +2493,6 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                         filter=tsi.CallsFilter(parent_ids=eval_root_children_ids),
                         columns=columns,
                         sort_by=[tsi.SortBy(field="started_at", direction="asc")],
-                        include_costs=include_costs,
                     )
                 )
 
@@ -6813,7 +6811,6 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                 req.project_id,
                 eval_root_ids,
                 include_children=req.include_predict_and_score_children,
-                include_costs=req.include_costs,
             )
         )
         if req.resolve_row_refs:
@@ -6915,6 +6912,11 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
         all_rows, _ = eval_helpers.eval_results_grouped_rows(
             all_rows_req, eval_root_ids, all_calls
         )
+
+        if req.include_costs:
+            eval_helpers.apply_predict_costs(
+                all_rows, req.project_id, self.calls_query_stream
+            )
 
         # ---- Apply per-evaluation filters ----
         if req.filters:

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -6913,6 +6913,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             all_rows_req, eval_root_ids, all_calls
         )
 
+        # ---- Fill predict-call costs onto trials ----
         if req.include_costs:
             eval_helpers.apply_predict_costs(
                 all_rows, req.project_id, self.calls_query_stream

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3295,9 +3295,10 @@ class EvalResultsQueryBody(BaseModelStrict):
     include_costs: bool = Field(
         default=False,
         description=(
-            "When true, enrich the predict-and-score child calls with cost so "
-            "the summary can report predict-only `predict_total_cost`. Opt-in: "
-            "other callers skip the cost computation."
+            "When true, price each trial's predict call so rows and summary "
+            "report predict-only cost (`total_cost` / `predict_total_cost`); "
+            "scorer costs are excluded. Opt-in: other callers skip the cost "
+            "computation."
         ),
     )
     sort_by: list[EvalResultsSortBy] | None = Field(


### PR DESCRIPTION
## JIRA Issue(s)
https://coreweave.atlassian.net/browse/WB-36670

## Description

This PR does three things:

* Stops computing the LLM judge/scorer costs that eval results throws away — this was the original ask.
* Stops dragging the scorers' big rows (inputs and outputs) through the cost SQL for nothing.
* Fixes a predict call's `genai_span_ref` getting dropped on ClickHouse when costs were requested.

Below is how this was found and why we fix it.

The eval results API shows the cost of the model's `predict()` calls only, not the LLM judge. That number is already correct.

While reviewing #7487, a reviewer pointed out we do extra work to get it. To read the predict cost, the server priced *every* child of a trial — the predict call and all the scorers — and then used only the predict part. The judge prices were computed and discarded (https://github.com/wandb/weave/pull/7487#discussion_r3515543189).

I looked closer, and it is worse than just the judge math. The cost step also carries each child's whole row — inputs and outputs, which can be kilobytes — through its heavy SQL. So even plain code scorers, which have nothing to price, had their big rows hauled through for nothing. On large evals that adds up.

The fix keeps scorers out of the cost step entirely. First we fetch the trial's children with no costs. Then, only when costs are asked for, a small second query prices just the predict calls and fills in each trial's cost.

While doing this I hit a second bug. On ClickHouse, asking for costs dropped the predict call's `genai_span_ref`. The cost SQL rebuilds the summary and ends up writing the `weave` key twice, so the last copy wins and the ref is lost. Now that the predict call is read outside that step, the ref survives — which is what the in-memory backend already did.

One note on speed: this trades one query for two, so the saving grows with eval size. Large evals stop hauling all those scorer rows; small evals come out about the same.

## Testing

The five existing cost tests still pass on both backends — they lock in the rules that must not change (predict-only, opt-in, judge excluded, None when unpriced). Three new tests cover the new paths: per-trial cost on the rows path, cost on the sorted path (which had no cost coverage before), and a regression test for the `genai_span_ref` fix. Full `tests/trace_server` run locally on ClickHouse; ty, pyright, mypy, and ruff are clean.
