### PR TITLE
perf(weave): batch content-object writes on the v1 call/upsert_batch path

### DIFF
--- a/tests/trace_server/conftest_lib/trace_server_external_adapter.py
+++ b/tests/trace_server/conftest_lib/trace_server_external_adapter.py
@@ -111,6 +111,12 @@ class UserInjectingExternalTraceServer(
         req.start.wb_user_id = self._user_id
         return super().call_start(req)
 
+    def call_start_batch(self, req: tsi.CallCreateBatchReq) -> tsi.CallCreateBatchRes:
+        for item in req.batch:
+            if isinstance(item, tsi.CallBatchStartMode):
+                item.req.start.wb_user_id = self._user_id
+        return super().call_start_batch(req)
+
     def calls_delete(self, req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
         req.wb_user_id = self._user_id
         return super().calls_delete(req)

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -10,7 +10,7 @@ from weave.trace_server.base64_content_conversion import (
     AUTO_CONVERSION_MIN_SIZE,
     is_base64,
     is_data_uri,
-    process_call_req_to_content,
+    process_call_content,
     replace_base64_in_raw_messages,
     replace_base64_with_content_objects,
     store_content_object,
@@ -216,7 +216,7 @@ class TestBase64Replacement:
         obj_create_req = trace_server.obj_create.call_args.args[0]
         assert obj_create_req.obj.wb_user_id == "user-123"
 
-    def test_process_call_req_to_content_start_and_end(self):
+    def test_process_call_content_start_and_end(self):
         """Test the main entry point for processing CallStartReq and CallEndReq."""
         # Mock trace server
         trace_server = MagicMock()
@@ -248,7 +248,7 @@ class TestBase64Replacement:
             )
         )
 
-        processed_start = process_call_req_to_content(start_req, trace_server)
+        processed_start = process_call_content(start_req, trace_server)
         assert processed_start.start.inputs["text"] == "Some normal text"
         _assert_content_ref(processed_start.start.inputs["image"], "proj")
 
@@ -264,7 +264,7 @@ class TestBase64Replacement:
             )
         )
 
-        processed_end = process_call_req_to_content(end_req, trace_server)
+        processed_end = process_call_content(end_req, trace_server)
         assert processed_end.end.output == long_b64
 
 
@@ -636,7 +636,7 @@ class TestThresholdAndStructuralIdentity:
 
         Confirms the no-copy path doesn't introduce a subtle aliasing bug:
         even though the result is the same object as the input, the
-        ``CallStartReq`` machinery in ``process_call_req_to_content`` just
+        ``CallStartReq`` machinery in ``process_call_content`` just
         rebinds the field, which is fine.
         """
         from datetime import datetime, timezone
@@ -652,7 +652,7 @@ class TestThresholdAndStructuralIdentity:
                 inputs=inputs_before,
             )
         )
-        processed = process_call_req_to_content(start_req, trace_server)
+        processed = process_call_content(start_req, trace_server)
         # Pydantic shallow-copies inputs at model construction, so we compare
         # by value rather than identity here — content must round-trip
         # unchanged regardless of the SDK copy.

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -1028,16 +1028,19 @@ def _make_content_start_batch(
 
 
 def test_call_start_batch_batches_content_object_inserts(
-    clickhouse_trace_server, monkeypatch
+    trace_server, clickhouse_trace_server, monkeypatch
 ):
     """The v1 /call/upsert_batch path batches content objects like calls_complete.
 
-    Duplicate blobs across the batch collapse to one ref, and the whole batch
+    Driven through the external adapter (the real HTTP entry converts project
+    ids the same way), so this also guards the adapter's call_start_batch
+    ext->int encoding. Duplicate blobs collapse to one ref, and the whole batch
     issues exactly one object_versions insert and no aliases insert (content
-    refs pin the digest, so the "latest" alias write is skipped) instead of
-    an inline obj_create per blob (the serial staircase this replaces).
+    refs pin the digest, so the "latest" alias write is skipped) instead of an
+    inline obj_create per blob (the serial staircase this replaces).
     """
-    internal_project_id = b64(f"{TEST_ENTITY}/call_start_batch_batched_objects")
+    project_id = f"{TEST_ENTITY}/call_start_batch_batched_objects"
+    internal_project_id = b64(project_id)
 
     raw_a = b"a" * (AUTO_CONVERSION_MIN_SIZE + 10)
     raw_b = b"b" * (AUTO_CONVERSION_MIN_SIZE + 10)
@@ -1047,7 +1050,7 @@ def test_call_start_batch_batches_content_object_inserts(
     started_at = datetime.datetime.now(datetime.timezone.utc)
     call_a1, call_a2, call_b = (str(uuid.uuid4()) for _ in range(3))
     batch = _make_content_start_batch(
-        internal_project_id,
+        project_id,
         started_at,
         [
             (call_a1, {"image": data_uri_a}),
@@ -1065,7 +1068,7 @@ def test_call_start_batch_batches_content_object_inserts(
 
     monkeypatch.setattr(type(clickhouse_trace_server), "_insert", _spy_insert)
 
-    clickhouse_trace_server.call_start_batch(batch)
+    trace_server.call_start_batch(batch)
 
     assert insert_tables.count("object_versions") == 1
     assert insert_tables.count("aliases") == 0

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -1033,7 +1033,8 @@ def test_call_start_batch_batches_content_object_inserts(
     """The v1 /call/upsert_batch path batches content objects like calls_complete.
 
     Duplicate blobs across the batch collapse to one ref, and the whole batch
-    issues exactly one object_versions insert and one aliases insert instead of
+    issues exactly one object_versions insert and no aliases insert (content
+    refs pin the digest, so the "latest" alias write is skipped) instead of
     an inline obj_create per blob (the serial staircase this replaces).
     """
     internal_project_id = b64(f"{TEST_ENTITY}/call_start_batch_batched_objects")
@@ -1067,7 +1068,7 @@ def test_call_start_batch_batches_content_object_inserts(
     clickhouse_trace_server.call_start_batch(batch)
 
     assert insert_tables.count("object_versions") == 1
-    assert insert_tables.count("aliases") == 1
+    assert insert_tables.count("aliases") == 0
     assert (
         _count_project_rows(
             clickhouse_trace_server.ch_client, "object_versions", internal_project_id

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -993,6 +993,238 @@ def test_calls_complete_tolerates_content_object_name_collision(
     assert inputs_c["image"] == data_uri_a
 
 
+def _fetch_v1_call_inputs(ch_client, project_id: str, call_id: str) -> dict[str, Any]:
+    """Read a v1 start row's inputs from call_parts (start rows carry no output)."""
+    row = _fetch_call_row(ch_client, "call_parts", project_id, call_id, ["inputs_dump"])
+    assert row is not None
+    return json.loads(row[0])
+
+
+def _make_content_start_batch(
+    project_id: str,
+    started_at: datetime.datetime,
+    calls: list[tuple[str, dict[str, Any]]],
+) -> tsi.CallCreateBatchReq:
+    """Build a v1 upsert batch of start ops, one per (call_id, inputs) pair."""
+    return tsi.CallCreateBatchReq(
+        batch=[
+            tsi.CallBatchStartMode(
+                mode="start",
+                req=tsi.CallStartReq(
+                    start=tsi.StartedCallSchemaForInsert(
+                        project_id=project_id,
+                        id=call_id,
+                        trace_id=str(uuid.uuid4()),
+                        op_name="test_op",
+                        started_at=started_at,
+                        attributes={},
+                        inputs=inputs,
+                    )
+                ),
+            )
+            for call_id, inputs in calls
+        ]
+    )
+
+
+def test_call_start_batch_batches_content_object_inserts(
+    clickhouse_trace_server, monkeypatch
+):
+    """The v1 /call/upsert_batch path batches content objects like calls_complete.
+
+    Duplicate blobs across the batch collapse to one ref, and the whole batch
+    issues exactly one object_versions insert and one aliases insert instead of
+    an inline obj_create per blob (the serial staircase this replaces).
+    """
+    internal_project_id = b64(f"{TEST_ENTITY}/call_start_batch_batched_objects")
+
+    raw_a = b"a" * (AUTO_CONVERSION_MIN_SIZE + 10)
+    raw_b = b"b" * (AUTO_CONVERSION_MIN_SIZE + 10)
+    data_uri_a = f"data:image/png;base64,{base64.b64encode(raw_a).decode('ascii')}"
+    data_uri_b = f"data:image/png;base64,{base64.b64encode(raw_b).decode('ascii')}"
+
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+    call_a1, call_a2, call_b = (str(uuid.uuid4()) for _ in range(3))
+    batch = _make_content_start_batch(
+        internal_project_id,
+        started_at,
+        [
+            (call_a1, {"image": data_uri_a}),
+            (call_a2, {"image": data_uri_a}),
+            (call_b, {"image": data_uri_b}),
+        ],
+    )
+
+    insert_tables = []
+    original_insert = type(clickhouse_trace_server)._insert
+
+    def _spy_insert(self, table, *args, **kwargs):
+        insert_tables.append(table)
+        return original_insert(self, table, *args, **kwargs)
+
+    monkeypatch.setattr(type(clickhouse_trace_server), "_insert", _spy_insert)
+
+    clickhouse_trace_server.call_start_batch(batch)
+
+    assert insert_tables.count("object_versions") == 1
+    assert insert_tables.count("aliases") == 1
+    assert (
+        _count_project_rows(
+            clickhouse_trace_server.ch_client, "object_versions", internal_project_id
+        )
+        == 2
+    )
+
+    inputs_a1 = _fetch_v1_call_inputs(
+        clickhouse_trace_server.ch_client, internal_project_id, call_a1
+    )
+    inputs_a2 = _fetch_v1_call_inputs(
+        clickhouse_trace_server.ch_client, internal_project_id, call_a2
+    )
+    inputs_b = _fetch_v1_call_inputs(
+        clickhouse_trace_server.ch_client, internal_project_id, call_b
+    )
+
+    ref_a1 = inputs_a1["image"]
+    assert ref_a1.startswith(f"weave-trace-internal:///{internal_project_id}/object/")
+    assert ref_a1 == inputs_a2["image"]
+    assert inputs_b["image"] != ref_a1
+
+    parsed_a = ri.parse_internal_uri(ref_a1)
+    obj_a = clickhouse_trace_server.obj_read(
+        tsi.ObjReadReq(
+            project_id=parsed_a.project_id,
+            object_id=parsed_a.name,
+            digest=parsed_a.version,
+        )
+    )
+    assert obj_a.obj.val["_type"] == "CustomWeaveType"
+    assert obj_a.obj.val["weave_type"] == {
+        "type": "weave.type_wrappers.Content.content.Content"
+    }
+
+
+@pytest.mark.disable_logging_error_check
+def test_call_start_batch_content_obj_failure_skips_calls_insert(
+    clickhouse_trace_server, monkeypatch
+):
+    """A failed content-object insert must skip the v1 calls insert.
+
+    call_start_batch raises so the client retries the whole batch, and no
+    call_parts row is written referencing an object that never landed.
+    """
+    internal_project_id = b64(f"{TEST_ENTITY}/call_start_batch_obj_failure")
+
+    raw = b"a" * (AUTO_CONVERSION_MIN_SIZE + 10)
+    data_uri = f"data:image/png;base64,{base64.b64encode(raw).decode('ascii')}"
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+    call_id = str(uuid.uuid4())
+    batch = _make_content_start_batch(
+        internal_project_id, started_at, [(call_id, {"image": data_uri})]
+    )
+
+    original_insert = type(clickhouse_trace_server)._insert
+
+    def _fail_object_versions(self, table, *args, **kwargs):
+        if table == "object_versions":
+            raise RuntimeError("simulated content object insert failure")
+        return original_insert(self, table, *args, **kwargs)
+
+    monkeypatch.setattr(type(clickhouse_trace_server), "_insert", _fail_object_versions)
+
+    with pytest.raises(RuntimeError, match="simulated content object insert failure"):
+        clickhouse_trace_server.call_start_batch(batch)
+
+    assert (
+        _count_project_rows(
+            clickhouse_trace_server.ch_client, "call_parts", internal_project_id
+        )
+        == 0
+    )
+    assert (
+        _count_project_rows(
+            clickhouse_trace_server.ch_client, "files", internal_project_id
+        )
+        >= 1
+    )
+
+
+def test_call_start_batch_tolerates_content_object_name_collision(
+    clickhouse_trace_server,
+):
+    """A colliding content object is skipped on the v1 batch path too.
+
+    Its call keeps the original inline data URI (no dangling ref), the batch's
+    other content object still lands, and object_versions holds only the seeded
+    object plus the non-colliding one.
+    """
+    seed_project_id = b64(f"{TEST_ENTITY}/call_start_batch_collision_seed")
+    internal_project_id = b64(f"{TEST_ENTITY}/call_start_batch_collision")
+
+    raw_a = b"a" * (AUTO_CONVERSION_MIN_SIZE + 10)
+    raw_b = b"b" * (AUTO_CONVERSION_MIN_SIZE + 10)
+    data_uri_a = f"data:image/png;base64,{base64.b64encode(raw_a).decode('ascii')}"
+    data_uri_b = f"data:image/png;base64,{base64.b64encode(raw_b).decode('ascii')}"
+
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+
+    # Learn the deterministic content object_id for payload a in a seed project.
+    seed_call_id = str(uuid.uuid4())
+    clickhouse_trace_server.call_start_batch(
+        _make_content_start_batch(
+            seed_project_id, started_at, [(seed_call_id, {"image": data_uri_a})]
+        )
+    )
+    seed_inputs = _fetch_v1_call_inputs(
+        clickhouse_trace_server.ch_client, seed_project_id, seed_call_id
+    )
+    content_object_id_a = ri.parse_internal_uri(seed_inputs["image"]).name
+
+    # Bind that object_id to a different base_object_class in the target project.
+    clickhouse_trace_server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=internal_project_id,
+                object_id=content_object_id_a,
+                val={"_bases": ["Object", "BaseModel"], "_class_name": "TypeA"},
+            )
+        )
+    )
+
+    call_a_id, call_b_id = str(uuid.uuid4()), str(uuid.uuid4())
+    clickhouse_trace_server.call_start_batch(
+        _make_content_start_batch(
+            internal_project_id,
+            started_at,
+            [(call_a_id, {"image": data_uri_a}), (call_b_id, {"image": data_uri_b})],
+        )
+    )
+
+    inputs_a = _fetch_v1_call_inputs(
+        clickhouse_trace_server.ch_client, internal_project_id, call_a_id
+    )
+    inputs_b = _fetch_v1_call_inputs(
+        clickhouse_trace_server.ch_client, internal_project_id, call_b_id
+    )
+
+    assert inputs_a["image"] == data_uri_a
+    parsed_b = ri.parse_internal_uri(inputs_b["image"])
+    obj_b = clickhouse_trace_server.obj_read(
+        tsi.ObjReadReq(
+            project_id=parsed_b.project_id,
+            object_id=parsed_b.name,
+            digest=parsed_b.version,
+        )
+    )
+    assert obj_b.obj.val["_type"] == "CustomWeaveType"
+    assert (
+        _count_project_rows(
+            clickhouse_trace_server.ch_client, "object_versions", internal_project_id
+        )
+        == 2
+    )
+
+
 def test_call_start_end_v2_updates_calls_complete(
     trace_server, clickhouse_trace_server
 ):

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -784,6 +784,61 @@ def test_calls_complete_batches_content_object_inserts(
     assert obj_a.obj.val != obj_b.obj.val
 
 
+@pytest.mark.disable_logging_error_check
+def test_calls_complete_content_obj_failure_skips_calls_insert(
+    trace_server, clickhouse_trace_server, monkeypatch
+):
+    """File chunks and content objects flush concurrently. If the content-object
+    insert fails, the peer file insert may still commit, but the calls insert
+    must not run: calls_complete raises so the client retries the whole batch,
+    and the content-addressed peer write reconciles idempotently on retry.
+    """
+    project_id = f"{TEST_ENTITY}/calls_complete_parallel_failure"
+    internal_project_id = b64(project_id)
+
+    raw = b"a" * (AUTO_CONVERSION_MIN_SIZE + 10)
+    data_uri = f"data:image/png;base64,{base64.b64encode(raw).decode('ascii')}"
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+    ended_at = started_at + datetime.timedelta(seconds=1)
+    call_id = str(uuid.uuid4())
+    call = _make_completed_call(
+        project_id,
+        call_id,
+        str(uuid.uuid4()),
+        started_at,
+        ended_at,
+        inputs={"image": data_uri},
+    )
+
+    original_insert = type(clickhouse_trace_server)._insert
+
+    def _fail_object_versions(self, table, *args, **kwargs):
+        if table == "object_versions":
+            raise RuntimeError("simulated content object insert failure")
+        return original_insert(self, table, *args, **kwargs)
+
+    monkeypatch.setattr(type(clickhouse_trace_server), "_insert", _fail_object_versions)
+
+    with pytest.raises(RuntimeError, match="simulated content object insert failure"):
+        trace_server.calls_complete(tsi.CallsUpsertCompleteReq(batch=[call]))
+
+    # The call was never written: the client can safely retry.
+    assert (
+        _count_project_rows(
+            clickhouse_trace_server.ch_client, "calls_complete", internal_project_id
+        )
+        == 0
+    )
+    # The peer file insert committed independently (joined before we raised);
+    # a retry re-writes the object over the same content-addressed file rows.
+    assert (
+        _count_project_rows(
+            clickhouse_trace_server.ch_client, "files", internal_project_id
+        )
+        >= 1
+    )
+
+
 def test_calls_complete_tolerates_content_object_name_collision(
     trace_server, clickhouse_trace_server
 ):

--- a/tests/trace_server/test_clickhouse_batching.py
+++ b/tests/trace_server/test_clickhouse_batching.py
@@ -162,12 +162,12 @@ def test_clickhouse_batching():
 
         # THE KEY ASSERTION: the whole request issues one insert per table.
         # The 3 distinct content objects are staged and written in a single
-        # obj_create_batch (one object_versions + one aliases insert) alongside
-        # the batched files and call_parts inserts, instead of one obj_create
-        # round-trip per object.
+        # obj_create_batch (one object_versions insert, no "latest" alias since
+        # content refs pin the digest) alongside the batched files and
+        # call_parts inserts, instead of one obj_create round-trip per object.
         insert_tables = [call[0][0] for call in mock_ch_client.insert.call_args_list]
         assert sorted(insert_tables) == sorted(
-            ["files", "call_parts", "object_versions", "aliases"]
+            ["files", "call_parts", "object_versions"]
         ), f"Unexpected inserts: {insert_tables}"
 
 
@@ -199,11 +199,11 @@ def test_clickhouse_batching_deduplicates_identical_files():
         )
         trace_server.call_start_batch(batch_req)
 
