### PR TITLE
feat(weave): whale cap + manifest.json

### DIFF
--- a/tests/trace_server/test_export_cap_manifest.py
+++ b/tests/trace_server/test_export_cap_manifest.py
@@ -1,0 +1,128 @@
+"""Functional whale-cap + manifest tests for the export write path."""
+
+import json
+import uuid
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from tests.trace.server_utils import find_server_layer
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
+from tests.trace_server.conftest import TEST_ENTITY
+from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
+from tests.trace_server.test_export_targets import _make_completed_call
+from weave.trace_server import export
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.file_storage import S3StorageClient
+from weave.trace_server.file_storage_credentials import AWSCredentials
+from weave.trace_server.file_storage_uris import S3FileStorageURI
+from weave.trace_server.project_version.types import CallsStorageServerMode
+
+pytestmark = pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: export cap + manifest"
+)
+
+BUCKET = "weave-export-cap-manifest"
+
+
+@pytest.fixture
+def clickhouse_trace_server(trace_server):
+    """Return the internal ClickHouse server and enforce AUTO routing mode."""
+    internal_server = find_server_layer(trace_server, ClickHouseTraceServer)
+    internal_server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
+    return internal_server
+
+
+@pytest.fixture
+def storage_client():
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=BUCKET)
+        credentials: AWSCredentials = {
+            "access_key_id": "test-key",
+            "secret_access_key": "test-secret",
+            "session_token": None,
+            "region": "us-east-1",
+            "kms_key": None,
+        }
+        yield S3StorageClient(
+            S3FileStorageURI.parse_uri_str(f"s3://{BUCKET}"), credentials
+        )
+
+
+def test_cap_trips_fail_closed(
+    trace_server, clickhouse_trace_server, storage_client: S3StorageClient, monkeypatch
+):
+    """Over-cap precount raises 409 TOO_LARGE and writes nothing durable."""
+    clickhouse_trace_server._file_storage_client = storage_client
+    clickhouse_trace_server._file_storage_client_initialized = True
+    project = f"{TEST_ENTITY}/export_cap_trips"
+    internal = b64(project)
+    _insert_calls(trace_server, project, 3)
+    monkeypatch.setenv("WF_EXPORT_MAX_ROWS", "2")
+    with pytest.raises(export.ExportError) as exc_info:
+        clickhouse_trace_server.export_start(
+            tsi.ExportStartReq(project_id=internal, targets=["calls"])
+        )
+    assert exc_info.value.http_status == 409
+    assert exc_info.value.code == "TOO_LARGE"
+    assert str(exc_info.value) == "target 'calls' has 3 rows > cap 2"
+    assert storage_client.client.list_objects_v2(Bucket=BUCKET).get("Contents") is None
+    assert clickhouse_trace_server.ch_client.query(
+        "EXISTS TABLE export_jobs"
+    ).result_rows == [(0,)]
+
+
+def test_cap_allows_and_writes_manifest(
+    trace_server,
+    clickhouse_trace_server,
+    storage_client: S3StorageClient,
+    monkeypatch,
+):
+    """Under-cap export persists its complete manifest before detached work starts."""
+    clickhouse_trace_server._file_storage_client = storage_client
+    clickhouse_trace_server._file_storage_client_initialized = True
+    project = f"{TEST_ENTITY}/export_cap_allows"
+    internal = b64(project)
+    _insert_calls(trace_server, project, 3)
+    monkeypatch.setenv("WF_EXPORT_MAX_ROWS", "100")
+    res = clickhouse_trace_server.export_start(
+        tsi.ExportStartReq(project_id=internal, targets=["calls"])
+    )
+    assert export.JOB_ID_RE.match(res.job_id)
+    manifest = json.loads(
+        storage_client.read(
+            storage_client.base_uri.with_path(
+                export.export_job_prefix(internal, res.job_id) + "manifest.json"
+            )
+        )
+    )
+    assert manifest["job_id"] == res.job_id
+    assert manifest["format"] == "parquet"
+    assert manifest["targets"] == [
+        {"target": "calls", "expected_rows": 3, "object": "calls/data.parquet"}
+    ]
+
+
+def test_manifest_builder_keeps_the_customer_facing_job_shape():
+    manifest = json.loads(
+        export.build_manifest_json("job-123", [("calls", 3), ("feedback", 1)])
+    )
+    assert manifest["job_id"] == "job-123"
+    assert manifest["format"] == "parquet"
+    assert manifest["targets"] == [
+        {"target": "calls", "expected_rows": 3, "object": "calls/data.parquet"},
+        {
+            "target": "feedback",
+            "expected_rows": 1,
+            "object": "feedback/data.parquet",
+        },
+    ]
+    assert export.export_job_prefix("p", "j") == "exports/p/j/"
+
+
+def _insert_calls(trace_server, project_id: str, count: int) -> None:
+    """Insert real completed calls through the public write path."""
+    batch = [_make_completed_call(project_id, str(uuid.uuid4())) for _ in range(count)]
+    trace_server.calls_complete(tsi.CallsUpsertCompleteReq(batch=batch))

--- a/tests/trace_server/test_export_status.py
+++ b/tests/trace_server/test_export_status.py
@@ -181,7 +181,7 @@ def test_presign_on_done_downloads_exact_artifact(
         storage_client.base_uri.with_path(
             export.export_job_prefix(project_id, job_id) + "manifest.json"
         ),
-        export.build_manifest_json(job_id, ["objects"]),
+        export.build_manifest_json(job_id, [("objects", 5)]),
     )
     key = export.export_object_prefix(project_id, job_id, "objects") + "data.parquet"
     artifact = b"PAR1-status-artifact"

--- a/tests/trace_server/test_export_status.py
+++ b/tests/trace_server/test_export_status.py
@@ -1,0 +1,221 @@
+"""Functional status-path tests for the managed-bucket export engine.
+
+Real ClickHouse provides the ``system.query_log`` oracle and moto exercises
+the real S3 storage client for the durable manifest, artifact, and presign
+paths. No job table or in-memory job registry participates in this flow.
+"""
+
+import time
+import uuid
+
+import boto3
+import pytest
+import requests
+from clickhouse_connect.driver.client import Client as CHClient
+from clickhouse_connect.driver.exceptions import DatabaseError
+from moto import mock_aws
+
+from tests.trace.server_utils import find_server_layer
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
+from tests.trace_server.conftest import TEST_ENTITY
+from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
+from weave.trace_server import export
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.file_storage import S3StorageClient
+from weave.trace_server.file_storage_credentials import AWSCredentials
+from weave.trace_server.file_storage_uris import S3FileStorageURI
+
+pytestmark = pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: export status via query_log"
+)
+
+ORACLE_DEADLINE_SECONDS = 20
+SCRATCH_TABLE = "export_status_scratch"
+BUCKET = "weave-exports"
+
+
+@pytest.fixture
+def clickhouse_trace_server(trace_server):
+    """Unwrap the internal ClickHouse server from the external fixture."""
+    return find_server_layer(trace_server, ClickHouseTraceServer)
+
+
+@pytest.fixture
+def storage_client():
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=BUCKET)
+        credentials: AWSCredentials = {
+            "access_key_id": "test-key",
+            "secret_access_key": "test-secret",
+            "session_token": None,
+            "region": "us-east-1",
+            "kms_key": None,
+        }
+        yield S3StorageClient(
+            S3FileStorageURI.parse_uri_str(f"s3://{BUCKET}"), credentials
+        )
+
+
+def test_poll_query_status_oracle_against_real_query_log(clickhouse_trace_server):
+    ch = clickhouse_trace_server.ch_client
+    _make_scratch_table(ch)
+
+    done_qid = f"{uuid.uuid4()}:objects"
+    ch.command(
+        f"INSERT INTO {SCRATCH_TABLE} SELECT number FROM numbers(7)",
+        settings={"query_id": done_qid},
+    )
+    assert _poll_until_terminal(ch, done_qid) == ("done", 7, None)
+
+    error_qid = f"{uuid.uuid4()}:objects"
+    with pytest.raises(DatabaseError):
+        ch.command(
+            "SELECT throwIf(number = 0, 'boom') FROM numbers(1)",
+            settings={"query_id": error_qid},
+        )
+    status, rows, error = _poll_until_terminal(ch, error_qid)
+    assert (status, rows) == ("error", 0)
+    assert error is not None
+    assert "boom" in error
+
+    assert export.poll_query_status(ch, f"{uuid.uuid4()}:objects") == (
+        "running",
+        0,
+        None,
+    )
+
+
+def test_export_status_recovers_job_with_no_memory_state(
+    clickhouse_trace_server, storage_client: S3StorageClient
+):
+    project_id = b64(f"{TEST_ENTITY}/export-status-recovery")
+    clickhouse_trace_server._file_storage_client = storage_client
+    clickhouse_trace_server._file_storage_client_initialized = True
+    start_res = clickhouse_trace_server.export_start(
+        tsi.ExportStartReq(project_id=project_id, targets=["objects", "feedback"])
+    )
+    # A brand-new server instance proves status is recovered from object storage
+    # plus query_log, not a process-local map or a ClickHouse metadata table.
+    fresh_server = ClickHouseTraceServer(
+        host=clickhouse_trace_server._host,
+        port=clickhouse_trace_server._port,
+        user=clickhouse_trace_server._user,
+        password=clickhouse_trace_server._password,
+        database=clickhouse_trace_server._database,
+    )
+    fresh_server._file_storage_client = storage_client
+    fresh_server._file_storage_client_initialized = True
+    status_req = tsi.ExportStatusReq(project_id=project_id, job_id=start_res.job_id)
+    deadline = time.monotonic() + ORACLE_DEADLINE_SECONDS
+    status_res = fresh_server.export_status(status_req)
+    # The detached inserts fail (no weave_exports collection in the test CH);
+    # wait until both targets reach their terminal error in query_log.
+    while time.monotonic() < deadline and any(
+        entry.status != "error" for entry in status_res.manifest
+    ):
+        time.sleep(0.5)
+        status_res = fresh_server.export_status(status_req)
+
+    assert status_res.status == "error"
+    assert [entry.target for entry in status_res.manifest] == ["objects", "feedback"]
+    for entry in status_res.manifest:
+        assert entry.status == "error"
+        assert entry.error is not None
+        assert entry.error != ""
+        assert entry.rows == 0
+        assert entry.objects == []
+        assert entry.urls == []
+        assert entry.expires_at is None
+
+
+def test_cross_tenant_unknown_and_traversal_guards(
+    clickhouse_trace_server, storage_client: S3StorageClient
+):
+    project_a = b64(f"{TEST_ENTITY}/export-status-tenant-a")
+    project_b = b64(f"{TEST_ENTITY}/export-status-tenant-b")
+    clickhouse_trace_server._file_storage_client = storage_client
+    clickhouse_trace_server._file_storage_client_initialized = True
+    start_res = clickhouse_trace_server.export_start(
+        tsi.ExportStartReq(project_id=project_a, targets=["objects"])
+    )
+
+    with pytest.raises(export.ExportError) as cross_tenant:
+        clickhouse_trace_server.export_status(
+            tsi.ExportStatusReq(project_id=project_b, job_id=start_res.job_id)
+        )
+    assert (cross_tenant.value.http_status, cross_tenant.value.code) == (
+        404,
+        "NOT_FOUND",
+    )
+
+    with pytest.raises(export.ExportError) as unknown:
+        clickhouse_trace_server.export_status(
+            tsi.ExportStatusReq(project_id=project_a, job_id=str(uuid.uuid4()))
+        )
+    assert (unknown.value.http_status, unknown.value.code) == (404, "NOT_FOUND")
+
+    with pytest.raises(export.ExportError) as traversal:
+        clickhouse_trace_server.export_status(
+            tsi.ExportStatusReq(project_id=project_a, job_id="../../etc/passwd")
+        )
+    assert (traversal.value.http_status, traversal.value.code) == (400, "BAD_JOB_ID")
+
+
+def test_presign_on_done_downloads_exact_artifact(
+    clickhouse_trace_server, storage_client: S3StorageClient
+):
+    ch = clickhouse_trace_server.ch_client
+    project_id = b64(f"{TEST_ENTITY}/export-status-presign")
+    job_id = str(uuid.uuid4())
+
+    # Make the oracle report objects done via a real insert under the job's query_id.
+    _make_scratch_table(ch)
+    ch.command(
+        f"INSERT INTO {SCRATCH_TABLE} SELECT number FROM numbers(5)",
+        settings={"query_id": f"{job_id}:objects"},
+    )
+    assert _poll_until_terminal(ch, f"{job_id}:objects") == ("done", 5, None)
+
+    storage_client.store(
+        storage_client.base_uri.with_path(
+            export.export_job_prefix(project_id, job_id) + "manifest.json"
+        ),
+        export.build_manifest_json(job_id, ["objects"]),
+    )
+    key = export.export_object_prefix(project_id, job_id, "objects") + "data.parquet"
+    artifact = b"PAR1-status-artifact"
+    storage_client.store(storage_client.base_uri.with_path(key), artifact)
+
+    res = export.get_export_status(ch, storage_client, project_id, job_id)
+    assert res.status == "done"
+    entry = res.manifest[0]
+    assert (entry.target, entry.status, entry.rows) == ("objects", "done", 5)
+    assert entry.objects == [key]
+    assert len(entry.urls) == 1
+    assert entry.expires_at is not None
+    assert entry.error is None
+    # Real read-only download over the presigned GET: no CH creds involved.
+    assert requests.get(entry.urls[0], timeout=5).content == artifact
+
+
+def _make_scratch_table(ch: CHClient) -> None:
+    ch.command(
+        f"CREATE TABLE IF NOT EXISTS {SCRATCH_TABLE} "
+        "(n UInt64) ENGINE = MergeTree ORDER BY n"
+    )
+
+
+def _poll_until_terminal(
+    ch: CHClient, query_id: str
+) -> tuple[tsi.ExportJobStatus, int, str | None]:
+    """FLUSH LOGS + poll the oracle until it leaves running (or times out)."""
+    deadline = time.monotonic() + ORACLE_DEADLINE_SECONDS
+    result: tuple[tsi.ExportJobStatus, int, str | None] = ("running", 0, None)
+    while time.monotonic() < deadline:
+        ch.command("SYSTEM FLUSH LOGS")
+        result = export.poll_query_status(ch, query_id)
+        if result[0] != "running":
+            return result
+        time.sleep(0.5)
+    return result

--- a/tests/trace_server/test_export_write_path.py
+++ b/tests/trace_server/test_export_write_path.py
@@ -1,0 +1,211 @@
+"""Write-path tests for the managed-bucket export engine.
+
+The job manifest is stored through the real file-storage implementation before
+the detached ClickHouse inserts begin. The local test ClickHouse intentionally
+has no production named collection, so the native inserts finish as errors in
+``system.query_log`` rather than writing production-like artifacts.
+"""
+
+import json
+import time
+import uuid
+from unittest.mock import MagicMock
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from tests.trace.server_utils import find_server_layer
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
+from tests.trace_server.conftest import TEST_ENTITY
+from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
+from weave.trace_server import export
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.export_targets import (
+    build_feedback_export_query,
+)
+from weave.trace_server.file_storage import S3StorageClient
+from weave.trace_server.file_storage_credentials import AWSCredentials
+from weave.trace_server.file_storage_uris import S3FileStorageURI
+from weave.trace_server.project_version.types import ReadTable
+
+pytestmark = pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: export write path"
+)
+
+QUERY_LOG_POLL_SECONDS = 20
+BUCKET = "weave-export-write-path"
+
+
+@pytest.fixture
+def storage_client():
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=BUCKET)
+        credentials: AWSCredentials = {
+            "access_key_id": "test-key",
+            "secret_access_key": "test-secret",
+            "session_token": None,
+            "region": "us-east-1",
+            "kms_key": None,
+        }
+        yield S3StorageClient(
+            S3FileStorageURI.parse_uri_str(f"s3://{BUCKET}"), credentials
+        )
+
+
+@pytest.fixture
+def clickhouse_trace_server(trace_server):
+    """Unwrap the internal ClickHouse server from the external fixture."""
+    return find_server_layer(trace_server, ClickHouseTraceServer)
+
+
+def test_build_export_insert_sql_exact_string():
+    sql = export.build_export_insert_sql(
+        export.ResolvedExportTarget("feedback", build_feedback_export_query()),
+        "exports/proj/job/feedback/data.parquet",
+    )
+    # Complete-string equality: the collection appears by name only, so the
+    # ch-writer credential can never leak into SQL or query_log.
+    assert sql == (
+        "INSERT INTO FUNCTION s3(weave_exports, "
+        "filename = 'exports/proj/job/feedback/data.parquet', format = 'Parquet') "
+        "SELECT * FROM feedback WHERE project_id = {project_id:String}"
+    )
+
+
+def test_start_export_runs_targets_serially_in_one_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    storage_client: S3StorageClient,
+):
+    worker_starts: list[tuple[object, tuple[object, ...], bool]] = []
+
+    class _ImmediateThread:
+        def __init__(self, *, target, args, daemon):
+            worker_starts.append((target, args, daemon))
+
+        def start(self):
+            target, args, _ = worker_starts[-1]
+            target(*args)
+
+    export_client = MagicMock()
+    command_query_ids: list[str] = []
+
+    def _command(_sql, *, parameters, settings):
+        assert parameters == {"project_id": "project"}
+        command_query_ids.append(settings["query_id"])
+        if len(command_query_ids) == 1:
+            raise RuntimeError("first target failed")
+
+    export_client.command.side_effect = _command
+    mint_client = MagicMock(return_value=export_client)
+    monkeypatch.setattr(export.threading, "Thread", _ImmediateThread)
+
+    job_id = export.start_export(
+        mint_client,
+        storage_client,
+        "project",
+        ["objects", "feedback"],
+        ReadTable.CALLS_COMPLETE,
+    )
+
+    assert len(worker_starts) == 1
+    assert worker_starts[0][2] is True
+    assert mint_client.call_count == 1
+    assert command_query_ids == [f"{job_id}:objects", f"{job_id}:feedback"]
+    manifest = json.loads(
+        storage_client.read(
+            storage_client.base_uri.with_path(
+                export.export_job_prefix("project", job_id) + "manifest.json"
+            )
+        )
+    )
+    assert manifest["job_id"] == job_id
+    assert [target["target"] for target in manifest["targets"]] == [
+        "objects",
+        "feedback",
+    ]
+
+
+def test_export_start_writes_manifest_without_creating_a_clickhouse_table(
+    clickhouse_trace_server, storage_client: S3StorageClient
+):
+    clickhouse_trace_server._file_storage_client = storage_client
+    clickhouse_trace_server._file_storage_client_initialized = True
+    project_id = b64(f"{TEST_ENTITY}/export-write-path")
+    res = clickhouse_trace_server.export_start(
+        tsi.ExportStartReq(project_id=project_id, targets=["objects", "feedback"])
+    )
+    assert export.JOB_ID_RE.match(res.job_id)
+    assert clickhouse_trace_server.ch_client.query(
+        "EXISTS TABLE export_jobs"
+    ).result_rows == [(0,)]
+    manifest = json.loads(
+        storage_client.read(
+            storage_client.base_uri.with_path(
+                export.export_job_prefix(project_id, res.job_id) + "manifest.json"
+            )
+        )
+    )
+    assert manifest["job_id"] == res.job_id
+    assert [target["target"] for target in manifest["targets"]] == [
+        "objects",
+        "feedback",
+    ]
+
+
+def test_export_start_query_id_lands_in_query_log(
+    clickhouse_trace_server, storage_client: S3StorageClient
+):
+    clickhouse_trace_server._file_storage_client = storage_client
+    clickhouse_trace_server._file_storage_client_initialized = True
+    project_id = b64(f"{TEST_ENTITY}/export-query-log")
+    res = clickhouse_trace_server.export_start(
+        tsi.ExportStartReq(project_id=project_id, targets=["objects"])
+    )
+    qid = f"{res.job_id}:objects"
+    ch = clickhouse_trace_server.ch_client
+    deadline = time.monotonic() + QUERY_LOG_POLL_SECONDS
+    rows: list[tuple[str]] = []
+    while time.monotonic() < deadline:
+        ch.command("SYSTEM FLUSH LOGS")
+        rows = ch.query(
+            "SELECT DISTINCT query_id FROM system.query_log "
+            "WHERE query_id = {qid:String}",
+            parameters={"qid": qid},
+        ).result_rows
+        if rows:
+            break
+        time.sleep(0.5)
+    assert rows == [(qid,)]
+
+
+def test_bad_target_and_job_id_validation(storage_client: S3StorageClient):
+    with pytest.raises(export.ExportError) as exc_info:
+        export.start_export(
+            MagicMock(),
+            storage_client,
+            "project",
+            ["objects", "nope"],
+            ReadTable.CALLS_COMPLETE,
+        )
+    assert exc_info.value.http_status == 400
+    assert exc_info.value.code == "BAD_TARGET"
+    assert export.JOB_ID_RE.match("not-a-uuid") is None
+    assert export.JOB_ID_RE.match(str(uuid.uuid4()))
+    assert export.export_object_prefix("p", "j", "calls") == "exports/p/j/calls/"
+
+
+@pytest.mark.parametrize("targets", [[], ["objects", "objects"]])
+def test_empty_and_duplicate_targets_are_rejected(
+    storage_client: S3StorageClient, targets: list[str]
+):
+    with pytest.raises(export.ExportError) as exc_info:
+        export.start_export(
+            MagicMock(),
+            storage_client,
+            "project",
+            targets,
+            ReadTable.CALLS_COMPLETE,
+        )
+    assert (exc_info.value.http_status, exc_info.value.code) == (400, "BAD_TARGET")

