### PR TITLE
chore(weave_ts): migrate node SDK to OpenTelemetry JS 2.x

### DIFF
--- a/sdks/node/CHANGELOG.md
+++ b/sdks/node/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Weave TypeScript SDK will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- Upgrade OpenTelemetry JS SDK dependencies to the 2.x line (`@opentelemetry/sdk-trace-base` / `@opentelemetry/resources` `^2.8.0`, `@opentelemetry/exporter-trace-otlp-proto` `^0.219.0`). Fixes a load-time crash (`Cannot read properties of undefined (reading 'AlwaysOn')`) in host applications that force-resolve `@opentelemetry/core@2.x` via npm overrides (e.g. OpenClaw's managed dependency pins), where the 1.x trace SDK is incompatible with the 2.x core.
+
 ## [0.16.2] - 2026-07-06
 
 ### Added

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -165,9 +165,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.53.0",
-    "@opentelemetry/resources": "^1.26.0",
-    "@opentelemetry/sdk-trace-base": "^1.26.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0",
+    "@opentelemetry/resources": "^2.8.0",
+    "@opentelemetry/sdk-trace-base": "^2.8.0",
     "cli-progress": "^3.12.0",
     "cross-spawn": "^7.0.5",
     "form-data": "^4.0.4",

--- a/sdks/node/pnpm-lock.yaml
+++ b/sdks/node/pnpm-lock.yaml
@@ -12,14 +12,14 @@ importers:
         specifier: ^1.9.1
         version: 1.9.1
       '@opentelemetry/exporter-trace-otlp-proto':
-        specifier: ^0.53.0
-        version: 0.53.0(@opentelemetry/api@1.9.1)
+        specifier: ^0.219.0
+        version: 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources':
-        specifier: ^1.26.0
-        version: 1.30.1(@opentelemetry/api@1.9.1)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base':
-        specifier: ^1.26.0
-        version: 1.30.1(@opentelemetry/api@1.9.1)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.1)
       cli-progress:
         specifier: ^3.12.0
         version: 3.12.0
