### PR TITLE
chore(weave): clickhouse export write path

### DIFF
--- a/tests/trace_server/test_export_write_path.py
+++ b/tests/trace_server/test_export_write_path.py
@@ -1,0 +1,211 @@
+"""Write-path tests for the managed-bucket export engine.
+
+The job manifest is stored through the real file-storage implementation before
+the detached ClickHouse inserts begin. The local test ClickHouse intentionally
+has no production named collection, so the native inserts finish as errors in
+``system.query_log`` rather than writing production-like artifacts.
+"""
+
+import json
+import time
+import uuid
+from unittest.mock import MagicMock
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from tests.trace.server_utils import find_server_layer
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
+from tests.trace_server.conftest import TEST_ENTITY
+from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
+from weave.trace_server import export
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.export_targets import (
+    build_feedback_export_query,
+)
+from weave.trace_server.file_storage import S3StorageClient
+from weave.trace_server.file_storage_credentials import AWSCredentials
+from weave.trace_server.file_storage_uris import S3FileStorageURI
+from weave.trace_server.project_version.types import ReadTable
+
+pytestmark = pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: export write path"
+)
+
+QUERY_LOG_POLL_SECONDS = 20
+BUCKET = "weave-export-write-path"
+
+
+@pytest.fixture
+def storage_client():
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=BUCKET)
+        credentials: AWSCredentials = {
+            "access_key_id": "test-key",
+            "secret_access_key": "test-secret",
+            "session_token": None,
+            "region": "us-east-1",
+            "kms_key": None,
+        }
+        yield S3StorageClient(
+            S3FileStorageURI.parse_uri_str(f"s3://{BUCKET}"), credentials
+        )
+
+
+@pytest.fixture
+def clickhouse_trace_server(trace_server):
+    """Unwrap the internal ClickHouse server from the external fixture."""
+    return find_server_layer(trace_server, ClickHouseTraceServer)
+
+
+def test_build_export_insert_sql_exact_string():
+    sql = export.build_export_insert_sql(
+        export.ResolvedExportTarget("feedback", build_feedback_export_query()),
+        "exports/proj/job/feedback/data.parquet",
+    )
+    # Complete-string equality: the collection appears by name only, so the
+    # ch-writer credential can never leak into SQL or query_log.
+    assert sql == (
+        "INSERT INTO FUNCTION s3(weave_exports, "
+        "filename = 'exports/proj/job/feedback/data.parquet', format = 'Parquet') "
+        "SELECT * FROM feedback WHERE project_id = {project_id:String}"
+    )
+
+
+def test_start_export_runs_targets_serially_in_one_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    storage_client: S3StorageClient,
+):
+    worker_starts: list[tuple[object, tuple[object, ...], bool]] = []
+
+    class _ImmediateThread:
+        def __init__(self, *, target, args, daemon):
+            worker_starts.append((target, args, daemon))
+
+        def start(self):
+            target, args, _ = worker_starts[-1]
+            target(*args)
+
+    export_client = MagicMock()
+    command_query_ids: list[str] = []
+
+    def _command(_sql, *, parameters, settings):
+        assert parameters == {"project_id": "project"}
+        command_query_ids.append(settings["query_id"])
+        if len(command_query_ids) == 1:
+            raise RuntimeError("first target failed")
+
+    export_client.command.side_effect = _command
+    mint_client = MagicMock(return_value=export_client)
+    monkeypatch.setattr(export.threading, "Thread", _ImmediateThread)
+
+    job_id = export.start_export(
+        mint_client,
+        storage_client,
+        "project",
+        ["objects", "feedback"],
+        ReadTable.CALLS_COMPLETE,
+    )
+
+    assert len(worker_starts) == 1
+    assert worker_starts[0][2] is True
+    assert mint_client.call_count == 1
+    assert command_query_ids == [f"{job_id}:objects", f"{job_id}:feedback"]
+    manifest = json.loads(
+        storage_client.read(
+            storage_client.base_uri.with_path(
+                export.export_job_prefix("project", job_id) + "manifest.json"
+            )
+        )
+    )
+    assert manifest["job_id"] == job_id
+    assert [target["target"] for target in manifest["targets"]] == [
+        "objects",
+        "feedback",
+    ]
+
+
+def test_export_start_writes_manifest_without_creating_a_clickhouse_table(
+    clickhouse_trace_server, storage_client: S3StorageClient
+):
+    clickhouse_trace_server._file_storage_client = storage_client
+    clickhouse_trace_server._file_storage_client_initialized = True
+    project_id = b64(f"{TEST_ENTITY}/export-write-path")
+    res = clickhouse_trace_server.export_start(
+        tsi.ExportStartReq(project_id=project_id, targets=["objects", "feedback"])
+    )
+    assert export.JOB_ID_RE.match(res.job_id)
+    assert clickhouse_trace_server.ch_client.query(
+        "EXISTS TABLE export_jobs"
+    ).result_rows == [(0,)]
+    manifest = json.loads(
+        storage_client.read(
+            storage_client.base_uri.with_path(
+                export.export_job_prefix(project_id, res.job_id) + "manifest.json"
+            )
+        )
+    )
+    assert manifest["job_id"] == res.job_id
+    assert [target["target"] for target in manifest["targets"]] == [
+        "objects",
+        "feedback",
+    ]
+
+
+def test_export_start_query_id_lands_in_query_log(
+    clickhouse_trace_server, storage_client: S3StorageClient
+):
+    clickhouse_trace_server._file_storage_client = storage_client
+    clickhouse_trace_server._file_storage_client_initialized = True
+    project_id = b64(f"{TEST_ENTITY}/export-query-log")
+    res = clickhouse_trace_server.export_start(
+        tsi.ExportStartReq(project_id=project_id, targets=["objects"])
+    )
+    qid = f"{res.job_id}:objects"
+    ch = clickhouse_trace_server.ch_client
+    deadline = time.monotonic() + QUERY_LOG_POLL_SECONDS
+    rows: list[tuple[str]] = []
+    while time.monotonic() < deadline:
+        ch.command("SYSTEM FLUSH LOGS")
+        rows = ch.query(
+            "SELECT DISTINCT query_id FROM system.query_log "
+            "WHERE query_id = {qid:String}",
+            parameters={"qid": qid},
+        ).result_rows
+        if rows:
+            break
+        time.sleep(0.5)
+    assert rows == [(qid,)]
+
+
+def test_bad_target_and_job_id_validation(storage_client: S3StorageClient):
+    with pytest.raises(export.ExportError) as exc_info:
+        export.start_export(
+            MagicMock(),
+            storage_client,
+            "project",
+            ["objects", "nope"],
+            ReadTable.CALLS_COMPLETE,
+        )
+    assert exc_info.value.http_status == 400
+    assert exc_info.value.code == "BAD_TARGET"
+    assert export.JOB_ID_RE.match("not-a-uuid") is None
+    assert export.JOB_ID_RE.match(str(uuid.uuid4()))
+    assert export.export_object_prefix("p", "j", "calls") == "exports/p/j/calls/"
+
+
+@pytest.mark.parametrize("targets", [[], ["objects", "objects"]])
+def test_empty_and_duplicate_targets_are_rejected(
+    storage_client: S3StorageClient, targets: list[str]
+):
+    with pytest.raises(export.ExportError) as exc_info:
+        export.start_export(
+            MagicMock(),
+            storage_client,
+            "project",
+            targets,
+            ReadTable.CALLS_COMPLETE,
+        )
+    assert (exc_info.value.http_status, exc_info.value.code) == (400, "BAD_TARGET")

