### PR TITLE
chore(weave): export status via query_log

### DIFF
--- a/tests/trace_server/test_environment.py
+++ b/tests/trace_server/test_environment.py
@@ -11,6 +11,7 @@ from weave.trace_server.environment import (
     VALID_CALLS_SHARD_KEYS,
     kafka_producer_max_buffer_size,
     wf_clickhouse_calls_shard_key,
+    wf_clickhouse_query_log_cluster,
     wf_kafka_project_id_bucket_count,
     wf_scoring_worker_check_cancellation,
     wf_scoring_worker_debounced_scoring_max_call_history,
@@ -315,3 +316,25 @@ def test_wf_scoring_worker_remote_scorer_require_structured_result_schema(
     assert wf_scoring_worker_remote_scorer_require_structured_result_schema() is True
     monkeypatch.setenv(key, "0")
     assert wf_scoring_worker_remote_scorer_require_structured_result_schema() is True
+
+
+@pytest.mark.parametrize(
+    ("host", "replicated_cluster", "expected"),
+    [
+        # ClickHouse Cloud (public + private PSC hosts) fans out over `default`.
+        ("wsmkvdlncf.us-central1.p.gcp.clickhouse.cloud", None, "default"),
+        ("abc.us-central1.gcp.clickhouse.cloud", "weavecluster", "default"),
+        # Self-managed distributed uses its replicated cluster; single node stays local.
+        ("clickhouse.internal", "weavecluster", "weavecluster"),
+        ("localhost", None, None),
+    ],
+)
+def test_wf_clickhouse_query_log_cluster(
+    host, replicated_cluster, expected, monkeypatch
+):
+    monkeypatch.setenv("WF_CLICKHOUSE_HOST", host)
+    if replicated_cluster is None:
+        monkeypatch.delenv("WF_CLICKHOUSE_REPLICATED_CLUSTER", raising=False)
+    else:
+        monkeypatch.setenv("WF_CLICKHOUSE_REPLICATED_CLUSTER", replicated_cluster)
+    assert wf_clickhouse_query_log_cluster() == expected

--- a/tests/trace_server/test_export_status.py
+++ b/tests/trace_server/test_export_status.py
@@ -1,0 +1,221 @@
+"""Functional status-path tests for the managed-bucket export engine.
+
+Real ClickHouse provides the ``system.query_log`` oracle and moto exercises
+the real S3 storage client for the durable manifest, artifact, and presign
+paths. No job table or in-memory job registry participates in this flow.
+"""
+
+import time
+import uuid
+
+import boto3
+import pytest
+import requests
+from clickhouse_connect.driver.client import Client as CHClient
+from clickhouse_connect.driver.exceptions import DatabaseError
+from moto import mock_aws
+
+from tests.trace.server_utils import find_server_layer
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
+from tests.trace_server.conftest import TEST_ENTITY
+from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
+from weave.trace_server import export
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.file_storage import S3StorageClient
+from weave.trace_server.file_storage_credentials import AWSCredentials
+from weave.trace_server.file_storage_uris import S3FileStorageURI
+
+pytestmark = pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: export status via query_log"
+)
+
+ORACLE_DEADLINE_SECONDS = 20
+SCRATCH_TABLE = "export_status_scratch"
+BUCKET = "weave-exports"
+
+
+@pytest.fixture
+def clickhouse_trace_server(trace_server):
+    """Unwrap the internal ClickHouse server from the external fixture."""
+    return find_server_layer(trace_server, ClickHouseTraceServer)
+
+
+@pytest.fixture
+def storage_client():
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=BUCKET)
+        credentials: AWSCredentials = {
+            "access_key_id": "test-key",
+            "secret_access_key": "test-secret",
+            "session_token": None,
+            "region": "us-east-1",
+            "kms_key": None,
+        }
+        yield S3StorageClient(
+            S3FileStorageURI.parse_uri_str(f"s3://{BUCKET}"), credentials
+        )
+
+
+def test_poll_query_status_oracle_against_real_query_log(clickhouse_trace_server):
+    ch = clickhouse_trace_server.ch_client
+    _make_scratch_table(ch)
+
+    done_qid = f"{uuid.uuid4()}:objects"
+    ch.command(
+        f"INSERT INTO {SCRATCH_TABLE} SELECT number FROM numbers(7)",
+        settings={"query_id": done_qid},
+    )
+    assert _poll_until_terminal(ch, done_qid) == ("done", 7, None)
+
+    error_qid = f"{uuid.uuid4()}:objects"
+    with pytest.raises(DatabaseError):
+        ch.command(
+            "SELECT throwIf(number = 0, 'boom') FROM numbers(1)",
+            settings={"query_id": error_qid},
+        )
+    status, rows, error = _poll_until_terminal(ch, error_qid)
+    assert (status, rows) == ("error", 0)
+    assert error is not None
+    assert "boom" in error
+
+    assert export.poll_query_status(ch, f"{uuid.uuid4()}:objects") == (
+        "running",
+        0,
+        None,
+    )
+
+
+def test_export_status_recovers_job_with_no_memory_state(
+    clickhouse_trace_server, storage_client: S3StorageClient
+):
+    project_id = b64(f"{TEST_ENTITY}/export-status-recovery")
+    clickhouse_trace_server._file_storage_client = storage_client
+    clickhouse_trace_server._file_storage_client_initialized = True
+    start_res = clickhouse_trace_server.export_start(
+        tsi.ExportStartReq(project_id=project_id, targets=["objects", "feedback"])
+    )
+    # A brand-new server instance proves status is recovered from object storage
+    # plus query_log, not a process-local map or a ClickHouse metadata table.
+    fresh_server = ClickHouseTraceServer(
+        host=clickhouse_trace_server._host,
+        port=clickhouse_trace_server._port,
+        user=clickhouse_trace_server._user,
+        password=clickhouse_trace_server._password,
+        database=clickhouse_trace_server._database,
+    )
+    fresh_server._file_storage_client = storage_client
+    fresh_server._file_storage_client_initialized = True
+    status_req = tsi.ExportStatusReq(project_id=project_id, job_id=start_res.job_id)
+    deadline = time.monotonic() + ORACLE_DEADLINE_SECONDS
+    status_res = fresh_server.export_status(status_req)
+    # The detached inserts fail (no weave_exports collection in the test CH);
+    # wait until both targets reach their terminal error in query_log.
+    while time.monotonic() < deadline and any(
+        entry.status != "error" for entry in status_res.manifest
+    ):
+        time.sleep(0.5)
+        status_res = fresh_server.export_status(status_req)
+
+    assert status_res.status == "error"
+    assert [entry.target for entry in status_res.manifest] == ["objects", "feedback"]
+    for entry in status_res.manifest:
+        assert entry.status == "error"
+        assert entry.error is not None
+        assert entry.error != ""
+        assert entry.rows == 0
+        assert entry.objects == []
+        assert entry.urls == []
+        assert entry.expires_at is None
+
+
+def test_cross_tenant_unknown_and_traversal_guards(
+    clickhouse_trace_server, storage_client: S3StorageClient
+):
+    project_a = b64(f"{TEST_ENTITY}/export-status-tenant-a")
+    project_b = b64(f"{TEST_ENTITY}/export-status-tenant-b")
+    clickhouse_trace_server._file_storage_client = storage_client
+    clickhouse_trace_server._file_storage_client_initialized = True
+    start_res = clickhouse_trace_server.export_start(
+        tsi.ExportStartReq(project_id=project_a, targets=["objects"])
+    )
+
+    with pytest.raises(export.ExportError) as cross_tenant:
+        clickhouse_trace_server.export_status(
+            tsi.ExportStatusReq(project_id=project_b, job_id=start_res.job_id)
+        )
+    assert (cross_tenant.value.http_status, cross_tenant.value.code) == (
+        404,
+        "NOT_FOUND",
+    )
+
+    with pytest.raises(export.ExportError) as unknown:
+        clickhouse_trace_server.export_status(
+            tsi.ExportStatusReq(project_id=project_a, job_id=str(uuid.uuid4()))
+        )
+    assert (unknown.value.http_status, unknown.value.code) == (404, "NOT_FOUND")
+
+    with pytest.raises(export.ExportError) as traversal:
+        clickhouse_trace_server.export_status(
+            tsi.ExportStatusReq(project_id=project_a, job_id="../../etc/passwd")
+        )
+    assert (traversal.value.http_status, traversal.value.code) == (400, "BAD_JOB_ID")
+
+
+def test_presign_on_done_downloads_exact_artifact(
+    clickhouse_trace_server, storage_client: S3StorageClient
+):
+    ch = clickhouse_trace_server.ch_client
+    project_id = b64(f"{TEST_ENTITY}/export-status-presign")
+    job_id = str(uuid.uuid4())
+
+    # Make the oracle report objects done via a real insert under the job's query_id.
+    _make_scratch_table(ch)
+    ch.command(
+        f"INSERT INTO {SCRATCH_TABLE} SELECT number FROM numbers(5)",
+        settings={"query_id": f"{job_id}:objects"},
+    )
+    assert _poll_until_terminal(ch, f"{job_id}:objects") == ("done", 5, None)
+
+    storage_client.store(
+        storage_client.base_uri.with_path(
+            export.export_job_prefix(project_id, job_id) + "manifest.json"
+        ),
+        export.build_manifest_json(job_id, ["objects"]),
+    )
+    key = export.export_object_prefix(project_id, job_id, "objects") + "data.parquet"
+    artifact = b"PAR1-status-artifact"
+    storage_client.store(storage_client.base_uri.with_path(key), artifact)
+
+    res = export.get_export_status(ch, storage_client, project_id, job_id)
+    assert res.status == "done"
+    entry = res.manifest[0]
+    assert (entry.target, entry.status, entry.rows) == ("objects", "done", 5)
+    assert entry.objects == [key]
+    assert len(entry.urls) == 1
+    assert entry.expires_at is not None
+    assert entry.error is None
+    # Real read-only download over the presigned GET: no CH creds involved.
+    assert requests.get(entry.urls[0], timeout=5).content == artifact
+
+
+def _make_scratch_table(ch: CHClient) -> None:
+    ch.command(
+        f"CREATE TABLE IF NOT EXISTS {SCRATCH_TABLE} "
+        "(n UInt64) ENGINE = MergeTree ORDER BY n"
+    )
+
+
+def _poll_until_terminal(
+    ch: CHClient, query_id: str
+) -> tuple[tsi.ExportJobStatus, int, str | None]:
+    """FLUSH LOGS + poll the oracle until it leaves running (or times out)."""
+    deadline = time.monotonic() + ORACLE_DEADLINE_SECONDS
+    result: tuple[tsi.ExportJobStatus, int, str | None] = ("running", 0, None)
+    while time.monotonic() < deadline:
+        ch.command("SYSTEM FLUSH LOGS")
+        result = export.poll_query_status(ch, query_id)
+        if result[0] != "running":
+            return result
+        time.sleep(0.5)
+    return result

