### PR TITLE
fix(weave): normalize Claude Code chat projection

### DIFF
--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -678,6 +678,184 @@ def test_invoke_agent_mirrors_child_llm_output_messages() -> None:
     assert _assistant_payload(agent_messages[0]).text == "It's 72°F."
 
 
+def test_chat_span_mirrors_assistant_text_child() -> None:
+    """Claude Code emits assistant text on both the model chat span and a
+    direct assistant_text transcript child. The child keeps its timeline
+    position and inherits the parent model's richer metadata.
+    """
+
+    def at(milliseconds: int) -> datetime.datetime:
+        return datetime.datetime(
+            2026,
+            1,
+            1,
+            0,
+            0,
+            0,
+            milliseconds * 1000,
+            tzinfo=datetime.timezone.utc,
+        )
+
+    final_text = [
+        {
+            "role": "assistant",
+            "content": _parts(_text_part("I'll inspect the trace.")),
+        }
+    ]
+    spans = [
+        _span(
+            span_id="chat",
+            operation_name="chat",
+            agent_name="claude-code",
+            request_model="claude-opus-4-8",
+            agent_version="1.2.3",
+            output_messages=final_text,
+            reasoning_content="Check the trace structure first.",
+            reasoning_tokens=12,
+            input_tokens=200,
+            output_tokens=40,
+            total_cost_usd=0.03,
+            started_at=at(100),
+            ended_at=at(900),
+        ),
+        _span(
+            span_id="assistant-text",
+            parent_span_id="chat",
+            operation_name="assistant_text",
+            agent_name="claude-code",
+            output_messages=final_text,
+            started_at=at(500),
+            ended_at=at(500),
+        ),
+    ]
+
+    assistant_messages = [
+        message
+        for message in build_chat_messages(spans)
+        if message.type == "assistant_message"
+    ]
+
+    assert len(assistant_messages) == 1
+    message = assistant_messages[0]
+    payload = _assistant_payload(message)
+    assert message.span_id == "assistant-text"
+    assert message.started_at == at(500)
+    assert message.agent_version == "1.2.3"
+    assert payload.text == "I'll inspect the trace."
+    assert payload.model == "claude-opus-4-8"
+    assert payload.reasoning_content == "Check the trace structure first."
+    assert payload.reasoning_tokens == 12
+    assert payload.input_tokens == 200
+    assert payload.output_tokens == 40
+    assert payload.total_cost_usd == 0.03
+    assert payload.duration_ms == 800
+
+
+def test_chat_span_keeps_distinct_child_assistant_text() -> None:
+    """Only exact mirrored text coalesces; distinct parent/child replies stay
+    separate.
+    """
+    spans = [
+        _span(
+            span_id="chat",
+            operation_name="chat",
+            output_messages=[{"role": "assistant", "content": "Final answer"}],
+        ),
+        _span(
+            span_id="assistant-text",
+            parent_span_id="chat",
+            operation_name="assistant_text",
+            output_messages=[{"role": "assistant", "content": "Progress update"}],
+        ),
+    ]
+
+    assistant_texts = [
+        _assistant_payload(message).text
+        for message in build_chat_messages(spans)
+        if message.type == "assistant_message"
+    ]
+
+    assert assistant_texts == ["Progress update", "Final answer"]
+
+
+def test_chat_spans_use_assistant_text_children_for_sibling_order() -> None:
+    """Claude Code chat siblings can share a coarse start timestamp while
+    their transcript children retain the true assistant-message order.
+    """
+
+    def at(milliseconds: int) -> datetime.datetime:
+        return datetime.datetime(
+            2026,
+            1,
+            1,
+            0,
+            0,
+            0,
+            milliseconds * 1000,
+            tzinfo=datetime.timezone.utc,
+        )
+
+    first = [{"role": "assistant", "content": "First update"}]
+    second = [{"role": "assistant", "content": "Second update"}]
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            started_at=at(0),
+            ended_at=at(400),
+        ),
+        # The later response has the longer parent span, which is the normal
+        # equal-start tiebreaker. Its transcript child must override that.
+        _span(
+            span_id="chat-second",
+            parent_span_id="agent",
+            operation_name="chat",
+            output_messages=second,
+            started_at=at(100),
+            ended_at=at(300),
+        ),
+        _span(
+            span_id="text-second",
+            parent_span_id="chat-second",
+            operation_name="assistant_text",
+            output_messages=second,
+            started_at=at(250),
+            ended_at=at(250),
+        ),
+        _span(
+            span_id="chat-first",
+            parent_span_id="agent",
+            operation_name="chat",
+            output_messages=first,
+            started_at=at(100),
+            ended_at=at(200),
+        ),
+        _span(
+            span_id="text-first",
+            parent_span_id="chat-first",
+            operation_name="assistant_text",
+            output_messages=first,
+            started_at=at(150),
+            ended_at=at(150),
+        ),
+    ]
+
+    assistants = [
+        message
+        for message in build_chat_messages(spans)
+        if message.type == "assistant_message"
+    ]
+
+    assert [message.span_id for message in assistants] == [
+        "text-first",
+        "text-second",
+    ]
+    assert [_assistant_payload(message).text for message in assistants] == [
+        "First update",
+        "Second update",
+    ]
+
+
 def test_invoke_agent_emits_when_no_descendant_llm_span() -> None:
     """If an invoke_agent has output_messages but no descendant LLM span
     carries them, the parent still emits — the guard is "child emitted
@@ -703,6 +881,34 @@ def test_invoke_agent_emits_when_no_descendant_llm_span() -> None:
     agent_messages = [m for m in messages if m.type == "assistant_message"]
     assert len(agent_messages) == 1
     assert _assistant_payload(agent_messages[0]).text == "hi there"
+
+
+def test_claude_async_agent_launch_renders_as_tool_activity() -> None:
+    """Claude Code's async launch envelope is execution state, not a reply."""
+    launch = json.dumps(
+        {
+            "isAsync": True,
+            "status": "async_launched",
+            "agentId": "worker-1",
+            "description": "Inspect the frontend cost card",
+        }
+    )
+    messages = build_chat_messages(
+        [
+            _span(
+                span_id="explore-agent",
+                operation_name="invoke_agent",
+                agent_name="Explore",
+                output_messages=[{"role": "assistant", "content": launch}],
+            )
+        ]
+    )
+
+    assert [message.type for message in messages] == ["agent_start", "tool_call"]
+    tool = _tool_payload(messages[1])
+    assert tool.tool_name == "Start Explore"
+    assert tool.tool_arguments == "Inspect the frontend cost card"
+    assert tool.tool_result == launch
 
 
 def test_reasoning_part_not_duplicated_in_assistant_text() -> None:
@@ -941,6 +1147,83 @@ def test_system_message_not_used_as_user_prompt_fallback() -> None:
     )
 
     assert [m.type for m in messages] == ["assistant_message"]
+
+
+def test_claude_task_notification_renders_as_tool_activity() -> None:
+    """Claude Code sends async subagent completions to the model as role=user,
+    but the chat trajectory must not present them as a human prompt.
+    """
+    notification = (
+        "<task-notification>\n"
+        "<task-id>worker-1</task-id>\n"
+        "<output-file>/tmp/worker-1.txt</output-file>\n"
+        "<status>completed</status>\n"
+        "</task-notification>"
+    )
+    messages = build_chat_messages(
+        [
+            _span(
+                span_id="claude-chat",
+                operation_name="chat",
+                agent_name="claude-code",
+                input_messages=[{"role": "user", "content": notification}],
+                output_messages=[
+                    {"role": "assistant", "content": "Worker result received."}
+                ],
+            )
+        ]
+    )
+
+    assert [message.type for message in messages] == [
+        "tool_call",
+        "assistant_message",
+    ]
+    tool_message = messages[0]
+    tool = _tool_payload(tool_message)
+    assert tool_message.span_id == "claude-chat"
+    assert tool_message.agent_name == "claude-code"
+    assert tool.tool_name == "Task notification"
+    assert tool.tool_result == notification
+    assert all(message.type != "user_message" for message in messages)
+
+
+def test_claude_task_notification_falls_back_from_invoke_agent() -> None:
+    """Claude session turns can record the notification only on the enclosing
+    invoke_agent span rather than the child chat span.
+    """
+    notification = (
+        "<task-notification>\n"
+        "<task-id>worker-1</task-id>\n"
+        "<status>completed</status>\n"
+        "</task-notification>"
+    )
+    messages = build_chat_messages(
+        [
+            _span(
+                span_id="agent",
+                operation_name="invoke_agent",
+                agent_name="claude-code",
+                input_messages=[{"role": "user", "content": notification}],
+            ),
+            _span(
+                span_id="chat",
+                parent_span_id="agent",
+                operation_name="chat",
+                output_messages=[
+                    {"role": "assistant", "content": "Worker result received."}
+                ],
+            ),
+        ]
+    )
+
+    assert [message.type for message in messages] == [
+        "tool_call",
+        "agent_start",
+        "assistant_message",
+    ]
+    tool_message = messages[0]
+    assert tool_message.span_id == "agent"
+    assert _tool_payload(tool_message).tool_result == notification
 
 
 def test_input_media_attaches_to_user_message_not_assistant() -> None:

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -7,9 +7,10 @@ tool calls, assistant responses, and context compaction events.
 
 This is a Weave product projection, not an OTel semantic-convention layer.
 Subagent spans remain inline in the same turn, inheriting the nearest enclosing
