### PR TITLE
perf(weave): skip cross-pod redundant bucket uploads via files-table pre-check

### DIFF
--- a/tests/trace/conftest.py
+++ b/tests/trace/conftest.py
@@ -66,11 +66,15 @@ class GCSMockState:
     Read-back:
       `blob_data`        - the in-memory backing store, keyed by full path.
       `upload_count`     - total successful uploads (skips not counted).
+      `upload_attempts`  - total upload_from_string calls, including ones that
+                     412 on `if_generation_match=0`; a cross-pod pre-check that
+                     skips the redundant write shows up here, not in upload_count.
       `concurrent_peak`  - max in-flight uploads observed across threads.
     """
 
     blob_data: dict[str, bytes] = field(default_factory=dict)
     upload_count: int = 0
+    upload_attempts: int = 0
     concurrent_peak: int = 0
     fail_paths: set[str] = field(default_factory=set)
     expected_concurrency: int | None = None
@@ -133,6 +137,8 @@ def gcs():
         blob.name = path
 
         def upload_from_string(data, timeout=None, if_generation_match=None, **kwargs):
+            with state_lock:
+                state.upload_attempts += 1
             if if_generation_match == 0 and path in state.blob_data:
                 raise gcp_exceptions.PreconditionFailed("Object already exists")
             if path in state.fail_paths:

--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -23,7 +23,11 @@ from moto import mock_aws
 from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from weave.shared.digest import compute_file_digest
 from weave.trace.weave_client import WeaveClient
-from weave.trace_server import clickhouse_trace_server_settings, file_storage
+from weave.trace_server import (
+    clickhouse_trace_server_batched,
+    clickhouse_trace_server_settings,
+    file_storage,
+)
 from weave.trace_server.trace_server_interface import (
     CallEndReq,
     CallEndV2Req,
@@ -688,6 +692,154 @@ def test_call_batch_uploads_files_to_bucket_in_parallel(client: WeaveClient, gcs
     project_b64 = base64.b64encode(client.project_id.encode()).decode()
     expected_prefix = f"weave/projects/{project_b64}/files/"
     assert all(k.startswith(expected_prefix) for k in gcs.state.blob_data)
+
+
+@pytest.fixture
+def no_server_cache(monkeypatch: pytest.MonkeyPatch):
+    """Disable the client-side file_create cache.
+
+    It memoizes file_create by (project, digest) and would mask the server-side
+    cross-pod pre-check under test (the prod trace server has no such client
+    cache). With it on, a repeat file_create never reaches ClickHouse.
+    """
+    monkeypatch.setattr(
+        "weave.trace_server_bindings.caching_middleware_trace_server.use_server_cache",
+        lambda: False,
+    )
+
+
+@pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials", "no_server_cache")
+@pytest.mark.disable_logging_error_check
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+)
+def test_cross_pod_precheck_skips_redundant_bucket_upload(client: WeaveClient, gcs):
+    """A digest already recorded in the shared `files` table is not re-uploaded
+    even after the per-pod stored-key cache is cleared (simulating a second
+    pod). Genuinely new content in the same later batch still uploads, and both
+    digests read back byte-for-byte.
+    """
+    server = client.server
+    shared = _unique_payload("shared", 50_000)
+    shared_digest = compute_file_digest(shared)
+
+    with server.call_batch():
+        server.file_create(
+            FileCreateReq(project_id=client.project_id, name="a.bin", content=shared)
+        )
+    assert gcs.state.upload_attempts == 1
+    assert gcs.state.upload_count == 1
+
+    # Second pod: same shared ClickHouse, cold per-pod LRU. The cross-pod
+    # pre-check must recognize `shared` is already stored and skip its upload.
+    file_storage.reset_stored_key_cache()
+
+    fresh = _unique_payload("fresh", 50_000)
+    fresh_digest = compute_file_digest(fresh)
+    with server.call_batch():
+        server.file_create(
+            FileCreateReq(project_id=client.project_id, name="a.bin", content=shared)
+        )
+        server.file_create(
+            FileCreateReq(project_id=client.project_id, name="b.bin", content=fresh)
+        )
+
+    # Only the new payload is attempted; the redundant 412 write is avoided.
+    assert gcs.state.upload_attempts == 2
+    assert gcs.state.upload_count == 2
+
+    for digest, expected in ((shared_digest, shared), (fresh_digest, fresh)):
+        read = server.file_content_read(
+            FileContentReadReq(project_id=client.project_id, digest=digest)
+        )
+        assert read.content == expected
+
+
+@pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials", "no_server_cache")
+@pytest.mark.disable_logging_error_check
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+)
+def test_precheck_skips_bucket_upload_when_only_inline_row_exists(
+    client: WeaveClient, gcs
+):
+    """A digest first stored as inline-CH chunks (storage disabled) is still
+    recognized by the pre-check on a later bucket-enabled write: the row means
+    the content is readable, so no bucket upload is attempted and the read path
+    serves the inline chunks.
+    """
+    server = client.server
+    payload = _unique_payload("inline", 50_000)
+    digest = compute_file_digest(payload)
+
+    # Storage disabled for this project => inline CH chunks, no bucket URI row.
+    with mock.patch.dict(
+        os.environ, {"WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "some-other-project"}
+    ):
+        with server.call_batch():
+            server.file_create(
+                FileCreateReq(
+                    project_id=client.project_id, name="i.bin", content=payload
+                )
+            )
+    assert gcs.state.upload_attempts == 0
+
+    file_storage.reset_stored_key_cache()
+
+    # Storage now enabled: the pre-check sees the inline row and skips the upload.
+    with server.call_batch():
+        server.file_create(
+            FileCreateReq(project_id=client.project_id, name="i.bin", content=payload)
+        )
+    assert gcs.state.upload_attempts == 0
+
+    read = server.file_content_read(
+        FileContentReadReq(project_id=client.project_id, digest=digest)
+    )
+    assert read.content == payload
+
+
+@pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials", "no_server_cache")
+@pytest.mark.disable_logging_error_check
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+)
+def test_precheck_failure_falls_back_to_upload(
+    client: WeaveClient, gcs, monkeypatch: pytest.MonkeyPatch
+):
+    """If the existence pre-check query throws, the write proceeds unconditionally
+    (backstopped by GCS if_generation_match=0) rather than failing the batch.
+    """
+    server = client.server
+    payload = _unique_payload("boom", 50_000)
+    digest = compute_file_digest(payload)
+
+    with server.call_batch():
+        server.file_create(
+            FileCreateReq(project_id=client.project_id, name="c.bin", content=payload)
+        )
+    assert gcs.state.upload_attempts == 1
+    file_storage.reset_stored_key_cache()
+
+    def _raise(*args: object, **kwargs: object) -> str:
+        raise RuntimeError("pre-check boom")
+
+    monkeypatch.setattr(
+        clickhouse_trace_server_batched,
+        "make_files_digests_existence_query",
+        _raise,
+    )
+    with server.call_batch():
+        server.file_create(
+            FileCreateReq(project_id=client.project_id, name="c.bin", content=payload)
+        )
+    # No dedup => the upload is attempted again (and 412s harmlessly at GCS).
+    assert gcs.state.upload_attempts == 2
+
+    read = server.file_content_read(
+        FileContentReadReq(project_id=client.project_id, digest=digest)
+    )
+    assert read.content == payload
 
 
 @pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials")

--- a/tests/trace_server/test_parallel_bucket_uploads.py
+++ b/tests/trace_server/test_parallel_bucket_uploads.py
@@ -12,6 +12,7 @@ from typing import cast
 import pytest
 
 from weave.trace_server import parallel_bucket_uploads as pbu
+from weave.trace_server.clickhouse_schema import FileChunkCreateCHInsertable
 from weave.trace_server.errors import RequestTooLarge
 from weave.trace_server.file_storage import FileStorageClient
 from weave.trace_server.parallel_bucket_uploads import BucketUploadBatch
@@ -20,6 +21,19 @@ from weave.trace_server.trace_server_interface import FileCreateReq
 
 def _req(content: bytes, name: str = "f.bin") -> FileCreateReq:
     return FileCreateReq(project_id="entity/project", name=name, content=content)
+
+
+def _bucket_row(p: pbu._Pending) -> FileChunkCreateCHInsertable:
+    return FileChunkCreateCHInsertable(
+        project_id=p.req.project_id,
+        digest=p.digest,
+        chunk_index=0,
+        n_chunks=1,
+        name=p.req.name,
+        val_bytes=b"",
+        bytes_stored=len(p.req.content),
+        file_storage_uri="gs://bucket/x",
+    )
 
 
 def test_stage_dedup_raises_on_duplicate_key() -> None:
@@ -70,3 +84,56 @@ def test_flush_resets_byte_counter(monkeypatch: pytest.MonkeyPatch) -> None:
     batch.flush(client=cast(FileStorageClient, object()))
     batch.stage(_req(b"y" * 900), digest="d2")
     assert batch.has("entity/project", "d2")
+
+
+def test_pending_keys_reflects_staged_items() -> None:
+    batch = BucketUploadBatch()
+    batch.stage(_req(b"a"), digest="d1")
+    batch.stage(_req(b"b"), digest="d2")
+    assert batch.pending_keys() == [
+        ("entity/project", "d1"),
+        ("entity/project", "d2"),
+    ]
+
+
+def test_flush_skips_already_stored_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """already_stored keys are neither uploaded nor emit a chunk row; the rest
+    upload normally.
+    """
+    uploaded: list[str] = []
+    monkeypatch.setattr(
+        pbu,
+        "_upload_one",
+        lambda p, client: uploaded.append(p.digest) or [_bucket_row(p)],
+    )
+    batch = BucketUploadBatch()
+    batch.stage(_req(b"a"), digest="d1")
+    batch.stage(_req(b"b"), digest="d2")
+    rows = batch.flush(
+        client=cast(FileStorageClient, object()),
+        already_stored=frozenset({("entity/project", "d1")}),
+    )
+    assert uploaded == ["d2"]
+    assert [r.digest for r in rows] == ["d2"]
+
+
+def test_flush_all_already_stored_uploads_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When every staged key is already stored, flush uploads nothing and returns
+    no rows (and must not build a zero-worker pool).
+    """
+    uploaded: list[str] = []
+    monkeypatch.setattr(
+        pbu,
+        "_upload_one",
+        lambda p, client: uploaded.append(p.digest) or [_bucket_row(p)],
+    )
+    batch = BucketUploadBatch()
+    batch.stage(_req(b"a"), digest="d1")
+    rows = batch.flush(
+        client=cast(FileStorageClient, object()),
+        already_stored=frozenset({("entity/project", "d1")}),
+    )
+    assert uploaded == []
+    assert rows == []

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -267,6 +267,7 @@ from weave.trace_server.query_builder.annotation_queues_query_builder import (
 )
 from weave.trace_server.query_builder.files_query_builder import (
     make_file_content_read_query,
+    make_files_digests_existence_query,
     make_files_stats_query,
 )
 from weave.trace_server.query_builder.obj_tags_query_builder import (
@@ -956,8 +957,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         """
         # Raises on fail
         try:
+            already_stored = self._query_existing_file_digests(
+                self._bucket_uploads.pending_keys()
+            )
             self._file_batch.extend(
-                self._bucket_uploads.flush(self.file_storage_client)
+                self._bucket_uploads.flush(
+                    self.file_storage_client, already_stored=already_stored
+                )
             )
         except Exception:
             logger.exception("Failed to flush bucket uploads")
@@ -969,6 +975,38 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         except Exception:
             logger.exception("Failed to flush file chunks")
             raise
+
+    def _query_existing_file_digests(
+        self, keys: list[tuple[str, str]]
+    ) -> frozenset[tuple[str, str]]:
+        """`(project_id, digest)` pairs from `keys` that already have a files row.
+
+        Cross-pod dedup against shared ClickHouse: a hit means the content is
+        already stored, so the bucket upload the provider would reject with a
+        412 (and its duplicate files row) is skipped. Advisory only. Any failure
+        returns the empty set, degrading to an unconditional upload backstopped
+        by GCS if_generation_match=0.
+        """
+        if not keys:
+            return frozenset()
+        try:
+            digests_by_project: dict[str, list[str]] = defaultdict(list)
+            for project_id, digest in keys:
+                digests_by_project[project_id].append(digest)
+            existing: set[tuple[str, str]] = set()
+            for project_id, digests in digests_by_project.items():
+                pb = ParamBuilder()
+                query = make_files_digests_existence_query(project_id, digests, pb)
+                res = self._query(query, pb.get_params())
+                for row in res.result_rows:
+                    existing.add((project_id, row[0]))
+            return frozenset(existing)
+        except Exception:
+            logger.warning(
+                "files existence pre-check failed; uploading without cross-pod dedup",
+                exc_info=True,
+            )
+            return frozenset()
 
     def _offload_call_content(self, req: _CallReqT) -> _CallReqT:
         """Replace inline base64 content with file refs, uploading in parallel.

--- a/weave/trace_server/parallel_bucket_uploads.py
+++ b/weave/trace_server/parallel_bucket_uploads.py
@@ -125,18 +125,30 @@ class BucketUploadBatch:
         """True if `(project_id, digest)` was already staged in this batch."""
         return (project_id, digest) in self._seen
 
+    def pending_keys(self) -> list[tuple[str, str]]:
+        """`(project_id, digest)` for every staged upload, for a cross-pod pre-check."""
+        return [(p.req.project_id, p.digest) for p in self._pending]
+
     def __bool__(self) -> bool:
         return bool(self._pending)
 
     @traced(name="bucket_upload_batch.flush")
     def flush(
-        self, client: FileStorageClient | None
+        self,
+        client: FileStorageClient | None,
+        already_stored: frozenset[tuple[str, str]] = frozenset(),
     ) -> list[FileChunkCreateCHInsertable]:
         """Run staged uploads in parallel; return chunk rows for the caller to insert.
 
         Each pending upload becomes either a single bucket-URI chunk
         (success) or N inline ClickHouse chunks (FileStorageWriteError
         fallback). Order is not preserved.
+
+        `already_stored` are `(project_id, digest)` keys the caller confirmed
+        already have a files row (cross-pod dedup); those uploads are skipped
+        entirely, yielding no rows since the existing row already serves reads.
+        This relies on files rows never being deleted; revisit if files-row GC
+        is ever introduced.
 
         `client` must be non-None whenever items have been staged. The
         staging path is gated on a non-None client at the call site, so
@@ -154,38 +166,51 @@ class BucketUploadBatch:
         pending, self._pending = self._pending, []
         self._seen = set()
         self._total_bytes = 0
+        staged_total = len(pending)
+
+        precheck_skipped = 0
+        if already_stored:
+            kept: list[_Pending] = []
+            for p in pending:
+                if (p.req.project_id, p.digest) in already_stored:
+                    precheck_skipped += 1
+                else:
+                    kept.append(p)
+            pending = kept
 
         rows: list[FileChunkCreateCHInsertable] = []
         bucket_success = 0
         ch_fallback = 0
-        with ThreadPoolExecutor(
-            max_workers=min(DEFAULT_BUCKET_UPLOAD_CONCURRENCY, len(pending)),
-            thread_name_prefix="bucket-upload",
-        ) as pool:
-            futs = [pool.submit(_upload_one, p, client) for p in pending]
-            try:
-                for fut in as_completed(futs):
-                    fut_rows = fut.result()
-                    # Single bucket-URI row vs N inline-CH rows; we use the URI
-                    # presence to classify the per-file outcome.
-                    if fut_rows and fut_rows[0].file_storage_uri is not None:
-                        bucket_success += 1
-                    else:
-                        ch_fallback += 1
-                    rows.extend(fut_rows)
-            except Exception:
-                logger.warning(
-                    "BucketUploadBatch worker raised an unwrapped exception; "
-                    "peer uploads may have completed without a files row. "
-                    "Retry will reconcile via if_generation_match=0.",
-                    exc_info=True,
-                )
-                raise
+        if pending:
+            with ThreadPoolExecutor(
+                max_workers=min(DEFAULT_BUCKET_UPLOAD_CONCURRENCY, len(pending)),
+                thread_name_prefix="bucket-upload",
+            ) as pool:
+                futs = [pool.submit(_upload_one, p, client) for p in pending]
+                try:
+                    for fut in as_completed(futs):
+                        fut_rows = fut.result()
+                        # Single bucket-URI row vs N inline-CH rows; we use the URI
+                        # presence to classify the per-file outcome.
+                        if fut_rows and fut_rows[0].file_storage_uri is not None:
+                            bucket_success += 1
+                        else:
+                            ch_fallback += 1
+                        rows.extend(fut_rows)
+                except Exception:
+                    logger.warning(
+                        "BucketUploadBatch worker raised an unwrapped exception; "
+                        "peer uploads may have completed without a files row. "
+                        "Retry will reconcile via if_generation_match=0.",
+                        exc_info=True,
+                    )
+                    raise
         set_current_span_dd_tags(
             {
                 "bucket_upload_batch.bucket_success": bucket_success,
                 "bucket_upload_batch.ch_fallback": ch_fallback,
-                "bucket_upload_batch.staged": len(pending),
+                "bucket_upload_batch.staged": staged_total,
+                "bucket_upload_batch.precheck_skipped": precheck_skipped,
             }
         )
         return rows

--- a/weave/trace_server/query_builder/files_query_builder.py
+++ b/weave/trace_server/query_builder/files_query_builder.py
@@ -34,6 +34,26 @@ def make_file_content_read_query(
     """
 
 
+def make_files_digests_existence_query(
+    project_id: str,
+    digests: list[str],
+    pb: ParamBuilder,
+) -> str:
+    """Digests in `digests` that already have a files row for this project.
+
+    Primary-key prefix lookup on (project_id, digest); a row existing (bucket-URI
+    or inline-CH chunk) means the content is already readable, so a repeat write
+    can skip the bucket upload the provider would reject as a 412 no-op.
+    """
+    project_id_param = pb.add_param(project_id)
+    digests_slot = pb.add(digests, param_type="Array(String)")
+    return f"""
+    SELECT DISTINCT digest
+    FROM files
+    WHERE project_id = {{{project_id_param}: String}} AND digest IN {digests_slot}
+    """
+
+
 def make_files_stats_query(
     project_id: str,
     pb: ParamBuilder,


### PR DESCRIPTION
## Summary
- ~51% of `calls/complete` GCS content-object uploads return HTTP 412: a content-addressed object already stored by another pod, re-uploaded (full body) then rejected. The per-pod LRU only dedups within a pod.
- Before flushing staged bucket uploads in a `call_batch`, query the shared `files` table for digests already present and skip those uploads (and their duplicate rows). ClickHouse is already the cross-pod source of truth, so no new infra.
- Advisory only: a `files` row means content is readable; any pre-check failure falls back to uploading, backstopped by `if_generation_match=0`. In-batch dedup and the per-pod LRU are unchanged.
- New DD tag `bucket_upload_batch.precheck_skipped` measures the win.

## Testing
functional CH tests: cross-pod skip, inline-row skip, and pre-check-failure fallback (all drive the real read path); unit tests for the flush skip-set.

## QA A/B (zoo-qa, server-side spans)
Deployed to zoo-qa (`cb6ba5a`) and ran a duplicate-heavy smoke (25x ~400KB attachments: warm-up + concurrent identical re-writes) vs master (`0c2c33a`), exactly the cross-pod repeat this PR targets.

| metric (matched windows) | master `0c2c33a` | PR `cb6ba5a` |
|---|---|---|
| GCS 412 no-op re-uploads | **644** (3 pods) | **0** |
| GCS 200 first-time creates | 50 | 50 |
| uploads skipped by pre-check | n/a (tag absent) | **450 / 500 staged** |
| `call_batch` @duration p50 / max | 2.20s / 3.71s | **0.82s / 2.25s** |
| burst load applied | 40 req | 120 req (3x) |

Left: master `call_batch` fans out storage.googleapis.com uploads (644x 412). Right: PR `call_batch` is ClickHouse-only, every upload skipped by the files-table pre-check. New `bucket_upload_batch.precheck_skipped` tag present only on the PR build; no new server-side error class (the client write-timeouts under the 3x burst were rollout/load timing on ~2 fresh pods, not the change).

<img width="470" src="https://github.com/user-attachments/assets/ec915c7a-a252-46bc-b2cd-ca98851a843f"> <img width="470" src="https://github.com/user-attachments/assets/553dab6f-b517-4598-b7a2-09f38d662111">