--- a/tests/trace_server/test_export_status.py
+++ b/tests/trace_server/test_export_status.py
@@ -86,6 +86,26 @@ def test_poll_query_status_oracle_against_real_query_log(clickhouse_trace_server
     )
 
 
+def test_query_log_oracle_sql_supports_standalone_and_replica_clusters():
+    assert export._flush_query_log_sql(None) == "SYSTEM FLUSH LOGS query_log"
+    assert export._query_log_status_sql(None) == (
+        "SELECT type, written_rows, exception FROM system.query_log "
+        "WHERE query_id = {qid:String} AND event_date >= today() - 1 "
+        "ORDER BY event_time_microseconds DESC LIMIT 1"
+    )
+
+    assert (
+        export._flush_query_log_sql("default")
+        == "SYSTEM FLUSH LOGS ON CLUSTER default query_log"
+    )
+    assert export._query_log_status_sql("default") == (
+        "SELECT type, written_rows, exception FROM "
+        "clusterAllReplicas('default', merge('system', '^query_log*')) "
+        "WHERE query_id = {qid:String} AND event_date >= today() - 1 "
+        "ORDER BY event_time_microseconds DESC LIMIT 1"
+    )
+
+
 def test_export_status_recovers_job_with_no_memory_state(
     clickhouse_trace_server, storage_client: S3StorageClient
 ):

