### PR TITLE
fix(weave): stabilize client-side digests across non-string dict keys

### DIFF
--- a/tests/trace_server/test_digest_validation.py
+++ b/tests/trace_server/test_digest_validation.py
@@ -7,10 +7,12 @@ that support it: FileCreateReq, ObjCreateReq, and TableCreateReq.
 from __future__ import annotations
 
 import json
+from enum import IntEnum
 
 import pytest
 
 from weave.shared.digest import (
+    canonical_json,
     compute_file_digest,
     compute_object_digest,
     compute_row_digest,
@@ -49,6 +51,44 @@ def test_row_digest_stable_across_json_roundtrip() -> None:
     """Same invariant for table row digests (non-string keys in a row)."""
     row = {"weights": {1: 0.5, 2: 0.3, 10: 0.2}}
     assert compute_row_digest(row) == compute_row_digest(json.loads(json.dumps(row)))
+
+
+class _Label(IntEnum):
+    NEG = 0
+    POS = 1
+
+
+@pytest.mark.parametrize(
+    "val",
+    [
+        {"floats": {"a": 1.5, "b": float("nan"), "c": float("inf")}},
+        {"unicode": {"emoji": "😀", "esc": 'a"b\\c'}},
+        {"nested": [{"x": 1}, {"y": [{"z": 2}]}]},
+        {"enum_val": {"score": _Label.POS}},
+        {"label_map": {1: "neg", 2: "neu", 10: "pos"}},
+        {"mixed": {1: "a", "b": 2}},
+        {"collision": {1: "a", "1": "b"}},
+        {"bools": {True: "on", False: "off"}},
+    ],
+    ids=[
+        "floats",
+        "unicode",
+        "nested",
+        "enum_value",
+        "int_keys",
+        "mixed_keys",
+        "key_collision",
+        "bool_keys",
+    ],
+)
+def test_canonical_json_matches_full_roundtrip(val: dict) -> None:
+    """The gated fast path must be byte-identical to the unconditional
+    dumps->loads->dumps round-trip for every payload, whether or not it has
+    non-string dict keys. Any divergence is a silent digest mismatch.
+    """
+    assert canonical_json(val) == json.dumps(
+        json.loads(json.dumps(val)), sort_keys=True
+    )
 
 
 def test_validate_expected_digest_match() -> None:

--- a/tests/trace_server/test_digest_validation.py
+++ b/tests/trace_server/test_digest_validation.py
@@ -6,8 +6,15 @@ that support it: FileCreateReq, ObjCreateReq, and TableCreateReq.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
+from weave.shared.digest import (
+    compute_file_digest,
+    compute_object_digest,
+    compute_row_digest,
+)
 from weave.trace_server.digest_validation import validate_expected_digest
 from weave.trace_server.errors import DigestMismatchError
 from weave.trace_server.trace_server_interface import (
@@ -17,6 +24,31 @@ from weave.trace_server.trace_server_interface import (
     TableCreateReq,
     TableSchemaForInsert,
 )
+
+
+@pytest.mark.parametrize(
+    "val",
+    [
+        {"label_map": {1: "neg", 2: "neu", 10: "pos"}},
+        {"cfg": {"thresholds": {10: 0.1, 2: 0.2, 30: 0.3}}},
+        {"flags": {True: "on", False: "off"}},
+    ],
+    ids=["int_keys", "nested_int_keys", "bool_keys"],
+)
+def test_object_digest_stable_across_json_roundtrip(val: dict) -> None:
+    """The client hashes the in-memory val; the server hashes it after it
+    round-trips through JSON over the wire, which turns non-string dict keys
+    into strings before sort_keys orders them. The digest must be identical
+    both ways, otherwise the client-side fast path 409s.
+    """
+    wire_val = json.loads(json.dumps(val))
+    assert compute_object_digest(val) == compute_object_digest(wire_val)
+
+
+def test_row_digest_stable_across_json_roundtrip() -> None:
+    """Same invariant for table row digests (non-string keys in a row)."""
+    row = {"weights": {1: 0.5, 2: 0.3, 10: 0.2}}
+    assert compute_row_digest(row) == compute_row_digest(json.loads(json.dumps(row)))
 
 
 def test_validate_expected_digest_match() -> None:
@@ -49,8 +81,6 @@ class TestFileCreateExpectedDigest:
 
     def test_correct_expected_digest(self, client) -> None:
         """file_create with correct expected_digest succeeds."""
-        from weave.shared.digest import compute_file_digest
-
         content = b"hello world"
         digest = compute_file_digest(content)
         req = FileCreateReq(
@@ -100,6 +130,25 @@ class TestObjCreateExpectedDigest:
         )
         with pytest.raises(DigestMismatchError):
             client.server.obj_create(req)
+
+    def test_client_digest_with_nonstring_keys(self, client) -> None:
+        """A client computes expected_digest over native (int) dict keys; the
+        server receives the JSON-serialized val (string keys) and must still
+        accept it rather than raising a 409 DigestMismatchError.
+        """
+        val = {"label_map": {1: "neg", 2: "neu", 10: "pos"}}
+        expected_digest = compute_object_digest(val)
+        wire_val = json.loads(json.dumps(val))
+        req = ObjCreateReq(
+            obj=ObjSchemaForInsert(
+                project_id=client.project_id,
+                object_id="scorer_obj",
+                val=wire_val,
+                expected_digest=expected_digest,
+            )
+        )
+        res = client.server.obj_create(req)
+        assert res.digest == expected_digest
 
 
 @pytest.mark.trace_server

--- a/weave/shared/digest.py
+++ b/weave/shared/digest.py
@@ -36,6 +36,17 @@ def str_digest(json_val: str) -> str:
     return bytes_digest(json_val.encode())
 
 
+def canonical_json(val: Any) -> str:
+    """Serialize val the way the server sees it after transport.
+
+    The client hashes an in-memory value while the server hashes the same
+    value after it round-trips through JSON over the wire, which coerces
+    non-string dict keys to strings before sort_keys orders them. Round-tripping
+    here keeps both sides byte-identical regardless of key types.
+    """
+    return json.dumps(json.loads(json.dumps(val)), sort_keys=True)
+
+
 @dataclass(slots=True, frozen=True)
 class ObjectDigestResult:
     """Deterministic digest data for object-create style payloads."""
@@ -53,8 +64,9 @@ def compute_object_digest_result(
     """Compute the object digest using server-equivalent normalization and hashing."""
     processed_result = process_incoming_object_val(val, builtin_object_class)
     processed_val = processed_result["val"]
-    # Keep object digests stable regardless of dictionary insertion order.
-    json_val = json.dumps(processed_val, sort_keys=True)
+    # Keep object digests stable regardless of dictionary insertion order
+    # and non-string key types (see canonical_json).
+    json_val = canonical_json(processed_val)
     digest = str_digest(json_val)
     return ObjectDigestResult(
         processed_val=processed_val,
@@ -72,8 +84,9 @@ def compute_object_digest(val: Any, builtin_object_class: str | None = None) -> 
 
 def compute_row_digest(row: dict[str, Any]) -> str:
     """Compute a single row digest exactly as table_create does server-side."""
-    # Keep table row digests stable regardless of dictionary insertion order.
-    row_json = json.dumps(row, sort_keys=True)
+    # Keep table row digests stable regardless of dictionary insertion order
+    # and non-string key types (see canonical_json).
+    row_json = canonical_json(row)
     return str_digest(row_json)
 
 

--- a/weave/shared/digest.py
+++ b/weave/shared/digest.py
@@ -39,12 +39,14 @@ def str_digest(json_val: str) -> str:
 def canonical_json(val: Any) -> str:
     """Serialize val the way the server sees it after transport.
 
-    The client hashes an in-memory value while the server hashes the same
-    value after it round-trips through JSON over the wire, which coerces
-    non-string dict keys to strings before sort_keys orders them. Round-tripping
-    here keeps both sides byte-identical regardless of key types.
+    The wire coerces non-string dict keys to strings before sort_keys orders
+    them. When every key is already a str (every server-side call, and
+    virtually all client payloads) a single dumps is byte-identical to the
+    round-trip, so the round-trip is only paid when a non-string key exists.
     """
-    return json.dumps(json.loads(json.dumps(val)), sort_keys=True)
+    if _has_non_string_dict_keys(val):
+        return json.dumps(json.loads(json.dumps(val)), sort_keys=True)
+    return json.dumps(val, sort_keys=True)
 
 
 @dataclass(slots=True, frozen=True)
@@ -101,3 +103,18 @@ def compute_table_digest(row_digests: list[str]) -> str:
 def compute_file_digest(content: bytes) -> str:
     """Compute file digest using server-equivalent file hashing."""
     return bytes_digest(content)
+
+
+def _has_non_string_dict_keys(val: Any) -> bool:
+    """True if any dict reachable from val has a non-str key.
+
+    Traverses exactly the containers json.dumps serializes (dict, list, tuple);
+    revisit if a default= or custom encoder is ever added to canonical_json.
+    """
+    if isinstance(val, dict):
+        return any(not isinstance(k, str) for k in val) or any(
+            _has_non_string_dict_keys(v) for v in val.values()
+        )
+    if isinstance(val, (list, tuple)):
+        return any(_has_non_string_dict_keys(v) for v in val)
+    return False


### PR DESCRIPTION
## Summary
- `/obj/create` returned 409 `DigestMismatchError` when an object (e.g. a scorer with an int-keyed label map) carried non-string dict keys.
- Client hashed the in-memory val; the server hashed it after a JSON round-trip, which stringifies keys before `sort_keys`. Keys whose numeric vs lexicographic order differs (`{1,2,10}`) diverged.
- Fix: hash over `canonical_json` (a JSON round-trip) so both sides agree. Plain string-keyed digests are byte-for-byte unchanged, so no stored digest changes.
- Jira: [WB-37011](https://coreweave.atlassian.net/browse/WB-37011)

## Testing
adds red-then-green digest round-trip invariance tests + a server-level obj_create repro (int keys).

[WB-37011]: https://coreweave.atlassian.net/browse/WB-37011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