### PR TITLE
chore(weave): document agent harness integration status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -452,4 +452,8 @@ If there is something that doesn't make sense architecturally, devex-wise, or pr
 Think of this as the reverse-task assignment - a place where you can communicate back to us.
 
 - [ ] Add TypeScript testing guidelines
+- [ ] Fix the `@wandb/weave-openclaw` ClawHub release artifact and add an
+  isolated install smoke test. Version `0.1.1` resolves successfully from
+  ClawHub but `openclaw plugins install clawhub:@wandb/weave-openclaw` fails
+  because the published archive omits `dist/index.js`.
 - [ ] ...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,27 @@ _Important:_ For OpenAI Codex agents (most likely you!), your environment does n
   - `weave/` - Python package implementation
   - `weave/trace_server` - Backend server implementation
 
+### Agent harness integrations and documentation surfaces
+
+Weave traces supported agent SDKs and coding-agent harnesses into the Agents
+view. Keep public documentation aligned with the released implementation and
+use each upstream project's preferred discovery surface.
+
+| Integration | Weave implementation | Preferred upstream surface |
+| --- | --- | --- |
+| Claude Code | `wandb/weave-claude-code` plugin | Anthropic's official plugin directory submission form |
+| Claude Agent SDK | Python and TypeScript SDK integrations | W&B integration guide; the Anthropic SDK repositories do not maintain vendor lists |
+| OpenAI Agents SDK | Python and TypeScript SDK integrations | External tracing processor lists in `openai-agents-python` and `openai-agents-js` |
+| Google ADK | Python patcher and TypeScript `WeaveAdkPlugin` | `google/adk-docs` integration catalog |
+| OpenClaw | `wandb/weave-openclaw` plugin | ClawHub; OpenClaw does not maintain a static third-party plugin catalog |
+| Pi | TypeScript `createOtelExtension` factory | Pi coding-agent SDK documentation, subject to its maintainer preflight |
+
+Pi's `@earendil-works/pi-coding-agent` dependency requires Node.js
+`>=22.19.0`. OpenCode is not supported on `master`: draft PR #7278 closed
+without merging. Do not publish or request upstream OpenCode documentation
+until an integration is merged, released, and validated against OpenCode's
+native OTLP export.
+
 ## Generated Files — Do Not Hand-Edit
 
 `weave/trace_server/model_providers/model_providers.json` and `weave/trace_server/costs/cost_checkpoint.json` are generated. Never edit them by hand — regenerate with `make update_model_providers` / `make update_costs` (see `weave/Makefile`).


### PR DESCRIPTION
## Description

Document the current agent harness integration matrix, the preferred upstream
documentation surfaces, Pi's Node.js `>=22.19.0` requirement, the OpenCode
release gate, and the discovered OpenClaw ClawHub artifact blocker in
`AGENTS.md`.

### User impact

This is contributor guidance only. It keeps future documentation work aligned
with released Weave integrations and prevents premature OpenCode claims.

### Privacy implications

None. This change does not alter tracing, content capture, storage, or runtime
behavior.

## Testing

- `git diff --cached --check`
- Verified the referenced current Weave Google ADK integrations:
  - Python: 15 focused tests passed
  - TypeScript: 26 focused tests passed
- Verified Pi's released package requires Node.js `>=22.19.0`
- Isolated OpenClaw install smoke test resolved ClawHub version `0.1.1` but
  failed because the archive omits `dist/index.js`; recorded as a human request

No breaking changes.