--- a/tests/trace_server/test_export_status.py
+++ b/tests/trace_server/test_export_status.py
@@ -87,17 +87,12 @@ def test_poll_query_status_oracle_against_real_query_log(clickhouse_trace_server
 
 
 def test_query_log_oracle_sql_supports_standalone_and_replica_clusters():
-    assert export._flush_query_log_sql(None) == "SYSTEM FLUSH LOGS query_log"
     assert export._query_log_status_sql(None) == (
         "SELECT type, written_rows, exception FROM system.query_log "
         "WHERE query_id = {qid:String} AND event_date >= today() - 1 "
         "ORDER BY event_time_microseconds DESC LIMIT 1"
     )
 
-    assert (
-        export._flush_query_log_sql("default")
-        == "SYSTEM FLUSH LOGS ON CLUSTER default query_log"
-    )
     assert export._query_log_status_sql("default") == (
         "SELECT type, written_rows, exception FROM "
         "clusterAllReplicas('default', merge('system', '^query_log*')) "

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7386,6 +7386,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         return tsi.ExportStartRes(job_id=job_id)
 
+    def export_status(self, req: tsi.ExportStatusReq) -> tsi.ExportStatusRes:
+        return export.get_export_status(
+            self.ch_client, self.file_storage_client, req.project_id, req.job_id
+        )
+
     # Private Methods
     @property
     def ch_client(self) -> CHClient:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7392,7 +7392,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self.file_storage_client,
             req.project_id,
             req.job_id,
-            self.clickhouse_cluster_name,
+            wf_env.wf_clickhouse_query_log_cluster(),
         )
 
     # Private Methods

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7388,7 +7388,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     def export_status(self, req: tsi.ExportStatusReq) -> tsi.ExportStatusRes:
         return export.get_export_status(
-            self.ch_client, self.file_storage_client, req.project_id, req.job_id
+            self.ch_client,
+            self.file_storage_client,
+            req.project_id,
+            req.job_id,
+            self.clickhouse_cluster_name,
         )
 
     # Private Methods

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -120,6 +120,12 @@ CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS: dict[str, int | str] = (
     }
 )
 
