### PR TITLE
fix(weave): use real Bedrock cache token field names

### DIFF
--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -720,7 +720,9 @@ def test_bedrock_converse_cache_tokens(
     calls = client.get_calls()
     assert len(calls) == 1
     model_usage = calls[0].summary["usage"][model_id]
-    assert model_usage["prompt_tokens"] == 100
+    # prompt_tokens is gross: inputTokens (100) excludes cached tokens, so the
+    # cache read (80) and cache write (15) counts are added in.
+    assert model_usage["prompt_tokens"] == 195
     assert model_usage["completion_tokens"] == 20
     assert model_usage["total_tokens"] == 120
     assert model_usage["cache_read_input_tokens"] == 80
@@ -751,7 +753,8 @@ def test_bedrock_converse_stream_cache_tokens(
     calls = client.get_calls()
     assert len(calls) == 1
     model_usage = calls[0].summary["usage"][model_id]
-    assert model_usage["prompt_tokens"] == 100
+    # Same gross prompt_tokens math as the non-streaming cache test above.
+    assert model_usage["prompt_tokens"] == 195
     assert model_usage["completion_tokens"] == 20
     assert model_usage["total_tokens"] == 120
     assert model_usage["cache_read_input_tokens"] == 80
@@ -783,6 +786,8 @@ def test_bedrock_converse_stream_cache_tokens_zero(
     model_usage = calls[0].summary["usage"][model_id]
     assert model_usage["cache_read_input_tokens"] == 0
     assert model_usage["cache_creation_input_tokens"] == 0
+    # Zero cache counts add nothing: prompt_tokens stays at inputTokens.
+    assert model_usage["prompt_tokens"] == 100
 
 
 @mock_aws

--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -71,8 +71,8 @@ MOCK_CONVERSE_RESPONSE_CACHE = {
         "inputTokens": 100,
         "outputTokens": 20,
         "totalTokens": 120,
-        "cacheReadInputTokenCount": 80,
-        "cacheWriteInputTokenCount": 15,
+        "cacheReadInputTokens": 80,
+        "cacheWriteInputTokens": 15,
     },
 }
 
@@ -115,7 +115,8 @@ MOCK_STREAM_EVENTS = [
 ]
 
 # Converse stream whose metadata reports prompt-cache token counts. Bedrock
-# names these cacheReadInputTokenCount / cacheWriteInputTokenCount.
+# names these cacheReadInputTokens / cacheWriteInputTokens (TokenUsage shape
+# in the botocore bedrock-runtime service model — there is no *Count variant).
 MOCK_STREAM_EVENTS_CACHE = [
     {"messageStart": {"role": "assistant"}},
     {
@@ -132,8 +133,8 @@ MOCK_STREAM_EVENTS_CACHE = [
                 "inputTokens": 100,
                 "outputTokens": 20,
                 "totalTokens": 120,
-                "cacheReadInputTokenCount": 80,
-                "cacheWriteInputTokenCount": 15,
+                "cacheReadInputTokens": 80,
+                "cacheWriteInputTokens": 15,
             },
             "metrics": {"latencyMs": 500},
         }
@@ -153,8 +154,8 @@ MOCK_STREAM_EVENTS_CACHE_ZERO = [
                 "inputTokens": 100,
                 "outputTokens": 20,
                 "totalTokens": 120,
-                "cacheReadInputTokenCount": 0,
-                "cacheWriteInputTokenCount": 0,
+                "cacheReadInputTokens": 0,
+                "cacheWriteInputTokens": 0,
             },
             "metrics": {"latencyMs": 500},
         }

--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -115,8 +115,7 @@ MOCK_STREAM_EVENTS = [
 ]
 
 # Converse stream whose metadata reports prompt-cache token counts. Bedrock
-# names these cacheReadInputTokens / cacheWriteInputTokens (TokenUsage shape
-# in the botocore bedrock-runtime service model — there is no *Count variant).
+# names these cacheReadInputTokens / cacheWriteInputTokens.
 MOCK_STREAM_EVENTS_CACHE = [
     {"messageStart": {"role": "assistant"}},
     {
@@ -810,6 +809,8 @@ def test_bedrock_mock_usage_keys_match_service_model() -> None:
             MOCK_STREAM_EVENTS,
             MOCK_STREAM_EVENTS_CACHE,
             MOCK_STREAM_EVENTS_CACHE_ZERO,
+            MOCK_STREAM_EVENTS_TOOL_USE,
+            MOCK_STREAM_EVENTS_TEXT_AND_TOOLS,
         )
         for event in events
         if "metadata" in event
@@ -819,7 +820,10 @@ def test_bedrock_mock_usage_keys_match_service_model() -> None:
         MOCK_CONVERSE_RESPONSE_CACHE["usage"],
         *stream_usages,
     ]:
-        assert set(usage) <= real_keys
+        unknown_keys = set(usage) - real_keys
+        assert not unknown_keys, (
+            f"mock usage keys Bedrock never sends: {sorted(unknown_keys)}"
+        )
 
 
 @mock_aws

--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -790,6 +790,38 @@ def test_bedrock_converse_stream_cache_tokens_zero(
     assert model_usage["prompt_tokens"] == 100
 
 
+def test_bedrock_mock_usage_keys_match_service_model() -> None:
+    """Pin the mocks' usage keys to the botocore service model.
+
+    The cache-token capture shipped broken twice because the code and the
+    test mocks agreed on a field name (cacheReadInputTokenCount) that real
+    Bedrock never sends. Mocked responses bypass botocore's parser, so a
+    made-up key sails through every other test; this check fails instead.
+    """
+    token_usage_shape = (
+        botocore.session.get_session()
+        .get_service_model("bedrock-runtime")
+        .shape_for("TokenUsage")
+    )
+    real_keys = set(token_usage_shape.members)
+    stream_usages = [
+        event["metadata"]["usage"]
+        for events in (
+            MOCK_STREAM_EVENTS,
+            MOCK_STREAM_EVENTS_CACHE,
+            MOCK_STREAM_EVENTS_CACHE_ZERO,
+        )
+        for event in events
+        if "metadata" in event
+    ]
+    for usage in [
+        MOCK_CONVERSE_RESPONSE["usage"],
+        MOCK_CONVERSE_RESPONSE_CACHE["usage"],
+        *stream_usages,
+    ]:
+        assert set(usage) <= real_keys
+
+
 @mock_aws
 @pytest.mark.parametrize("model_identifier", [model_id, inference_profile_id])
 def test_bedrock_invoke(

--- a/weave/integrations/bedrock/bedrock_sdk.py
+++ b/weave/integrations/bedrock/bedrock_sdk.py
@@ -33,13 +33,18 @@ def bedrock_on_finish_converse(
             "completion_tokens": output_usage["outputTokens"],
             "total_tokens": output_usage["totalTokens"],
         }
-        # Bedrock Converse API returns cache tokens when prompt caching is used
+        # Bedrock Converse API returns cache tokens when prompt caching is used.
+        # Bedrock's inputTokens excludes cached tokens, while Weave's cost math
+        # treats prompt_tokens as the gross total and subtracts the cache counts
+        # from it, so add them in (litellm maps Bedrock usage the same way).
         cache_read = output_usage.get("cacheReadInputTokens")
         if cache_read is not None:
             tokens_metrics["cache_read_input_tokens"] = cache_read
+            tokens_metrics["prompt_tokens"] += cache_read
         cache_write = output_usage.get("cacheWriteInputTokens")
         if cache_write is not None:
             tokens_metrics["cache_creation_input_tokens"] = cache_write
+            tokens_metrics["prompt_tokens"] += cache_write
         usage[model_name].update(tokens_metrics)
     if call.summary is not None:
         call.summary.update(summary_update)

--- a/weave/integrations/bedrock/bedrock_sdk.py
+++ b/weave/integrations/bedrock/bedrock_sdk.py
@@ -34,10 +34,10 @@ def bedrock_on_finish_converse(
             "total_tokens": output_usage["totalTokens"],
         }
         # Bedrock Converse API returns cache tokens when prompt caching is used
-        cache_read = output_usage.get("cacheReadInputTokenCount")
+        cache_read = output_usage.get("cacheReadInputTokens")
         if cache_read is not None:
             tokens_metrics["cache_read_input_tokens"] = cache_read
-        cache_write = output_usage.get("cacheWriteInputTokenCount")
+        cache_write = output_usage.get("cacheWriteInputTokens")
         if cache_write is not None:
             tokens_metrics["cache_creation_input_tokens"] = cache_write
         usage[model_name].update(tokens_metrics)
@@ -420,12 +420,12 @@ def bedrock_stream_accumulator(
             acc["usage"]["totalTokens"] = usage.get("totalTokens", 0)
             # Preserve Bedrock's cache token keys so bedrock_on_finish_converse
             # captures them; caching may be off, so a count of 0 is meaningful.
-            cache_read = usage.get("cacheReadInputTokenCount")
+            cache_read = usage.get("cacheReadInputTokens")
             if cache_read is not None:
-                acc["usage"]["cacheReadInputTokenCount"] = cache_read
-            cache_write = usage.get("cacheWriteInputTokenCount")
+                acc["usage"]["cacheReadInputTokens"] = cache_read
+            cache_write = usage.get("cacheWriteInputTokens")
             if cache_write is not None:
-                acc["usage"]["cacheWriteInputTokenCount"] = cache_write
+                acc["usage"]["cacheWriteInputTokens"] = cache_write
         if "metrics" in metadata:
             acc["latency_ms"] = metadata["metrics"].get("latencyMs", 0)
 


### PR DESCRIPTION
## Description

- Fixes [WB-36951](https://coreweave.atlassian.net/browse/WB-36951)
- Fixes #7326

Bedrock reports cache token counts as `cacheReadInputTokens` / `cacheWriteInputTokens`. Our integration read `cacheReadInputTokenCount` / `cacheWriteInputTokenCount` — fields that don't exist. So cache tokens were never recorded, on both the `converse` and `converse_stream` paths.

The tests didn't catch it because the mocks used the same wrong names. That's how it shipped twice (#6516, then #7525). @kimnamu diagnosed this and opened #7328 with the right names — thank you! His PR now conflicts with master, so this one re-lands the rename (first commit co-authored) and fixes the mocks.

One more thing had to change: `prompt_tokens`. Bedrock's `inputTokens` does not include cache tokens ([AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html)). Our cost math subtracts cache counts from `prompt_tokens`, so it expects the total. A plain rename would make it subtract tokens that were never there. Fix: `prompt_tokens = inputTokens + cache read + cache write`. litellm maps Bedrock usage the same way. Calls without caching are not affected.

## Testing

All 15 bedrock tests pass, on both the in-memory and ClickHouse backends. I also checked the tests can actually catch the bug now: revert the source fix, keep the tests — the three cache tests fail; restore the fix — they pass. There is also a new test that checks mock usage keys against the botocore service model, so a made-up field name can't go green again.

[WB-36951]: https://coreweave.atlassian.net/browse/WB-36951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