### PR TITLE
perf(weave): flush file chunks and content objects concurrently in calls_complete

### DIFF
--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -784,6 +784,61 @@ def test_calls_complete_batches_content_object_inserts(
     assert obj_a.obj.val != obj_b.obj.val
 
 
+@pytest.mark.disable_logging_error_check
+def test_calls_complete_content_obj_failure_skips_calls_insert(
+    trace_server, clickhouse_trace_server, monkeypatch
+):
+    """File chunks and content objects flush concurrently. If the content-object
+    insert fails, the peer file insert may still commit, but the calls insert
+    must not run: calls_complete raises so the client retries the whole batch,
+    and the content-addressed peer write reconciles idempotently on retry.
+    """
+    project_id = f"{TEST_ENTITY}/calls_complete_parallel_failure"
+    internal_project_id = b64(project_id)
+
+    raw = b"a" * (AUTO_CONVERSION_MIN_SIZE + 10)
+    data_uri = f"data:image/png;base64,{base64.b64encode(raw).decode('ascii')}"
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+    ended_at = started_at + datetime.timedelta(seconds=1)
+    call_id = str(uuid.uuid4())
+    call = _make_completed_call(
+        project_id,
+        call_id,
+        str(uuid.uuid4()),
+        started_at,
+        ended_at,
+        inputs={"image": data_uri},
+    )
+
+    original_insert = type(clickhouse_trace_server)._insert
+
+    def _fail_object_versions(self, table, *args, **kwargs):
+        if table == "object_versions":
+            raise RuntimeError("simulated content object insert failure")
+        return original_insert(self, table, *args, **kwargs)
+
+    monkeypatch.setattr(type(clickhouse_trace_server), "_insert", _fail_object_versions)
+
+    with pytest.raises(RuntimeError, match="simulated content object insert failure"):
+        trace_server.calls_complete(tsi.CallsUpsertCompleteReq(batch=[call]))
+
+    # The call was never written: the client can safely retry.
+    assert (
+        _count_project_rows(
+            clickhouse_trace_server.ch_client, "calls_complete", internal_project_id
+        )
+        == 0
+    )
+    # The peer file insert committed independently (joined before we raised);
+    # a retry re-writes the object over the same content-addressed file rows.
+    assert (
+        _count_project_rows(
+            clickhouse_trace_server.ch_client, "files", internal_project_id
+        )
+        >= 1
+    )
+
+
 def test_calls_complete_tolerates_content_object_name_collision(
     trace_server, clickhouse_trace_server
 ):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -8,6 +8,7 @@ import threading
 import time
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from functools import partial
 from re import sub
@@ -911,28 +912,37 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._flush_immediately = True
 
     def _flush_all_batches_in_order(self) -> None:
-        """Flush all batches in order of dependency.
+        """Flush all batches, respecting cross-table write dependencies.
         1. Bucket uploads, fanned out in parallel. Resulting chunks join
            _file_batch before the file_chunks insert so URIs are persisted
            atomically with any inline-CH chunks accumulated alongside.
-        2. File chunks, if this fails, we raise so that we don't insert calls that
-           are missing file data. Forces retry.
-        3. Content objects, if this fails, we raise. Written after their file
-           bytes so a committed object row never references unwritten content.
-        4. Calls, if this fails, we raise so that clients can retry, and so we don't
+        2. File chunks and content objects, inserted concurrently. Both must be
+           durable before calls and neither reads the other. If either fails we
+           raise, so calls (below) never commit referencing unwritten data.
+        3. Calls, if this fails, we raise so that clients can retry, and so we don't
            continue and push bad ids to the queue.
-        5. Produce to kafka, if this fails, we don't raise because all of the data
+        4. Produce to kafka, if this fails, we don't raise because all of the data
            is already in the database, we don't want the client to retry.
            TODO: consider kafka retry logic.
         """
-        self._flush_file_batches()
+        self._flush_immediately = True
 
         # Raises on fail
         try:
-            self._flush_content_objs()
+            self._file_batch.extend(
+                self._bucket_uploads.flush(self.file_storage_client)
+            )
         except Exception:
-            logger.exception("Failed to flush content objects")
+            logger.exception("Failed to flush bucket uploads")
             raise
+
+        # File chunks || content objects. Snapshot the thread-local batches so
+        # each worker inserts an explicit list on its own pooled ch_client.
+        file_rows = self._file_batch
+        content_objs = self._content_obj_batch
+        self._file_batch = []
+        self._content_obj_batch = []
+        self._flush_referenced_data_in_parallel(file_rows, content_objs)
 
         # Raises on fail
         try:
@@ -947,6 +957,46 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._flush_kafka_producer()
         except Exception:
             logger.exception("Failed to flush kafka producer")
+
+    @traced(name="clickhouse_trace_server_batched._flush_referenced_data_in_parallel")
+    def _flush_referenced_data_in_parallel(
+        self,
+        file_rows: list[FileChunkCreateCHInsertable],
+        content_objs: list[tsi.ObjSchemaForInsert],
+    ) -> None:
+        """Insert file chunks and content objects concurrently.
+
+        Both must commit before the calls that reference them, and neither reads
+        the other, so they run in parallel on separate ch_clients (ch_client is
+        thread-local, so each worker mints its own from the shared pool). Every
+        task is joined before returning; if either raises, the first error is
+        re-raised so the caller skips the calls insert and the client retries.
+        """
+        tasks: list[tuple[str, Callable[[], None]]] = []
+        if file_rows:
+            tasks.append(("files", lambda: self._insert_file_chunks(file_rows)))
+        if content_objs:
+            tasks.append(
+                ("content_objs", lambda: self._flush_content_objs_batch(content_objs))
+            )
+        if len(tasks) < 2:
+            for _, run in tasks:
+                run()
+            return
+
+        with ThreadPoolExecutor(
+            max_workers=len(tasks), thread_name_prefix="flush-insert"
+        ) as pool:
+            futures = {pool.submit(run): label for label, run in tasks}
+            errors: list[Exception] = []
+            for future in as_completed(futures):
+                try:
+                    future.result()
+                except Exception as e:
+                    logger.exception("Failed to flush %s", futures[future])
+                    errors.append(e)
+        if errors:
+            raise errors[0]
 
     def _flush_file_batches(self) -> None:
         """Fan out staged bucket uploads in parallel, then insert their chunk rows.
@@ -1154,8 +1204,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         Read-only: dedupes by (project_id, object_id, digest) so identical
         content embedded in multiple calls is written once, runs one WB-30574
         collision check per project, and stages the survivors into
-        _content_obj_batch for the ordered flush. The actual obj_create_batch
-        write happens later in _flush_content_objs, after file bytes land.
+        _content_obj_batch for the parallel flush. The actual obj_create_batch
+        write happens later in _flush_content_objs_batch, alongside file chunks.
 
         A collision must not fail the calls batch: the colliding object is
         skipped and reported in the returned {ref: raw_value} map so the
@@ -1193,13 +1243,15 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return pending_objs.restore_map()
 
-    def _flush_content_objs(self) -> None:
-        """Write staged content objects, grouped by project (obj_create_batch
-        takes a single project). Runs after _flush_file_batches so a committed
-        object row never references content that has not landed in storage.
+    def _flush_content_objs_batch(
+        self, content_objs: list[tsi.ObjSchemaForInsert]
+    ) -> None:
+        """Write content objects, grouped by project (obj_create_batch takes a
+        single project). Runs concurrently with the file-chunk insert; both land
+        before the calls that reference them.
         """
         by_project: dict[str, list[tsi.ObjSchemaForInsert]] = {}
-        for obj in self._content_obj_batch:
+        for obj in content_objs:
             by_project.setdefault(obj.project_id, []).append(obj)
         for project_objs in by_project.values():
             self.obj_create_batch(project_objs)


### PR DESCRIPTION
## Summary
- `_flush_all_batches_in_order` was a strict serial chain: bucket → files → content objects → calls. File chunks and content objects hit different tables, neither reads the other, and both must land before calls, so they now insert concurrently on separate pooled `ch_client`s (`ch_client` is thread-local, so each worker mints its own).
- Calls run only after both succeed, so a 200 still means every row a call references is durable; on partial failure the peer write reconciles idempotently on retry (content-addressed).
- Relaxes the prior "content object written strictly after its file bytes" ordering: during the concurrent window a committed object row may briefly reference a not-yet-committed file. This is the one semantic change worth a close look.

## Performance
On cache-miss batches the file-chunk insert (~264ms) overlaps the object insert (~940ms) instead of summing; warm batches are unaffected (content-ref cache already skips both). Verify span nesting still attaches under the request in Datadog (worker-thread context propagation).

## Testing
Added a failure-injection test asserting a failed content-object insert skips the calls insert (client can retry) while the peer file insert still commits. Existing calls_complete suite green.

## QA validation (zoo-qa)
Deployed to zoo-qa (weave-trace `d95bedd10`) and A/B'd vs master (`ba2c62e2`) via server-side Datadog `@duration` on `POST calls/complete`. Same driver both builds: 8 requests, 15 distinct >8KB base64 blobs each (guaranteed content-ref cache-miss, so both the file-chunk and content-object inserts run every time).

Flame graphs of representative P50 traces show the mechanism directly, master's serial insert staircase vs the PR's tighter overlapping cluster:

| master `ba2c62e2` (2.39s) — serial staircase | PR `d95bedd10` (1.91s) — concurrent flush |
|---|---|
| ![master flame](https://github.com/user-attachments/assets/b5c7c5b7-1394-47ae-aa3e-9bbc046222f0) | ![pr flame](https://github.com/user-attachments/assets/8d8e7344-3db1-464e-9ffd-2938e4a0e425) |

| build | sha | P50 | MAX | n |
|---|---|---|---|---|
| master | `ba2c62e2` | 2.38s | 5.85s | 7 |
| PR | `d95bedd10` | **1.91s** | 5.22s | 7 |

~20% faster P50 (1.25x), ~11% faster tail, consistent with overlapping the ~264ms file insert under the ~940ms object insert: median flush latency drops, tail stays gated by the slowest single insert. All 8 requests 200 + calls written; no new error class vs master.

Traces: master https://us5.datadoghq.com/apm/trace/689b0db0fde515a9e5284cfec5320e17 · PR https://us5.datadoghq.com/apm/trace/a32f711a327dfb890b6aae52a6c105d7
