### PR TITLE
fix(weave): attribute subagent tool spans to their owning agent

### DIFF
--- a/tests/trace_server/query_builder/test_agent_trace_attribution.py
+++ b/tests/trace_server/query_builder/test_agent_trace_attribution.py
@@ -38,27 +38,39 @@ def test_attributed_source_inherits_agent_triple_coherently() -> None:
     sql = attributed_spans_source(
         pb, project_id="p1", started_after=None, started_before=None
     )
-    # agent_name / agent_version / agent_id inherit together as one tuple taken
-    # from a single span (argMinIf by started_at, gated on agent_name), so a
+    # agent_name / agent_version / agent_id inherit together as one tuple: the
+    # span's immediate parent if it declares an identity, else the earliest
+    # identity-declaring span in the trace (argMinIf by started_at), so a
     # span's inherited identity can never mix two agents. A span that declares
     # its own agent_name keeps its entire own triple. conversation_id is
     # inherited on its own.
     expected = """
         (SELECT * EXCEPT (agent_name, agent_version, agent_id, conversation_id,
-                          has_own_agent_identity, fb_agent_identity, fb_conversation_id),
-            if(has_own_agent_identity, agent_name, fb_agent_identity.1) AS agent_name,
-            if(has_own_agent_identity, agent_version, fb_agent_identity.2) AS agent_version,
-            if(has_own_agent_identity, agent_id, fb_agent_identity.3) AS agent_id,
+                          has_own_agent_identity, has_parent_agent_identity,
+                          fb_agent_identity, fb_conversation_id, parent_agent_identity),
+            multiIf(has_own_agent_identity, agent_name,
+                    has_parent_agent_identity, parent_agent_identity.1,
+                    fb_agent_identity.1) AS agent_name,
+            multiIf(has_own_agent_identity, agent_version,
+                    has_parent_agent_identity, parent_agent_identity.2,
+                    fb_agent_identity.2) AS agent_version,
+            multiIf(has_own_agent_identity, agent_id,
+                    has_parent_agent_identity, parent_agent_identity.3,
+                    fb_agent_identity.3) AS agent_id,
             if(conversation_id != '', conversation_id, fb_conversation_id) AS conversation_id
          FROM (
            SELECT s0.*, (s0.agent_name != '') AS has_own_agent_identity,
-                  tf.fb_agent_identity, tf.fb_conversation_id
+                  tf.fb_agent_identity, tf.fb_conversation_id,
+                  tf.fb_span_agents[s0.parent_span_id] AS parent_agent_identity,
+                  (parent_agent_identity.1 != '') AS has_parent_agent_identity
            FROM spans s0
            LEFT JOIN (
              SELECT trace_id,
                  argMinIf((agent_name, agent_version, agent_id), started_at, agent_name != '')
                    AS fb_agent_identity,
-                 anyIf(conversation_id, conversation_id != '') AS fb_conversation_id
+                 anyIf(conversation_id, conversation_id != '') AS fb_conversation_id,
+                 CAST(groupArrayIf((span_id, (agent_name, agent_version, agent_id)), agent_name != ''),
+                      'Map(String, Tuple(String, String, String))') AS fb_span_agents
              FROM spans
              WHERE project_id = {genai_0:String}
              GROUP BY trace_id) tf ON s0.trace_id = tf.trace_id
@@ -83,20 +95,31 @@ def test_attributed_source_scopes_fallback_to_trace_ids() -> None:
     )
     expected = """
         (SELECT * EXCEPT (agent_name, agent_version, agent_id, conversation_id,
-                          has_own_agent_identity, fb_agent_identity, fb_conversation_id),
-            if(has_own_agent_identity, agent_name, fb_agent_identity.1) AS agent_name,
-            if(has_own_agent_identity, agent_version, fb_agent_identity.2) AS agent_version,
-            if(has_own_agent_identity, agent_id, fb_agent_identity.3) AS agent_id,
+                          has_own_agent_identity, has_parent_agent_identity,
+                          fb_agent_identity, fb_conversation_id, parent_agent_identity),
+            multiIf(has_own_agent_identity, agent_name,
+                    has_parent_agent_identity, parent_agent_identity.1,
+                    fb_agent_identity.1) AS agent_name,
+            multiIf(has_own_agent_identity, agent_version,
+                    has_parent_agent_identity, parent_agent_identity.2,
+                    fb_agent_identity.2) AS agent_version,
+            multiIf(has_own_agent_identity, agent_id,
+                    has_parent_agent_identity, parent_agent_identity.3,
+                    fb_agent_identity.3) AS agent_id,
             if(conversation_id != '', conversation_id, fb_conversation_id) AS conversation_id
          FROM (
            SELECT s0.*, (s0.agent_name != '') AS has_own_agent_identity,
-                  tf.fb_agent_identity, tf.fb_conversation_id
+                  tf.fb_agent_identity, tf.fb_conversation_id,
+                  tf.fb_span_agents[s0.parent_span_id] AS parent_agent_identity,
+                  (parent_agent_identity.1 != '') AS has_parent_agent_identity
            FROM page s0
            LEFT JOIN (
              SELECT trace_id,
                  argMinIf((agent_name, agent_version, agent_id), started_at, agent_name != '')
                    AS fb_agent_identity,
-                 anyIf(conversation_id, conversation_id != '') AS fb_conversation_id
+                 anyIf(conversation_id, conversation_id != '') AS fb_conversation_id,
+                 CAST(groupArrayIf((span_id, (agent_name, agent_version, agent_id)), agent_name != ''),
+                      'Map(String, Tuple(String, String, String))') AS fb_span_agents
              FROM spans
              WHERE project_id = {genai_0:String} AND trace_id IN (SELECT trace_id FROM page)
              GROUP BY trace_id) tf ON s0.trace_id = tf.trace_id

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -487,6 +487,166 @@ def test_span_with_own_identity_is_not_reattributed(ch_server):
     assert {s.span_id for s in coordinator.spans} == {coordinator_span_id}
 
 
+def test_execute_tool_span_inherits_identity_from_its_owning_subagent(ch_server):
+    """A tool-execution span with no direct agent metadata inherits its
+    *immediate parent's* identity, not the trace's root agent.
+
+    Reproduces a production bug: a subagent's `invoke_agent` span declares its
+    own identity, but its `execute_tool` children carry no agent_name (the
+    OTel emitter never sets it on tool spans). Before the one-hop parent
+    lookup, the flat per-trace fallback always inherited the root agent's
+    identity, since the root's `invoke_agent` span necessarily starts first —
+    so `agent_name=<subagent> AND operation_name=execute_tool` matched nothing.
+    """
+    project_id = _make_project_id("attribution_subagent_tool")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    trace_id = uuid.uuid4().hex
+    root_span_id = uuid.uuid4().hex
+    subagent_span_id = uuid.uuid4().hex
+    subagent_tool_span_id = uuid.uuid4().hex
+    root_tool_span_id = uuid.uuid4().hex
+
+    spans = [
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=root_span_id,
+            operation_name="invoke_agent",
+            agent_name="claude-code",
+            started_at=now,
+        ),
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=subagent_span_id,
+            parent_span_id=root_span_id,
+            operation_name="invoke_agent",
+            agent_name="Explore",
+            started_at=now + datetime.timedelta(seconds=1),
+        ),
+        # Direct child of the subagent's invoke_agent span; no own identity.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=subagent_tool_span_id,
+            parent_span_id=subagent_span_id,
+            operation_name="execute_tool",
+            agent_name="",
+            started_at=now + datetime.timedelta(seconds=2),
+        ),
+        # Direct child of the root's invoke_agent span; no own identity.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=root_tool_span_id,
+            parent_span_id=root_span_id,
+            operation_name="execute_tool",
+            agent_name="",
+            started_at=now + datetime.timedelta(seconds=3),
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    listed = ch_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
+    by_id = {s.span_id: s for s in listed.spans}
+    assert by_id[subagent_tool_span_id].agent_name == "Explore"
+    assert by_id[root_tool_span_id].agent_name == "claude-code"
+
+    # Filtering execute_tool spans by the subagent now matches its own tool
+    # call — not zero rows (the bug), and not the root's tool call either.
+    matched = ch_server.agent_spans_query(
+        AgentSpansQueryReq(
+            project_id=project_id,
+            query=Query.model_validate(
+                {
+                    "$expr": {
+                        "$and": [
+                            {
+                                "$eq": [
+                                    {"$getField": "agent.name"},
+                                    {"$literal": "Explore"},
+                                ]
+                            },
+                            {
+                                "$eq": [
+                                    {"$getField": "operation_name"},
+                                    {"$literal": "execute_tool"},
+                                ]
+                            },
+                        ]
+                    }
+                }
+            ),
+        )
+    )
+    assert {s.span_id for s in matched.spans} == {subagent_tool_span_id}
+
+
+def test_span_separated_from_subagent_by_identity_less_span_falls_back_to_trace(
+    ch_server,
+):
+    """A span two hops below its owning subagent, with an identity-less
+    intermediate span in between, is a documented limitation of the one-hop
+    parent lookup: it falls through to the flat, trace-wide fallback rather
+    than resolving to the subagent.
+    """
+    project_id = _make_project_id("attribution_subagent_grandchild")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    trace_id = uuid.uuid4().hex
+    root_span_id = uuid.uuid4().hex
+    subagent_span_id = uuid.uuid4().hex
+    intermediate_span_id = uuid.uuid4().hex
+    grandchild_span_id = uuid.uuid4().hex
+
+    spans = [
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=root_span_id,
+            operation_name="invoke_agent",
+            agent_name="claude-code",
+            started_at=now,
+        ),
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=subagent_span_id,
+            parent_span_id=root_span_id,
+            operation_name="invoke_agent",
+            agent_name="Explore",
+            started_at=now + datetime.timedelta(seconds=1),
+        ),
+        # No own identity; direct child of subagent, so it resolves to Explore.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=intermediate_span_id,
+            parent_span_id=subagent_span_id,
+            operation_name="chat",
+            agent_name="",
+            started_at=now + datetime.timedelta(seconds=2),
+        ),
+        # No own identity, and its parent (intermediate_span) has no own
+        # identity either -> the one-hop lookup misses, so this falls back to
+        # the trace's earliest-declared agent (claude-code), not Explore.
+        _make_span(
+            project_id,
+            trace_id=trace_id,
+            span_id=grandchild_span_id,
+            parent_span_id=intermediate_span_id,
+            operation_name="execute_tool",
+            agent_name="",
+            started_at=now + datetime.timedelta(seconds=3),
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    listed = ch_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
+    by_id = {s.span_id: s for s in listed.spans}
+    assert by_id[intermediate_span_id].agent_name == "Explore"
+    assert by_id[grandchild_span_id].agent_name == "claude-code"
+
+
 def _identity(span: object) -> tuple[str, str, str, str]:
     return (
         span.agent_name,

--- a/weave/trace_server/query_builder/agent_trace_attribution.py
+++ b/weave/trace_server/query_builder/agent_trace_attribution.py
@@ -6,11 +6,16 @@ span, not on the child llm / tool spans it encloses. A span-exact read of those
 columns therefore shows blank identity on every child span and undercounts the
 turn's real work.
 
-This module attributes that identity at *read time* with a single rule:
+This module attributes that identity at *read time* with a three-step rule,
+checked in order:
 
-    if a span declares its own agent (`agent_name != ''`), use its own
-    identity (singleton / span-exact); otherwise inherit the identity of the
-    span's trace.
+    1. if a span declares its own agent (`agent_name != ''`), use its own
+       identity (singleton / span-exact);
+    2. otherwise, if the span's immediate parent declares its own agent, inherit
+       that parent's identity (the common case for a tool/llm span that is a
+       direct child of the `invoke_agent` span that issued it, including a
+       *sub*-agent's `invoke_agent` span);
+    3. otherwise inherit the trace's earliest-declared agent.
 
 It is expressed by wrapping the `spans` table in an *attributed-spans*
 subquery (see :func:`attributed_spans_source`). Callers swap their
@@ -20,20 +25,27 @@ aggregate) transparently sees the attributed value — what you filter on equals
 what you display.
 
 `agent_name` / `agent_version` / `agent_id` identify one agent, so they
-are inherited *together* as a single tuple taken from one span — the earliest
-span in the trace that declares an `agent_name` (`argMinIf` by
-`started_at`). Picking each column independently could synthesize a
-`(name, version)` pair that never co-occurred on any real span. Likewise, a
-span that declares its own `agent_name` keeps its *entire* own triple, so its
-version / id are never crossed with an inherited agent's. `conversation_id` is
-trace-scoped and inherited on its own.
+are inherited *together* as a single tuple taken from one span — either the
+span's immediate parent (step 2) or, failing that, the earliest span in the
+trace that declares an `agent_name` (`argMinIf` by `started_at`, step 3).
+Picking each column independently could synthesize a `(name, version)` pair
+that never co-occurred on any real span. Likewise, a span that declares its
+own `agent_name` keeps its *entire* own triple, so its version / id are never
+crossed with an inherited agent's. `conversation_id` is trace-scoped and
+inherited on its own (step 3 only; it has no per-parent step).
 
-This is a deliberately *flat* attribution: in a multi-agent trace an unset span
-inherits the trace's earliest-declared agent. A span that set its own identity
-always keeps it, so sub-agent spans are never wrongly attributed. The
-hierarchical "nearest enclosing agent" projection used by the chat view lives in
-`weave.trace_server.agents.chat_view` and is intentionally separate — queries
-that feed the chat view must NOT use this source or they would double-attribute.
+Step 2 is a *one-hop* parent lookup, not a full nearest-enclosing-agent walk:
+a span separated from its owning agent by an identity-less intermediate span
+still falls through to step 3's flat, trace-wide fallback. That is a known,
+documented limitation, not a bug — it trades exact hierarchical resolution
+(which would need an unbounded parent-chain walk ClickHouse cannot express
+without a recursive CTE) for a bounded, single-scan fix that resolves the
+common case: it never over-corrects, since step 2 only fires when the parent
+itself declares an identity, and step 3 is unchanged for every span step 2
+doesn't resolve. The full hierarchical "nearest enclosing agent" projection
+used by the chat view lives in `weave.trace_server.agents.chat_view` and is
+intentionally separate — queries that feed the chat view must NOT use this
+source or they would double-attribute.
 """
 
 from __future__ import annotations
@@ -161,7 +173,11 @@ def attributed_spans_source(
 
     The inner scan is bounded to `project_id` and the outer time window so it
     prunes by primary key; the fallback scan is bounded to the same window
-    widened by one trace-duration of slack so edge spans still resolve.
+    widened by one trace-duration of slack so edge spans still resolve. The
+    same fallback scan also builds a per-trace `span_id -> agent identity` map
+    (restricted to identity-declaring spans, so it stays small) used to resolve
+    a span's *immediate parent* identity in one map lookup, at no extra scan or
+    join cost.
     """
     pid_slot = pb.add(project_id, param_type="String")
 
@@ -186,14 +202,18 @@ def attributed_spans_source(
         base_before = pb.add(started_before, param_type="DateTime64(6)")
         base_conds.append(f"s0.started_at < {base_before}")
 
-    # The agent triple is inherited together from one span (the earliest in the
-    # trace that declares an agent_name); conversation_id is inherited on its
+    # The agent triple is inherited together from one span: the span's own
+    # immediate parent if it declares an identity, else the earliest
+    # identity-declaring span in the trace; conversation_id is inherited on its
     # own. Picking each agent column independently could mix two agents.
     agent_tuple = ", ".join(_AGENT_IDENTITY_COLUMNS)
+    agent_tuple_type = ", ".join("String" for _ in _AGENT_IDENTITY_COLUMNS)
     fallback_selects = (
         f"argMinIf(({agent_tuple}), started_at, {_AGENT_IDENTITY_MARKER} != '')\n"
         "            AS fb_agent_identity,\n"
-        "          anyIf(conversation_id, conversation_id != '') AS fb_conversation_id"
+        "          anyIf(conversation_id, conversation_id != '') AS fb_conversation_id,\n"
+        f"          CAST(groupArrayIf((span_id, ({agent_tuple})), {_AGENT_IDENTITY_MARKER} != ''),"
+        f" 'Map(String, Tuple({agent_tuple_type}))') AS fb_span_agents"
     )
     # Whether the span declares its own agent, computed from the raw column so
     # the coalesce gates below read it instead of the rewritten `agent_name`
@@ -201,17 +221,29 @@ def attributed_spans_source(
     # SELECT alias — gating on `agent_name` itself would see the *attributed*
     # value and leak one column of a different agent onto this span).
     own_marker = "has_own_agent_identity"
+    parent_marker = "has_parent_agent_identity"
     middle_refs = (
         f"(s0.{_AGENT_IDENTITY_MARKER} != '') AS {own_marker},"
-        " tf.fb_agent_identity, tf.fb_conversation_id"
+        " tf.fb_agent_identity, tf.fb_conversation_id,"
+        " tf.fb_span_agents[s0.parent_span_id] AS parent_agent_identity,"
+        f" (parent_agent_identity.1 != '') AS {parent_marker}"
     )
     except_cols = ", ".join(
-        [*IDENTITY_COLUMNS, own_marker, "fb_agent_identity", "fb_conversation_id"]
+        [
+            *IDENTITY_COLUMNS,
+            own_marker,
+            parent_marker,
+            "fb_agent_identity",
+            "fb_conversation_id",
+            "parent_agent_identity",
+        ]
     )
-    # A span that declares its own agent keeps its entire own triple; otherwise
-    # the whole triple is inherited — never a mix.
+    # A span keeps its entire own triple if set; else its immediate parent's
+    # entire triple if the parent declares one; else the trace-wide fallback.
+    # Never a mix of two agents' columns.
     agent_coalesced = ",\n    ".join(
-        f"if({own_marker}, {col}, fb_agent_identity.{idx}) AS {col}"
+        f"multiIf({own_marker}, {col}, {parent_marker}, parent_agent_identity.{idx},"
+        f" fb_agent_identity.{idx}) AS {col}"
         for idx, col in enumerate(_AGENT_IDENTITY_COLUMNS, start=1)
     )
     coalesced = (


### PR DESCRIPTION
## Summary
- `attributed_spans_source`'s read-time agent-identity fallback was per-trace flat (earliest agent-declaring span in the whole trace), so a subagent's tool/llm spans - which never carry their own `agent_name` - always resolved to the root agent instead of the subagent, since the root's `invoke_agent` span necessarily starts first.
- Adds a one-hop parent lookup (via the existing per-trace rollup, no extra scan/join) ahead of the flat fallback: a span now inherits its immediate parent's identity when the parent declares one.

## Testing
new ClickHouse-backed tests in `test_genai_agent_queries.py` reproduce the bug (subagent tool span now attributes to the subagent) and pin the documented one-hop limitation (a grandchild separated by an identity-less span still falls back to trace-flat); updated SQL snapshot assertions in `test_agent_trace_attribution.py`.