### PR TITLE
fix(weave): relax agent-search matched-message role to str

### DIFF
--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -2808,6 +2808,34 @@ def test_message_search_indexes_tool_calls(ch_server):
     assert res_tool_alias.results[0].matched_messages[0].role == "tool_call"
 
 
+def test_message_search_normalizes_camel_case_role(ch_server):
+    """A stored message role of 'toolResult' (e.g. from a client that sends
+    camelCase OTel roles) must not 500 on `AgentSearchMatchedMessage.role`;
+    it should normalize to the canonical 'tool_result' literal.
+    """
+    project_id = _make_project_id("search_role_normalize")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    spans = [
+        _make_span(
+            project_id,
+            conversation_id="camel-role-conv",
+            output_messages=[
+                NormalizedMessage(role="toolResult", content="the weather is sunny"),
+            ],
+            started_at=now,
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_search(AgentSearchReq(project_id=project_id, query="sunny"))
+    assert len(res.results) == 1
+    matched = res.results[0].matched_messages
+    assert len(matched) == 1
+    assert matched[0].role == "tool_result"
+    assert matched[0].content_preview == "the weather is sunny"
+
+
 # ---------------------------------------------------------------------------
 # Test: Query DSL end-to-end
 # ---------------------------------------------------------------------------

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -2808,12 +2808,12 @@ def test_message_search_indexes_tool_calls(ch_server):
     assert res_tool_alias.results[0].matched_messages[0].role == "tool_call"
 
 
-def test_message_search_normalizes_camel_case_role(ch_server):
-    """A stored message role of 'toolResult' (e.g. from a client that sends
-    camelCase OTel roles) must not 500 on `AgentSearchMatchedMessage.role`;
-    it should normalize to the canonical 'tool_result' literal.
+def test_message_search_passes_through_noncanonical_role(ch_server):
+    """A stored message role that is not a canonical value (e.g. 'toolResult'
+    from a client sending camelCase OTel roles) must not 500 the search; it is
+    returned verbatim on `AgentSearchMatchedMessage.role`.
     """
-    project_id = _make_project_id("search_role_normalize")
+    project_id = _make_project_id("search_role_passthrough")
     now = datetime.datetime.now(tz=datetime.timezone.utc)
 
     spans = [
@@ -2832,7 +2832,7 @@ def test_message_search_normalizes_camel_case_role(ch_server):
     assert len(res.results) == 1
     matched = res.results[0].matched_messages
     assert len(matched) == 1
-    assert matched[0].role == "tool_result"
+    assert matched[0].role == "toolResult"
     assert matched[0].content_preview == "the weather is sunny"
 
 

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -81,7 +81,6 @@ from weave.trace_server.agents.types import (
     GenAIOTelExportReq,
     GenAIOTelExportRes,
     group_by_ref_alias,
-    normalize_search_message_role,
 )
 from weave.trace_server.clickhouse.utilities import insert_with_empty_query_retry
 from weave.trace_server.datadog import record_db_insert, set_root_span_dd_tags
@@ -625,7 +624,7 @@ class AgentQueryHandler:
                 AgentSearchMatchedMessage(
                     span_id=safe_str(r.get("span_id")),
                     trace_id=safe_str(r.get("trace_id")),
-                    role=normalize_search_message_role(safe_str(r.get("role"))),
+                    role=safe_str(r.get("role")),
                     content_preview=safe_str(r.get("content")),
                     content_digest=safe_str(r.get("content_digest")),
                     started_at=started_at,

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -81,6 +81,7 @@ from weave.trace_server.agents.types import (
     GenAIOTelExportReq,
     GenAIOTelExportRes,
     group_by_ref_alias,
+    normalize_search_message_role,
 )
 from weave.trace_server.clickhouse.utilities import insert_with_empty_query_retry
 from weave.trace_server.datadog import record_db_insert, set_root_span_dd_tags
@@ -624,7 +625,7 @@ class AgentQueryHandler:
                 AgentSearchMatchedMessage(
                     span_id=safe_str(r.get("span_id")),
                     trace_id=safe_str(r.get("trace_id")),
-                    role=safe_str(r.get("role")),
+                    role=normalize_search_message_role(safe_str(r.get("role"))),
                     content_preview=safe_str(r.get("content")),
                     content_digest=safe_str(r.get("content_digest")),
                     started_at=started_at,

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -58,31 +58,6 @@ SearchMessageRole = Literal[
     "tool_result",
 ]
 
-# Ingested message roles are unvalidated client OTel attribute strings (see
-# `opentelemetry/genai_extraction.py::_normalize_single_message`), so known
-# non-canonical spellings must be mapped to the search response Literal.
-_SEARCH_MESSAGE_ROLE_ALIASES: dict[str, SearchMessageRole] = {
-    "": "",
-    "user": "user",
-    "assistant": "assistant",
-    "system": "system",
-    "tool": "tool",
-    "tool_call": "tool_call",
-    "tool_result": "tool_result",
-    "toolcall": "tool_call",
-    "toolresult": "tool_result",
-}
-
-
-def normalize_search_message_role(role: str) -> SearchMessageRole:
-    """Canonicalize a raw stored message role for the search response model.
-
-    Unrecognized roles fall back to `""` (already a valid, neutral role) rather
-    than raising, since malformed ingest data must not break search.
-    """
-    return _SEARCH_MESSAGE_ROLE_ALIASES.get(role.lower(), "")
-
-
 AgentSpanStatsValueType = Literal["datetime", "number", "boolean", "string"]
 AgentSpanStatsColumnValueType = Literal["datetime", "number", "boolean", "string"]
 AgentSpanStatsCell = datetime.datetime | str | int | float | bool | None
@@ -1005,7 +980,7 @@ class AgentSearchMatchedMessage(BaseModel):
 
     span_id: str
     trace_id: str
-    role: SearchMessageRole
+    role: str
     content_preview: str
     content_digest: str
     started_at: datetime.datetime

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -980,7 +980,9 @@ class AgentSearchMatchedMessage(BaseModel):
 
     span_id: str
     trace_id: str
-    role: str
+    # Canonical roles are in SearchMessageRole; stored data may carry
+    # arbitrary client-supplied role strings, so accept both.
+    role: SearchMessageRole | str
     content_preview: str
     content_digest: str
     started_at: datetime.datetime

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -58,6 +58,31 @@ SearchMessageRole = Literal[
     "tool_result",
 ]
 
+# Ingested message roles are unvalidated client OTel attribute strings (see
+# `opentelemetry/genai_extraction.py::_normalize_single_message`), so known
+# non-canonical spellings must be mapped to the search response Literal.
+_SEARCH_MESSAGE_ROLE_ALIASES: dict[str, SearchMessageRole] = {
+    "": "",
+    "user": "user",
+    "assistant": "assistant",
+    "system": "system",
+    "tool": "tool",
+    "tool_call": "tool_call",
+    "tool_result": "tool_result",
+    "toolcall": "tool_call",
+    "toolresult": "tool_result",
+}
+
+
+def normalize_search_message_role(role: str) -> SearchMessageRole:
+    """Canonicalize a raw stored message role for the search response model.
+
+    Unrecognized roles fall back to `""` (already a valid, neutral role) rather
+    than raising, since malformed ingest data must not break search.
+    """
+    return _SEARCH_MESSAGE_ROLE_ALIASES.get(role.lower(), "")
+
+
 AgentSpanStatsValueType = Literal["datetime", "number", "boolean", "string"]
 AgentSpanStatsColumnValueType = Literal["datetime", "number", "boolean", "string"]
 AgentSpanStatsCell = datetime.datetime | str | int | float | bool | None


### PR DESCRIPTION
## Summary
- `/agents/search` 500'd when a stored message had a non-canonical `role` (e.g. camelCase `toolResult` from a client's OTel span data): the strict `SearchMessageRole` Literal on the response model rejected a value written unvalidated at ingest.
- Relax `AgentSearchMatchedMessage.role` to `str` (it's already `str` in `schema.py` and `clickhouse.py`) so the stored value passes through instead of failing the whole search. No coercion / alias map.
- Jira: [WB-37225](https://coreweave.atlassian.net/browse/WB-37225)

## Testing
functional test: a stored `toolResult` role round-trips through search without a 500.

prod repro of the error case ([Datadog](https://us5.datadoghq.com/apm/traces?query=env%3Aprod%20service%3Aweave-trace%20resource_name%3A%22POST%20/agents/search%22%20%40error.type%3AValidationError), env:prod service:weave-trace):

[<img width="900" alt="POST /agents/search 500 ValidationError on role='toolResult'" src="https://github.com/user-attachments/assets/93f0225f-8f15-4eb7-b240-00a20e756b13">](https://github.com/user-attachments/assets/93f0225f-8f15-4eb7-b240-00a20e756b13)


[WB-37225]: https://coreweave.atlassian.net/browse/WB-37225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
