### PR TITLE
chore(weave_ts): bump TS SDK version to 0.16.3

### DIFF
--- a/sdks/node/CHANGELOG.md
+++ b/sdks/node/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Weave TypeScript SDK will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.16.3] - 2026-07-15
+
+### Added
+
+- Add `SubAgent.startLLM()`, `SubAgent.startTool()`, and `SubAgent.startSubagent()` to nest a subagent's child spans under its `invoke_agent` span. ([#7077](https://github.com/wandb/weave/pull/7077))
+
+### Fixed
+
+- Propagate conversation attributes across `runIsolated` frames. ([#7577](https://github.com/wandb/weave/pull/7577))
+- Keep typedoc reference docs rendering on `Turn`. ([#7521](https://github.com/wandb/weave/pull/7521))
+
+
 ## [0.16.2] - 2026-07-06
 
 ### Added

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weave",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "AI development toolkit",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/sdks/node/src/utils/packageVersion.ts
+++ b/sdks/node/src/utils/packageVersion.ts
@@ -5,4 +5,4 @@
 // Lives as a constant — rather than being read from package.json at runtime —
 // so the source compiles cleanly to both CJS and ESM without needing
 // `__dirname` (CJS-only) or `import.meta.url` (ESM-only).
-export const packageVersion = '0.16.2';
+export const packageVersion = '0.16.3';


### PR DESCRIPTION
Cuts **v0.16.3** of the Weave TS SDK (`0.16.2` is already on npm). Bumps `package.json` + the lockstep `packageVersion.ts`, and adds the changelog for the `weave_ts` changes since 0.16.2:

- **feat #7077** — `SubAgent.startLLM()`/`startTool()`/`startSubagent()` to nest child spans under a subagent.
- **fix #7577** — propagate conversation attributes across `runIsolated` frames.
- **chore #7521** — typedoc fix on `Turn` (internal-only; happy to drop from the changelog).

Not given a changelog line: **#7477** (`weave` backend) regenerated the client — additive only, no removed types.

**Blast radius:** `src/genai/` only; no runtime code changed in this PR.

**Publish after merge:** run the `publish-typescript-sdk-npm` workflow (dist-tag `latest`).
