### PR TITLE
feat(weave): export api contract

### DIFF
--- a/tests/trace_server/test_trace_server_interface_util.py
+++ b/tests/trace_server/test_trace_server_interface_util.py
@@ -112,6 +112,14 @@ class _EncodingIdConverter(IdConverter):
                 filter=tsi.CallsFilter(wb_user_ids=["user-x"], wb_run_ids=["run-y"]),
             ),
         ),
+        (
+            "export_start",
+            lambda: tsi.ExportStartReq(project_id="ent/proj", targets=["calls"]),
+        ),
+        (
+            "export_status",
+            lambda: tsi.ExportStatusReq(project_id="ent/proj", job_id="j"),
+        ),
     ],
 )
 def test_adapter_does_not_mutate_req_when_inner_raises(
@@ -132,6 +140,39 @@ def test_adapter_does_not_mutate_req_when_inner_raises(
         getattr(adapter, method_name)(req)
 
     assert req.model_dump() == snapshot
+
+
+def test_export_adapter_converts_project_id_and_delegates() -> None:
+    """The export endpoints must convert the external entity/project id to the
+    internal (base64) form before delegating, leaving the caller's req intact.
+    Without an explicit adapter override, project_id would reach the internal
+    server unconverted (the __getattr__ fallthrough), a cross-tenant hazard.
+    """
+    idc = _EncodingIdConverter()
+    internal_project_id = idc.ext_to_int_project_id("ent/proj")
+
+    inner = MagicMock(spec=tsi.FullTraceServerInterface)
+    inner.export_start.return_value = tsi.ExportStartRes(job_id="job-1")
+    inner.export_status.return_value = tsi.ExportStatusRes(
+        status="done",
+        manifest=[
+            tsi.ExportManifestEntry(target="calls", status="done", rows=3),
+        ],
+    )
+    adapter = ExternalTraceServer(inner, idc)
+
+    start_req = tsi.ExportStartReq(project_id="ent/proj", targets=["calls"])
+    start_res = adapter.export_start(start_req)
+    assert start_res.job_id == "job-1"
+    assert inner.export_start.call_args.args[0].project_id == internal_project_id
+    assert start_req.project_id == "ent/proj"
+
+    status_req = tsi.ExportStatusReq(project_id="ent/proj", job_id="job-1")
+    status_res = adapter.export_status(status_req)
+    assert status_res.status == "done"
+    assert status_res.manifest[0].rows == 3
+    assert inner.export_status.call_args.args[0].project_id == internal_project_id
+    assert status_req.project_id == "ent/proj"
 
 
 # --- genai_otel_export ext→int ref rewriting in OTel attribute values ---

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -664,6 +664,17 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.files_stats, req, req.project_id
         )
 
+    def export_start(self, req: tsi.ExportStartReq) -> tsi.ExportStartRes:
+        req = req.model_copy(deep=True)
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        # Artifacts hold ref strings verbatim; no ext<->int ref conversion here.
+        return self._internal_trace_server.export_start(req)
+
+    def export_status(self, req: tsi.ExportStatusReq) -> tsi.ExportStatusRes:
+        req = req.model_copy(deep=True)
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._internal_trace_server.export_status(req)
+
     def feedback_create(self, req: tsi.FeedbackCreateReq) -> tsi.FeedbackCreateRes:
         req = req.model_copy(deep=True)
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1719,6 +1719,53 @@ class FilesStatsRes(BaseModel):
     total_size_bytes: int
 
 
+# Export API
+ExportJobStatus = Literal["running", "done", "error"]
+
+
+class ExportStartReq(BaseModelStrict):
+    project_id: str = Field(examples=["entity/project"])
+    targets: list[str] = Field(
+        description="Export target names resolved against the server-side registry, e.g. ['calls', 'objects', 'feedback']."
+    )
+    wb_user_id: str | None = Field(None, description=WB_USER_ID_DESCRIPTION)
+
+
+class ExportStartRes(BaseModel):
+    job_id: str = Field(
+        description="Server-generated uuid4 identifying the export job."
+    )
+
+
+class ExportStatusReq(BaseModelStrict):
+    project_id: str = Field(examples=["entity/project"])
+    job_id: str = Field(description="Export job id returned by export_start.")
+    wb_user_id: str | None = Field(None, description=WB_USER_ID_DESCRIPTION)
+
+
+class ExportManifestEntry(BaseModel):
+    target: str
+    status: ExportJobStatus
+    rows: int = 0
+    objects: list[str] = Field(
+        default_factory=list,
+        description="Artifact object keys written for this target.",
+    )
+    urls: list[str] = Field(
+        default_factory=list,
+        description="Per-object short-lived presigned GET URLs (only when status is done).",
+    )
+    expires_at: str | None = Field(
+        None, description="ISO-8601 expiry of the presigned URLs."
+    )
+    error: str | None = None
+
+
+class ExportStatusRes(BaseModel):
+    status: ExportJobStatus
+    manifest: list[ExportManifestEntry] = Field(default_factory=list)
+
+
 class CostCreateInput(BaseModelStrict):
     prompt_token_cost: float
     completion_token_cost: float
@@ -3543,6 +3590,10 @@ class TraceServerInterface(Protocol):
     def file_create(self, req: FileCreateReq) -> FileCreateRes: ...
     def file_content_read(self, req: FileContentReadReq) -> FileContentReadRes: ...
     def files_stats(self, req: FilesStatsReq) -> FilesStatsRes: ...
+
+    # Export API
+    def export_start(self, req: ExportStartReq) -> ExportStartRes: ...
+    def export_status(self, req: ExportStatusReq) -> ExportStatusRes: ...
 
     # Feedback API
     def feedback_create(self, req: FeedbackCreateReq) -> FeedbackCreateRes: ...


### PR DESCRIPTION
## Summary
- Jira: [WB-37450](https://coreweave.atlassian.net/browse/WB-37450)
- Bottom of a stacked spike for managed-bucket bulk export. Contract only, no behavior.
- Adds `ExportStartReq/Res`, `ExportStatusReq/Res`, `ExportManifestEntry` + `export_start`/`export_status` on the Protocol; explicit `ExternalTraceServer` overrides convert `project_id` ext->int (a cross-tenant hazard if left to the `__getattr__` fallthrough).
- openapi/node-SDK regen is deferred to the routes PR (in wandb/core): FastAPI only schematizes models a route references, and no route exists yet.

## Testing
adapter unit tests: ext->int conversion + req immutability across the export methods.


[WB-37450]: https://coreweave.atlassian.net/browse/WB-37450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