--- a/tests/trace_server/test_export_write_path.py
+++ b/tests/trace_server/test_export_write_path.py
@@ -1,14 +1,8 @@
-"""Write-path tests for the managed-bucket export engine.
+"""Tests for the detached ClickHouse-to-S3 export write path."""
 
-The job manifest is stored through the real file-storage implementation before
-the detached ClickHouse inserts begin. The local test ClickHouse intentionally
-has no production named collection, so the native inserts finish as errors in
-``system.query_log`` rather than writing production-like artifacts.
-"""
-
+import datetime
 import json
 import time
-import uuid
 from unittest.mock import MagicMock
 
 import boto3
@@ -24,15 +18,12 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.export_targets import (
     build_feedback_export_query,
+    build_objects_export_query,
 )
-from weave.trace_server.file_storage import S3StorageClient
+from weave.trace_server.file_storage import FileStorageWriteError, S3StorageClient
 from weave.trace_server.file_storage_credentials import AWSCredentials
 from weave.trace_server.file_storage_uris import S3FileStorageURI
 from weave.trace_server.project_version.types import ReadTable
-
-pytestmark = pytest.mark.skipif(
-    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: export write path"
-)
 
 QUERY_LOG_POLL_SECONDS = 20
 BUCKET = "weave-export-write-path"
