### PR TITLE
feat(weave): add exclude_subagents flag to agent spans query

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -659,6 +659,29 @@ class TestMakeSpansListQuery:
                 include_details=True,
             )
 
+    def test_exclude_subagents_adds_where_exclusion(self) -> None:
+        # exclude_subagents hides sub-agent invocation marker spans (invoke_agent
+        # with a non-empty parent_span_id) from the ungrouped list; it adds only
+        # a static WHERE clause, no new bind params.
+        pb = ParamBuilder("genai")
+        query = make_spans_list_query(
+            pb, AgentSpansQueryReq(project_id="p1", exclude_subagents=True)
+        )
+
+        src = _AttrSrc(3, base_relation="page", fallback_scope_relation="page")
+        expected = _two_pass_expected(
+            base="spans",
+            where=(
+                "s.project_id = {genai_0:String} AND "
+                "NOT (s.operation_name = 'invoke_agent' AND s.parent_span_id != '')"
+            ),
+            order_by="started_at DESC, span_id DESC",
+            projection=SPANS_LIST_COLS,
+            attr_sql=src.sql,
+        )
+        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0, **src.params}
+        assert_sql(expected, expected_params, query, pb.get_params())
+
 
 # ============================================================================
 # make_spans_count_query (grouped)
@@ -865,6 +888,36 @@ class TestMakeGroupedSpansCountQuery:
             "genai_2": ["x"],
             **src.params,
         }
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+    def test_exclude_subagents_true_adds_where_and_having(self) -> None:
+        # Grouping/counting by conversation_id references identity, so the
+        # count subquery reads the attributed source; exclude_subagents must
+        # still only add the WHERE exclusion + HAVING root-invocation guard on
+        # top of it, so the count matches the (also-filtered) list query —
+        # this is what keeps grouped pagination's total_count correct.
+        pb = ParamBuilder("genai")
+        query = make_spans_count_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+                exclude_subagents=True,
+            ),
+        )
+
+        expected = """
+            SELECT count() FROM (
+                SELECT s.conversation_id FROM {_ATTR_SRC} s
+                WHERE s.project_id = {genai_0:String}
+                  AND NOT (s.operation_name = 'invoke_agent' AND s.parent_span_id != '')
+                GROUP BY s.conversation_id
+                HAVING countIf(s.operation_name = 'invoke_agent' AND s.parent_span_id = '') >= 1
+            )
+        """
+        src = _AttrSrc(1)
+        expected = expected.replace("{_ATTR_SRC}", src.sql)
+        expected_params = {"genai_0": "p1", **src.params}
         assert_sql(expected, expected_params, query, pb.get_params())
 
 
@@ -1246,6 +1299,36 @@ class TestMakeGroupedSpansListQuery:
         expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0, **src.params}
         assert_sql(expected, expected_params, query, pb.get_params())
 
+    def test_exclude_subagents_true_adds_where_and_having(self) -> None:
+        # exclude_subagents both hides sub-agent invocation marker spans from
+        # the WHERE clause and (for grouped queries) drops groups with no root
+        # invocation via HAVING, so a conversation that is purely sub-agent
+        # activity no longer shows up as a row.
+        pb = ParamBuilder("genai")
+        query = make_spans_list_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+                exclude_subagents=True,
+            ),
+        )
+
+        src = _AttrSrc(3)
+        expected = f"""
+            SELECT s.conversation_id AS conversation_id,
+                   {_GROUPED_AGG_TAIL}
+            FROM {src.sql} s
+            WHERE s.project_id = {{genai_0:String}}
+              AND NOT (s.operation_name = 'invoke_agent' AND s.parent_span_id != '')
+            GROUP BY conversation_id
+            HAVING countIf(s.operation_name = 'invoke_agent' AND s.parent_span_id = '') >= 1
+            ORDER BY last_seen DESC
+            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
+        """
+        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0, **src.params}
+        assert_sql(expected, expected_params, query, pb.get_params())
+
     def test_grouped_query_with_signal_filter_adds_semijoin(self) -> None:
         """Grouped query with signal_filters appends AND s.conversation_id IN (...)."""
         pb = ParamBuilder("genai")
@@ -1286,6 +1369,34 @@ class TestMakeGroupedSpansListQuery:
             "genai_4": ["x"],
             **src.params,
         }
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+    def test_exclude_subagents_false_matches_default(self) -> None:
+        """Explicitly setting the flag off must be indistinguishable from the
+        default (flag-omitted) case in `test_group_by_trace_id` — no WHERE
+        exclusion and no HAVING clause are added.
+        """
+        pb = ParamBuilder("genai")
+        query = make_spans_list_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="column", key="trace_id")],
+                exclude_subagents=False,
+            ),
+        )
+
+        src = _AttrSrc(3)
+        expected = f"""
+            SELECT s.trace_id AS trace_id,
+                   {_GROUPED_AGG_TAIL}
+            FROM {src.sql} s
+            WHERE s.project_id = {{genai_0:String}}
+            GROUP BY trace_id
+            ORDER BY last_seen DESC
+            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
+        """
+        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0, **src.params}
         assert_sql(expected, expected_params, query, pb.get_params())
 
 

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -816,6 +816,12 @@ class AgentSpansQueryReq(BaseModel):
     # ungrouped span rows, or summed total_cost_usd/total_input_cost_usd/
     # total_output_cost_usd to grouped rows. See agents/span_costs.py.
     include_costs: bool = False