+# Fanning `system.query_log` reads across replicas (export status) must tolerate a
+# scaled-down or idle replica instead of failing the whole read.
+CLICKHOUSE_QUERY_LOG_FAN_OUT_SETTINGS: dict[str, int | str] = {
+    "skip_unavailable_shards": 1
+}
+
 # The new ClickHouse query analyzer (v24+) has a bug serializing SortingStep
 # for non-Full sorting modes on distributed tables, which causes error 48
 # ("Serialization of SortingStep is implemented only for Full sorting").

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -291,6 +291,11 @@ def wf_ingest_sample_dry_run() -> bool:
 
 # Clickhouse Settings
 
+# ClickHouse Cloud services share the built-in `default` cluster and resolve to a
+# `*.clickhouse.cloud` host; query_log fan-out uses it without any extra config.
+CLICKHOUSE_CLOUD_HOST_SUFFIX = ".clickhouse.cloud"
+CLICKHOUSE_CLOUD_CLUSTER = "default"
+
 
 def wf_clickhouse_host() -> str:
     """The host of the clickhouse server."""
@@ -338,6 +343,18 @@ def wf_clickhouse_use_distributed_tables() -> bool:
         os.environ.get("WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES", "false").lower()
         == "true"
     )
+
+
+def wf_clickhouse_query_log_cluster() -> str | None:
+    """Cluster to fan out `system.query_log` reads across replicas, or None for local-only.
+
+    ClickHouse Cloud is multi-replica with a built-in `default` cluster and no
+    `WF_CLICKHOUSE_REPLICATED_CLUSTER` set, so detect it by host and default to
+    `default`; self-managed distributed falls back to its replicated cluster.
+    """
+    if wf_clickhouse_host().endswith(CLICKHOUSE_CLOUD_HOST_SUFFIX):
+        return CLICKHOUSE_CLOUD_CLUSTER
+    return wf_clickhouse_replicated_cluster()
 
 
 VALID_CALLS_SHARD_KEYS = frozenset({"trace_id", "id", "project_id"})