@@ -74,7 +65,7 @@ def test_build_export_insert_sql_exact_string():
     )
 
 
-def test_start_export_runs_targets_serially_in_one_worker(
+def test_start_export_persists_manifest_and_runs_targets_serially_in_one_worker(
     monkeypatch: pytest.MonkeyPatch,
     storage_client: S3StorageClient,
 ):
@@ -89,12 +80,12 @@ def test_start_export_runs_targets_serially_in_one_worker(
             target(*args)
 
     export_client = MagicMock()
-    command_query_ids: list[str] = []
+    commands: list[tuple[str, dict[str, str], dict[str, object]]] = []
 
-    def _command(_sql, *, parameters, settings):
+    def _command(sql, *, parameters, settings):
         assert parameters == {"project_id": "project"}
-        command_query_ids.append(settings["query_id"])
-        if len(command_query_ids) == 1:
+        commands.append((sql, parameters, settings))
+        if len(commands) == 1:
             raise RuntimeError("first target failed")
 
     export_client.command.side_effect = _command
@@ -112,7 +103,24 @@ def test_start_export_runs_targets_serially_in_one_worker(
     assert len(worker_starts) == 1
     assert worker_starts[0][2] is True
     assert mint_client.call_count == 1
-    assert command_query_ids == [f"{job_id}:objects", f"{job_id}:feedback"]
+    assert [command[2]["query_id"] for command in commands] == [
+        f"{job_id}:objects",
+        f"{job_id}:feedback",
+    ]
+    assert [command[0] for command in commands] == [
+        (
+            "INSERT INTO FUNCTION s3(weave_exports, "
+            f"filename = 'exports/project/{job_id}/objects/data.parquet', "
+            "format = 'Parquet') "
+            f"{build_objects_export_query()}"
+        ),
+        (
+            "INSERT INTO FUNCTION s3(weave_exports, "
+            f"filename = 'exports/project/{job_id}/feedback/data.parquet', "
+            "format = 'Parquet') "
+            f"{build_feedback_export_query()}"
+        ),
+    ]
     manifest = json.loads(
         storage_client.read(
             storage_client.base_uri.with_path(
@@ -120,14 +128,22 @@ def test_start_export_runs_targets_serially_in_one_worker(
             )
         )
     )
-    assert manifest["job_id"] == job_id
-    assert [target["target"] for target in manifest["targets"]] == [
-        "objects",
-        "feedback",
-    ]
+    created_at = datetime.datetime.fromisoformat(manifest.pop("created_at"))
+    assert created_at.tzinfo == datetime.timezone.utc
+    assert manifest == {
+        "job_id": job_id,
+        "format": "parquet",
+        "targets": [
+            {"target": "objects", "object": "objects/data.parquet"},
+            {"target": "feedback", "object": "feedback/data.parquet"},
+        ],
+    }
 
 
-def test_export_start_writes_manifest_without_creating_a_clickhouse_table(
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: export server entry point"
+)
+def test_export_start_persists_manifest(
     clickhouse_trace_server, storage_client: S3StorageClient
 ):
     clickhouse_trace_server._file_storage_client = storage_client
@@ -137,9 +153,6 @@ def test_export_start_writes_manifest_without_creating_a_clickhouse_table(
         tsi.ExportStartReq(project_id=project_id, targets=["objects", "feedback"])
     )
     assert export.JOB_ID_RE.match(res.job_id)
-    assert clickhouse_trace_server.ch_client.query(
-        "EXISTS TABLE export_jobs"
-    ).result_rows == [(0,)]
     manifest = json.loads(
         storage_client.read(
             storage_client.base_uri.with_path(
@@ -147,13 +160,21 @@ def test_export_start_writes_manifest_without_creating_a_clickhouse_table(
             )
         )
     )
-    assert manifest["job_id"] == res.job_id
-    assert [target["target"] for target in manifest["targets"]] == [
-        "objects",
-        "feedback",
-    ]
+    created_at = datetime.datetime.fromisoformat(manifest.pop("created_at"))
+    assert created_at.tzinfo == datetime.timezone.utc
+    assert manifest == {
+        "job_id": res.job_id,
+        "format": "parquet",
+        "targets": [
+            {"target": "objects", "object": "objects/data.parquet"},
+            {"target": "feedback", "object": "feedback/data.parquet"},
+        ],
+    }
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: query_log verification"
+)
 def test_export_start_query_id_lands_in_query_log(
     clickhouse_trace_server, storage_client: S3StorageClient
 ):
@@ -180,32 +201,59 @@ def test_export_start_query_id_lands_in_query_log(
     assert rows == [(qid,)]
 
 
-def test_bad_target_and_job_id_validation(storage_client: S3StorageClient):
-    with pytest.raises(export.ExportError) as exc_info:
-        export.start_export(
-            MagicMock(),
-            storage_client,
-            "project",
-            ["objects", "nope"],
-            ReadTable.CALLS_COMPLETE,
-        )
-    assert exc_info.value.http_status == 400
-    assert exc_info.value.code == "BAD_TARGET"
-    assert export.JOB_ID_RE.match("not-a-uuid") is None
-    assert export.JOB_ID_RE.match(str(uuid.uuid4()))
-    assert export.export_object_prefix("p", "j", "calls") == "exports/p/j/calls/"
-
-
-@pytest.mark.parametrize("targets", [[], ["objects", "objects"]])
-def test_empty_and_duplicate_targets_are_rejected(
-    storage_client: S3StorageClient, targets: list[str]
+def test_start_export_requires_durable_manifest(
+    monkeypatch: pytest.MonkeyPatch,
 ):
+    mint_client = MagicMock()
     with pytest.raises(export.ExportError) as exc_info:
         export.start_export(
-            MagicMock(),
-            storage_client,
+            mint_client,
+            None,
             "project",
-            targets,
+            ["objects"],
             ReadTable.CALLS_COMPLETE,
         )
-    assert (exc_info.value.http_status, exc_info.value.code) == (400, "BAD_TARGET")
+    assert (exc_info.value.http_status, exc_info.value.code) == (
+        503,
+        "EXPORT_STORAGE_UNAVAILABLE",
+    )
+
+    failed_write = MagicMock(side_effect=FileStorageWriteError())
+    monkeypatch.setattr(export, "store_in_bucket", failed_write)
+    with pytest.raises(export.ExportError) as exc_info:
+        export.start_export(
+            mint_client,
+            MagicMock(),
+            "project",
+            ["objects"],
+            ReadTable.CALLS_COMPLETE,
+        )
+    assert (exc_info.value.http_status, exc_info.value.code) == (
+        503,
+        "EXPORT_STORAGE_UNAVAILABLE",
+    )
+    failed_write.assert_called_once()
+    assert mint_client.call_count == 0
+
+
+def test_start_export_rejects_invalid_targets_before_writing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    store = MagicMock()
+    monkeypatch.setattr(export, "store_in_bucket", store)
+    for targets in ([], ["objects", "objects"], ["objects", "nope"]):
+        mint_client = MagicMock()
+        with pytest.raises(export.ExportError) as exc_info:
+            export.start_export(
+                mint_client,
+                MagicMock(),
+                "project",
+                targets,
+                ReadTable.CALLS_COMPLETE,
+            )
+        assert (exc_info.value.http_status, exc_info.value.code) == (
+            400,
+            "BAD_TARGET",
+        )
+        assert mint_client.call_count == 0
+    store.assert_not_called()

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -45,6 +45,7 @@ from weave.shared.trace_server_interface_util import (
 from weave.trace_server import (
     ch_sentinel_values,
     constants,
+    export,
     object_creation_utils,
     usage_utils,
 )
@@ -7367,6 +7368,23 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 )
 
         return res
+
+    def export_start(self, req: tsi.ExportStartReq) -> tsi.ExportStartRes:
+        calls_read_table = ReadTable.CALLS_COMPLETE
+        if "calls" in req.targets:
+            calls_read_table = self.table_routing_resolver.resolve_read_table(
+                req.project_id, self.ch_client
+            )
+        job_id = export.start_export(
+            lambda: self._mint_client(
+                send_receive_timeout=export.EXPORT_MAX_EXECUTION_SECONDS
+            ),
+            self.file_storage_client,
+            req.project_id,
+            req.targets,
+            calls_read_table,
+        )
+        return tsi.ExportStartRes(job_id=job_id)
 
     # Private Methods
     @property

--- a/weave/trace_server/export.py
+++ b/weave/trace_server/export.py
@@ -1,0 +1,185 @@
+"""Detached ClickHouse -> S3 export write path.
+
+`start_export` writes the job's manifest object before starting one background
+worker. The worker runs each `INSERT INTO FUNCTION s3()` serially, while the
+manifest and `system.query_log` are the durable read path.
+"""
+
+import datetime
+import json
+import logging
+import re
+import threading
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from clickhouse_connect.driver.client import Client as CHClient
+
+from weave.trace_server import clickhouse_trace_server_settings as ch_settings
+from weave.trace_server.export_targets import EXPORT_TARGET_NAMES, build_export_query
+from weave.trace_server.file_storage import (
+    FileStorageClient,
+    FileStorageWriteError,
+    store_in_bucket,
+)
+from weave.trace_server.project_version.types import ReadTable
+
+logger = logging.getLogger(__name__)
+
+
+class ExportError(Exception):
+    def __init__(self, http_status: int, code: str, message: str) -> None:
+        super().__init__(message)
+        self.http_status = http_status
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ResolvedExportTarget:
+    """A target name paired with the one query used for count and export."""
+
+    name: str
+    source_sql: str
+
+
+def start_export(
+    mint_client: Callable[[], CHClient],
+    file_storage_client: FileStorageClient | None,
+    project_id: str,
+    target_names: list[str],
+    calls_read_table: ReadTable,
+) -> str:
+    """Write the job manifest, then run its targets serially off-thread."""
+    targets = _resolve_targets(target_names, calls_read_table)
+    if file_storage_client is None:
+        raise ExportError(
+            503,
+            "EXPORT_STORAGE_UNAVAILABLE",
+            "export storage is not configured",
+        )
+    job_id = str(uuid.uuid4())
+    if not JOB_ID_RE.match(job_id):
+        raise ExportError(500, "BAD_JOB_ID", f"job_id {job_id!r} fails validation")
+    _write_manifest(file_storage_client, project_id, job_id, target_names)
+    threading.Thread(
+        target=_run_export,
+        args=(mint_client, project_id, job_id, targets),
+        daemon=True,
+    ).start()
+    return job_id
+
+
+def build_export_insert_sql(target: ResolvedExportTarget, filename: str) -> str:
+    """Build the detached export INSERT.
+
+    The named collection is referenced by name only, so no credential ever
+    appears in the SQL or query_log. `filename` is built from server-derived,
+    validated parts (internal project_id, uuid4 job_id, supported target name);
+    the SELECT still binds project_id as `{project_id:String}`.
+    """
+    return (
+        f"INSERT INTO FUNCTION s3({EXPORT_S3_NAMED_COLLECTION}, "
+        f"filename = '{filename}', format = 'Parquet') {target.source_sql}"
+    )
+
+
+def export_object_prefix(project_id: str, job_id: str, target: str) -> str:
+    return export_job_prefix(project_id, job_id) + f"{target}/"
+
+
+def export_job_prefix(project_id: str, job_id: str) -> str:
+    return f"exports/{project_id}/{job_id}/"
+
+
+def build_manifest_json(job_id: str, target_names: list[str]) -> bytes:
+    """Build the durable job index without exposing the internal project id."""
+    manifest = {
+        "job_id": job_id,
+        "format": "parquet",
+        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "targets": [
+            {"target": name, "object": f"{name}/data.parquet"} for name in target_names
+        ],
+    }
+    return json.dumps(manifest, sort_keys=True).encode()
+
+
+def _write_manifest(
+    file_storage_client: FileStorageClient,
+    project_id: str,
+    job_id: str,
+    target_names: list[str],
+) -> None:
+    """Persist the job record before accepting detached work."""
+    try:
+        store_in_bucket(
+            file_storage_client,
+            export_job_prefix(project_id, job_id) + "manifest.json",
+            build_manifest_json(job_id, target_names),
+        )
+    except FileStorageWriteError as exc:
+        raise ExportError(
+            503,
+            "EXPORT_STORAGE_UNAVAILABLE",
+            "failed to persist export manifest",
+        ) from exc
+
+
+def _run_export(
+    mint_client: Callable[[], CHClient],
+    project_id: str,
+    job_id: str,
+    targets: list[ResolvedExportTarget],
+) -> None:
+    """Run one job's targets serially to bound its ClickHouse concurrency."""
+    client = mint_client()
+    for target in targets:
+        _run_target_insert(client, project_id, job_id, target)
+
+
+def _run_target_insert(
+    client: CHClient,
+    project_id: str,
+    job_id: str,
+    target: ResolvedExportTarget,
+) -> None:
+    filename = export_object_prefix(project_id, job_id, target.name) + "data.parquet"
+    sql = build_export_insert_sql(target, filename)
+    # `query_id` rides in settings: the driver routes valid_transport_settings
+    # keys to URL params (the `transport_settings` kwarg is raw headers CH ignores).
+    settings = ch_settings.merge_default_command_settings(
+        {
+            "max_execution_time": EXPORT_MAX_EXECUTION_SECONDS,
+            "query_id": f"{job_id}:{target.name}",
+        }
+    )
+    try:
+        client.command(sql, parameters={"project_id": project_id}, settings=settings)
+    except Exception:
+        # Detached by design: query_log records the failure for the status path.
+        logger.debug("export insert failed: %s:%s", job_id, target.name, exc_info=True)
+
+
+def _resolve_targets(
+    target_names: list[str], calls_read_table: ReadTable
+) -> list[ResolvedExportTarget]:
+    if not target_names:
+        raise ExportError(400, "BAD_TARGET", "at least one export target is required")
+    if len(set(target_names)) != len(target_names):
+        raise ExportError(400, "BAD_TARGET", "export targets must be unique")
+    targets: list[ResolvedExportTarget] = []
+    for name in target_names:
+        if name not in EXPORT_TARGET_NAMES:
+            raise ExportError(400, "BAD_TARGET", f"unknown export target {name!r}")
+        targets.append(
+            ResolvedExportTarget(name, build_export_query(name, calls_read_table))
+        )
+    return targets
+
+
+# CH server-config named collection holding the ch-writer S3 identity.
+EXPORT_S3_NAMED_COLLECTION = "weave_exports"
+# Bounds CH cost per detached insert via max_execution_time.
+EXPORT_MAX_EXECUTION_SECONDS = 300
+JOB_ID_RE = re.compile(r"^[0-9a-f-]{36}$")


### PR DESCRIPTION
## Summary
- `export_start` persists `manifest.json` through the configured file-storage client, then starts one daemon worker for the job. The worker executes target `INSERT INTO FUNCTION s3()` commands serially, so a single export does not fan out across targets.
- Export data goes directly from ClickHouse to Parquet through the server-configured `weave_exports` named collection. The application does not create or insert into any ClickHouse job table.
- The manifest is the durable job record; it contains the selected targets and deterministic object names without exposing the internal project ID.

## Testing
- Real ClickHouse query-log coverage, real S3 manifest persistence, and explicit proof that `export_jobs` is absent.
- Serial-worker ordering, target-failure continuation, invalid/empty/duplicate target rejection, and exact native export SQL.