### PR TITLE
chore(weave): add docstring to StringPrompt Python Class

### DIFF
--- a/weave/prompt/prompt.py
+++ b/weave/prompt/prompt.py
@@ -87,6 +87,20 @@ class Prompt(Object):
 
 @register_object
 class StringPrompt(Prompt):
+    """A prompt template for plain text prompts.
+
+    Add variables in braces, then pass values for those variables to `format`
+    to produce the final prompt text.
+
+    Example:
+        prompt = StringPrompt("Hello {name}")
+        prompt.format(name="Ada")
+        'Hello Ada'
+
+    Raises:
+        KeyError: If you call `format` without a required template variable.
+    """
+
     content: str = ""
 
     def __init__(self, content: str):


### PR DESCRIPTION
## Description

Adds missing docstring to public-facing class `StringPrompt`. Currently missing in the public docs + IDE shows inherited Pydantic Base Class definition.
