### PR TITLE
fix(weave): trace direct openai calls under otel_v2

### DIFF
--- a/tests/integrations/test_autopatch.py
+++ b/tests/integrations/test_autopatch.py
@@ -12,6 +12,7 @@ import pytest
 import weave.integrations.patch as patch_module
 from weave.integrations.patch import (
     _PATCHED_INTEGRATIONS,
+    _dispatch_openai,
     _patch_if_needed,
     _patch_integration,
     implicit_patch,
@@ -407,7 +408,7 @@ def test_direct_openai_patched_by_default_without_agents(setup_env, monkeypatch)
     Pins the WB-37240 regression where ``_dispatch_openai`` skipped openai
     entirely in OTel V2 mode, silently dropping spans/usage for direct calls.
     """
-    assert patch_module.INTEGRATION_MODULE_MAPPING["openai"] is patch_openai
+    assert patch_module.INTEGRATION_MODULE_MAPPING["openai"] is _dispatch_openai
     _reset_import(monkeypatch, "agents")
     _inject_fake_module(monkeypatch, "openai")
 
@@ -480,6 +481,55 @@ def test_openai_agents_otel_suppresses_direct_openai(setup_env, monkeypatch):
         patch_openai()
         _patch_if_needed("openai")
         openai_factory.assert_not_called()
+
+
+def test_deferred_agents_import_suppresses_openai(setup_env, monkeypatch):
+    """Agents imported after ``weave.init()`` still suppresses direct openai.
+
+    ``agents`` imports ``openai`` internally, so the import hook fires for
+    openai (the nested dependency) before agents. Dict order only helps
+    ``implicit_patch``; here ``_dispatch_openai`` must patch the agents
+    processor first so it claims openai. Otherwise openai is patched and then
+    suppressed, double-logging every in-agent LLM call.
+    """
+    # weave.init() ran with neither imported, so implicit_patch was a no-op;
+    # both arrive later via the import hook, openai first.
+    _inject_fake_module(monkeypatch, "agents")
+    _inject_fake_module(monkeypatch, "openai")
+
+    agents_patcher = MagicMock()
+    agents_patcher.attempt_patch.return_value = True
+    fake_agents_mod = cast(
+        Any, types.ModuleType("weave.integrations.openai_agents.patcher")
+    )
+    fake_agents_mod.get_openai_agents_otel_patcher = MagicMock(
+        return_value=agents_patcher
+    )
+
+    openai_factory = MagicMock()
+    fake_openai_sdk = cast(
+        Any, types.ModuleType("weave.integrations.openai.openai_sdk")
+    )
+    fake_openai_sdk.get_openai_patcher = openai_factory
+
+    def fake_import(path: str) -> types.ModuleType:
+        if path == "weave.integrations.openai_agents.patcher":
+            return fake_agents_mod
+        if path == "weave.integrations.openai.openai_sdk":
+            return fake_openai_sdk
+        raise ImportError(path)
+
+    with patch(
+        "weave.integrations.patch.importlib.import_module", side_effect=fake_import
+    ):
+        _patch_if_needed("openai")
+        _patch_if_needed("agents")
+
+    agents_patcher.attempt_patch.assert_called_once()
+    openai_factory.assert_not_called()
+    assert "openai_agents_otel" in patch_module._PATCHED_INTEGRATIONS
+    assert "openai" in patch_module._SUPPRESSED_INTEGRATIONS
+    assert "openai" not in patch_module._PATCHED_INTEGRATIONS
 
 
 def test_legacy_openai_agents_patch_does_not_suppress_openai(setup_env):

--- a/tests/integrations/test_autopatch.py
+++ b/tests/integrations/test_autopatch.py
@@ -16,6 +16,7 @@ from weave.integrations.patch import (
     _patch_integration,
     implicit_patch,
     patch_openai,
+    patch_openai_agents,
     register_import_hook,
     reset_patched_integrations,
     unregister_import_hook,
@@ -397,6 +398,109 @@ def test_patch_integration(setup_env, success):
             mock_getter.assert_called_once()
             mock_patcher.attempt_patch.assert_called_once()
         assert ("single_symbol" in patch_module._PATCHED_INTEGRATIONS) is success
+
+
+def test_direct_openai_patched_by_default_without_agents(setup_env, monkeypatch):
+    """Direct openai use is implicitly patched under the default settings
+    (``use_otel_v2=True``) when the Agents SDK is not imported.
+
+    Pins the WB-37240 regression where ``_dispatch_openai`` skipped openai
+    entirely in OTel V2 mode, silently dropping spans/usage for direct calls.
+    """
+    assert patch_module.INTEGRATION_MODULE_MAPPING["openai"] is patch_openai
+    _reset_import(monkeypatch, "agents")
+    _inject_fake_module(monkeypatch, "openai")
+
+    openai_patcher = MagicMock()
+    openai_patcher.attempt_patch.return_value = True
+    fake_openai_sdk = cast(
+        Any, types.ModuleType("weave.integrations.openai.openai_sdk")
+    )
+    fake_openai_sdk.get_openai_patcher = MagicMock(return_value=openai_patcher)
+
+    def fake_import(path: str) -> types.ModuleType:
+        if path == "weave.integrations.openai.openai_sdk":
+            return fake_openai_sdk
+        raise ImportError(path)
+
+    with patch(
+        "weave.integrations.patch.importlib.import_module", side_effect=fake_import
+    ):
+        implicit_patch()
+
+    openai_patcher.attempt_patch.assert_called_once()
+    assert "openai" in patch_module._PATCHED_INTEGRATIONS
+    assert "openai" not in patch_module._SUPPRESSED_INTEGRATIONS
+
+
+def test_openai_agents_otel_suppresses_direct_openai(setup_env, monkeypatch):
+    """When the OTel agents processor patches, direct openai patching is
+    suppressed on every path (implicit, explicit, import hook) so in-agent
+    LLM calls are not double-logged.
+    """
+    # Agents must precede openai in the mapping so the suppression lands
+    # before implicit_patch reaches openai.
+    keys = list(patch_module.INTEGRATION_MODULE_MAPPING)
+    assert keys.index("agents") < keys.index("openai")
+
+    _inject_fake_module(monkeypatch, "agents")
+    _inject_fake_module(monkeypatch, "openai")
+
+    agents_patcher = MagicMock()
+    agents_patcher.attempt_patch.return_value = True
+    fake_agents_mod = cast(
+        Any, types.ModuleType("weave.integrations.openai_agents.patcher")
+    )
+    fake_agents_mod.get_openai_agents_otel_patcher = MagicMock(
+        return_value=agents_patcher
+    )
+
+    openai_factory = MagicMock()
+    fake_openai_sdk = cast(
+        Any, types.ModuleType("weave.integrations.openai.openai_sdk")
+    )
+    fake_openai_sdk.get_openai_patcher = openai_factory
+
+    def fake_import(path: str) -> types.ModuleType:
+        if path == "weave.integrations.openai_agents.patcher":
+            return fake_agents_mod
+        if path == "weave.integrations.openai.openai_sdk":
+            return fake_openai_sdk
+        raise ImportError(path)
+
+    with patch(
+        "weave.integrations.patch.importlib.import_module", side_effect=fake_import
+    ):
+        implicit_patch()
+        agents_patcher.attempt_patch.assert_called_once()
+        assert "openai_agents_otel" in patch_module._PATCHED_INTEGRATIONS
+        assert "openai" in patch_module._SUPPRESSED_INTEGRATIONS
+        assert "openai" not in patch_module._PATCHED_INTEGRATIONS
+
+        patch_openai()
+        _patch_if_needed("openai")
+        openai_factory.assert_not_called()
+
+
+def test_legacy_openai_agents_patch_does_not_suppress_openai(setup_env):
+    """The calls-based agents patcher (non-OTel path) leaves direct openai
+    patching enabled, preserving pre-OTel-V2 behavior.
+    """
+    agents_patcher = MagicMock()
+    agents_patcher.attempt_patch.return_value = True
+    fake_agents_mod = cast(
+        Any, types.ModuleType("weave.integrations.openai_agents.patcher")
+    )
+    fake_agents_mod.get_openai_agents_patcher = MagicMock(return_value=agents_patcher)
+
+    with patch(
+        "weave.integrations.patch.importlib.import_module",
+        return_value=fake_agents_mod,
+    ):
+        patch_openai_agents()
+
+    assert "openai_agents" in patch_module._PATCHED_INTEGRATIONS
+    assert "openai" not in patch_module._SUPPRESSED_INTEGRATIONS
 
 
 @pytest.mark.parametrize("success", [True, False])

--- a/weave/integrations/patch.py
+++ b/weave/integrations/patch.py
@@ -103,21 +103,6 @@ def patch_openai(settings: IntegrationSettings | None = None) -> None:
     )
 
 
-def _dispatch_openai() -> None:
-    """Implicit-patch entry for ``openai``.
-
-    Under ``WEAVE_USE_OTEL_V2`` (now the default), openai itself is NOT patched.
-    The Agents SDK integration is the system under observation and already
-    exposes the LLM call data via ``ResponseSpanData`` / ``GenerationSpanData`` —
-    instrumenting openai separately would dual-log every call from inside an
-    agent. Direct (non-agent) calls to ``openai.*`` are temporarily untraced in
-    OTel V2 mode.
-    """
-    if should_use_otel_v2():
-        return
-    patch_openai()
-
-
 def patch_anthropic(settings: IntegrationSettings | None = None) -> None:
     """Enable Weave tracing for Anthropic."""
     _patch_integration(
@@ -347,13 +332,23 @@ def patch_openai_agents(settings: IntegrationSettings | None = None) -> None:
 
 
 def patch_openai_agents_otel(settings: IntegrationSettings | None = None) -> None:
-    """Enable Weave OTel tracing for OpenAI Agents (Agents-tab destination)."""
+    """Enable Weave OTel tracing for OpenAI Agents (Agents-tab destination).
+
+    The OTel agents processor already exposes each in-agent LLM call via
+    ``ResponseSpanData`` / ``GenerationSpanData``, so once it is installed we
+    suppress the direct ``openai`` integration to avoid double-logging those
+    calls (same pattern as ``patch_google_adk`` suppressing google-genai).
+    """
     _patch_integration(
         module_path="weave.integrations.openai_agents.patcher",
         patcher_func_getter_name="get_openai_agents_otel_patcher",
         triggering_symbols=["openai_agents_otel"],
         settings=settings,
     )
+    # Only suppress openai if the agents processor actually patched (i.e.
+    # ``settings.enabled`` wasn't False).
+    if "openai_agents_otel" in _PATCHED_INTEGRATIONS:
+        _SUPPRESSED_INTEGRATIONS.add("openai")
 
 
 def _dispatch_openai_agents() -> None:
@@ -485,7 +480,12 @@ def patch_openai_realtime(settings: IntegrationSettings | None = None) -> None:
 # When a module is already imported, we'll automatically call its patch function
 
 INTEGRATION_MODULE_MAPPING: dict[str, Callable[[], None]] = {
-    "openai": _dispatch_openai,
+    # The Agents SDK must come before ``openai``: patching the OTel agents
+    # processor suppresses direct openai patching (see
+    # ``patch_openai_agents_otel``), but the suppression only takes effect
+    # if agents is patched first.
+    "agents": _dispatch_openai_agents,
+    "openai": patch_openai,
     "anthropic": patch_anthropic,
     "mistralai": patch_mistral,
     "groq": patch_groq,
@@ -509,7 +509,6 @@ INTEGRATION_MODULE_MAPPING: dict[str, Callable[[], None]] = {
     "mcp": patch_fastmcp,
     "langchain_nvidia_ai_endpoints": patch_nvidia,
     "smolagents": patch_smolagents,
-    "agents": _dispatch_openai_agents,
     "claude_agent_sdk": _dispatch_claude_agent_sdk,
     "verdict": patch_verdict,
     "verifiers": patch_verifiers,

--- a/weave/integrations/patch.py
+++ b/weave/integrations/patch.py
@@ -103,6 +103,21 @@ def patch_openai(settings: IntegrationSettings | None = None) -> None:
     )
 
 
+def _dispatch_openai() -> None:
+    """Implicit/import-hook entry for ``openai``.
+
+    ``agents`` imports ``openai`` internally, so under the import hook openai's
+    patcher can fire before the agents patcher (dict order only governs
+    ``implicit_patch``). When the Agents SDK is present under otel_v2, patch it
+    first so it can claim (suppress) openai before we'd patch openai directly
+    and double-log every in-agent LLM call.
+    """
+    if should_use_otel_v2() and "agents" in sys.modules:
+        _dispatch_openai_agents()
+    if "openai" not in _SUPPRESSED_INTEGRATIONS:
+        patch_openai()
+
+
 def patch_anthropic(settings: IntegrationSettings | None = None) -> None:
     """Enable Weave tracing for Anthropic."""
     _patch_integration(
@@ -485,7 +500,7 @@ INTEGRATION_MODULE_MAPPING: dict[str, Callable[[], None]] = {
     # ``patch_openai_agents_otel``), but the suppression only takes effect
     # if agents is patched first.
     "agents": _dispatch_openai_agents,
-    "openai": patch_openai,
+    "openai": _dispatch_openai,
     "anthropic": patch_anthropic,
     "mistralai": patch_mistral,
     "groq": patch_groq,
@@ -619,7 +634,10 @@ def _patch_if_needed(module_name: str) -> None:
         patch_func = INTEGRATION_MODULE_MAPPING[module_name]
         try:
             patch_func()
-            _PATCHED_INTEGRATIONS.add(module_name)
+            # ``patch_func`` may suppress this module instead of patching it
+            # (e.g. ``_dispatch_openai`` deferring to the agents processor).
+            if module_name not in _SUPPRESSED_INTEGRATIONS:
+                _PATCHED_INTEGRATIONS.add(module_name)
         except Exception:
             # Silently skip if patching fails - this maintains backward compatibility
             # and doesn't break existing code if an integration can't be patched


### PR DESCRIPTION
## Summary
Under the default `use_otel_v2=True`, `weave.init()` did not patch `openai`, so **direct** (non-Agents-SDK) openai calls were silently untraced: no `openai.chat.completions.create` child span, no token usage, `$0` cost. This patches `openai` by default again and suppresses it **only** while the OpenAI Agents OTel processor is active (that processor already emits those calls via `ResponseSpanData`/`GenerationSpanData`), so in-agent calls are not double-logged.

Mirrors the existing `patch_google_adk` -> google-genai suppression: drop the blanket `should_use_otel_v2()` gate in `_dispatch_openai`, have `patch_openai_agents_otel` add `"openai"` to `_SUPPRESSED_INTEGRATIONS`, and order `agents` ahead of `openai` in the implicit-patch mapping so suppression lands first.

Jira: [WB-37240](https://coreweave.atlassian.net/browse/WB-37240)

## Behavior (default `use_otel_v2=True`)

| Scenario | Before | After |
| --- | --- | --- |
| Direct `openai` call inside a `@weave.op` | no child span, no usage/cost | child span + usage + cost |
| Direct `openai` + explicit `patch_openai()` | works (was required) | works (no longer required) |
| LLM call inside the OpenAI Agents SDK (OTel) | single span | single span (still no double-log) |
| `use_otel_v2=False` (legacy path) | works | works (unchanged) |

### What did not work before, now does
```python
import weave
from openai import OpenAI

weave.init("entity/project")   # use_otel_v2=True (the default)

@weave.op
def summarize(text: str) -> str:
    resp = OpenAI().chat.completions.create(
        model="gpt-4o-mini",
        messages=[{"role": "user", "content": text}],
    )
    return resp.choices[0].message.content

summarize("hello")
```
Before: `summarize` is logged, but there is no `openai.chat.completions.create` child span and no token usage or cost. The only way to trace it was to add `weave.integrations.patch_openai()` after `init`. After: the child span is logged with usage and cost rolls up, with no extra call.

### What must keep working, and does
```python
import weave
from agents import Agent, Runner   # OpenAI Agents SDK

weave.init("entity/project")
# run an agent whose model/tools call openai internally
```
The Agents OTel processor already logs each in-agent LLM call. Before and after this PR that stays a single span per call: once `patch_openai_agents_otel` runs it adds `"openai"` to `_SUPPRESSED_INTEGRATIONS`, so direct-openai patching is skipped while the agents processor is live.

## Testing
unit tests pin all three paths: direct openai patched by default without agents, suppressed once the OTel agents processor patches (implicit, explicit, and import-hook), and the legacy calls-based `patch_openai_agents` leaving openai enabled.

<details>
<summary>Background: how the gap arose</summary>

- The `should_use_otel_v2()` gate in `_dispatch_openai` was added in #6917 (OpenAI Agents OTel integration). At that point `use_otel_v2` defaulted to `False`, so the suppression only affected opt-in users. Rationale (from the docstring): the Agents OTel processor already exposes in-agent LLM calls via `ResponseSpanData`/`GenerationSpanData`, so patching `openai` too would double-log them.
- #7048 flipped `use_otel_v2` to `True` by default, which generalized the suppression to all direct-openai users. The workaround (`weave.integrations.patch_openai()`) was documented in the settings docstring, but direct calls were untraced by default from then on.
- This PR keeps the double-log protection but narrows it to exactly the agents-active case, restoring default tracing for direct openai use.

Note: the Claude Agent SDK OTel path (`patch_claude_agent_sdk_otel`) has a similar shape but does not add `"anthropic"` to `_SUPPRESSED_INTEGRATIONS`, and `anthropic` was never gated by `use_otel_v2`. If that processor emits equivalent LLM spans, direct-anthropic calls may double-log when both are active. Out of scope here, flagged for that integration's owner.
</details>


[WB-37240]: https://coreweave.atlassian.net/browse/WB-37240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