-agent label unless they provide their own. When SDKs mirror the final assistant
-text onto both an `invoke_agent` span and a descendant LLM span, the descendant
-message wins and the parent invoke output is suppressed.
+agent label unless they provide their own. When SDKs mirror assistant text onto
+both a model span and a descendant transcript span, the descendant message keeps
+its precise ordering while inheriting the model span's richer metadata. Mirrored
+`invoke_agent` output is likewise suppressed when a descendant already emitted.
 """
 
 from __future__ import annotations
@@ -52,6 +53,14 @@ _NON_USER_PROMPT_ROLES = {
     "tool_call",
     "tool_result",
 }
+
+# Claude Code feeds asynchronous subagent completions back into the model as a
+# synthetic role=user XML message. It is execution context, not a human prompt,
+# and belongs with tool activity in the trajectory.
+_CLAUDE_TASK_NOTIFICATION_OPEN = "<task-notification>"
+_CLAUDE_TASK_NOTIFICATION_CLOSE = "</task-notification>"
+_CHAT_OPERATION = "chat"
+_ASSISTANT_TEXT_OPERATION = "assistant_text"
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +121,36 @@ def _span_sort_key(span: AgentSpanSchema) -> tuple[bool, float, bool, float, str
         span.ended_at is None,
         -_datetime_sort_seconds(span.ended_at),
         span.span_id,
+    )
+
+
+def _span_node_sort_key(
+    node: SpanNode,
+) -> tuple[bool, float, bool, float, str]:
+    """Order chat nodes by their precise transcript event when available.
+
+    Claude Code can give sibling ``chat`` spans the same coarse start time.
+    Their direct ``assistant_text`` children carry the actual emission times,
+    so use the earliest such child to place the whole model-response node among
+    its siblings. Other nodes retain the established span ordering policy.
+    """
+    event_time = node.span.started_at
+    if node.span.operation_name == _CHAT_OPERATION:
+        transcript_times = [
+            child.span.started_at
+            for child in node.children
+            if child.span.operation_name == _ASSISTANT_TEXT_OPERATION
+            and child.span.started_at is not None
+        ]
+        if transcript_times:
+            event_time = min(transcript_times)
+
+    return (
+        event_time is None,
+        _datetime_sort_seconds(event_time),
+        node.span.ended_at is None,
+        -_datetime_sort_seconds(node.span.ended_at),
+        node.span.span_id,
     )
 
 
@@ -218,7 +257,9 @@ def build_chat_messages(spans: list[AgentSpanSchema]) -> list[AgentChatMessage]:
 
     Only when the walk surfaces no user message at all — e.g. an SDK that
     records the prompt on the enclosing `invoke_agent` span rather than the LLM
-    span — do we fall back to a single synthesized leading prompt.
+    span — do we fall back to a synthesized leading prompt. Claude Code task
+    notifications recorded only on that wrapper receive the equivalent fallback
+    as tool activity.
     """
     if not spans:
         return []
@@ -228,8 +269,14 @@ def build_chat_messages(spans: list[AgentSpanSchema]) -> list[AgentChatMessage]:
     traversal.walk_roots(tree)
 
     messages = traversal.messages
+    leading_context: list[AgentChatMessage] = []
     if not traversal.emitted_user and (user_message := _find_user_message(spans)):
-        messages.insert(0, user_message)
+        leading_context.append(user_message)
+    if not traversal.emitted_task_notification and (
+        task_notification := _find_task_notification(spans)
+    ):
+        leading_context.append(task_notification)
+    messages[:0] = leading_context
 
     # The walk emits an invoke_agent's `agent_start` before descending to the
     # chat span that carries that turn's user message, but the user speaks
