### PR TITLE
fix(weave): drop stalling calls_complete reclaim DELETE

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -15,7 +15,6 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     _invalid_field_message,
     _is_minimal_filter,
     _maybe_convert_datetime_operands,
-    build_calls_complete_delete_query,
     build_calls_complete_soft_delete_query,
     build_calls_complete_update_end_query,
     build_calls_complete_update_query,
@@ -4190,77 +4189,8 @@ def test_query_with_summary_weave_status_filter_calls_complete() -> None:
     )
 
 
-def test_build_calls_complete_delete_query() -> None:
-    """Ensure the delete helper builds the expected query."""
-    query = build_calls_complete_delete_query(
-        table_name="calls_complete",
-        project_id_param="project_id",
-        call_ids_param="call_ids",
-    )
-
-    expected = sqlparse.format(
-        """
-        DELETE FROM calls_complete
-        WHERE project_id = {project_id:String} AND id IN {call_ids:Array(String)}
-        """,
-        reindent=True,
-    )
-
-    assert query == expected, f"\nExpected:\n{expected}\n\nGot:\n{query}"
-
-
-def test_build_calls_complete_delete_query_with_cluster() -> None:
-    """Ensure the delete helper builds the expected query with cluster name.
-
-    _format_table_name_with_cluster only adds ON CLUSTER; the caller is
-    responsible for passing the correct table name (e.g. calls_complete_local
-    in distributed mode via _get_calls_complete_table_name).
-    """
-    query = build_calls_complete_delete_query(
-        table_name="calls_complete",
-        project_id_param="project_id",
-        call_ids_param="call_ids",
-        cluster_name="my_cluster",
-    )
-
-    expected = sqlparse.format(
-        """
-        DELETE FROM calls_complete ON CLUSTER my_cluster
-        WHERE project_id = {project_id:String} AND id IN {call_ids:Array(String)}
-        """,
-        reindent=True,
-    )
-
-    assert query == expected, f"\nExpected:\n{expected}\n\nGot:\n{query}"
-
-
-def test_build_calls_complete_delete_query_with_started_at_window() -> None:
-    """started_at bounds bracket the partition/primary key so the delete prunes."""
-    query = build_calls_complete_delete_query(
-        table_name="calls_complete",
-        project_id_param="project_id",
-        call_ids_param="call_ids",
-        started_at_min_param="started_at_min",
-        started_at_max_param="started_at_max",
-        cluster_name="my_cluster",
-    )
-
-    expected = sqlparse.format(
-        """
-        DELETE FROM calls_complete ON CLUSTER my_cluster
-        WHERE project_id = {project_id:String}
-        AND started_at >= fromUnixTimestamp64Micro({started_at_min:Int64}, 'UTC')
-        AND started_at <= fromUnixTimestamp64Micro({started_at_max:Int64}, 'UTC')
-        AND id IN {call_ids:Array(String)}
-        """,
-        reindent=True,
-    )
-
-    assert query == expected, f"\nExpected:\n{expected}\n\nGot:\n{query}"
-
-
 def test_build_calls_complete_soft_delete_query() -> None:
-    """Soft-delete marks deleted_at via a lightweight UPDATE, pruned by the started_at window."""
+    """Soft-delete marks deleted_at and expire_at in one lightweight UPDATE, pruned by the started_at window."""
     query = build_calls_complete_soft_delete_query(
         table_name="calls_complete",
         project_id_param="project_id",
@@ -4273,7 +4203,7 @@ def test_build_calls_complete_soft_delete_query() -> None:
     expected = sqlparse.format(
         """
         UPDATE calls_complete ON CLUSTER my_cluster
-        SET deleted_at = now64(3)
+        SET deleted_at = now64(3), expire_at = now64(3)
         WHERE project_id = {project_id:String}
         AND started_at >= fromUnixTimestamp64Micro({started_at_min:Int64}, 'UTC')
         AND started_at <= fromUnixTimestamp64Micro({started_at_max:Int64}, 'UTC')

--- a/tests/trace_server/query_builder/test_on_cluster_query_builder.py
+++ b/tests/trace_server/query_builder/test_on_cluster_query_builder.py
@@ -13,7 +13,6 @@ import pytest
 from weave.trace_server import environment as wf_env
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.calls_query_builder.calls_query_builder import (
-    build_calls_complete_delete_query,
     build_calls_complete_update_end_query,
     build_calls_complete_update_query,
 )
@@ -64,14 +63,6 @@ def test_on_cluster_mutations_never_inject_local_suffix() -> None:
         cluster_name=CLUSTER,
     )
     assert f"calls_complete ON CLUSTER {CLUSTER}" in update_end
-
-    delete = build_calls_complete_delete_query(
-        table_name="calls_complete",
-        project_id_param="p",
-        call_ids_param="c",
-        cluster_name=CLUSTER,
-    )
-    assert f"calls_complete ON CLUSTER {CLUSTER}" in delete
 
     update = build_calls_complete_update_query(
         table_name="calls_complete",

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -15,6 +15,7 @@ from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
 from weave.trace_server.calls_query_builder.utils import param_slot
+from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER, SENTINEL_EPOCH
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.errors import (
     CallsCompleteModeRequired,
@@ -1749,6 +1750,58 @@ def test_calls_delete(trace_server, clickhouse_trace_server):
     )
     assert res.num_deleted == 2
     assert len(_fetch_calls_stream(trace_server, project_id)) == 0
+
+
+def test_calls_delete_marks_deleted_at_and_expire_at(
+    trace_server, clickhouse_trace_server
+):
+    """Delete sets deleted_at (read hiding) and expire_at (native TTL reclamation) in one UPDATE.
+
+    Both markers are the same instant on the deleted row (expire_at is a second-precision
+    DateTime, so it is deleted_at floored to the second); the surviving sibling keeps its
+    sentinels, so TTL never reclaims it.
+    """
+    project_id = f"{TEST_ENTITY}/calls_complete_delete_markers"
+    internal_project_id = b64(project_id)
+    ch_client = clickhouse_trace_server.ch_client
+
+    deleted_id, kept_id = str(uuid.uuid4()), str(uuid.uuid4())
+    now = datetime.datetime.now(datetime.timezone.utc)
+    trace_server.calls_complete(
+        tsi.CallsUpsertCompleteReq(
+            batch=[
+                _make_completed_call(project_id, cid, str(uuid.uuid4()), now, now)
+                for cid in (deleted_id, kept_id)
+            ]
+        )
+    )
+
+    res = trace_server.calls_delete(
+        tsi.CallsDeleteReq(project_id=project_id, call_ids=[deleted_id])
+    )
+    assert res.num_deleted == 1
+    assert {c.id for c in _fetch_calls_stream(trace_server, project_id)} == {kept_id}
+
+    deleted_at, expire_at = _fetch_call_row(
+        ch_client,
+        "calls_complete",
+        internal_project_id,
+        deleted_id,
+        ["deleted_at", "expire_at"],
+    )
+    assert deleted_at != SENTINEL_EPOCH.replace(tzinfo=None)
+    assert expire_at != EXPIRE_AT_NEVER.replace(tzinfo=None)
+    assert expire_at == deleted_at.replace(microsecond=0)
+
+    kept_deleted_at, kept_expire_at = _fetch_call_row(
+        ch_client,
+        "calls_complete",
+        internal_project_id,
+        kept_id,
+        ["deleted_at", "expire_at"],
+    )
+    assert kept_deleted_at == SENTINEL_EPOCH.replace(tzinfo=None)
+    assert kept_expire_at == EXPIRE_AT_NEVER.replace(tzinfo=None)
 
 
 def test_calls_delete_cascade(trace_server, clickhouse_trace_server):

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -3717,10 +3717,14 @@ def build_calls_complete_soft_delete_query(
     started_at_max_param: str | None = None,
     cluster_name: str | None = None,
 ) -> str:
-    """Build the calls_complete soft-delete: a lightweight UPDATE marking deleted_at.
+    """Build the calls_complete soft-delete: a lightweight UPDATE of deleted_at and expire_at.
 
-    This writes a patch part (no mutation, no part rewrite) that the read path
-    applies on the fly via its deleted_at filter, so the calls disappear immediately.
+    Writes one patch part (no mutation, no part rewrite) that the read path applies
+    on the fly via its deleted_at filter, so the calls disappear immediately. expire_at
+    is set to the same instant so the table's native `TTL expire_at DELETE` reclaims the
+    rows physically in the background. expire_at now means the earliest permitted physical
+    reclamation (retention or deletion); an undelete, if ever added, must recompute it from
+    started_at + the project's retention.
     """
     formatted_table = _format_table_name_with_cluster(table_name, cluster_name)
     where_clause = _calls_complete_id_window_where(
@@ -3728,27 +3732,7 @@ def build_calls_complete_soft_delete_query(
     )
     raw_sql = f"""
         UPDATE {formatted_table}
-        SET deleted_at = now64(3)
-        WHERE {where_clause}
-        """
-    return safely_format_sql(raw_sql, logger)
-
-
-def build_calls_complete_delete_query(
-    table_name: str,
-    project_id_param: str,
-    call_ids_param: str,
-    started_at_min_param: str | None = None,
-    started_at_max_param: str | None = None,
-    cluster_name: str | None = None,
-) -> str:
-    """Build the calls_complete physical DELETE (async reclamation after soft-delete)."""
-    formatted_table = _format_table_name_with_cluster(table_name, cluster_name)
-    where_clause = _calls_complete_id_window_where(
-        project_id_param, call_ids_param, started_at_min_param, started_at_max_param
-    )
-    raw_sql = f"""
-        DELETE FROM {formatted_table}
+        SET deleted_at = now64(3), expire_at = now64(3)
         WHERE {where_clause}
         """
     return safely_format_sql(raw_sql, logger)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -102,7 +102,6 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     OrderField,
     QueryBuilderDynamicField,
     QueryBuilderField,
-    build_calls_complete_delete_query,
     build_calls_complete_soft_delete_query,
     build_calls_complete_started_at_select_query,
     build_calls_complete_update_end_query,
@@ -2095,9 +2094,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 datetime_to_microseconds(started_at_window[1] + pad)
             )
         table_name = self._get_calls_complete_table_name()
-        # Logical delete: a lightweight UPDATE writes a patch part the read path
-        # applies on the fly (via its deleted_at filter), so the calls vanish
-        # immediately with no mutation and no part rewrite.
+        # A single lightweight UPDATE writes one patch part that both hides the
+        # rows (deleted_at, applied on read) and marks them for physical
+        # reclamation by the table's native `TTL expire_at DELETE` (expire_at).
         soft_delete_query = build_calls_complete_soft_delete_query(
             table_name,
             project_id_param,
@@ -2110,21 +2109,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             soft_delete_query,
             parameters=pb.get_params(),
             settings=ch_settings.CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
-        )
-        # Physical reclamation runs async (sync=0) and unwaited: the marker above
-        # already hid the rows, so a slow reclaim never blocks the request.
-        delete_query = build_calls_complete_delete_query(
-            table_name,
-            project_id_param,
-            call_ids_param,
-            started_at_min_param=started_at_min_param,
-            started_at_max_param=started_at_max_param,
-            cluster_name=self.clickhouse_cluster_name,
-        )
-        self._command(
-            delete_query,
-            parameters=pb.get_params(),
-            settings=ch_settings.CLICKHOUSE_ASYNC_DELETE_SETTINGS,
         )
 
     def _ensure_valid_update_field(self, req: tsi.CallUpdateReq) -> None:

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -120,12 +120,6 @@ CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS: dict[str, int | str] = (
     }
 )
 
-# Physical reclamation of soft-deleted calls_complete rows: sync=0 lets the lightweight
-# DELETE return once scheduled (never blocks). A DELETE needs none of the UPDATE settings.
-CLICKHOUSE_ASYNC_DELETE_SETTINGS: dict[str, int | str] = {
-    "lightweight_deletes_sync": 0,
-}
-
 # The new ClickHouse query analyzer (v24+) has a bug serializing SortingStep
 # for non-Full sorting modes on distributed tables, which causes error 48
 # ("Serialization of SortingStep is implemented only for Full sorting").


### PR DESCRIPTION
## Summary
- The post-soft-delete reclaim `DELETE FROM calls_complete` runs as a lightweight delete on the same rows the soft-delete UPDATE just patched; on CH Cloud it stalls past the 60s `max_execution_time` (code 394) and, being un-guarded, 502s `/calls/delete` even though the soft-delete already hid the rows.
- Drop the inline DELETE; the soft-delete UPDATE now also sets `expire_at = now64(3)` so the table's native `TTL expire_at DELETE` reclaims. Deletes reduce to one non-blocking statement.
- Reclamation is now eventual (rides on the lightweight-update patch materializing into the base part, then TTL); rows are hidden immediately by the `deleted_at` filter. Not a regression: prod currently reclaims nothing since the DELETE always 502s.
- Removes dead `build_calls_complete_delete_query` + `CLICKHOUSE_ASYNC_DELETE_SETTINGS`.

## Testing
functional test (real CH): after delete the call is hidden, `deleted_at` + `expire_at` are both set to the delete instant, sibling keeps its sentinels.

QA'd on zoo-qa (real CH Cloud) via `/qa-this`. Server-side A/B of `/calls/delete`, master vs this build: master's `_delete_calls_complete` fires 2 ClickHouse commands (UPDATE + `DELETE FROM calls_complete`), this build fires 1 (UPDATE only). Both 200, zero code-394 in the window. UI delete of 10 calls succeeds and persists across reload.

[![datadog before/after](https://github.com/user-attachments/assets/1ed76557-36cc-4864-840e-6a8a48762436)](https://github.com/user-attachments/assets/1ed76557-36cc-4864-840e-6a8a48762436)

[![delete via weave UI](https://github.com/user-attachments/assets/140d242e-d24b-495a-adb0-2f04f0233ada)](https://github.com/user-attachments/assets/140d242e-d24b-495a-adb0-2f04f0233ada)
