### PR TITLE
feat(weave): expose reasoning_effort on the completions API

### DIFF
--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -1804,5 +1804,42 @@ def test_get_custom_provider_info_requires_secret_fetcher_on_cache_hit(
         get_custom_provider_info(project_id, provider_id, model_object_id, obj_read)
 
 
+def test_build_litellm_kwargs_forwards_reasoning_effort():
+    """reasoning_effort passes through to litellm; drop_params drops it for unsupported models."""
+    inputs = tsi.CompletionsCreateRequestInputs(
+        model="my-model",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort="low",
+    )
+    kwargs = llm_mod._build_litellm_kwargs(
+        api_key="sk-test",
+        inputs=inputs,
+        provider="custom",
+        base_url="https://example.com/v1",
+        extra_headers=None,
+        vertex_credentials=None,
+    )
+    assert kwargs["reasoning_effort"] == "low"
+    assert kwargs["model"] == "my-model"
+    assert kwargs["api_base"] == "https://example.com/v1"
+
+
+def test_build_litellm_kwargs_omits_unset_reasoning_effort():
+    """An unset reasoning_effort is excluded (exclude_none) rather than sent as null."""
+    inputs = tsi.CompletionsCreateRequestInputs(
+        model="my-model",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    kwargs = llm_mod._build_litellm_kwargs(
+        api_key="sk-test",
+        inputs=inputs,
+        provider="custom",
+        base_url="https://example.com/v1",
+        extra_headers=None,
+        vertex_credentials=None,
+    )
+    assert "reasoning_effort" not in kwargs
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -511,6 +511,7 @@ class CompletionsCreateRequestInputs(BaseModel):
     logprobs: bool | None = None
     top_logprobs: int | None = None
     parallel_tool_calls: bool | None = None
+    reasoning_effort: str | None = None
     extra_headers: dict | None = None
     # soon to be deprecated params by OpenAI
     functions: list | None = None


### PR DESCRIPTION
## Summary
- Add `reasoning_effort` to `CompletionsCreateRequestInputs`; forwards to litellm via the existing `model_dump` passthrough (`drop_params=True` drops it for unsupported models).
- Prerequisite for capping reasoning on judge completions in core (gpt-oss judges truncate at max_tokens when the reasoning channel exhausts the budget before the answer).
- Jira: [WB-37460](https://coreweave.atlassian.net/browse/WB-37460)

## Testing
unit test: `_build_litellm_kwargs` forwards `reasoning_effort` and omits it when unset.


[WB-37460]: https://coreweave.atlassian.net/browse/WB-37460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