@@ -260,6 +307,10 @@ class ChatTraversal:
     # True once any per-turn user message has been emitted during the walk;
     # gates the invoke_agent leading-prompt fallback in build_chat_messages.
     emitted_user: bool = False
+    # True once a Claude Code async task notification has been surfaced as
+    # tool activity. Like emitted_user, this prevents the invoke_agent input
+    # fallback from projecting the same context twice.
+    emitted_task_notification: bool = False
     # (text, media-digests) of the most recently emitted user message, so the
     # same message replayed by a following LLM span is not emitted twice.
     _last_user_sig: tuple[str, tuple[str, ...]] | None = None
@@ -359,8 +410,37 @@ class ChatTraversal:
         if not subtree_emitted_assistant:
             msg = _emit_assistant_message(span, subtree_agent, aggregate_node=node)
             if msg:
-                self.messages.append(msg)
-                subtree_emitted_assistant = True
+                assistant = msg.assistant_message
+                launch = (
+                    _claude_async_agent_launch(assistant.text) if assistant else None
+                )
+                if launch is not None and assistant is not None:
+                    description = launch.get("description")
+                    self.messages.append(
+                        AgentChatMessage(
+                            type="tool_call",
+                            span_id=span.span_id,
+                            agent_name=subtree_agent,
+                            agent_version=span.agent_version,
+                            status_code=span.status_code,
+                            started_at=span.started_at,
+                            tool_call=AgentChatToolCall(
+                                tool_name=f"Start {subtree_agent or 'subagent'}",
+                                tool_arguments=(
+                                    description
+                                    if isinstance(description, str)
+                                    else None
+                                ),
+                                tool_result=assistant.text,
+                                duration_ms=assistant.duration_ms,
+                                status=assistant.status,
+                                content_refs=assistant.content_refs,
+                            ),
+                        )
+                    )
+                else:
+                    self.messages.append(msg)
+                    subtree_emitted_assistant = True
 
         return subtree_emitted_assistant
 
@@ -404,7 +484,8 @@ class ChatTraversal:
         span = node.span
         agent_name = _agent_label(span, nearest_agent)
         self._emit_system_instructions(span, agent_name)
-        self._emit_user_turn(span)
+        self._emit_user_turn(span, agent_name)
+        child_message_start = len(self.messages)
         subtree_emitted_assistant = self._walk_children(
             node, nearest_agent=agent_name, depth=depth
         )
@@ -412,6 +493,12 @@ class ChatTraversal:
         msg = _emit_assistant_message(span, agent_name)
         if msg is None:
             return subtree_emitted_assistant
+        if _coalesce_mirrored_child_assistant(
+            node,
+            self.messages[child_message_start:],
+            msg,
+        ):
+            return True
         self.messages.append(msg)
         assistant = msg.assistant_message
         emitted_text = bool(assistant and assistant.text)
@@ -473,7 +560,7 @@ class ChatTraversal:
             )
         )
 
