### PR TITLE
feat(weave): denormalize scorer_trace_id onto feedback

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -215,6 +215,7 @@ def test_annotation_feedback(client: WeaveClient) -> None:
         "span_status_code": "UNSET",
         "span_conversation_id": "",
         "span_trace_id": "",
+        "scorer_trace_id": "",
     }
 
 
@@ -404,6 +405,7 @@ def test_runnable_feedback(client: WeaveClient) -> None:
         "span_status_code": "UNSET",
         "span_conversation_id": "",
         "span_trace_id": "",
+        "scorer_trace_id": "",
     }
 
     # Runnable scorer feedback may also populate typed scorer columns while

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -3268,10 +3268,15 @@ def test_feedback_create_persists_supplied_conversation_target_id(ch_server):
 
 
 def test_feedback_create_persists_supplied_span_target_ids(ch_server):
-    """Span-targeted feedback persists supplied denormalized IDs."""
+    """Span-targeted feedback persists supplied denormalized IDs.
+
+    scorer_trace_id (the judge's own trace) round-trips alongside span_trace_id
+    (the scored turn), and the two are stored independently.
+    """
     project_id = _make_project_id("fb-span-id")
     conv_id = f"conv-{uuid.uuid4().hex[:8]}"
     trace_id = uuid.uuid4().hex
+    scorer_trace_id = uuid.uuid4().hex
     span_id = uuid.uuid4().hex
     span_ref = ri.InternalAgentSpanRef(project_id=project_id, span_id=span_id).uri
 
@@ -3284,6 +3289,7 @@ def test_feedback_create_persists_supplied_span_target_ids(ch_server):
             scorer_tags=["needs-review"],
             span_conversation_id=conv_id,
             span_trace_id=trace_id,
+            scorer_trace_id=scorer_trace_id,
             wb_user_id="u3",
         )
     )
@@ -3291,13 +3297,19 @@ def test_feedback_create_persists_supplied_span_target_ids(ch_server):
     res = ch_server.feedback_query(
         tsi.FeedbackQueryReq(
             project_id=project_id,
-            fields=["span_conversation_id", "span_trace_id", "scorer_tags"],
+            fields=[
+                "span_conversation_id",
+                "span_trace_id",
+                "scorer_trace_id",
+                "scorer_tags",
+            ],
         )
     )
     assert res.result == [
         {
             "span_conversation_id": conv_id,
             "span_trace_id": trace_id,
+            "scorer_trace_id": scorer_trace_id,
             "scorer_tags": ["needs-review"],
         }
     ]

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -379,6 +379,8 @@ def format_feedback_to_row(
         "span_status_code": feedback_req.span_status_code,
         "span_conversation_id": span_conversation_id,
         "span_trace_id": span_trace_id,
+        # Raw pass-through: no ref encodes the judge's own trace, so there is
+        # nothing to derive or cross-check it against (unlike span_trace_id).
         "scorer_trace_id": feedback_req.scorer_trace_id,
     }
 

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -62,6 +62,7 @@ TABLE_FEEDBACK = Table(
         Column("span_status_code", "string"),
         Column("span_conversation_id", "string"),
         Column("span_trace_id", "string"),
+        Column("scorer_trace_id", "string"),
     ],
 )
 
@@ -378,6 +379,7 @@ def format_feedback_to_row(
         "span_status_code": feedback_req.span_status_code,
         "span_conversation_id": span_conversation_id,
         "span_trace_id": span_trace_id,
+        "scorer_trace_id": feedback_req.scorer_trace_id,
     }
 
 

--- a/weave/trace_server/migrations/039_add_scorer_trace_id_to_feedback.down.sql
+++ b/weave/trace_server/migrations/039_add_scorer_trace_id_to_feedback.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feedback DROP COLUMN IF EXISTS scorer_trace_id;

--- a/weave/trace_server/migrations/039_add_scorer_trace_id_to_feedback.up.sql
+++ b/weave/trace_server/migrations/039_add_scorer_trace_id_to_feedback.up.sql
@@ -8,6 +8,7 @@ span_* / span_trace_id denormalization (migrations 033, 038).
 Distinct from span_trace_id: span_trace_id is the trace being scored (the
 agent turn), scorer_trace_id is the trace that did the scoring (the judge LLM
 call). No index: it is projected out and resolved against spans.trace_id, which
-already carries its own bloom-filter index (migration 032).
+already carries its own bloom-filter index (migration 030, inline on the spans
+table).
 */
 ALTER TABLE feedback ADD COLUMN IF NOT EXISTS scorer_trace_id String DEFAULT '';

--- a/weave/trace_server/migrations/039_add_scorer_trace_id_to_feedback.up.sql
+++ b/weave/trace_server/migrations/039_add_scorer_trace_id_to_feedback.up.sql
@@ -1,0 +1,13 @@
+/*
+Denormalize the trace the scorer (judge) itself ran under, so signals can price
+each invocation by reading total_cost_usd off the judge's own agent span
+(joined on spans.trace_id) instead of the `calls` model. Populated going
+forward only, while `spans` remains the source of truth. Mirrors the existing
+span_* / span_trace_id denormalization (migrations 033, 038).
+
+Distinct from span_trace_id: span_trace_id is the trace being scored (the
+agent turn), scorer_trace_id is the trace that did the scoring (the judge LLM
+call). No index: it is projected out and resolved against spans.trace_id, which
+already carries its own bloom-filter index (migration 032).
+*/
+ALTER TABLE feedback ADD COLUMN IF NOT EXISTS scorer_trace_id String DEFAULT '';

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1282,6 +1282,15 @@ class FeedbackCreateReq(BaseModelStrict):
         default="",
         description="Turn the feedback belongs to (from spans.trace_id)",
     )
+    scorer_trace_id: str = Field(
+        default="",
+        description=(
+            "Trace of the scorer (judge) invocation that produced this feedback "
+            "(spans.trace_id of the judge call). Distinct from span_trace_id, "
+            "which is the scored turn. Lets signals price the invocation off the "
+            "judge span without joining the calls model."
+        ),
+    )
 
     # wb_user_id is automatically populated by the server
     wb_user_id: str | None = Field(None, description=WB_USER_ID_DESCRIPTION)


### PR DESCRIPTION
## Summary
Adds one column, `feedback.scorer_trace_id` (migration 039), so agent signals can price a scorer invocation off the judge's own agent span instead of the calls model. Consumer (worker populate + FE) lands in wandb/core#47751.

## Migration 039: why one new column
`scorer_trace_id String DEFAULT ''` on `feedback`.

- **What:** the trace id of the scorer's judge LLM call (the invocation that wrote this feedback row).
- **Why:** signals wants to show what each scorer cost. That cost lives on the judge's agent span, keyed by `trace_id`. A feedback row today points at the *scored turn* (`weave_ref`) and the scorer *wrapper call* (`call_ref`, a calls URI), but never the judge span. This is the missing pointer.
- **Why a typed column, not payload:** it is a join key, not scorer output. Mirrors the `span_*` denormalization (033, 038); `spans` stays the source of truth.
- **Why no cost stored:** cost is priced at read time (`span_costs.py` joins the span's model against `llm_token_prices`). We persist a key, never a dollar figure, so prices can't go stale.
- **Blast radius:** additive, populated going forward (no backfill), no index (resolved against `spans.trace_id`, already bloom-indexed by 030). Down-migration drops the column.

## Testing
feedback round-trip asserts `scorer_trace_id` persists independently of `span_trace_id`.