### PR TITLE
chore(weave): add gpt-5.6

### DIFF
--- a/weave/trace_server/costs/cost_checkpoint.json
+++ b/weave/trace_server/costs/cost_checkpoint.json
@@ -28124,5 +28124,165 @@
       "cache_creation_input": 0.0,
       "created_at": "2026-07-07 13:24:02"
     }
+  ],
+  "azure/us/gpt-5.4": [
+    {
+      "provider": "azure",
+      "input": 2.75e-06,
+      "output": 1.65e-05,
+      "cache_read_input": 2.8e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "azure/eu/gpt-5.4": [
+    {
+      "provider": "azure",
+      "input": 2.75e-06,
+      "output": 1.65e-05,
+      "cache_read_input": 2.8e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "azure/us/gpt-5.4-2026-03-05": [
+    {
+      "provider": "azure",
+      "input": 2.75e-06,
+      "output": 1.65e-05,
+      "cache_read_input": 2.8e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "azure/eu/gpt-5.4-2026-03-05": [
+    {
+      "provider": "azure",
+      "input": 2.75e-06,
+      "output": 1.65e-05,
+      "cache_read_input": 2.8e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "azure/us/gpt-5.5": [
+    {
+      "provider": "azure",
+      "input": 5.5e-06,
+      "output": 3.3e-05,
+      "cache_read_input": 5.5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "azure/eu/gpt-5.5": [
+    {
+      "provider": "azure",
+      "input": 5.5e-06,
+      "output": 3.3e-05,
+      "cache_read_input": 5.5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "azure/us/gpt-5.5-2026-04-23": [
+    {
+      "provider": "azure",
+      "input": 5.5e-06,
+      "output": 3.3e-05,
+      "cache_read_input": 5.5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "azure/eu/gpt-5.5-2026-04-23": [
+    {
+      "provider": "azure",
+      "input": 5.5e-06,
+      "output": 3.3e-05,
+      "cache_read_input": 5.5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "gpt-5.6": [
+    {
+      "provider": "openai",
+      "input": 5e-06,
+      "output": 3e-05,
+      "cache_read_input": 5e-07,
+      "cache_creation_input": 6.25e-06,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "gpt-5.6-sol": [
+    {
+      "provider": "openai",
+      "input": 5e-06,
+      "output": 3e-05,
+      "cache_read_input": 5e-07,
+      "cache_creation_input": 6.25e-06,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "gpt-5.6-terra": [
+    {
+      "provider": "openai",
+      "input": 2.5e-06,
+      "output": 1.5e-05,
+      "cache_read_input": 2.5e-07,
+      "cache_creation_input": 3.125e-06,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "gpt-5.6-luna": [
+    {
+      "provider": "openai",
+      "input": 1e-06,
+      "output": 6e-06,
+      "cache_read_input": 1e-07,
+      "cache_creation_input": 1.25e-06,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "gpt-realtime-2.1": [
+    {
+      "provider": "openai",
+      "input": 4e-06,
+      "output": 2.4e-05,
+      "cache_read_input": 4e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "gpt-realtime-2.1-mini": [
+    {
+      "provider": "openai",
+      "input": 6e-07,
+      "output": 2.4e-06,
+      "cache_read_input": 6e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "xai/grok-4.5": [
+    {
+      "provider": "xai",
+      "input": 2e-06,
+      "output": 6e-06,
+      "cache_read_input": 5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-09 13:23:56"
+    }
+  ],
+  "xai/grok-4.5-latest": [
+    {
+      "provider": "xai",
+      "input": 2e-06,
+      "output": 6e-06,
+      "cache_read_input": 5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-09 13:23:56"
+    }
   ]
 }

--- a/weave/trace_server/model_providers/model_providers.json
+++ b/weave/trace_server/model_providers/model_providers.json
@@ -1091,7 +1091,23 @@
     "litellm_provider": "azure",
     "api_key_name": "AZURE_API_KEY"
   },
+  "azure/us/gpt-5.4": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/eu/gpt-5.4": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
   "azure/gpt-5.4-2026-03-05": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/us/gpt-5.4-2026-03-05": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/eu/gpt-5.4-2026-03-05": {
     "litellm_provider": "azure",
     "api_key_name": "AZURE_API_KEY"
   },
@@ -1107,7 +1123,23 @@
     "litellm_provider": "azure",
     "api_key_name": "AZURE_API_KEY"
   },
+  "azure/us/gpt-5.5": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/eu/gpt-5.5": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
   "azure/gpt-5.5-2026-04-23": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/us/gpt-5.5-2026-04-23": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/eu/gpt-5.5-2026-04-23": {
     "litellm_provider": "azure",
     "api_key_name": "AZURE_API_KEY"
   },
@@ -3725,6 +3757,22 @@
     "deprecated_reason": "litellm.APIConnectionError: APIConnectionError: OpenAIException - argument of type 'NoneType' is not iterable",
     "deprecated_date": "2026-01-29T17:58:16.718606"
   },
+  "gpt-5.6": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-5.6-sol": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-5.6-terra": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-5.6-luna": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
   "gpt-5.5": {
     "litellm_provider": "openai",
     "api_key_name": "OPENAI_API_KEY"
@@ -3859,6 +3907,14 @@
     "api_key_name": "OPENAI_API_KEY"
   },
   "gpt-realtime-2": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-realtime-2.1": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-realtime-2.1-mini": {
     "litellm_provider": "openai",
     "api_key_name": "OPENAI_API_KEY"
   },
@@ -4882,6 +4938,10 @@
     "litellm_provider": "vertex_ai",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },
+  "vertex_ai/chirp_3": {
+    "litellm_provider": "vertex_ai",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
   "vertex_ai/gemini-2.5-flash-image": {
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
@@ -5080,6 +5140,14 @@
     "api_key_name": "XAI_API_KEY"
   },
   "xai/grok-4.3-latest": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-4.5": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-4.5-latest": {
     "litellm_provider": "xai",
     "api_key_name": "XAI_API_KEY"
   },


### PR DESCRIPTION
## Summary
- ran make update_costs and update_model_providers
- add gpt-5.6 (+ gpt-5.6-sol / -terra / -luna) to model routing and costs via `make update_model_providers` + `make update_costs`
- diff also picks up litellm churn since last sync: azure regional gpt-5.4/5.5 keys, gpt-realtime-2.1, grok-4.5, vertex chirp_3

## Testing
ids + costs verified against litellm; live validation via update_playground_llms.py pending (no provider keys in this env)