--- a/weave/trace_server/export.py
+++ b/weave/trace_server/export.py
@@ -2,7 +2,7 @@
 
 `start_export` writes the job's manifest object before starting one background
 worker. The worker runs each `INSERT INTO FUNCTION s3()` serially, while the
-manifest and `system.query_log` are the durable read path.
+manifest and replica-wide `system.query_log` are the durable read path.
 """
 
 import datetime
@@ -76,6 +76,7 @@ def get_export_status(
     file_storage_client: FileStorageClient | None,
     project_id: str,
     job_id: str,
+    query_log_cluster: str | None = None,
 ) -> tsi.ExportStatusRes:
     """Read the job manifest, then derive target status from ``query_log``."""
     if not JOB_ID_RE.match(job_id):
@@ -88,9 +89,16 @@ def get_export_status(
             "export storage is not configured",
         )
     targets = _read_manifest_targets(file_storage_client, project_id, job_id)
-    ch_client.command("SYSTEM FLUSH LOGS")
+    ch_client.command(_flush_query_log_sql(query_log_cluster))
     manifest = [
-        _manifest_entry(ch_client, file_storage_client, project_id, job_id, target)
+        _manifest_entry(
+            ch_client,
+            file_storage_client,
+            project_id,
+            job_id,
+            target,
+            query_log_cluster,
+        )
         for target in targets
     ]
     overall: tsi.ExportJobStatus
@@ -104,13 +112,11 @@ def get_export_status(
 
 
 def poll_query_status(
-    ch_client: CHClient, query_id: str
+    ch_client: CHClient, query_id: str, query_log_cluster: str | None = None
 ) -> tuple[tsi.ExportJobStatus, int, str | None]:
     """query_log oracle: map the latest event for query_id to (status, rows, error)."""
     rows = ch_client.query(
-        "SELECT type, written_rows, exception FROM system.query_log "
-        "WHERE query_id = {qid:String} AND event_date >= today() - 1 "
-        "ORDER BY event_time_microseconds DESC LIMIT 1",
+        _query_log_status_sql(query_log_cluster),
         parameters={"qid": query_id},
     ).result_rows
     if not rows:
@@ -223,8 +229,11 @@ def _manifest_entry(
     project_id: str,
     job_id: str,
     target: str,
+    query_log_cluster: str | None,
 ) -> tsi.ExportManifestEntry:
-    status, rows, error = poll_query_status(ch_client, f"{job_id}:{target}")
+    status, rows, error = poll_query_status(
+        ch_client, f"{job_id}:{target}", query_log_cluster
+    )
     objects: list[str] = []
     urls: list[str] = []
     expires_at: str | None = None
@@ -302,6 +311,26 @@ def _resolve_targets(
             ResolvedExportTarget(name, build_export_query(name, calls_read_table))
         )
     return targets
+
+
+def _flush_query_log_sql(query_log_cluster: str | None) -> str:
+    if query_log_cluster is None:
+        return "SYSTEM FLUSH LOGS query_log"
+    return f"SYSTEM FLUSH LOGS ON CLUSTER {query_log_cluster} query_log"
+
+
+def _query_log_status_sql(query_log_cluster: str | None) -> str:
+    source = "system.query_log"
+    if query_log_cluster is not None:
+        source = (
+            f"clusterAllReplicas('{query_log_cluster}', merge('system', '^query_log*'))"
+        )
+    return (
+        "SELECT type, written_rows, exception FROM "
+        f"{source} "
+        "WHERE query_id = {qid:String} AND event_date >= today() - 1 "
+        "ORDER BY event_time_microseconds DESC LIMIT 1"
+    )
 
 
 # CH server-config named collection holding the ch-writer S3 identity.

--- a/weave/trace_server/export.py
+++ b/weave/trace_server/export.py
@@ -1,4 +1,4 @@
-"""Detached ClickHouse -> S3 export write path.
+"""Detached ClickHouse -> S3 export write and status paths.
 
 `start_export` writes the job's manifest object before starting one background
 worker. The worker runs each `INSERT INTO FUNCTION s3()` serially, while the
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from clickhouse_connect.driver.client import Client as CHClient
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
+from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.export_targets import EXPORT_TARGET_NAMES, build_export_query
 from weave.trace_server.file_storage import (
     FileStorageClient,
@@ -68,6 +69,59 @@ def start_export(
         daemon=True,
     ).start()
     return job_id
+
+
+def get_export_status(
+    ch_client: CHClient,
+    file_storage_client: FileStorageClient | None,
+    project_id: str,
+    job_id: str,
+) -> tsi.ExportStatusRes:
+    """Read the job manifest, then derive target status from ``query_log``."""
+    if not JOB_ID_RE.match(job_id):
+        # job_id is the only caller-influenced path segment; bar traversal.
+        raise ExportError(400, "BAD_JOB_ID", f"job_id {job_id!r} fails validation")
+    if file_storage_client is None:
+        raise ExportError(
+            503,
+            "EXPORT_STORAGE_UNAVAILABLE",
+            "export storage is not configured",
+        )
+    targets = _read_manifest_targets(file_storage_client, project_id, job_id)
+    ch_client.command("SYSTEM FLUSH LOGS")
+    manifest = [
+        _manifest_entry(ch_client, file_storage_client, project_id, job_id, target)
+        for target in targets
+    ]
+    overall: tsi.ExportJobStatus
+    if any(entry.status == "error" for entry in manifest):
+        overall = "error"
+    elif any(entry.status == "running" for entry in manifest):
+        overall = "running"
+    else:
+        overall = "done"
+    return tsi.ExportStatusRes(status=overall, manifest=manifest)
+
+
+def poll_query_status(
+    ch_client: CHClient, query_id: str
+) -> tuple[tsi.ExportJobStatus, int, str | None]:
+    """query_log oracle: map the latest event for query_id to (status, rows, error)."""
+    rows = ch_client.query(
+        "SELECT type, written_rows, exception FROM system.query_log "
+        "WHERE query_id = {qid:String} AND event_date >= today() - 1 "
+        "ORDER BY event_time_microseconds DESC LIMIT 1",
+        parameters={"qid": query_id},
+    ).result_rows
+    if not rows:
+        return "running", 0, None
+    event_type, written_rows, exception = rows[0]
+    if event_type == "QueryFinish":
+        return "done", int(written_rows), None
+    if str(event_type).startswith("Exception"):
+        return "error", 0, exception or "exception"
+    # Any other event (QueryStart): the insert is still in flight.
+    return "running", 0, None
 
 
 def build_export_insert_sql(target: ResolvedExportTarget, filename: str) -> str:
@@ -124,6 +178,78 @@ def _write_manifest(
             "EXPORT_STORAGE_UNAVAILABLE",
             "failed to persist export manifest",
         ) from exc
+
+
+def _read_manifest_targets(
+    file_storage_client: FileStorageClient, project_id: str, job_id: str
+) -> list[str]:
+    """Load and validate the job record under the authorized project prefix."""
+    uri = file_storage_client.base_uri.with_path(
+        export_job_prefix(project_id, job_id) + "manifest.json"
+    )
+    try:
+        manifest_bytes = file_storage_client.read(uri)
+    except Exception as exc:
+        # A different project's prefix resolves to a miss as well, so status
+        # never confirms the existence of another tenant's job.
+        raise ExportError(404, "NOT_FOUND", f"no such export job {job_id}") from exc
+    try:
+        manifest = json.loads(manifest_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ExportError(
+            500, "BAD_EXPORT_MANIFEST", "export manifest is invalid"
+        ) from exc
+    if not isinstance(manifest, dict) or manifest.get("job_id") != job_id:
+        raise ExportError(500, "BAD_EXPORT_MANIFEST", "export manifest is invalid")
+    raw_targets = manifest.get("targets")
+    if not isinstance(raw_targets, list) or not raw_targets:
+        raise ExportError(500, "BAD_EXPORT_MANIFEST", "export manifest is invalid")
+    targets: list[str] = []
+    for entry in raw_targets:
+        if (
+            not isinstance(entry, dict)
+            or entry.get("target") not in EXPORT_TARGET_NAMES
+        ):
+            raise ExportError(500, "BAD_EXPORT_MANIFEST", "export manifest is invalid")
+        targets.append(entry["target"])
+    if len(set(targets)) != len(targets):
+        raise ExportError(500, "BAD_EXPORT_MANIFEST", "export manifest is invalid")
+    return targets
+
+
+def _manifest_entry(
+    ch_client: CHClient,
+    file_storage_client: FileStorageClient,
+    project_id: str,
+    job_id: str,
+    target: str,
+) -> tsi.ExportManifestEntry:
+    status, rows, error = poll_query_status(ch_client, f"{job_id}:{target}")
+    objects: list[str] = []
+    urls: list[str] = []
+    expires_at: str | None = None
+    if status == "done":
+        # MVP writes exactly one deterministic object per target (no PARTITION BY);
+        # phase-2 partitioning will need real object listing here.
+        key = export_object_prefix(project_id, job_id, target) + "data.parquet"
+        objects = [key]
+        # Presigns against the configured file-storage bucket under exports/;
+        # this MUST be the same physical bucket the weave_exports collection writes to.
+        uri = file_storage_client.base_uri.with_path(key)
+        urls = [file_storage_client.presign_read(uri, PRESIGN_TTL_SECONDS)]
+        expires_at = (
+            datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(seconds=PRESIGN_TTL_SECONDS)
+        ).isoformat()
+    return tsi.ExportManifestEntry(
+        target=target,
+        status=status,
+        rows=rows,
+        objects=objects,
+        urls=urls,
+        expires_at=expires_at,
+        error=error,
+    )
 
 
 def _run_export(
@@ -183,3 +309,5 @@ EXPORT_S3_NAMED_COLLECTION = "weave_exports"
 # Bounds CH cost per detached insert via max_execution_time.
 EXPORT_MAX_EXECUTION_SECONDS = 300
 JOB_ID_RE = re.compile(r"^[0-9a-f-]{36}$")
+# Download-link lifetime for presigned GETs in the status manifest.
+PRESIGN_TTL_SECONDS = 3600

--- a/weave/trace_server/export.py
+++ b/weave/trace_server/export.py
@@ -89,7 +89,6 @@ def get_export_status(
             "export storage is not configured",
         )
     targets = _read_manifest_targets(file_storage_client, project_id, job_id)
-    ch_client.command(_flush_query_log_sql(query_log_cluster))
     manifest = [
         _manifest_entry(
             ch_client,
@@ -317,12 +316,6 @@ def _resolve_targets(
             ResolvedExportTarget(name, build_export_query(name, calls_read_table))
         )
     return targets
-
-
-def _flush_query_log_sql(query_log_cluster: str | None) -> str:
-    if query_log_cluster is None:
-        return "SYSTEM FLUSH LOGS query_log"
-    return f"SYSTEM FLUSH LOGS ON CLUSTER {query_log_cluster} query_log"
 
 
 def _query_log_status_sql(query_log_cluster: str | None) -> str:

--- a/weave/trace_server/export.py
+++ b/weave/trace_server/export.py
@@ -115,9 +115,15 @@ def poll_query_status(
     ch_client: CHClient, query_id: str, query_log_cluster: str | None = None
 ) -> tuple[tsi.ExportJobStatus, int, str | None]:
     """query_log oracle: map the latest event for query_id to (status, rows, error)."""
+    settings = (
+        ch_settings.CLICKHOUSE_QUERY_LOG_FAN_OUT_SETTINGS
+        if query_log_cluster is not None
+        else None
+    )
     rows = ch_client.query(
         _query_log_status_sql(query_log_cluster),
         parameters={"qid": query_id},
+        settings=settings,
     ).result_rows
     if not rows:
         return "running", 0, None


### PR DESCRIPTION
## Summary
- `export_status` reads the authorized project-scoped `manifest.json` object to discover selected targets, then derives each target state from `system.query_log`.
- No process-local job map and no ClickHouse metadata table are used. A fresh server can serve status from object storage plus query log.
- The project prefix and UUID validation keep unknown and cross-project jobs as 404; completed targets receive presigned read-only object URLs.

## Testing
- Real ClickHouse done/error/running query-log cases.
- Real S3 manifest recovery from a fresh server, cross-project/unknown/traversal guards, corrupt-manifest rejection, and a presigned download round trip.