+    # When true, hide delegated sub-agent activity: exclude sub-agent invocation
+    # marker spans (invoke_agent with a non-empty parent_span_id) from results,
+    # and — for grouped queries — drop groups with no root invocation (i.e.
+    # groups that are purely sub-agent activity). Child chat/tool spans of a
+    # sub-agent are kept, so their work stays attributed to the parent.
+    exclude_subagents: bool = False
     sort_by: list[AgentSortBy] | None = None
     limit: int = Field(
         default=DEFAULT_AGENT_QUERY_LIMIT, ge=0, le=MAX_AGENT_QUERY_LIMIT

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -848,6 +848,23 @@ def _group_filter_bound_slot(
     return pb.add(value, param_type="Float64")
 
 
+def _spans_group_having(
+    pb: ParamBuilder,
+    req: AgentSpansQueryReq,
+    group_filters: list[AgentSpanGroupFilter],
+) -> str:
+    """Combine the request's group_filters HAVING with the optional
+    root-invocation HAVING added by `exclude_subagents`.
+    """
+    conditions: list[str] = []
+    gf = group_filters_having_sql(pb, group_filters)
+    if gf:
+        conditions.append(gf)
+    if req.exclude_subagents:
+        conditions.append(_HAS_ROOT_INVOCATION_SQL)
+    return " AND ".join(conditions)
+
+
 # ---------------------------------------------------------------------------
 # WHERE builders (private — shared between count + list variants)
 # ---------------------------------------------------------------------------
@@ -883,6 +900,8 @@ def _spans_filter_sql(
         from weave.trace_server.query_builder import agent_query_compiler
 
         where_conditions.append(agent_query_compiler.compile_agent_query(req.query, pb))
+    if isinstance(req, AgentSpansQueryReq) and req.exclude_subagents:
+        where_conditions.append(_EXCLUDE_SUBAGENT_INVOCATIONS_SQL)
     return _FilterSQL(where=" AND ".join(where_conditions))
 
 
@@ -1115,6 +1134,20 @@ def _search_filter_sql(pb: ParamBuilder, req: AgentSearchReq) -> _FilterSQL:
 # ---------------------------------------------------------------------------
 
 
+# A sub-agent invocation is an `invoke_agent` span nested under a parent turn
+# (root/top-level invocations have an empty parent_span_id). Excluding these
+# marker spans hides delegated sub-agents from listings, while their child
+# chat/tool spans (the real work) stay attributed to the parent conversation.
+_EXCLUDE_SUBAGENT_INVOCATIONS_SQL = (
+    "NOT (s.operation_name = 'invoke_agent' AND s.parent_span_id != '')"
+)
+# A grouped result (e.g. a conversation) is "purely sub-agent activity" when it
+# contains no root invocation. This HAVING condition drops such groups when
+# sub-agents are hidden, so sub-agent-only conversations don't appear as rows.
+_HAS_ROOT_INVOCATION_SQL = (
+    "countIf(s.operation_name = 'invoke_agent' AND s.parent_span_id = '') >= 1"
+)
+
 # Aggregate SELECT list shared between grouped list queries.
 # The bundle is intentionally fixed because callers do not pick aggregates.
 # Fields that map to specific UI pivots (invocation_count, conversation_names)
@@ -1159,7 +1192,7 @@ def make_spans_count_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
         default_group_by=req.group_by,
     )
     ensure_group_filters_match(group_filters, req.group_by, context="spans count")
-    having = group_filters_having_sql(pb, group_filters)
+    having = _spans_group_having(pb, req, group_filters)
     having_sql = f" HAVING {having}" if having else ""
     # Apply the signal semi-join here too, so total_count matches the filtered list
     # (an unfiltered count produces phantom empty pages). Filtering on the attributed
@@ -1264,7 +1297,7 @@ def make_spans_list_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
         default_group_by=req.group_by,
     )
     ensure_group_filters_match(group_filters, req.group_by, context="spans list")
-    having = group_filters_having_sql(pb, group_filters)
+    having = _spans_group_having(pb, req, group_filters)
     having_sql = f"HAVING {having}" if having else ""
     signal_clause = build_signal_filter_clause(pb, req.project_id, req.signal_filters)
     grouped_where = span_filters.where


### PR DESCRIPTION
## What & why

Adds an `exclude_subagents: bool` flag to `AgentSpansQueryReq` so the Agents UI can hide delegated sub-agent activity from spans/conversation queries. When set, the server:

- **WHERE** — excludes sub-agent *invocation marker* spans: `operation_name = 'invoke_agent' AND parent_span_id != ''` (root/top-level invocations have an empty `parent_span_id`). A sub-agent's child chat/tool spans are kept, so its work stays attributed to the parent conversation.
- **HAVING** (grouped queries only) — keeps only groups with at least one root invocation, dropping groups that are purely sub-agent activity (e.g. sub-agent-only conversation rows).

Applied to **both** `make_spans_list_query` and `make_spans_count_query`, so grouped `total_count` matches the filtered rows (pagination stays correct). No HTTP route change — FastAPI parses the new field automatically.

## Consumer

wandb/core frontend PR: https://github.com/wandb/core/pull/47812 — the "Show subagents" toggle passes `exclude_subagents`. This server change should land + deploy first.

## Testing

- `tests/trace_server/query_builder/test_agent_query_builder.py`: **78 passing**, incl. new assert-SQL cases: ungrouped (WHERE only), grouped list (WHERE + HAVING), grouped count (WHERE + HAVING), and a flag-off case asserting the SQL is byte-identical to the existing golden query (no behavior change when off).
- `ruff check` + `ruff format --check` clean.
- The HAVING behavior was validated against a live project (conversations `168 → 166`).