-        # Dedup collapses the object too: one object_versions + aliases pair
-        # for the single unique content object, alongside the batched inserts.
+        # Dedup collapses the object too: one object_versions insert for the
+        # single unique content object, alongside the batched inserts.
         insert_tables = [call[0][0] for call in mock_ch_client.insert.call_args_list]
         assert sorted(insert_tables) == sorted(
-            ["files", "call_parts", "object_versions", "aliases"]
+            ["files", "call_parts", "object_versions"]
         ), f"Unexpected inserts: {insert_tables}"
 
         # The files insert should contain chunks for only 1 unique file

--- a/tests/trace_server/test_clickhouse_batching.py
+++ b/tests/trace_server/test_clickhouse_batching.py
@@ -160,13 +160,14 @@ def test_clickhouse_batching():
         # Execute the batch
         trace_server.call_start_batch(batch_req)
 
-        # THE KEY ASSERTION: one batched files insert and one batched
-        # call_parts insert for the whole request. The 3 distinct content
-        # objects each publish via obj_create (unbatched on this path), so
-        # object_versions and aliases get one insert per object.
+        # THE KEY ASSERTION: the whole request issues one insert per table.
+        # The 3 distinct content objects are staged and written in a single
+        # obj_create_batch (one object_versions + one aliases insert) alongside
+        # the batched files and call_parts inserts, instead of one obj_create
+        # round-trip per object.
         insert_tables = [call[0][0] for call in mock_ch_client.insert.call_args_list]
         assert sorted(insert_tables) == sorted(
-            ["files", "call_parts"] + ["object_versions", "aliases"] * 3
+            ["files", "call_parts", "object_versions", "aliases"]
         ), f"Unexpected inserts: {insert_tables}"
 
 

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -410,23 +410,21 @@ def replace_base64_with_content_objects(
     return _visit(vals)
 
 
-R = TypeVar("R", bound=CallStartReq | CallEndReq | CallEndV2Req)
+R = TypeVar(
+    "R", bound=CallStartReq | CallEndReq | CallEndV2Req | CompletedCallSchemaForInsert
+)
 
 
-def process_call_req_to_content(
+def process_call_content(
     req: R,
     trace_server: TraceServerInterface,
+    pending_objs: PendingContentObjs | None = None,
 ) -> R:
-    """Process call inputs/outputs to replace base64 content.
+    """Replace base64 content in a call's inputs/outputs with Content refs.
 
-    This is the main entry point for processing trace data before insertion.
-
-    Args:
-        req: Call request (start, end, or end v2)
-        trace_server: Trace server instance
-
-    Returns:
-        Request with base64 content replaced by Content objects.
+    Single entry point for every write path. ``pending_objs`` queues the
+    objects for a batched flush instead of writing each inline; passing None
+    keeps the immediate obj_create behavior for standalone calls.
     """
     if isinstance(req, CallStartReq):
         req.start.inputs = replace_base64_with_content_objects(
@@ -434,6 +432,7 @@ def process_call_req_to_content(
             req.start.project_id,
             trace_server,
             req.start.wb_user_id,
+            pending_objs,
         )
     elif isinstance(req, (CallEndReq, CallEndV2Req)):
         # NOTE: EndedCallSchemaForInsert has no ``wb_user_id`` field, so Content
@@ -442,58 +441,41 @@ def process_call_req_to_content(
         # to the ``wb_user_id=None`` default (unattributed) — see the report /
         # PR discussion for the required follow-up.
         req.end.output = replace_base64_with_content_objects(
-            req.end.output, req.end.project_id, trace_server
+            req.end.output, req.end.project_id, trace_server, None, pending_objs
         )
+    elif isinstance(req, CompletedCallSchemaForInsert):
+        req.inputs = replace_base64_with_content_objects(
+            req.inputs, req.project_id, trace_server, req.wb_user_id, pending_objs
+        )
+        req.output = replace_base64_with_content_objects(
+            req.output, req.project_id, trace_server, req.wb_user_id, pending_objs
+        )
+    else:
+        raise TypeError(f"Unsupported call request type: {type(req)}")
 
     return req
 
 
-def process_complete_call_to_content(
-    complete_call: CompletedCallSchemaForInsert,
-    trace_server: TraceServerInterface,
-    pending_objs: PendingContentObjs | None = None,
-) -> CompletedCallSchemaForInsert:
-    """Process a complete call to replace base64 content in inputs and outputs.
-
-    Args:
-        complete_call: Complete call schema with both inputs and outputs.
-        trace_server: Trace server instance for file storage.
-        pending_objs: When given, content objects are queued here instead of
-            being written immediately, so a caller can batch the writes.
-
-    Returns:
-        CompletedCallSchemaForInsert with base64 content replaced by Content objects.
-    """
-    complete_call.inputs = replace_base64_with_content_objects(
-        complete_call.inputs,
-        complete_call.project_id,
-        trace_server,
-        complete_call.wb_user_id,
-        pending_objs,
-    )
-    complete_call.output = replace_base64_with_content_objects(
-        complete_call.output,
-        complete_call.project_id,
-        trace_server,
-        complete_call.wb_user_id,
-        pending_objs,
-    )
-    return complete_call
-
-
 def restore_raw_content_values(
-    complete_call: CompletedCallSchemaForInsert,
+    req: R,
     raw_by_ref: dict[str, str],
-) -> CompletedCallSchemaForInsert:
+) -> R:
     """Replace embedded content refs with the raw values they came from.
 
     Used when a queued content object was skipped at flush time (name/type
     collision): the call payload keeps the original inline value instead of
     a ref that resolves to nothing.
     """
-    complete_call.inputs = _restore_refs(complete_call.inputs, raw_by_ref)
-    complete_call.output = _restore_refs(complete_call.output, raw_by_ref)
-    return complete_call
+    if isinstance(req, CallStartReq):
+        req.start.inputs = _restore_refs(req.start.inputs, raw_by_ref)
+    elif isinstance(req, (CallEndReq, CallEndV2Req)):
+        req.end.output = _restore_refs(req.end.output, raw_by_ref)
+    elif isinstance(req, CompletedCallSchemaForInsert):
+        req.inputs = _restore_refs(req.inputs, raw_by_ref)
+        req.output = _restore_refs(req.output, raw_by_ref)
+    else:
+        raise TypeError(f"Unsupported call request type: {type(req)}")
+    return req
 
 
 def _restore_refs(val: Any, raw_by_ref: dict[str, str]) -> Any:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -8,6 +8,7 @@ import threading
 import time
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from functools import partial
 from re import sub
@@ -911,28 +912,37 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._flush_immediately = True
 
     def _flush_all_batches_in_order(self) -> None:
-        """Flush all batches in order of dependency.
+        """Flush all batches, respecting cross-table write dependencies.
         1. Bucket uploads, fanned out in parallel. Resulting chunks join
            _file_batch before the file_chunks insert so URIs are persisted
            atomically with any inline-CH chunks accumulated alongside.
-        2. File chunks, if this fails, we raise so that we don't insert calls that
-           are missing file data. Forces retry.
-        3. Content objects, if this fails, we raise. Written after their file
-           bytes so a committed object row never references unwritten content.
-        4. Calls, if this fails, we raise so that clients can retry, and so we don't
+        2. File chunks and content objects, inserted concurrently. Both must be
+           durable before calls and neither reads the other. If either fails we
+           raise, so calls (below) never commit referencing unwritten data.
+        3. Calls, if this fails, we raise so that clients can retry, and so we don't
            continue and push bad ids to the queue.
-        5. Produce to kafka, if this fails, we don't raise because all of the data
+        4. Produce to kafka, if this fails, we don't raise because all of the data
            is already in the database, we don't want the client to retry.
            TODO: consider kafka retry logic.
         """
-        self._flush_file_batches()
+        self._flush_immediately = True
 
         # Raises on fail
         try:
-            self._flush_content_objs()
+            self._file_batch.extend(
+                self._bucket_uploads.flush(self.file_storage_client)
+            )
         except Exception:
-            logger.exception("Failed to flush content objects")
+            logger.exception("Failed to flush bucket uploads")
             raise
+
+        # File chunks || content objects. Snapshot the thread-local batches so
+        # each worker inserts an explicit list on its own pooled ch_client.
+        file_rows = self._file_batch
+        content_objs = self._content_obj_batch
+        self._file_batch = []
+        self._content_obj_batch = []
+        self._flush_referenced_data_in_parallel(file_rows, content_objs)
 
         # Raises on fail
         try:
@@ -947,6 +957,46 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._flush_kafka_producer()
         except Exception:
             logger.exception("Failed to flush kafka producer")
+
+    @traced(name="clickhouse_trace_server_batched._flush_referenced_data_in_parallel")
+    def _flush_referenced_data_in_parallel(
+        self,
+        file_rows: list[FileChunkCreateCHInsertable],
+        content_objs: list[tsi.ObjSchemaForInsert],
+    ) -> None:
+        """Insert file chunks and content objects concurrently.
+
+        Both must commit before the calls that reference them, and neither reads
+        the other, so they run in parallel on separate ch_clients (ch_client is
+        thread-local, so each worker mints its own from the shared pool). Every
+        task is joined before returning; if either raises, the first error is
+        re-raised so the caller skips the calls insert and the client retries.
+        """
+        tasks: list[tuple[str, Callable[[], None]]] = []
+        if file_rows:
+            tasks.append(("files", lambda: self._insert_file_chunks(file_rows)))
+        if content_objs:
+            tasks.append(
+                ("content_objs", lambda: self._flush_content_objs_batch(content_objs))
+            )
+        if len(tasks) < 2:
+            for _, run in tasks:
+                run()
+            return
+
+        with ThreadPoolExecutor(
+            max_workers=len(tasks), thread_name_prefix="flush-insert"
+        ) as pool:
+            futures = {pool.submit(run): label for label, run in tasks}
+            errors: list[Exception] = []
+            for future in as_completed(futures):
+                try:
+                    future.result()
+                except Exception as e:
+                    logger.exception("Failed to flush %s", futures[future])
+                    errors.append(e)
+        if errors:
+            raise errors[0]
 
     def _flush_file_batches(self) -> None:
         """Fan out staged bucket uploads in parallel, then insert their chunk rows.
@@ -1154,8 +1204,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         Read-only: dedupes by (project_id, object_id, digest) so identical
         content embedded in multiple calls is written once, runs one WB-30574
         collision check per project, and stages the survivors into
-        _content_obj_batch for the ordered flush. The actual obj_create_batch
-        write happens later in _flush_content_objs, after file bytes land.
+        _content_obj_batch for the parallel flush. The actual obj_create_batch
+        write happens later in _flush_content_objs_batch, alongside file chunks.
 
         A collision must not fail the calls batch: the colliding object is
         skipped and reported in the returned {ref: raw_value} map so the
@@ -1193,13 +1243,15 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return pending_objs.restore_map()
 
-    def _flush_content_objs(self) -> None:
-        """Write staged content objects, grouped by project (obj_create_batch
-        takes a single project). Runs after _flush_file_batches so a committed
-        object row never references content that has not landed in storage.
+    def _flush_content_objs_batch(
+        self, content_objs: list[tsi.ObjSchemaForInsert]
+    ) -> None:
+        """Write content objects, grouped by project (obj_create_batch takes a
+        single project). Runs concurrently with the file-chunk insert; both land
+        before the calls that reference them.
         """
         by_project: dict[str, list[tsi.ObjSchemaForInsert]] = {}
-        for obj in self._content_obj_batch:
+        for obj in content_objs:
             by_project.setdefault(obj.project_id, []).append(obj)
         for project_objs in by_project.values():
             self.obj_create_batch(project_objs)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -84,8 +84,7 @@ from weave.trace_server.agents.types import (
 )
 from weave.trace_server.base64_content_conversion import (
     PendingContentObjs,
-    process_call_req_to_content,
-    process_complete_call_to_content,
+    process_call_content,
     replace_base64_with_content_objects,
     restore_raw_content_values,
 )
@@ -1023,7 +1022,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             logger.exception("Failed to flush file chunks")
             raise
 
-    def _offload_call_content(self, req: _CallReqT) -> _CallReqT:
+    def _offload_call_content(
+        self, req: _CallReqT, pending_objs: PendingContentObjs | None = None
+    ) -> _CallReqT:
         """Replace inline base64 content with file refs, uploading in parallel.
 
         Each extracted attachment becomes a file_create; staging them and
@@ -1031,12 +1032,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         one parallel batch. Files persist before this returns, so the caller's
         call insert/UPDATE can reference them. Deferral is a no-op when already
         inside call_batch(), which owns the flush.
+
+        When ``pending_objs`` is given, content objects are staged there for a
+        batched flush instead of written inline; the caller resolves and flushes
+        them (see call_start_batch). Without it, each object is written inline.
         """
         if not self._flush_immediately:
-            return process_call_req_to_content(req, self)
+            return process_call_content(req, self, pending_objs)
         self._flush_immediately = False
         try:
-            processed = process_call_req_to_content(req, self)
+            processed = process_call_content(req, self, pending_objs)
             self._flush_immediately = True
             self._flush_file_batches()
             return processed
@@ -1047,26 +1052,49 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @tag_db_insert_path("call_start_batch")
     def call_start_batch(self, req: tsi.CallCreateBatchReq) -> tsi.CallCreateBatchRes:
+        """Insert a batch of start/end ops, batching their content objects.
+
+        Content objects embedded across the batch are staged into one
+        PendingContentObjs, deduped and collision-checked once per project, and
+        written in a single obj_create_batch (parallel with file chunks) before
+        the calls that reference them, instead of one inline obj_create per blob.
+        Mirrors calls_complete; standalone call_start/call_end keep inline writes.
+        """
+        set_current_span_dd_tags(
+            {"weave_trace_server.insert_call_count": len(req.batch)}
+        )
+        pending_objs = PendingContentObjs()
         with self.call_batch():
+            for item in req.batch:
+                self._offload_call_content(item.req, pending_objs)
+
+            raw_by_ref = self._resolve_pending_content_objs(pending_objs)
+
             res = []
             for item in req.batch:
+                if raw_by_ref:
+                    restore_raw_content_values(item.req, raw_by_ref)
                 if item.mode == "start":
-                    res.append(self.call_start(item.req))
+                    res.append(self._call_start_processed(item.req))
                 elif item.mode == "end":
-                    res.append(self.call_end(item.req))
+                    res.append(self._call_end_processed(item.req))
                 else:
                     raise ValueError("Invalid mode")
+        pending_objs.publish_refs()
         return tsi.CallCreateBatchRes(res=res)
 
     @tag_db_insert_path("call_start")
     def call_start(self, req: tsi.CallStartReq) -> tsi.CallStartRes:
         """Creates a new call."""
+        set_current_span_dd_tags({"weave_trace_server.insert_call_count": 1})
+        req = self._offload_call_content(req)
+        return self._call_start_processed(req)
+
+    def _call_start_processed(self, req: tsi.CallStartReq) -> tsi.CallStartRes:
+        """Insert a start whose content was already offloaded (batch or inline)."""
         # Converts the user-provided call details into a clickhouse schema.
         # This does validation and conversion of the input data as well
         # as enforcing business rules and defaults
-        set_current_span_dd_tags({"weave_trace_server.insert_call_count": 1})
-
-        req = self._offload_call_content(req)
         retention_days = get_project_retention_days(
             req.start.project_id, self.ch_client
         )
@@ -1096,10 +1124,18 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         req: tsi.CallEndReq,
         publish: bool = True,
     ) -> tsi.CallEndRes:
+        req = self._offload_call_content(req)
+        return self._call_end_processed(req, publish)
+
+    def _call_end_processed(
+        self,
+        req: tsi.CallEndReq,
+        publish: bool = True,
+    ) -> tsi.CallEndRes:
+        """Insert an end whose content was already offloaded (batch or inline)."""
         # Converts the user-provided call details into a clickhouse schema.
         # This does validation and conversion of the input data as well
         # as enforcing business rules and defaults
-        req = self._offload_call_content(req)
         retention_days = get_project_retention_days(req.end.project_id, self.ch_client)
         ch_call = end_call_for_insert_to_ch_insertable(req.end, retention_days)
 
@@ -1154,7 +1190,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         pending_objs = PendingContentObjs()
         with self.call_batch():
             processed_calls = [
-                process_complete_call_to_content(complete_call, self, pending_objs)
+                process_call_content(complete_call, self, pending_objs)
                 for complete_call in req.batch
             ]
             # Resolve collisions now (read-only) so call payloads can restore

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -263,7 +263,7 @@ def wf_ingest_sample_rate() -> float:
     """Fraction of non-eval traces to keep at ingest (0.0-1.0).
 
     Governs BOTH data models: the calls-model sampler reads the same variable.
-    Defaults to 1.0 (sampling off); an unparseable or out-of-range value falls
+    Defaults to 1.0 (sampling off); an unparsable or out-of-range value falls
     back to 1.0, so a bad config can never start dropping data.
 
     The value comes from the process environment and is not mutated in-process,

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -341,21 +341,43 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
 
     def call_start(self, req: tsi.CallStartReq) -> tsi.CallStartRes:
         req = req.model_copy(deep=True)
+        pid = self._encode_call_start_inplace(req)
+        return self._ref_apply(self._internal_trace_server.call_start, req, pid)
+
+    def call_end(self, req: tsi.CallEndReq) -> tsi.CallEndRes:
+        req = req.model_copy(deep=True)
+        pid = self._encode_call_end_inplace(req)
+        return self._ref_apply(self._internal_trace_server.call_end, req, pid)
+
+    def call_start_batch(self, req: tsi.CallCreateBatchReq) -> tsi.CallCreateBatchRes:
+        """Batch of start/end ops, converting each item's ids ext->int.
+
+        Delegates the whole batch to the internal batched writer in one call so
+        content objects are staged and written once (see call_start_batch there),
+        instead of a per-item round-trip.
+        """
+        req = req.model_copy(deep=True)
+        pid = ""
+        for item in req.batch:
+            if isinstance(item, tsi.CallBatchStartMode):
+                pid = self._encode_call_start_inplace(item.req)
+            elif isinstance(item, tsi.CallBatchEndMode):
+                pid = self._encode_call_end_inplace(item.req)
+            else:
+                raise TypeError(f"Unsupported batch item mode: {type(item)}")
+        return self._ref_apply(self._internal_trace_server.call_start_batch, req, pid)
+
+    def _encode_call_start_inplace(self, req: tsi.CallStartReq) -> str:
         req.start.project_id = self._idc.ext_to_int_project_id(req.start.project_id)
         if req.start.wb_run_id is not None:
             req.start.wb_run_id = self._idc.ext_to_int_run_id(req.start.wb_run_id)
         if req.start.wb_user_id is not None:
             req.start.wb_user_id = self._idc.ext_to_int_user_id(req.start.wb_user_id)
-        return self._ref_apply(
-            self._internal_trace_server.call_start, req, req.start.project_id
-        )
+        return req.start.project_id
 
-    def call_end(self, req: tsi.CallEndReq) -> tsi.CallEndRes:
-        req = req.model_copy(deep=True)
+    def _encode_call_end_inplace(self, req: tsi.CallEndReq) -> str:
         req.end.project_id = self._idc.ext_to_int_project_id(req.end.project_id)
-        return self._ref_apply(
-            self._internal_trace_server.call_end, req, req.end.project_id
-        )
+        return req.end.project_id
 
     def call_read(self, req: tsi.CallReadReq) -> tsi.CallReadRes:
         req = req.model_copy(deep=True)


### PR DESCRIPTION
## Summary
- Extends the calls_complete content-object batching to the v1 `/call/upsert_batch` path. `call_start_batch` now threads one `PendingContentObjs` through the batch: content objects are deduped and written in a single `obj_create_batch` (in parallel with file chunks, before the calls that reference them) instead of one inline synchronous `obj_create` per base64 blob.
- Exposes `call_start_batch` on `ExternalTraceServer` so the HTTP handler (wandb/core#48000) can reach this batched path in one call; without it the handler looped `call_start` per item and never batched.
- Root cause of a 55s prod `upsert_batch` trace: 16 inline blobs = 16 serial `obj_create` round-trips (~1.2s each). This collapses them to one batched insert.
- Converges the two content walks into one `process_call_content`; standalone (non-batch) `call_start`/`call_end` keep inline writes.

## Testing
adds v1 batching/failure-injection/collision tests to test_calls_complete.py (real CH); the adapter path is covered by the retargeted upsert_batch test.


---

### QA A/B (zoo-qa, /qa-this)

Deployed `ee192c21` (weave a950fa7) to zoo-qa, A/B vs master `43f264d` on server-side `@duration` of `POST /call/upsert_batch` (`service:weave-trace env:qa`), identical input (8-call batch, 120 content blobs each).

| build | P50 | MAX | count | errors |
| --- | --- | --- | --- | --- |
| master `43f264d` | 60.8s | 63.9s | 12 | none |
| PR `ee192c21` | 62.0s | 73.7s | 11 | none |

Parity + zero new error classes = no regression from the concurrent file‖content-obj flush. All requests 200 OK; trace structure unchanged. This workload uses large (>8KB) distinct blobs so it is byte-upload-bound (the intended per-blob `obj_create` round-trip win needs many small blobs to surface), so the A/B validates no-regression rather than the speedup.

| master | PR |
| --- | --- |
| ![master](https://github.com/user-attachments/assets/31fa35a8-5b78-4512-aa97-600f1b73aa31) | ![pr](https://github.com/user-attachments/assets/75ab073a-fce0-42e0-93b3-4ce3080ced8b) |