@@ -1166,9 +1166,9 @@ packages:
     resolution: {integrity: sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/api-logs@0.53.0':
-    resolution: {integrity: sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==}
-    engines: {node: '>=14'}
+  '@opentelemetry/api-logs@0.219.0':
+    resolution: {integrity: sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==}
+    engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -1181,18 +1181,6 @@ packages:
   '@opentelemetry/context-async-hooks@2.8.0':
     resolution: {integrity: sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==}
     engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/core@1.26.0':
-    resolution: {integrity: sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/core@1.30.1':
-    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
-    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
@@ -1226,11 +1214,11 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-trace-otlp-proto@0.53.0':
-    resolution: {integrity: sha512-T/bdXslwRKj23S96qbvGtaYOdfyew3TjPEKOk5mHjkCmkVl1O9C/YMdejwSsdLdOq2YW30KjR9kVi0YMxZushQ==}
-    engines: {node: '>=14'}
+  '@opentelemetry/exporter-trace-otlp-proto@0.219.0':
+    resolution: {integrity: sha512-lF/LUBfhOFmxJa+SQsLN7ziV4MHa2pyKgOM6JNehSOfU+npjM4gwm9oIKEJrzrWcexMcqydiyoFy0XCb1Ql3wQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
-      '@opentelemetry/api': ^1.0.0
+      '@opentelemetry/api': ^1.3.0
 
   '@opentelemetry/otlp-exporter-base@0.205.0':
     resolution: {integrity: sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==}
@@ -1238,11 +1226,11 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-exporter-base@0.53.0':
-    resolution: {integrity: sha512-UCWPreGQEhD6FjBaeDuXhiMf6kkBODF0ZQzrk/tuQcaVDJ+dDQ/xhJp192H9yWnKxVpEjFrSSLnpqmX4VwX+eA==}
-    engines: {node: '>=14'}
+  '@opentelemetry/otlp-exporter-base@0.219.0':
+    resolution: {integrity: sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
-      '@opentelemetry/api': ^1.0.0
+      '@opentelemetry/api': ^1.3.0
 
   '@opentelemetry/otlp-transformer@0.205.0':
     resolution: {integrity: sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==}
@@ -1250,9 +1238,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-transformer@0.53.0':
-    resolution: {integrity: sha512-rM0sDA9HD8dluwuBxLetUmoqGJKSAbWenwD65KY9iZhUxdBHRLrIdrABfNDP7aiTjcgK8XFyTn5fhDz7N+W6DA==}
-    engines: {node: '>=14'}
+  '@opentelemetry/otlp-transformer@0.219.0':
+    resolution: {integrity: sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -1261,18 +1249,6 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
-
-  '@opentelemetry/resources@1.26.0':
-    resolution: {integrity: sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/resources@1.30.1':
-    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/resources@2.1.0':
     resolution: {integrity: sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==}
@@ -1292,17 +1268,11 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
-  '@opentelemetry/sdk-logs@0.53.0':
-    resolution: {integrity: sha512-dhSisnEgIj/vJZXZV6f6KcTnyLDx/VuQ6l3ejuZpMpPlh9S1qMHiZU9NMmOkVkwwHkMy3G6mEBwdP23vUZVr4g==}
-    engines: {node: '>=14'}
+  '@opentelemetry/sdk-logs@0.219.0':
+    resolution: {integrity: sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
-
-  '@opentelemetry/sdk-metrics@1.26.0':
-    resolution: {integrity: sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/sdk-metrics@2.1.0':
     resolution: {integrity: sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==}
@@ -1315,18 +1285,6 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-base@1.26.0':
-    resolution: {integrity: sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-base@1.30.1':
-    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/sdk-trace-base@2.1.0':
     resolution: {integrity: sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==}
@@ -1345,14 +1303,6 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/semantic-conventions@1.27.0':
-    resolution: {integrity: sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==}
-    engines: {node: '>=14'}
-
-  '@opentelemetry/semantic-conventions@1.28.0':
-    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
-    engines: {node: '>=14'}
 
   '@opentelemetry/semantic-conventions@1.41.1':
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
@@ -5648,13 +5598,13 @@ snapshots:
       '@shikijs/types': 3.4.2
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
-      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
       '@google-cloud/precise-date': 4.0.0
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.0)
       google-auth-library: 9.15.1(encoding@0.1.13)
       googleapis: 137.1.0(encoding@0.1.13)
@@ -5662,25 +5612,25 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+  '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)':
     dependencies:
-      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.8.1
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       google-auth-library: 9.15.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@google-cloud/opentelemetry-resource-util@3.0.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+  '@google-cloud/opentelemetry-resource-util@3.0.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)':
     dependencies:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.28.0
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
       gcp-metadata: 6.1.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
@@ -5731,8 +5681,8 @@ snapshots:
   '@google/adk@1.2.0(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@22.14.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)':
     dependencies:
       '@a2a-js/sdk': 0.3.13(@grpc/grpc-js@1.14.4)(express@4.22.2)
-      '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
-      '@google-cloud/opentelemetry-cloud-trace-exporter': 3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/opentelemetry-cloud-trace-exporter': 3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
       '@google-cloud/storage': 7.21.0(encoding@0.1.13)
       '@google-cloud/vertexai': 1.12.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(encoding@0.1.13)
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
@@ -6448,7 +6398,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/api-logs@0.53.0':
+  '@opentelemetry/api-logs@0.219.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
@@ -6459,16 +6409,6 @@ snapshots:
   '@opentelemetry/context-async-hooks@2.8.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-
-  '@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.27.0
-
-  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -6512,14 +6452,14 @@ snapshots:
       '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/exporter-trace-otlp-proto@0.53.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.53.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.53.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/otlp-exporter-base@0.205.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -6527,11 +6467,11 @@ snapshots:
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/otlp-exporter-base@0.53.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/otlp-exporter-base@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.53.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/otlp-transformer@0.205.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -6544,16 +6484,15 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
       protobufjs: 7.5.4
 
-  '@opentelemetry/otlp-transformer@0.53.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/otlp-transformer@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.53.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.53.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 1.26.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 1.26.0(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.4
+      '@opentelemetry/api-logs': 0.219.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/resource-detector-gcp@0.40.3(@opentelemetry/api@1.9.0)(encoding@0.1.13)':
     dependencies:
@@ -6564,18 +6503,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  '@opentelemetry/resources@1.26.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.27.0
-
-  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/resources@2.1.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -6589,6 +6516,12 @@ snapshots:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
 
+  '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
   '@opentelemetry/sdk-logs@0.205.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -6596,18 +6529,13 @@ snapshots:
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/sdk-logs@0.53.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.53.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/sdk-metrics@1.26.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api-logs': 0.219.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-metrics@2.1.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -6621,19 +6549,11 @@ snapshots:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.27.0
-
-  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.28.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -6649,16 +6569,19 @@ snapshots:
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
 
+  '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
   '@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/context-async-hooks': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/semantic-conventions@1.27.0': {}
-
-  '@opentelemetry/semantic-conventions@1.28.0': {}
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
 

--- a/sdks/node/src/__tests__/genai/api.test.ts
+++ b/sdks/node/src/__tests__/genai/api.test.ts
@@ -79,8 +79,8 @@ describe('genai api (top-level functions)', () => {
     const turnSpan = findSpan(spans, 'invoke_agent');
     const llmSpan = findSpan(spans, 'chat');
     const toolSpan = findSpan(spans, 'execute_tool');
-    expect(llmSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
-    expect(toolSpan.parentSpanId).toBe(llmSpan.spanContext().spanId);
+    expect(llmSpan.parentSpanContext?.spanId).toBe(turnSpan.spanContext().spanId);
+    expect(toolSpan.parentSpanContext?.spanId).toBe(llmSpan.spanContext().spanId);
     for (const s of spans) {
       expect(s.attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('conv-1');
     }
@@ -128,7 +128,7 @@ describe('genai api (top-level functions)', () => {
     const spans = getExporter().getFinishedSpans();
     const toolSpan = findSpan(spans, 'execute_tool');
     const llmSpan = findSpan(spans, 'chat');
-    expect(toolSpan.parentSpanId).toBe(llmSpan.spanContext().spanId);
+    expect(toolSpan.parentSpanContext?.spanId).toBe(llmSpan.spanContext().spanId);
   });
 
   it('startTool without an active LLM places the Tool as a sibling under Turn', () => {
@@ -140,7 +140,7 @@ describe('genai api (top-level functions)', () => {
     const spans = getExporter().getFinishedSpans();
     const toolSpan = findSpan(spans, 'execute_tool');
     const turnSpan = findSpan(spans, 'invoke_agent');
-    expect(toolSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
+    expect(toolSpan.parentSpanContext?.spanId).toBe(turnSpan.spanContext().spanId);
   });
 
   // -------------------------------------------------------------------------

--- a/sdks/node/src/__tests__/genai/chain.test.ts
+++ b/sdks/node/src/__tests__/genai/chain.test.ts
@@ -36,9 +36,9 @@ describe('end-to-end chain', () => {
     expect(toolSpan.spanContext().traceId).toBe(traceId);
 
     // Parent-child chain.
-    expect(turnSpan.parentSpanId).toBeUndefined();
-    expect(llmSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
-    expect(toolSpan.parentSpanId).toBe(llmSpan.spanContext().spanId);
+    expect(turnSpan.parentSpanContext?.spanId).toBeUndefined();
+    expect(llmSpan.parentSpanContext?.spanId).toBe(turnSpan.spanContext().spanId);
+    expect(toolSpan.parentSpanContext?.spanId).toBe(llmSpan.spanContext().spanId);
 
     // Conversation id propagates everywhere.
     for (const s of spans) {

--- a/sdks/node/src/__tests__/genai/llm.test.ts
+++ b/sdks/node/src/__tests__/genai/llm.test.ts
@@ -38,7 +38,7 @@ describe('LLM (via Turn.startLLM)', () => {
     const turnSpan = findSpan(spans, 'invoke_agent');
 
     expect(llmSpan.kind).toBe(SpanKind.CLIENT);
-    expect(llmSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
+    expect(llmSpan.parentSpanContext?.spanId).toBe(turnSpan.spanContext().spanId);
     expect(llmSpan.spanContext().traceId).toBe(turnSpan.spanContext().traceId);
 
     expect(spanSnapshot(llmSpan)).toMatchInlineSnapshot(`

--- a/sdks/node/src/__tests__/genai/provider.test.ts
+++ b/sdks/node/src/__tests__/genai/provider.test.ts
@@ -44,7 +44,12 @@ describe('otel/provider', () => {
     // Exact match over our own attributes (ignoring OTel defaults) guards
     // against `wandb.entity`/`wandb.project` reappearing on the Resource, which
     // would misroute spans (the server ranks those above the project_id header).
-    const attrs = provider!.resource.attributes;
+    // SDK 2.x made the provider's resource private; reach in for the assertion.
+    const attrs = (
+      provider as unknown as {
+        _resource: {attributes: Record<string, unknown>};
+      }
+    )._resource.attributes;
     const weaveOwned = Object.fromEntries(
       Object.entries(attrs).filter(
         ([k]) => k.startsWith('weave.') || k.startsWith('wandb.')
@@ -107,10 +112,18 @@ describe('otel/provider', () => {
     // routing target a re-init must follow, but it's coupled to exporter
     // internals — better replaced by an integration test that asserts the
     // header on a captured export once we have that harness.
-    function exporterProjectId(provider: BasicTracerProvider): string {
-      const processor = (provider as any)._registeredSpanProcessors?.[0];
+    // (Chain per otlp-exporter-base 0.2xx: exporter._delegate wraps a
+    // retrying transport around the HTTP transport, and `headers` became an
+    // async provider function.)
+    async function exporterProjectId(
+      provider: BasicTracerProvider
+    ): Promise<string | undefined> {
+      const processor = (provider as any)._activeSpanProcessor
+        ?._spanProcessors?.[0];
       const exporter = processor?._exporter;
-      const headers = exporter?._transport?._transport?._parameters?.headers;
+      const headersFn =
+        exporter?._delegate?._transport?._transport?._parameters?.headers;
+      const headers = headersFn ? await headersFn() : undefined;
       return headers?.project_id;
     }
 
@@ -149,12 +162,16 @@ describe('otel/provider', () => {
       shutdownSpy.mockRestore();
     });
 
-    it('routes the rebuilt provider to the new project via the project_id header', () => {
+    it('routes the rebuilt provider to the new project via the project_id header', async () => {
       reinit('ent/A');
-      expect(exporterProjectId(getWeaveTracerProvider()!)).toBe('ent/A');
+      await expect(exporterProjectId(getWeaveTracerProvider()!)).resolves.toBe(
+        'ent/A'
+      );
 
       reinit('ent/B');
-      expect(exporterProjectId(getWeaveTracerProvider()!)).toBe('ent/B');
+      await expect(exporterProjectId(getWeaveTracerProvider()!)).resolves.toBe(
+        'ent/B'
+      );
     });
   });
 });

--- a/sdks/node/src/__tests__/genai/subagent.test.ts
+++ b/sdks/node/src/__tests__/genai/subagent.test.ts
@@ -38,7 +38,7 @@ describe('SubAgent', () => {
     );
     expect(subSpan).toBeDefined();
     expect(parentTurnSpan).toBeDefined();
-    expect(subSpan!.parentSpanId).toBe(parentTurnSpan!.spanContext().spanId);
+    expect(subSpan!.parentSpanContext?.spanId).toBe(parentTurnSpan!.spanContext().spanId);
 
     expect(spanSnapshot(subSpan!)).toMatchInlineSnapshot(`
       {
@@ -222,8 +222,8 @@ describe('SubAgent', () => {
     expect(chatSpan).toBeDefined();
     expect(toolSpan).toBeDefined();
     // Both children parent to the subagent, not the enclosing Turn.
-    expect(chatSpan!.parentSpanId).toBe(subSpan.spanContext().spanId);
-    expect(toolSpan!.parentSpanId).toBe(subSpan.spanContext().spanId);
+    expect(chatSpan!.parentSpanContext?.spanId).toBe(subSpan.spanContext().spanId);
+    expect(toolSpan!.parentSpanContext?.spanId).toBe(subSpan.spanContext().spanId);
   });
 
   it('nests a child SubAgent (and its descendants) under the parent subagent', () => {
@@ -253,9 +253,9 @@ describe('SubAgent', () => {
     // Full chain: turn -> outer -> inner -> chat. The nested SubAgent parents
     // to the outer subagent (not the Turn), and threads its own context down to the
     // LLM it starts.
-    expect(outerSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
-    expect(innerSpan.parentSpanId).toBe(outerSpan.spanContext().spanId);
-    expect(chatSpan!.parentSpanId).toBe(innerSpan.spanContext().spanId);
+    expect(outerSpan.parentSpanContext?.spanId).toBe(turnSpan.spanContext().spanId);
+    expect(innerSpan.parentSpanContext?.spanId).toBe(outerSpan.spanContext().spanId);
+    expect(chatSpan!.parentSpanContext?.spanId).toBe(innerSpan.spanContext().spanId);
   });
 
   it('binds children eagerly, not via ambient context: a child created after the SubAgent (and Turn) end still nests under it', () => {
@@ -279,7 +279,7 @@ describe('SubAgent', () => {
     const toolSpan = spans.find(s => s.name === 'execute_tool');
     expect(chatSpan).toBeDefined();
     expect(toolSpan).toBeDefined();
-    expect(chatSpan!.parentSpanId).toBe(subSpan.spanContext().spanId);
-    expect(toolSpan!.parentSpanId).toBe(subSpan.spanContext().spanId);
+    expect(chatSpan!.parentSpanContext?.spanId).toBe(subSpan.spanContext().spanId);
+    expect(toolSpan!.parentSpanContext?.spanId).toBe(subSpan.spanContext().spanId);
   });
 });

--- a/sdks/node/src/__tests__/genai/tool.test.ts
+++ b/sdks/node/src/__tests__/genai/tool.test.ts
@@ -47,7 +47,7 @@ describe('Tool', () => {
     );
     expect(toolSpan.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBe('75F');
     expect(toolSpan.attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('conv-1');
-    expect(toolSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
+    expect(toolSpan.parentSpanContext?.spanId).toBe(turnSpan.spanContext().spanId);
   });
 
   it('attaches to the LLM span when started via llm.startTool() (nested)', () => {
@@ -61,7 +61,7 @@ describe('Tool', () => {
     const spans = getExporter().getFinishedSpans();
     const toolSpan = findSpan(spans, 'execute_tool');
     const llmSpan = findSpan(spans, 'chat');
-    expect(toolSpan.parentSpanId).toBe(llmSpan.spanContext().spanId);
+    expect(toolSpan.parentSpanContext?.spanId).toBe(llmSpan.spanContext().spanId);
   });
 
   it('setAttributes records attributes on the tool span; warns + no-op after end()', () => {

--- a/sdks/node/src/__tests__/hostApps/fixtures/claude-agent-sdk/main.mjs
+++ b/sdks/node/src/__tests__/hostApps/fixtures/claude-agent-sdk/main.mjs
@@ -29,7 +29,7 @@ const captureExporter = {
       captured.push({
         name: span.name,
         spanId: span.spanContext().spanId,
-        parentSpanId: span.parentSpanId,
+        parentSpanId: span.parentSpanContext?.spanId,
         traceId: span.spanContext().traceId,
         attributes: span.attributes,
         statusCode: span.status.code,

--- a/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
+++ b/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
@@ -276,7 +276,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
     expect(invoke.attributes[ATTR_GEN_AI_AGENT_NAME]).toBe('claude_agent_sdk');
     expect(invoke.attributes[ATTR_GEN_AI_PROVIDER_NAME]).toBe('anthropic');
     expect(invoke.attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('sess-1');
-    expect(invoke.parentSpanId).toBeUndefined();
+    expect(invoke.parentSpanContext?.spanId).toBeUndefined();
     // The root carries no token usage of its own — per-model usage rides on
     // child `chat` spans (asserted below) so the trace server costs and rolls
     // it up per model. The SDK's authoritative total cost stays on the root.
@@ -306,7 +306,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
     expect(chat.attributes[ATTR_GEN_AI_RESPONSE_FINISH_REASONS]).toEqual([
       'tool_use',
     ]);
-    expect(chat.parentSpanId).toBe(invoke.spanContext().spanId);
+    expect(chat.parentSpanContext?.spanId).toBe(invoke.spanContext().spanId);
     expect(
       JSON.parse(chat.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string)
     ).toEqual([
@@ -345,7 +345,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
     expect(usageChat.attributes[ATTR_GEN_AI_AGENT_NAME]).toBe(
       'claude_agent_sdk'
     );
-    expect(usageChat.parentSpanId).toBe(invoke.spanContext().spanId);
+    expect(usageChat.parentSpanContext?.spanId).toBe(invoke.spanContext().spanId);
 
     const tool = findSpan(spans, 'execute_tool Bash');
     expect(tool.kind).toBe(SpanKind.INTERNAL);
@@ -356,7 +356,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
     );
     expect(tool.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBe('Sunny');
     expect(tool.attributes[ATTR_GEN_AI_AGENT_NAME]).toBe('claude_agent_sdk');
-    expect(tool.parentSpanId).toBe(invoke.spanContext().spanId);
+    expect(tool.parentSpanContext?.spanId).toBe(invoke.spanContext().spanId);
 
     // The whole tree shares one trace.
     const traceId = invoke.spanContext().traceId;
@@ -407,7 +407,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
     expect(opus.attributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS]).toBe(100);
     expect(opus.attributes[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]).toBe(40);
     expect(opus.attributes[ATTR_GEN_AI_USAGE_TOTAL_TOKENS]).toBe(140);
-    expect(opus.parentSpanId).toBe(invoke.spanContext().spanId);
+    expect(opus.parentSpanContext?.spanId).toBe(invoke.spanContext().spanId);
 
     // The internal fast model has no content chat span, only a usage span —
     // sourcing from `modelUsage` is what makes its tokens visible at all.
@@ -426,7 +426,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
     ).toBe(3);
     // total_tokens = inclusive input (28) + output (8).
     expect(haiku.attributes[ATTR_GEN_AI_USAGE_TOTAL_TOKENS]).toBe(36);
-    expect(haiku.parentSpanId).toBe(invoke.spanContext().spanId);
+    expect(haiku.parentSpanContext?.spanId).toBe(invoke.spanContext().spanId);
   });
 
   test('a tool_result flagged is_error marks the execute_tool span as error', () => {

--- a/sdks/node/src/__tests__/integrations/googleAdk.test.ts
+++ b/sdks/node/src/__tests__/integrations/googleAdk.test.ts
@@ -222,7 +222,7 @@ describe('Google ADK integration', () => {
 
       const [root] = byOperation(exporter.getFinishedSpans(), 'invoke_agent');
       expect(root).toBeDefined();
-      expect(root.parentSpanId).toBeUndefined();
+      expect(root.parentSpanContext?.spanId).toBeUndefined();
       expect(root.name).toBe('invoke_agent agent_a');
       expect(root.attributes).toMatchObject({
         'gen_ai.operation.name': 'invoke_agent',
@@ -262,7 +262,7 @@ describe('Google ADK integration', () => {
 
       const root = requireSpan(
         byOperation(exporter.getFinishedSpans(), 'invoke_agent').find(
-          span => !span.parentSpanId
+          span => !span.parentSpanContext?.spanId
         )
       );
       expect(root.name).toBe('invoke_agent runner_agent');
@@ -381,7 +381,7 @@ describe('Google ADK integration', () => {
       const spans = exporter.getFinishedSpans();
       const chatSpans = byOperation(spans, 'chat');
       const root = requireSpan(
-        byOperation(spans, 'invoke_agent').find(span => !span.parentSpanId)
+        byOperation(spans, 'invoke_agent').find(span => !span.parentSpanContext?.spanId)
       );
 
       expect(chatSpans).toHaveLength(1);
@@ -647,10 +647,10 @@ describe('Google ADK integration', () => {
       expect(toolSpans).toHaveLength(1);
 
       const root = requireSpan(
-        invokeAgentSpans.find(span => !span.parentSpanId)
+        invokeAgentSpans.find(span => !span.parentSpanContext?.spanId)
       );
       const agentSpan = requireSpan(
-        invokeAgentSpans.find(span => span.parentSpanId)
+        invokeAgentSpans.find(span => span.parentSpanContext?.spanId)
       );
       const [toolSpan] = toolSpans;
 
@@ -665,12 +665,12 @@ describe('Google ADK integration', () => {
 
       // Structure: root invoke_agent → invoke_agent → (chat, chat, tool).
       expect(root.name).toBe('invoke_agent weather_agent');
-      expect(agentSpan.parentSpanId).toBe(spanId(root));
+      expect(agentSpan.parentSpanContext?.spanId).toBe(spanId(root));
       expect(agentSpan.attributes).toMatchObject({
         'gen_ai.agent.name': 'weather_agent',
       });
       for (const span of [...chatSpans, ...toolSpans]) {
-        expect(span.parentSpanId).toBe(spanId(agentSpan));
+        expect(span.parentSpanContext?.spanId).toBe(spanId(agentSpan));
       }
 
       // Root carries the user message in and the final answer out.
@@ -761,25 +761,25 @@ describe('Google ADK integration', () => {
       const chatSpans = byOperation(spans, 'chat');
 
       const root = requireSpan(
-        invokeAgentSpans.find(span => !span.parentSpanId)
+        invokeAgentSpans.find(span => !span.parentSpanContext?.spanId)
       );
       const byAgent = (name: string) =>
         requireSpan(
           invokeAgentSpans.find(
             span =>
-              span.parentSpanId && span.attributes['gen_ai.agent.name'] === name
+              span.parentSpanContext?.spanId && span.attributes['gen_ai.agent.name'] === name
           )
         );
       const pipelineSpan = byAgent('pipeline');
       const firstSpan = byAgent('first_agent');
       const secondSpan = byAgent('second_agent');
 
-      expect(pipelineSpan.parentSpanId).toBe(spanId(root));
-      expect(firstSpan.parentSpanId).toBe(spanId(pipelineSpan));
-      expect(secondSpan.parentSpanId).toBe(spanId(pipelineSpan));
+      expect(pipelineSpan.parentSpanContext?.spanId).toBe(spanId(root));
+      expect(firstSpan.parentSpanContext?.spanId).toBe(spanId(pipelineSpan));
+      expect(secondSpan.parentSpanContext?.spanId).toBe(spanId(pipelineSpan));
 
       expect(chatSpans).toHaveLength(2);
-      const chatParents = chatSpans.map(span => span.parentSpanId).sort();
+      const chatParents = chatSpans.map(span => span.parentSpanContext?.spanId).sort();
       expect(chatParents).toEqual(
         [spanId(firstSpan), spanId(secondSpan)].sort()
       );
@@ -822,7 +822,7 @@ describe('Google ADK integration', () => {
           span => span.attributes['gen_ai.agent.name'] === 'outside_agent'
         )
       );
-      expect(outsideAgent.parentSpanId).toBe(spanId(toolSpan));
+      expect(outsideAgent.parentSpanContext?.spanId).toBe(spanId(toolSpan));
     });
 
     test('tool errors record span errors; the late afterToolCallback is ignored', async () => {
@@ -963,7 +963,7 @@ describe('Google ADK integration', () => {
       const roots = byOperation(
         exporter.getFinishedSpans(),
         'invoke_agent'
-      ).filter(span => !span.parentSpanId);
+      ).filter(span => !span.parentSpanContext?.spanId);
       // The run-root span was ended (and thus exported) despite the early
       // break — the invocation did not leak.
       expect(roots).toHaveLength(1);

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -623,9 +623,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
 
     // Child OTel span points back at the agent OTel span via parentSpanId,
     // and they share the same traceId.
-    expect(fn.parentSpanId).toBe(agent.spanContext().spanId);
+    expect(fn.parentSpanContext?.spanId).toBe(agent.spanContext().spanId);
     expect(fn.spanContext().traceId).toBe(agent.spanContext().traceId);
-    expect(agent.parentSpanId).toBeUndefined();
+    expect(agent.parentSpanContext?.spanId).toBeUndefined();
   });
 
   test('agent run with tool call emits expected OTel spans', async () => {
@@ -683,7 +683,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'integration.version': packageVersion,
     });
     // Span is a child of the agent span.
-    expect(executeToolSpan.parentSpanId).toBe(agentSpan!.spanContext().spanId);
+    expect(executeToolSpan.parentSpanContext?.spanId).toBe(agentSpan!.spanContext().spanId);
     expect(executeToolSpan.spanContext().traceId).toBe(
       agentSpan!.spanContext().traceId
     );

--- a/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
@@ -285,7 +285,7 @@ describe('PiCodingAgentOtelAdapter', () => {
       )!;
       const chat = spans.find(s => s.name.startsWith('chat '))!;
       expect(chat.kind).toBe(SpanKind.CLIENT);
-      expect(chat.parentSpanId).toBe(invoke.spanContext().spanId);
+      expect(chat.parentSpanContext?.spanId).toBe(invoke.spanContext().spanId);
       expect(chat.attributes['gen_ai.operation.name']).toBe('chat');
       expect(chat.attributes['gen_ai.provider.name']).toBe('anthropic');
       expect(chat.attributes['gen_ai.request.model']).toBe(
@@ -413,7 +413,7 @@ describe('PiCodingAgentOtelAdapter', () => {
       )!;
       const tool = spans.find(s => s.name === 'execute_tool bash')!;
       expect(tool.kind).toBe(SpanKind.INTERNAL);
-      expect(tool.parentSpanId).toBe(invoke.spanContext().spanId);
+      expect(tool.parentSpanContext?.spanId).toBe(invoke.spanContext().spanId);
       expect(tool.attributes['gen_ai.tool.name']).toBe('bash');
       expect(tool.attributes['gen_ai.tool.call.id']).toBe('call-1');
       expect(tool.attributes['gen_ai.conversation.id']).toBe('test-session-id');
@@ -503,7 +503,7 @@ describe('PiCodingAgentOtelAdapter', () => {
         .getFinishedSpans()
         .find(s => s.name === 'pi.coding_agent.compaction')!;
       expect(compact).toBeDefined();
-      expect(compact.parentSpanId).toBeUndefined();
+      expect(compact.parentSpanContext?.spanId).toBeUndefined();
       expect(compact.attributes['pi.compaction.reason']).toBe('context_limit');
       expect(compact.attributes['pi.compaction.aborted']).toBe(false);
       expect(compact.attributes['pi.compaction.will_retry']).toBe(false);

--- a/sdks/node/src/genai/provider.ts
+++ b/sdks/node/src/genai/provider.ts
@@ -1,6 +1,6 @@
 import type {Tracer} from '@opentelemetry/api';
 import {OTLPTraceExporter} from '@opentelemetry/exporter-trace-otlp-proto';
-import {Resource} from '@opentelemetry/resources';
+import {resourceFromAttributes} from '@opentelemetry/resources';
 import {
   AlwaysOffSampler,
   BasicTracerProvider,
@@ -90,7 +90,7 @@ function getOrBuildProvider(client: WeaveClient): BasicTracerProvider {
     return cached.tracerProvider;
   }
 
-  const resource = new Resource({
+  const resource = resourceFromAttributes({
     [WEAVE_RESOURCE_ATTR.WEAVE_SDK_VERSION]: packageVersion,
     [WEAVE_RESOURCE_ATTR.WEAVE_SDK_LANGUAGE]: SDK_LANGUAGE,
   });


### PR DESCRIPTION
### Why

The published `weave` npm package depends on the OTel **1.x** trace stack
(`@opentelemetry/sdk-trace-base@^1.26.0`, `@opentelemetry/resources@^1.26.0`,
`@opentelemetry/exporter-trace-otlp-proto@^0.53.0`). Host applications that
force-resolve `@opentelemetry/core@2.x` via npm `overrides` crash the SDK at
load time:

```
TypeError: Cannot read properties of undefined (reading 'AlwaysOn')
```

(`TracesSamplerValues` was removed from `@opentelemetry/core` in 2.x, but
sdk-trace-base 1.x still imports it.)

This is not hypothetical: OpenClaw's plugin installer writes managed
dependency overrides — including `@opentelemetry/core: 2.8.0` — into every
installed plugin's package.json, which makes `weave-openclaw` (and any other
OpenClaw plugin that depends on `weave`) crash on gateway startup with the
error above. Reproduced on a fresh OpenClaw install; fixed by this migration.

### What

- `@opentelemetry/sdk-trace-base` / `@opentelemetry/resources`: `^1.26.0` -> `^2.8.0`
- `@opentelemetry/exporter-trace-otlp-proto`: `^0.53.0` -> `^0.219.0`
- `new Resource({...})` -> `resourceFromAttributes({...})` (2.x API)
- Tests migrated for 2.x renames/privatization:
  - `ReadableSpan.parentSpanId` -> `parentSpanContext?.spanId`
  - `BasicTracerProvider.resource` is private now; the resource-attribute
    assertion reaches `_resource`
  - the exporter-internals probe in provider.test.ts follows the new
    otlp-exporter-base 0.2xx chain (`_delegate`, async `headers()`)
- CHANGELOG entry under Unreleased.

No public API changes. `@opentelemetry/api` stays `^1.9.1` (unchanged, 2.x
compatible).

### Validation

- `pnpm typecheck:cjs`, `pnpm typecheck:esm`, `pnpm lint`: clean
- `jest --selectProjects default modern legacy`: 53 suites / 421 tests pass
- End-to-end: packed this branch (`pnpm pack`), overrode `weave` in an
  OpenClaw `weave-openclaw` plugin install (which forces core 2.8.0), ran an
  agent turn through the gateway — plugin loads cleanly and spans land in the
  Weave Agents store (`agents/spans/query`) with a consistent OTel 2.x tree
  (core 2.8.0, sdk-trace-base 2.9.0, exporter 0.219.0).

Made with [Cursor](https://cursor.com)