### PR TITLE
feat(weave): report deleted versions in ObjDeleteRes

### DIFF
--- a/tests/trace/test_obj_delete.py
+++ b/tests/trace/test_obj_delete.py
@@ -387,6 +387,54 @@ def test_delete_object_versions_api(client: WeaveClient):
     assert len(objs) == 0
 
 
+def test_delete_reports_deleted_versions(client: WeaveClient):
+    v0 = weave.publish({"i": 1}, name="obj_1")
+    v1 = weave.publish({"i": 2}, name="obj_1")
+
+    res = client.server.obj_delete(
+        tsi.ObjDeleteReq(
+            project_id=client.project_id,
+            object_id="obj_1",
+            digests=[v0.digest],
+        )
+    )
+    assert res.num_deleted == 1
+    assert res.deleted_versions == [
+        tsi.DeletedObjVersion(
+            digest=v0.digest, base_object_class=None, leaf_object_class=None
+        )
+    ]
+
+    # Alias digests are resolved to content digests in the report.
+    res = client.server.obj_delete(
+        tsi.ObjDeleteReq(
+            project_id=client.project_id,
+            object_id="obj_1",
+            digests=["latest"],
+        )
+    )
+    assert res.deleted_versions == [
+        tsi.DeletedObjVersion(
+            digest=v1.digest, base_object_class=None, leaf_object_class=None
+        )
+    ]
+
+
+def test_delete_all_reports_deleted_versions_with_classes(client: WeaveClient):
+    p0 = weave.publish(weave.StringPrompt("hello"), name="prompt_1")
+    p1 = weave.publish(weave.StringPrompt("world"), name="prompt_1")
+
+    res = client.server.obj_delete(
+        tsi.ObjDeleteReq(project_id=client.project_id, object_id="prompt_1")
+    )
+    assert res.num_deleted == 2
+    assert sorted(dv.digest for dv in res.deleted_versions) == sorted(
+        [p0.digest, p1.digest]
+    )
+    assert {dv.base_object_class for dv in res.deleted_versions} == {"Prompt"}
+    assert {dv.leaf_object_class for dv in res.deleted_versions} == {"StringPrompt"}
+
+
 def _datasets_query(client: WeaveClient, latest_only: bool) -> list[tsi.ObjSchema]:
     objs = client.server.objs_query(
         tsi.ObjQueryReq(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2603,7 +2603,17 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     deleted_at=now,
                 )
 
-        return tsi.ObjDeleteRes(num_deleted=num_deleted)
+        return tsi.ObjDeleteRes(
+            num_deleted=num_deleted,
+            deleted_versions=[
+                tsi.DeletedObjVersion(
+                    digest=obj.digest,
+                    base_object_class=obj.base_object_class,
+                    leaf_object_class=obj.leaf_object_class,
+                )
+                for obj in delete_insertables
+            ],
+        )
 
     # --- Tags & Aliases ---
 

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -3195,7 +3195,17 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             for rec in self._objs_for_object_id(req.project_id, req.object_id):
                 rec.is_latest = 1 if rec.digest == latest_digest else 0
 
-        return tsi.ObjDeleteRes(num_deleted=len(matching_objects))
+        return tsi.ObjDeleteRes(
+            num_deleted=len(matching_objects),
+            deleted_versions=[
+                tsi.DeletedObjVersion(
+                    digest=rec.digest,
+                    base_object_class=rec.base_object_class,
+                    leaf_object_class=rec.leaf_object_class,
+                )
+                for rec in matching_objects
+            ],
+        )
 
     def _ensure_obj_version_exists(
         self, project_id: str, object_id: str, digest: str

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -835,8 +835,18 @@ class ObjDeleteReq(BaseModelStrict):
     )
 
 
+class DeletedObjVersion(BaseModel):
+    digest: str
+    base_object_class: str | None = None
+    leaf_object_class: str | None = None
+
+
 class ObjDeleteRes(BaseModel):
     num_deleted: int
+    deleted_versions: list[DeletedObjVersion] | None = Field(
+        default=None,
+        description="Metadata for each deleted object version, with digest aliases resolved to content digests. None when the backing server does not report it.",
+    )
 
 
 # --- Tag and Alias types ---


### PR DESCRIPTION
## Description

- `obj_delete` now returns a `deleted_versions` list (`digest`, `base_object_class`, `leaf_object_class`) alongside `num_deleted`, populated by both the ClickHouse and in-memory servers from the version rows they already read to perform the delete (no additional queries). Digest aliases are resolved to content digests in the report.
- the field is optional and defaults to `None`, making it backwards compatible.

This will be used in W&B trace server, which uses the classes to determine whether to cascade registry-artifact cleanup.
Trace server PR: https://github.com/wandb/core/pull/47609
Weave Assets in Registry: [WB-33689](https://coreweave.atlassian.net/browse/WB-33689)

## Testing
- Added unit tests
- Ran end-to-end integration test in dev environment with corresponding trace server PR


[WB-33689]: https://coreweave.atlassian.net/browse/WB-33689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