--- a/tests/trace_server/test_export_write_path.py
+++ b/tests/trace_server/test_export_write_path.py
@@ -99,9 +99,12 @@ def test_start_export_runs_targets_serially_in_one_worker(
 
     export_client.command.side_effect = _command
     mint_client = MagicMock(return_value=export_client)
+    count_client = MagicMock()
+    count_client.query.return_value.result_rows = [(0,)]
     monkeypatch.setattr(export.threading, "Thread", _ImmediateThread)
 
     job_id = export.start_export(
+        count_client,
         mint_client,
         storage_client,
         "project",
@@ -184,6 +187,7 @@ def test_bad_target_and_job_id_validation(storage_client: S3StorageClient):
     with pytest.raises(export.ExportError) as exc_info:
         export.start_export(
             MagicMock(),
+            MagicMock(),
             storage_client,
             "project",
             ["objects", "nope"],
@@ -202,6 +206,7 @@ def test_empty_and_duplicate_targets_are_rejected(
 ):
     with pytest.raises(export.ExportError) as exc_info:
         export.start_export(
+            MagicMock(),
             MagicMock(),
             storage_client,
             "project",

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7386,6 +7386,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         return tsi.ExportStartRes(job_id=job_id)
 
+    def export_status(self, req: tsi.ExportStatusReq) -> tsi.ExportStatusRes:
+        return export.get_export_status(
+            self.ch_client, self.file_storage_client, req.project_id, req.job_id
+        )
+
     # Private Methods
     @property
     def ch_client(self) -> CHClient:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -45,6 +45,7 @@ from weave.shared.trace_server_interface_util import (
 from weave.trace_server import (
     ch_sentinel_values,
     constants,
+    export,
     object_creation_utils,
     usage_utils,
 )
@@ -7367,6 +7368,23 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 )
 
         return res
+
+    def export_start(self, req: tsi.ExportStartReq) -> tsi.ExportStartRes:
+        calls_read_table = ReadTable.CALLS_COMPLETE
+        if "calls" in req.targets:
+            calls_read_table = self.table_routing_resolver.resolve_read_table(
+                req.project_id, self.ch_client
+            )
+        job_id = export.start_export(
+            lambda: self._mint_client(
+                send_receive_timeout=export.EXPORT_MAX_EXECUTION_SECONDS
+            ),
+            self.file_storage_client,
+            req.project_id,
+            req.targets,
+            calls_read_table,
+        )
+        return tsi.ExportStartRes(job_id=job_id)
 
     # Private Methods
     @property

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7376,6 +7376,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 req.project_id, self.ch_client
             )
         job_id = export.start_export(
+            self.ch_client,
             lambda: self._mint_client(
                 send_receive_timeout=export.EXPORT_MAX_EXECUTION_SECONDS
             ),

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -15,6 +15,9 @@ DEFAULT_SCORING_WORKER_BATCH_TIMEOUT = 5
 DEFAULT_ASYNC_INSERT_BUSY_TIMEOUT_MIN_MS = 100
 DEFAULT_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS = 1000
 
+# Managed-bucket export defaults
+DEFAULT_EXPORT_MAX_ROWS = 5_000_000
+
 # Kafka Settings
 
 
@@ -570,6 +573,27 @@ def wf_file_storage_project_ramp_pct() -> int | None:
         )
 
     return pct
+
+
+# Export Settings
+
+
+def wf_export_max_rows() -> int:
+    """Per-target row cap for managed-bucket exports.
+
+    Raises:
+        ValueError: If the value is set but not a valid integer.
+    """
+    raw = os.environ.get("WF_EXPORT_MAX_ROWS")
+    if not raw:
+        return DEFAULT_EXPORT_MAX_ROWS
+
+    try:
+        return int(raw)
+    except ValueError as e:
+        raise ValueError(
+            f"WF_EXPORT_MAX_ROWS is not a valid integer: {raw}. Error: {e!s}"
+        ) from e
 
 
 # Inference Service Settings

--- a/weave/trace_server/export.py
+++ b/weave/trace_server/export.py
@@ -1,4 +1,4 @@
-"""Detached ClickHouse -> S3 export write path.
+"""Detached ClickHouse -> S3 export write and status paths.
 
 `start_export` writes the job's manifest object before starting one background
 worker. The worker runs each `INSERT INTO FUNCTION s3()` serially, while the
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from clickhouse_connect.driver.client import Client as CHClient
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
+from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.export_targets import EXPORT_TARGET_NAMES, build_export_query
 from weave.trace_server.file_storage import (
     FileStorageClient,
@@ -68,6 +69,59 @@ def start_export(
         daemon=True,
     ).start()
     return job_id
+
+
+def get_export_status(
+    ch_client: CHClient,
+    file_storage_client: FileStorageClient | None,
+    project_id: str,
+    job_id: str,
+) -> tsi.ExportStatusRes:
+    """Read the job manifest, then derive target status from ``query_log``."""
+    if not JOB_ID_RE.match(job_id):
+        # job_id is the only caller-influenced path segment; bar traversal.
+        raise ExportError(400, "BAD_JOB_ID", f"job_id {job_id!r} fails validation")
+    if file_storage_client is None:
+        raise ExportError(
+            503,
+            "EXPORT_STORAGE_UNAVAILABLE",
+            "export storage is not configured",
+        )
+    targets = _read_manifest_targets(file_storage_client, project_id, job_id)
+    ch_client.command("SYSTEM FLUSH LOGS")
+    manifest = [
+        _manifest_entry(ch_client, file_storage_client, project_id, job_id, target)
+        for target in targets
+    ]
+    overall: tsi.ExportJobStatus
+    if any(entry.status == "error" for entry in manifest):
+        overall = "error"
+    elif any(entry.status == "running" for entry in manifest):
+        overall = "running"
+    else:
+        overall = "done"
+    return tsi.ExportStatusRes(status=overall, manifest=manifest)
+
+
+def poll_query_status(
+    ch_client: CHClient, query_id: str
+) -> tuple[tsi.ExportJobStatus, int, str | None]:
+    """query_log oracle: map the latest event for query_id to (status, rows, error)."""
+    rows = ch_client.query(
+        "SELECT type, written_rows, exception FROM system.query_log "
+        "WHERE query_id = {qid:String} AND event_date >= today() - 1 "
+        "ORDER BY event_time_microseconds DESC LIMIT 1",
+        parameters={"qid": query_id},
+    ).result_rows
+    if not rows:
+        return "running", 0, None
+    event_type, written_rows, exception = rows[0]
+    if event_type == "QueryFinish":
+        return "done", int(written_rows), None
+    if str(event_type).startswith("Exception"):
+        return "error", 0, exception or "exception"
+    # Any other event (QueryStart): the insert is still in flight.
+    return "running", 0, None
 
 
 def build_export_insert_sql(target: ResolvedExportTarget, filename: str) -> str:
@@ -124,6 +178,78 @@ def _write_manifest(
             "EXPORT_STORAGE_UNAVAILABLE",
             "failed to persist export manifest",
         ) from exc
+
+
+def _read_manifest_targets(
+    file_storage_client: FileStorageClient, project_id: str, job_id: str
+) -> list[str]:
+    """Load and validate the job record under the authorized project prefix."""
+    uri = file_storage_client.base_uri.with_path(
+        export_job_prefix(project_id, job_id) + "manifest.json"
+    )
+    try:
+        manifest_bytes = file_storage_client.read(uri)
+    except Exception as exc:
+        # A different project's prefix resolves to a miss as well, so status
+        # never confirms the existence of another tenant's job.
+        raise ExportError(404, "NOT_FOUND", f"no such export job {job_id}") from exc
+    try:
+        manifest = json.loads(manifest_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ExportError(
+            500, "BAD_EXPORT_MANIFEST", "export manifest is invalid"
+        ) from exc
+    if not isinstance(manifest, dict) or manifest.get("job_id") != job_id:
+        raise ExportError(500, "BAD_EXPORT_MANIFEST", "export manifest is invalid")
+    raw_targets = manifest.get("targets")
+    if not isinstance(raw_targets, list) or not raw_targets:
+        raise ExportError(500, "BAD_EXPORT_MANIFEST", "export manifest is invalid")
+    targets: list[str] = []
+    for entry in raw_targets:
+        if (
+            not isinstance(entry, dict)
+            or entry.get("target") not in EXPORT_TARGET_NAMES
+        ):
+            raise ExportError(500, "BAD_EXPORT_MANIFEST", "export manifest is invalid")
+        targets.append(entry["target"])
+    if len(set(targets)) != len(targets):
+        raise ExportError(500, "BAD_EXPORT_MANIFEST", "export manifest is invalid")
+    return targets
+
+
+def _manifest_entry(
+    ch_client: CHClient,
+    file_storage_client: FileStorageClient,
+    project_id: str,
+    job_id: str,
+    target: str,
+) -> tsi.ExportManifestEntry:
+    status, rows, error = poll_query_status(ch_client, f"{job_id}:{target}")
+    objects: list[str] = []
+    urls: list[str] = []
+    expires_at: str | None = None
+    if status == "done":
+        # MVP writes exactly one deterministic object per target (no PARTITION BY);
+        # phase-2 partitioning will need real object listing here.
+        key = export_object_prefix(project_id, job_id, target) + "data.parquet"
+        objects = [key]
+        # Presigns against the configured file-storage bucket under exports/;
+        # this MUST be the same physical bucket the weave_exports collection writes to.
+        uri = file_storage_client.base_uri.with_path(key)
+        urls = [file_storage_client.presign_read(uri, PRESIGN_TTL_SECONDS)]
+        expires_at = (
+            datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(seconds=PRESIGN_TTL_SECONDS)
+        ).isoformat()
+    return tsi.ExportManifestEntry(
+        target=target,
+        status=status,
+        rows=rows,
+        objects=objects,
+        urls=urls,
+        expires_at=expires_at,
+        error=error,
+    )
 
 
 def _run_export(
@@ -183,3 +309,5 @@ EXPORT_S3_NAMED_COLLECTION = "weave_exports"
 # Bounds CH cost per detached insert via max_execution_time.
 EXPORT_MAX_EXECUTION_SECONDS = 300
 JOB_ID_RE = re.compile(r"^[0-9a-f-]{36}$")
+# Download-link lifetime for presigned GETs in the status manifest.
+PRESIGN_TTL_SECONDS = 3600

--- a/weave/trace_server/export.py
+++ b/weave/trace_server/export.py
@@ -1,0 +1,185 @@
+"""Detached ClickHouse -> S3 export write path.
+
+`start_export` writes the job's manifest object before starting one background
+worker. The worker runs each `INSERT INTO FUNCTION s3()` serially, while the
+manifest and `system.query_log` are the durable read path.
+"""
+
+import datetime
+import json
+import logging
+import re
+import threading
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from clickhouse_connect.driver.client import Client as CHClient
+
+from weave.trace_server import clickhouse_trace_server_settings as ch_settings
+from weave.trace_server.export_targets import EXPORT_TARGET_NAMES, build_export_query
+from weave.trace_server.file_storage import (
+    FileStorageClient,
+    FileStorageWriteError,
+    store_in_bucket,
+)
+from weave.trace_server.project_version.types import ReadTable
+
+logger = logging.getLogger(__name__)
+
+
+class ExportError(Exception):
+    def __init__(self, http_status: int, code: str, message: str) -> None:
+        super().__init__(message)
+        self.http_status = http_status
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ResolvedExportTarget:
+    """A target name paired with the one query used for count and export."""
+
+    name: str
+    source_sql: str
+
+
+def start_export(
+    mint_client: Callable[[], CHClient],
+    file_storage_client: FileStorageClient | None,
+    project_id: str,
+    target_names: list[str],
+    calls_read_table: ReadTable,
+) -> str:
+    """Write the job manifest, then run its targets serially off-thread."""
+    targets = _resolve_targets(target_names, calls_read_table)
+    if file_storage_client is None:
+        raise ExportError(
+            503,
+            "EXPORT_STORAGE_UNAVAILABLE",
+            "export storage is not configured",
+        )
+    job_id = str(uuid.uuid4())
+    if not JOB_ID_RE.match(job_id):
+        raise ExportError(500, "BAD_JOB_ID", f"job_id {job_id!r} fails validation")
+    _write_manifest(file_storage_client, project_id, job_id, target_names)
+    threading.Thread(
+        target=_run_export,
+        args=(mint_client, project_id, job_id, targets),
+        daemon=True,
+    ).start()
+    return job_id
+
+
+def build_export_insert_sql(target: ResolvedExportTarget, filename: str) -> str:
+    """Build the detached export INSERT.
+
+    The named collection is referenced by name only, so no credential ever
+    appears in the SQL or query_log. `filename` is built from server-derived,
+    validated parts (internal project_id, uuid4 job_id, supported target name);
+    the SELECT still binds project_id as `{project_id:String}`.
+    """
+    return (
+        f"INSERT INTO FUNCTION s3({EXPORT_S3_NAMED_COLLECTION}, "
+        f"filename = '{filename}', format = 'Parquet') {target.source_sql}"
+    )
+
+
+def export_object_prefix(project_id: str, job_id: str, target: str) -> str:
+    return export_job_prefix(project_id, job_id) + f"{target}/"
+
+
+def export_job_prefix(project_id: str, job_id: str) -> str:
+    return f"exports/{project_id}/{job_id}/"
+
+
+def build_manifest_json(job_id: str, target_names: list[str]) -> bytes:
+    """Build the durable job index without exposing the internal project id."""
+    manifest = {
+        "job_id": job_id,
+        "format": "parquet",
+        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "targets": [
+            {"target": name, "object": f"{name}/data.parquet"} for name in target_names
+        ],
+    }
+    return json.dumps(manifest, sort_keys=True).encode()
+
+
+def _write_manifest(
+    file_storage_client: FileStorageClient,
+    project_id: str,
+    job_id: str,
+    target_names: list[str],
+) -> None:
+    """Persist the job record before accepting detached work."""
+    try:
+        store_in_bucket(
+            file_storage_client,
+            export_job_prefix(project_id, job_id) + "manifest.json",
+            build_manifest_json(job_id, target_names),
+        )
+    except FileStorageWriteError as exc:
+        raise ExportError(
+            503,
+            "EXPORT_STORAGE_UNAVAILABLE",
+            "failed to persist export manifest",
+        ) from exc
+
+
+def _run_export(
+    mint_client: Callable[[], CHClient],
+    project_id: str,
+    job_id: str,
+    targets: list[ResolvedExportTarget],
+) -> None:
+    """Run one job's targets serially to bound its ClickHouse concurrency."""
+    client = mint_client()
+    for target in targets:
+        _run_target_insert(client, project_id, job_id, target)
+
+
+def _run_target_insert(
+    client: CHClient,
+    project_id: str,
+    job_id: str,
+    target: ResolvedExportTarget,
+) -> None:
+    filename = export_object_prefix(project_id, job_id, target.name) + "data.parquet"
+    sql = build_export_insert_sql(target, filename)
+    # `query_id` rides in settings: the driver routes valid_transport_settings
+    # keys to URL params (the `transport_settings` kwarg is raw headers CH ignores).
+    settings = ch_settings.merge_default_command_settings(
+        {
+            "max_execution_time": EXPORT_MAX_EXECUTION_SECONDS,
+            "query_id": f"{job_id}:{target.name}",
+        }
+    )
+    try:
+        client.command(sql, parameters={"project_id": project_id}, settings=settings)
+    except Exception:
+        # Detached by design: query_log records the failure for the status path.
+        logger.debug("export insert failed: %s:%s", job_id, target.name, exc_info=True)
+
+
+def _resolve_targets(
+    target_names: list[str], calls_read_table: ReadTable
+) -> list[ResolvedExportTarget]:
+    if not target_names:
+        raise ExportError(400, "BAD_TARGET", "at least one export target is required")
+    if len(set(target_names)) != len(target_names):
+        raise ExportError(400, "BAD_TARGET", "export targets must be unique")
+    targets: list[ResolvedExportTarget] = []
+    for name in target_names:
+        if name not in EXPORT_TARGET_NAMES:
+            raise ExportError(400, "BAD_TARGET", f"unknown export target {name!r}")
+        targets.append(
+            ResolvedExportTarget(name, build_export_query(name, calls_read_table))
+        )
+    return targets
+
+
+# CH server-config named collection holding the ch-writer S3 identity.
+EXPORT_S3_NAMED_COLLECTION = "weave_exports"
+# Bounds CH cost per detached insert via max_execution_time.
+EXPORT_MAX_EXECUTION_SECONDS = 300
+JOB_ID_RE = re.compile(r"^[0-9a-f-]{36}$")

--- a/weave/trace_server/export.py
+++ b/weave/trace_server/export.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from clickhouse_connect.driver.client import Client as CHClient
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
+from weave.trace_server import environment as wf_env
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.export_targets import EXPORT_TARGET_NAMES, build_export_query
 from weave.trace_server.file_storage import (
@@ -45,6 +46,7 @@ class ResolvedExportTarget:
 
 
 def start_export(
+    ch_client: CHClient,
     mint_client: Callable[[], CHClient],
     file_storage_client: FileStorageClient | None,
     project_id: str,
@@ -59,10 +61,23 @@ def start_export(
             "EXPORT_STORAGE_UNAVAILABLE",
             "export storage is not configured",
         )
+    # Fail closed before a job or artifact exists, so a rejected request cannot
+    # leave an object the status API might later discover.
+    targets_with_counts: list[tuple[str, int]] = []
+    cap = wf_env.wf_export_max_rows()
+    for target in targets:
+        rows = precount_rows(ch_client, project_id, target)
+        if rows > cap:
+            raise ExportError(
+                409,
+                "TOO_LARGE",
+                f"target {target.name!r} has {rows} rows > cap {cap}",
+            )
+        targets_with_counts.append((target.name, rows))
     job_id = str(uuid.uuid4())
     if not JOB_ID_RE.match(job_id):
         raise ExportError(500, "BAD_JOB_ID", f"job_id {job_id!r} fails validation")
-    _write_manifest(file_storage_client, project_id, job_id, target_names)
+    _write_manifest(file_storage_client, project_id, job_id, targets_with_counts)
     threading.Thread(
         target=_run_export,
         args=(mint_client, project_id, job_id, targets),
@@ -124,6 +139,17 @@ def poll_query_status(
     return "running", 0, None
 
 
+def precount_rows(
+    ch_client: CHClient, project_id: str, target: ResolvedExportTarget
+) -> int:
+    """Count the rows a target would export, project_id bound as a param."""
+    result = ch_client.query(
+        f"SELECT count() FROM ({target.source_sql})",
+        parameters={"project_id": project_id},
+    )
+    return int(result.result_rows[0][0])
+
+
 def build_export_insert_sql(target: ResolvedExportTarget, filename: str) -> str:
     """Build the detached export INSERT.
 
@@ -146,14 +172,21 @@ def export_job_prefix(project_id: str, job_id: str) -> str:
     return f"exports/{project_id}/{job_id}/"
 
 
-def build_manifest_json(job_id: str, target_names: list[str]) -> bytes:
+def build_manifest_json(
+    job_id: str, targets_with_counts: list[tuple[str, int]]
+) -> bytes:
     """Build the durable job index without exposing the internal project id."""
     manifest = {
         "job_id": job_id,
         "format": "parquet",
         "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         "targets": [
-            {"target": name, "object": f"{name}/data.parquet"} for name in target_names
+            {
+                "target": name,
+                "expected_rows": rows,
+                "object": f"{name}/data.parquet",
+            }
+            for name, rows in targets_with_counts
         ],
     }
     return json.dumps(manifest, sort_keys=True).encode()
@@ -163,14 +196,14 @@ def _write_manifest(
     file_storage_client: FileStorageClient,
     project_id: str,
     job_id: str,
-    target_names: list[str],
+    targets_with_counts: list[tuple[str, int]],
 ) -> None:
     """Persist the job record before accepting detached work."""
     try:
         store_in_bucket(
             file_storage_client,
             export_job_prefix(project_id, job_id) + "manifest.json",
-            build_manifest_json(job_id, target_names),
+            build_manifest_json(job_id, targets_with_counts),
         )
     except FileStorageWriteError as exc:
         raise ExportError(


### PR DESCRIPTION
## Summary
- Apply the per-target `WF_EXPORT_MAX_ROWS` cap before a job ID or manifest exists; an over-cap request fails closed with `409 TOO_LARGE` and leaves no export artifact.
- Successful starts add exact `expected_rows` values to the same S3-backed `manifest.json` job record. There is no ClickHouse job table and no best-effort second manifest write.

## Testing
- Real ClickHouse source data for cap accounting.
- Real S3 assertions that rejected jobs leave no objects, accepted jobs persist the expected manifest, and `export_jobs` remains absent.