### PR TITLE
perf(weave): skip latest alias write for content objects in calls_complete

### DIFF
--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -661,7 +661,8 @@ def test_calls_complete_batches_content_object_inserts(
 
     Duplicate content across calls in the batch collapses to the same ref,
     and the whole batch issues exactly one insert into object_versions and
-    one into aliases instead of one pair of inserts per object.
+    none into aliases: content refs pin the version digest, so the "latest"
+    alias is never written or read for these objects.
     """
     project_id = f"{TEST_ENTITY}/calls_complete_batched_objects"
     internal_project_id = b64(project_id)
@@ -716,7 +717,7 @@ def test_calls_complete_batches_content_object_inserts(
     trace_server.calls_complete(tsi.CallsUpsertCompleteReq(batch=calls))
 
     assert insert_tables.count("object_versions") == 1
-    assert insert_tables.count("aliases") == 1
+    assert insert_tables.count("aliases") == 0
     assert (
         _count_project_rows(
             clickhouse_trace_server.ch_client, "object_versions", internal_project_id
@@ -727,7 +728,7 @@ def test_calls_complete_batches_content_object_inserts(
         _count_project_rows(
             clickhouse_trace_server.ch_client, "aliases", internal_project_id
         )
-        == 2
+        == 0
     )
 
     inputs_1, output_1 = _fetch_call_dumps(
@@ -782,6 +783,19 @@ def test_calls_complete_batches_content_object_inserts(
     }
     assert obj_b.obj.val["_type"] == "CustomWeaveType"
     assert obj_a.obj.val != obj_b.obj.val
+
+    # No "latest" alias row is written, yet "latest" still resolves to the sole
+    # version via the query builder's computed is_latest fallback: dropping the
+    # alias insert is read-transparent for these single-version objects.
+    latest_a = clickhouse_trace_server.obj_read(
+        tsi.ObjReadReq(
+            project_id=parsed_a.project_id,
+            object_id=parsed_a.name,
+            digest="latest",
+        )
+    )
+    assert latest_a.obj.digest == parsed_a.version
+    assert latest_a.obj.val == obj_a.obj.val
 
 
 def test_calls_complete_tolerates_content_object_name_collision(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1197,12 +1197,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         """Write staged content objects, grouped by project (obj_create_batch
         takes a single project). Runs after _flush_file_batches so a committed
         object row never references content that has not landed in storage.
+
+        Content refs pin the version digest (see base64_content_conversion.
+        _content_ref), so these objects are never resolved via the "latest"
+        alias; skipping that INSERT drops one CH round-trip per batch.
         """
         by_project: dict[str, list[tsi.ObjSchemaForInsert]] = {}
         for obj in self._content_obj_batch:
             by_project.setdefault(obj.project_id, []).append(obj)
         for project_objs in by_project.values():
-            self.obj_create_batch(project_objs)
+            self.obj_create_batch(project_objs, write_latest_alias=False)
 
     @tag_db_insert_path("call_start_v2")
     def call_start_v2(self, req: tsi.CallStartV2Req) -> tsi.CallStartV2Res:
@@ -2330,7 +2334,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     @traced(name="clickhouse_trace_server_batched.create_obj_batch")
     @tag_db_insert_path("obj_create_batch")
     def obj_create_batch(
-        self, batch: list[tsi.ObjSchemaForInsert]
+        self, batch: list[tsi.ObjSchemaForInsert], write_latest_alias: bool = True
     ) -> list[tsi.ObjCreateRes]:
         """This method is for the special case where all objects are known to use a placeholder.
         We lose any knowledge of what version the created object is in return for an enormous
@@ -2346,6 +2350,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         Unlike obj_create, no WB-30574 name/type collision guard runs here:
         callers must know their object_ids are fresh or check beforehand
         (see _resolve_pending_content_objs).
+
+        write_latest_alias=False skips the second "latest" alias INSERT. Only
+        safe for objects addressed exclusively by digest (never resolved via
+        the "latest" alias or listed in latest_only object queries), e.g.
+        content objects whose ref pins the version digest.
         """
         set_current_span_dd_tags(
             {"clickhouse_trace_server_batched.create_obj_batch.count": str(len(batch))}
@@ -2410,7 +2419,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
         # Batch-write the "latest" alias for every row, matching obj_create.
-        if alias_rows:
+        if write_latest_alias and alias_rows:
             ch_alias_rows = [
                 list(
                     AliasCHInsertable(


### PR DESCRIPTION
## Summary
- Content refs pin the version digest (`base64_content_conversion._content_ref`), so content objects are never resolved via the `latest` alias.
- `_flush_content_objs` now calls `obj_create_batch(..., write_latest_alias=False)`, dropping one CH insert per `calls_complete` batch on the ingest hot path.
- Read-transparent: the objects query builder's `is_latest` has a computed most-recent-version fallback, so `obj_read("latest")` and `latest_only` still resolve the sole version without an alias row.

## Testing
Updated `test_calls_complete_batches_content_object_inserts` to assert zero alias inserts/rows and that `latest` still resolves to the version via the computed fallback.

## QA validation (zoo-qa)
Deployed on multi-qa (zoo-qa) via core#47636, verified live via `/version`; A/B vs master.

| master `8400594` (2.78s, 20 SQL queries) | PR `4840b6e` (1.78s, 14 SQL queries) |
|---|---|
| ![master](https://github.com/user-attachments/assets/1c04b3f0-d3de-454c-9020-bc5ab18a75bb) | ![pr](https://github.com/user-attachments/assets/81482189-84f1-4cc7-8675-23836763e7cf) |

Server-side Datadog spans, per `calls/complete` batch embedding content objects, grouped by build version:

| build | `aliases` | `object_versions` | `files` | full-batch traces |
|---|---|---|---|---|
| master `8400594` | 1 | 1 | 1 | 3/4 |
| PR `4840b6e` | 0 | 1 | 1 | 7/8 |

PR drops the `aliases` INSERT to 0 while `object_versions`/`files` still fire (object write path intact, only the latest-alias write skipped; the 1 bare trace on each build is a content-ref cache hit). Endpoint `@duration` P50 1.87s -> 1.76s; no new error classes on the PR build. Traces: [master](https://us5.datadoghq.com/apm/trace/257aa411722c62d09f222bfc60e10f07) / [PR](https://us5.datadoghq.com/apm/trace/51143537976376d0c903fca880328a04).


**Frontend render check (QA weave UI):** content objects written without an alias row still render and resolve `latest` via the computed fallback.

| object renders in the call view | Versions tab: empty `Aliases`, still resolves |
|---|---|
| ![object render](https://github.com/user-attachments/assets/3966ab3d-515d-409c-bf31-c033ce5e54aa) | ![versions](https://github.com/user-attachments/assets/b10b7630-5b12-43a4-8c53-243981fa8794) |
