### PR TITLE
fix(weave): apply signal filters to agent stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,9 @@ _Important:_ For OpenAI Codex agents (most likely you!), your environment does n
 - `weave/` - Core implementation
   - `weave/` - Python package implementation
   - `weave/trace_server` - Backend server implementation
+  - Agent span list and stats requests both support conversation Signal filters;
+    use the shared `agent_signal_filters` semi-join so list rows, counts, and
+    histogram buckets apply identical tag/rating semantics.
 
 ## Generated Files — Do Not Hand-Edit
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,9 +72,6 @@ _Important:_ For OpenAI Codex agents (most likely you!), your environment does n
 - `weave/` - Core implementation
   - `weave/` - Python package implementation
   - `weave/trace_server` - Backend server implementation
-  - Agent span list and stats requests both support conversation Signal filters;
-    use the shared `agent_signal_filters` semi-join so list rows, counts, and
-    histogram buckets apply identical tag/rating semantics.
 
 ## Generated Files — Do Not Hand-Edit
 

--- a/tests/trace_server/query_builder/test_agent_stats_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_stats_query_builder.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from weave.trace_server.agents.constants import MAX_AGENT_STATS_RESULT_ROWS
 from weave.trace_server.agents.types import (
     AgentGroupByRef,
+    AgentSignalFilter,
     AgentSpanGroupFilter,
     AgentSpanMeasureSpec,
     AgentSpanStatsMetricSpec,
@@ -18,6 +19,8 @@ from weave.trace_server.agents.types import (
 from weave.trace_server.interface.query import Query
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.agent_stats_query_builder import (
+    _spans_source_filter_sql,
+    _SpanSourceFilterSQL,
     build_agent_span_stats_query,
 )
 from weave.trace_server.query_builder.agent_trace_attribution import (
@@ -107,6 +110,44 @@ def test_time_bucket_epoch_bounds_are_whole_second_ints() -> None:
     assert end_epoch in params.values()
     epochs = [v for v in params.values() if v in {start_epoch, end_epoch}]
     assert [type(v) for v in epochs] == [int, int]
+
+
+def test_signal_filters_add_conversation_semi_join_and_attribution() -> None:
+    start = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    end = datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc)
+    pb = ParamBuilder("genai")
+
+    result = _spans_source_filter_sql(
+        pb,
+        _req(signal_filters=AgentSignalFilter(tags=["flagged"])),
+        start,
+        end,
+    )
+
+    expected_source, source_params = _attr_src(
+        5, started_after=start, started_before=end
+    )
+    assert result == _SpanSourceFilterSQL(
+        where=(
+            "s.project_id = {genai_0:String} "
+            "AND s.started_at >= {genai_1:DateTime64(6)} "
+            "AND s.started_at < {genai_2:DateTime64(6)} "
+            "AND s.conversation_id IN (SELECT span_conversation_id FROM feedback "
+            "WHERE project_id = {genai_3:String} AND feedback_type IN "
+            "('wandb.agent_monitor', 'wandb.agent_user_feedback') "
+            "AND span_conversation_id != '' GROUP BY span_conversation_id "
+            "HAVING sum(hasAny(scorer_tags, {genai_4:Array(String)})) > 0)"
+        ),
+        source=expected_source,
+    )
+    assert pb.get_params() == {
+        "genai_0": "p1",
+        "genai_1": start,
+        "genai_2": end,
+        "genai_3": "p1",
+        "genai_4": ["flagged"],
+        **source_params,
+    }
 
 
 def test_ungrouped_stats_query_full_sql_shape() -> None:

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -365,6 +365,10 @@ class AgentSpanStatsReq(BaseModel):
     )
     bucket_by: AgentSpanStatsBucketSpec | None = None
     group_filters: list[AgentSpanGroupFilter] = Field(default_factory=list)
+    # Restrict stats to spans belonging to conversations that carry all of the
+    # requested signal tags/ratings. Signal timestamps are intentionally not
+    # constrained by the stats window; they annotate the conversation.
+    signal_filters: AgentSignalFilter | None = None
 
     @model_validator(mode="after")
     def validate_stats_request(self) -> AgentSpanStatsReq:

--- a/weave/trace_server/query_builder/agent_stats_query_builder.py
+++ b/weave/trace_server/query_builder/agent_stats_query_builder.py
@@ -53,6 +53,9 @@ from weave.trace_server.query_builder.agent_query_builder import (
     span_value_sql,
 )
 from weave.trace_server.query_builder.agent_query_compiler import compile_agent_query
+from weave.trace_server.query_builder.agent_signal_filters import (
+    build_signal_filter_clause,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -426,6 +429,9 @@ def _spans_source_filter_sql(
     )
     if req.query is not None:
         where_conditions.append(compile_agent_query(req.query, pb))
+    signal_clause = build_signal_filter_clause(pb, req.project_id, req.signal_filters)
+    if signal_clause is not None:
+        where_conditions.append(signal_clause)
     # The base relation carries cost columns only when the request needs them;
     # attribution then wraps that base so identity columns inherit from their
     # trace while any cost columns pass through untouched.
@@ -435,7 +441,7 @@ def _spans_source_filter_sql(
         else _SPANS_TABLE
     )
     source = base
-    if _stats_references_identity(req):
+    if signal_clause is not None or _stats_references_identity(req):
         source = agent_trace_attribution.attributed_spans_source(
             pb,
             project_id=req.project_id,


### PR DESCRIPTION
## Summary
- add Signal tag/rating filters to agent span stats requests
- reuse the conversation Signal semi-join for histogram buckets
- force trace attribution so child spans inherit conversation identity

## Testing
- uvx ruff check on changed Python files
- 19 agent stats query-builder tests