-    def _emit_user_turn(self, span: AgentSpanSchema) -> None:
+    def _emit_user_turn(self, span: AgentSpanSchema, agent_name: str | None) -> None:
         """Emit the user message(s) for the new turn this LLM span answers.
 
         The new user input is the trailing run of consecutive user-role
@@ -498,6 +585,31 @@ class ChatTraversal:
             if sig == self._last_user_sig:
                 continue
             self._last_user_sig = sig
+            if _is_claude_task_notification(message):
+                # Claude's async subagent completion is encoded as role=user so
+                # the next model call consumes it, but it is not a new human
+                # turn. Preserve the event as foldable tool activity instead
+                # of rendering a misleading user bubble.
+                self._pending_agent_start = None
+                self.emitted_task_notification = True
+                self.messages.append(
+                    AgentChatMessage(
+                        type="tool_call",
+                        span_id=span.span_id,
+                        agent_name=agent_name,
+                        agent_version=span.agent_version,
+                        status_code=span.status_code,
+                        started_at=span.started_at,
+                        tool_call=AgentChatToolCall(
+                            tool_name="Task notification",
+                            tool_result=text,
+                            duration_ms=0,
+                            status=span.status_code,
+                            content_refs=media,
+                        ),
+                    )
+                )
+                continue
             self.emitted_user = True
             # A user message marks a new turn; an unfilled agent_start from an
             # earlier turn must not absorb this turn's instructions.
@@ -542,7 +654,7 @@ def build_span_tree(spans: list[AgentSpanSchema]) -> list[SpanNode]:
             roots.append(node)
 
     def _sort(nodes: list[SpanNode]) -> None:
-        nodes.sort(key=lambda n: _span_sort_key(n.span))
+        nodes.sort(key=_span_node_sort_key)
         for n in nodes:
             _sort(n.children)
 
@@ -609,6 +721,37 @@ def _display_text(content: str) -> str:
     return "\n".join(texts)
 
 
+def _is_claude_task_notification(message: NormalizedMessage) -> bool:
+    """Whether a role=user message is Claude Code execution context.
+
+    Claude Code represents an asynchronous subagent completion as a synthetic
+    user message containing one complete ``<task-notification>`` XML element.
+    Match the full wrapper so ordinary prompts that merely discuss the tag are
+    not reclassified.
+    """
+    if message.role != _USER_ROLE:
+        return False
+    content = message.content.strip()
+    return content.startswith(_CLAUDE_TASK_NOTIFICATION_OPEN) and content.endswith(
+        _CLAUDE_TASK_NOTIFICATION_CLOSE
+    )
+
+
+def _claude_async_agent_launch(text: str) -> dict[str, Any] | None:
+    """Parse Claude Code's non-conversational async subagent launch result."""
+    try:
+        payload = json.loads(text)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("isAsync") is not True or payload.get("status") != "async_launched":
+        return None
+    if not isinstance(payload.get("agentId"), str):
+        return None
+    return payload
+
+
 def _filter_message_texts(
     messages: list[NormalizedMessage],
     *,
@@ -668,6 +811,7 @@ def _user_prompt_texts(messages: list[NormalizedMessage]) -> list[str]:
     messages. We intentionally exclude assistant, system, and tool roles so
     those do not render as a user prompt.
     """
+    messages = [m for m in messages if not _is_claude_task_notification(m)]
     if not messages:
         return []
     texts = _filter_message_texts(messages, include_roles={_USER_ROLE})
@@ -871,7 +1015,11 @@ def _user_messages(messages: list[NormalizedMessage]) -> list[NormalizedMessage]
     assistant/system/tool context (explicit ``user`` plus provider-variant
     empty/unknown roles).
     """
-    return [m for m in messages if m.role not in _NON_USER_PROMPT_ROLES]
+    return [
+        m
+        for m in messages
+        if m.role not in _NON_USER_PROMPT_ROLES and not _is_claude_task_notification(m)
+    ]
 
 
 def _trailing_user_messages(
@@ -977,6 +1125,122 @@ def _find_user_message(spans: list[AgentSpanSchema]) -> AgentChatMessage | None:
                 ),
             )
     return None
