### PR TITLE
chore(weave): cap openai below 2.45.0 for openai_agents shard

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -147,9 +147,17 @@ def tests(session: nox.Session, shard: str):
     session.run(*sync_args)
 
     if shard == "openai_agents":
-        # Keep the public extra broad for runtime compatibility, but exercise the
-        # newer SDK span classes in CI.
-        session.run("uv", "pip", "install", "--upgrade", "openai-agents>=0.14.7")
+        # Exercise the newer SDK span classes in CI. Cap openai below 2.45.0:
+        # it made InputTokensDetails.cache_write_tokens required, but openai-agents
+        # still constructs InputTokensDetails without it.
+        session.run(
+            "uv",
+            "pip",
+            "install",
+            "--upgrade",
+            "openai-agents>=0.14.7",
+            "openai<2.45.0",
+        )
 
     if shard == "google_adk":
         # Installed here (not via an extra) so it stays out of the shared


### PR DESCRIPTION
## Summary
- openai 2.45.0 (released 2026-07-09) made `InputTokensDetails.cache_write_tokens` required, but every `openai-agents` release (0.18.0, latest) still builds `InputTokensDetails(cached_tokens=0)` in `usage.py`, so agent runs raise a pydantic `ValidationError`.
- The shard's `--upgrade openai-agents>=0.14.7` pulled `openai` to 2.45.0. `openai-agents 0.18.0` + `openai<2.45.0` (2.44.0) is a healthy, supported combo; the cap selects it. No `openai-agents` release yet supports 2.45.0 (0.18.0 shipped 2 days before it); drop the cap once upstream adds the field.

Original failure ([CI job](https://github.com/wandb/weave/actions/runs/29039938371/job/86194289100?pr=7545)):
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for InputTokensDetails
cache_write_tokens
  Field required [type=missing, input_value={'cached_tokens': 0}, input_type=dict]
```

## Testing
verified in a clean venv: `openai<2.45.0` resolves openai 2.44.0 and `InputTokensDetails(cached_tokens=0)` constructs; uncapped resolves 2.45.0 and reproduces the ValidationError.
