### PR TITLE
fix(weave): allow span_name in agent-spans group_by/filter

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -935,6 +935,40 @@ class TestMakeGroupedSpansListQuery:
         }
         assert_sql(expected, expected_params, query, pb.get_params())
 
+    def test_group_by_span_name_sorted_by_count(self) -> None:
+        start = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        pb = ParamBuilder("genai")
+        query = make_spans_list_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="column", key="span_name")],
+                sort_by=[AgentSortBy(field="span_count", direction="desc")],
+                started_after=start,
+                limit=1000,
+            ),
+        )
+
+        src = _AttrSrc(4, started_after=start)
+        expected = f"""
+            SELECT s.span_name AS span_name,
+                   {_GROUPED_AGG_TAIL}
+            FROM {src.sql} s
+            WHERE s.project_id = {{genai_0:String}}
+              AND s.started_at >= {{genai_1:DateTime64(6)}}
+            GROUP BY span_name
+            ORDER BY span_count desc
+            LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
+        """
+        expected_params = {
+            "genai_0": "p1",
+            "genai_1": start,
+            "genai_2": 1000,
+            "genai_3": 0,
+            **src.params,
+        }
+        assert_sql(expected, expected_params, query, pb.get_params())
+
     def test_group_by_custom_attr(self) -> None:
         pb = ParamBuilder("genai")
         query = make_spans_list_query(

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -68,6 +68,7 @@ from weave.trace_server.query_builder.agent_signal_filters import (
 # Columns on spans that can be filtered with equality/IN.
 SPAN_FILTERABLE_COLS: frozenset[str] = frozenset(
     {
+        "span_name",
         "operation_name",
         "provider_name",
         "agent_name",


### PR DESCRIPTION
## Summary
- `span_name` was missing from `SPAN_FILTERABLE_COLS`, which `SPAN_GROUP_BY_COLS` unions from, so the "Span name" alert filter dropdown was always empty.
- Added `span_name` as the first entry in the allowlist.

## Testing
unit test