+
+
+def _find_task_notification(
+    spans: list[AgentSpanSchema],
+) -> AgentChatMessage | None:
+    """Find Claude Code execution context recorded on an enclosing span.
+
+    Some Claude traces carry the task notification only on ``invoke_agent``
+    input rather than on a walked content span. This mirrors
+    ``_find_user_message``'s fallback, but projects the synthetic role=user
+    payload as tool activity.
+    """
+    prioritized = sorted(
+        spans,
+        key=lambda s: (s.operation_name != OP_INVOKE_AGENT, _span_sort_key(s)),
+    )
+    for span in prioritized:
+        for message in reversed(span.input_messages):
+            if not _is_claude_task_notification(message):
+                continue
+            text = _display_text(message.content)
+            media = _message_content_refs(span, [message])
+            return AgentChatMessage(
+                type="tool_call",
+                span_id=span.span_id,
+                agent_name=_own_agent_label(span),
+                agent_version=span.agent_version,
+                status_code=span.status_code,
+                started_at=span.started_at,
+                tool_call=AgentChatToolCall(
+                    tool_name="Task notification",
+                    tool_result=text,
+                    duration_ms=0,
+                    status=span.status_code,
+                    content_refs=media,
+                ),
+            )
+    return None
+
+
+def _coalesce_mirrored_child_assistant(
+    node: SpanNode,
+    child_messages: list[AgentChatMessage],
+    parent_message: AgentChatMessage,
+) -> bool:
+    """Fold a model span's mirrored text into its transcript child event.
+
+    Claude Code emits a model ``chat`` span plus direct ``assistant_text``
+    children. The model span carries tokens, cost, model, and reasoning while
+    each transcript child carries the precise event position; both contain the
+    same assistant text. When a direct child emitted an exact text match, keep
+    that child in the timeline and enrich it from the parent rather than
+    appending a duplicate parent bubble.
+
+    Exact text and direct parentage are both required. A distinct child reply
+    (for example, a nested agent response) remains separate from its parent's
+    final output.
+    """
+    parent = parent_message.assistant_message
+    if parent is None or not parent.text:
+        return False
+
+    direct_child_ids = {child.span.span_id for child in node.children}
+    for candidate_message in reversed(child_messages):
+        if (
+            candidate_message.type != "assistant_message"
+            or candidate_message.span_id not in direct_child_ids
+        ):
+            continue
+        candidate = candidate_message.assistant_message
+        if candidate is None or candidate.text != parent.text:
+            continue
+
+        candidate_message.agent_name = (
+            candidate_message.agent_name or parent_message.agent_name
+        )
+        candidate_message.agent_version = (
+            candidate_message.agent_version or parent_message.agent_version
+        )
+        candidate_message.status_code = (
+            candidate_message.status_code or parent_message.status_code
+        )
+
+        # Transcript spans intentionally carry little metadata. Preserve any
+        # values they do have, filling gaps from the enclosing model span.
+        candidate.model = candidate.model or parent.model
+        candidate.reasoning_content = (
+            candidate.reasoning_content or parent.reasoning_content
+        )
+        candidate.reasoning_tokens = (
+            candidate.reasoning_tokens or parent.reasoning_tokens
+        )
+        candidate.input_tokens = candidate.input_tokens or parent.input_tokens
+        candidate.output_tokens = candidate.output_tokens or parent.output_tokens
+        candidate.input_cost_usd = (
+            candidate.input_cost_usd
+            if candidate.input_cost_usd is not None
+            else parent.input_cost_usd
+        )
+        candidate.output_cost_usd = (
+            candidate.output_cost_usd
+            if candidate.output_cost_usd is not None
+            else parent.output_cost_usd
+        )
+        candidate.total_cost_usd = (
+            candidate.total_cost_usd
+            if candidate.total_cost_usd is not None
+            else parent.total_cost_usd
+        )
+        candidate.duration_ms = candidate.duration_ms or parent.duration_ms
+        candidate.status = candidate.status or parent.status
+        candidate.content_refs = list(
+            dict.fromkeys([*candidate.content_refs, *parent.content_refs])
+        )
+        return True
+    return False
 
 
 def _emit_assistant_message(


### PR DESCRIPTION
## Summary

- coalesce exact assistant text mirrored by a model `chat` span and its direct `assistant_text` transcript child
- use the transcript child's timestamp for response ordering while inheriting model, reasoning, token, cost, duration, and status metadata from the parent
- render Claude Code async `<task-notification>` inputs and async subagent-launch envelopes as tool activity instead of human/assistant chat bubbles
- add regression coverage for mirroring, distinct replies, transcript ordering, task notifications, and launch envelopes

## Root cause

Claude Code represents assistant output twice in the agent span tree: a richly attributed model `chat` span and a direct `assistant_text` child used for precise transcript ordering. The projection only suppressed mirrored output on `invoke_agent` wrappers, so both ordinary content spans became assistant bubbles. Some sibling model spans also share a coarse start time even though their transcript children record the true response order.

Claude Code additionally feeds async task completion notifications back to the model with provider role `user`, and records async subagent launch results as assistant JSON. Those execution events therefore appeared as human prompts or assistant chat bubbles.

The fix requires exact mirrored text plus direct parent/child linkage, and recognizes only the complete Claude task-notification wrapper and async-launch envelope. Distinct replies and ordinary invoke-agent output remain unchanged.

## Validation

- `nox -e lint` — passed all pre-push hooks, including ty, import-linter, pyright, mypy, Ruff, and format checks
- `python -m pytest tests/trace_server/test_genai_chat_view.py -q` — 41 passed, 1 expected xfail
- replayed all six turns of production Claude Code conversation `82736943-ae35-414e-859c-bd51de3055f2` through the patched projector:
  - all 13 exact `chat` → `assistant_text` mirrors emitted once at the child position, with parent model metadata inherited
  - both task notifications rendered as tools and none rendered as users
  - zero duplicate assistant texts; coarse sibling ties followed transcript-child timestamps
- passed the patched turn-1 projection through the actual frontend grouping functions: 17 visible assistant messages became 17 response segments, no assistant text remained inside a work fold, and both async launches remained in tool activity
- `bun test frontends/weave/src/components/PagePanelComponents/Home/Browse3/pages/AgentsPage/chat/sections.test.ts` — 12 passed
