### PR TITLE
feat(weave): limit active exports per user

### DIFF
--- a/tests/trace_server/test_export_rate_limit.py
+++ b/tests/trace_server/test_export_rate_limit.py
@@ -1,0 +1,139 @@
+"""Unit tests for the export Redis concurrency guard."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from weave.trace_server import export, export_rate_limit
+from weave.trace_server.project_version.types import ReadTable
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    def set(self, key: str, value: str, *, nx: bool, ex: int) -> bool:
+        assert nx is True
+        assert ex == export_rate_limit.EXPORT_LOCK_TTL_SECONDS
+        if key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
+    def eval(self, script: str, numkeys: int, key: str, token: str) -> int:
+        assert script == export_rate_limit._RELEASE_IF_OWNED
+        assert numkeys == 1
+        if self.values.get(key) != token:
+            return 0
+        del self.values[key]
+        return 1
+
+
+def test_export_slot_limits_one_user_and_fails_closed_without_redis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    redis = _FakeRedis()
+    monkeypatch.setattr(export_rate_limit, "get_redis_client", lambda: redis)
+    first_slot = export_rate_limit.acquire_export_slot("user-1")
+    second_user_slot = export_rate_limit.acquire_export_slot("user-2")
+    assert second_user_slot.key != first_slot.key
+
+    with pytest.raises(export_rate_limit.ExportRateLimitError) as exc_info:
+        export_rate_limit.acquire_export_slot("user-1")
+    assert (exc_info.value.http_status, exc_info.value.code) == (
+        409,
+        "EXPORT_ALREADY_RUNNING",
+    )
+
+    # An expired lock may already have a new owner; old cleanup must not delete it.
+    redis.values[first_slot.key] = "new-owner"
+    export_rate_limit.release_export_slot(first_slot)
+    assert redis.values[first_slot.key] == "new-owner"
+    del redis.values[first_slot.key]
+    assert export_rate_limit.acquire_export_slot("user-1").key == first_slot.key
+
+    monkeypatch.setattr(export_rate_limit, "get_redis_client", lambda: None)
+    with pytest.raises(export_rate_limit.ExportRateLimitError) as unavailable:
+        export_rate_limit.acquire_export_slot("user-3")
+    assert (unavailable.value.http_status, unavailable.value.code) == (
+        503,
+        "EXPORT_LIMIT_UNAVAILABLE",
+    )
+
+
+def test_start_export_maps_limit_errors_to_export_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_limit_error(_wb_user_id: str) -> None:
+        raise export_rate_limit.ExportRateLimitError(
+            409, "EXPORT_ALREADY_RUNNING", "an export is already running for this user"
+        )
+
+    monkeypatch.setattr(export_rate_limit, "acquire_export_slot", _raise_limit_error)
+    with pytest.raises(export.ExportError) as exc_info:
+        export.start_export(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            "project",
+            ["calls"],
+            ReadTable.CALLS_COMPLETE,
+            "user",
+        )
+    assert (exc_info.value.http_status, exc_info.value.code) == (
+        409,
+        "EXPORT_ALREADY_RUNNING",
+    )
+
+
+def test_preflight_failure_releases_its_slot(monkeypatch: pytest.MonkeyPatch) -> None:
+    redis = _FakeRedis()
+    monkeypatch.setattr(export_rate_limit, "get_redis_client", lambda: redis)
+
+    with pytest.raises(export.ExportError) as exc_info:
+        export.start_export(
+            MagicMock(),
+            MagicMock(),
+            None,
+            "project",
+            ["objects"],
+            ReadTable.CALLS_COMPLETE,
+            "user-1",
+        )
+    assert (exc_info.value.http_status, exc_info.value.code) == (
+        503,
+        "EXPORT_STORAGE_UNAVAILABLE",
+    )
+    assert export_rate_limit.acquire_export_slot("user-1").key
+
+
+def test_worker_releases_its_slot_after_completion_or_startup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    redis = _FakeRedis()
+    monkeypatch.setattr(export_rate_limit, "get_redis_client", lambda: redis)
+
+    # A target failure is recorded by query_log and must still free the user slot.
+    first_slot = export_rate_limit.acquire_export_slot("user-1")
+    command_client = MagicMock()
+    command_client.command.side_effect = RuntimeError("target failed")
+    export._run_export(
+        lambda: command_client,
+        "project",
+        "job",
+        [export.ResolvedExportTarget("objects", "SELECT 1")],
+        first_slot,
+    )
+    assert first_slot.key not in redis.values
+
+    # If the detached client cannot even start, its reservation still cannot leak.
+    second_slot = export_rate_limit.acquire_export_slot("user-1")
+    with pytest.raises(RuntimeError, match="client failed"):
+        export._run_export(
+            lambda: (_ for _ in ()).throw(RuntimeError("client failed")),
+            "project",
+            "job",
+            [],
+            second_slot,
+        )
+    assert second_slot.key not in redis.values

--- a/tests/trace_server/test_export_status.py
+++ b/tests/trace_server/test_export_status.py
@@ -7,6 +7,7 @@ paths. No job table or in-memory job registry participates in this flow.
 
 import time
 import uuid
+from unittest.mock import MagicMock
 
 import boto3
 import pytest
@@ -160,6 +161,38 @@ def test_cross_tenant_unknown_and_traversal_guards(
             tsi.ExportStatusReq(project_id=project_a, job_id="../../etc/passwd")
         )
     assert (traversal.value.http_status, traversal.value.code) == (400, "BAD_JOB_ID")
+
+
+def test_status_rejects_corrupt_and_unsupported_manifests(
+    storage_client: S3StorageClient,
+):
+    project_id = b64(f"{TEST_ENTITY}/export-status-invalid-manifest")
+    corrupt_job_id = str(uuid.uuid4())
+    unsupported_job_id = str(uuid.uuid4())
+    storage_client.store(
+        storage_client.base_uri.with_path(
+            export.export_job_prefix(project_id, corrupt_job_id) + "manifest.json"
+        ),
+        b"not-json",
+    )
+    storage_client.store(
+        storage_client.base_uri.with_path(
+            export.export_job_prefix(project_id, unsupported_job_id) + "manifest.json"
+        ),
+        (
+            '{"job_id": "'
+            + unsupported_job_id
+            + '", "targets": [{"target": "not-a-target"}]}'
+        ).encode(),
+    )
+
+    for job_id in [corrupt_job_id, unsupported_job_id]:
+        with pytest.raises(export.ExportError) as exc_info:
+            export.get_export_status(MagicMock(), storage_client, project_id, job_id)
+        assert (exc_info.value.http_status, exc_info.value.code) == (
+            500,
+            "BAD_EXPORT_MANIFEST",
+        )
 
 
 def test_presign_on_done_downloads_exact_artifact(

--- a/tests/trace_server/test_export_write_path.py
+++ b/tests/trace_server/test_export_write_path.py
@@ -110,6 +110,7 @@ def test_start_export_runs_targets_serially_in_one_worker(
         "project",
         ["objects", "feedback"],
         ReadTable.CALLS_COMPLETE,
+        None,
     )
 
     assert len(worker_starts) == 1
@@ -192,6 +193,7 @@ def test_bad_target_and_job_id_validation(storage_client: S3StorageClient):
             "project",
             ["objects", "nope"],
             ReadTable.CALLS_COMPLETE,
+            None,
         )
     assert exc_info.value.http_status == 400
     assert exc_info.value.code == "BAD_TARGET"
@@ -212,5 +214,6 @@ def test_empty_and_duplicate_targets_are_rejected(
             "project",
             targets,
             ReadTable.CALLS_COMPLETE,
+            None,
         )
     assert (exc_info.value.http_status, exc_info.value.code) == (400, "BAD_TARGET")

--- a/tests/trace_server/test_trace_server_interface_util.py
+++ b/tests/trace_server/test_trace_server_interface_util.py
@@ -114,7 +114,9 @@ class _EncodingIdConverter(IdConverter):
         ),
         (
             "export_start",
-            lambda: tsi.ExportStartReq(project_id="ent/proj", targets=["calls"]),
+            lambda: tsi.ExportStartReq(
+                project_id="ent/proj", targets=["calls"], wb_user_id="u"
+            ),
         ),
         (
             "export_status",
@@ -161,11 +163,17 @@ def test_export_adapter_converts_project_id_and_delegates() -> None:
     )
     adapter = ExternalTraceServer(inner, idc)
 
-    start_req = tsi.ExportStartReq(project_id="ent/proj", targets=["calls"])
+    start_req = tsi.ExportStartReq(
+        project_id="ent/proj", targets=["calls"], wb_user_id="u"
+    )
     start_res = adapter.export_start(start_req)
     assert start_res.job_id == "job-1"
     assert inner.export_start.call_args.args[0].project_id == internal_project_id
+    assert inner.export_start.call_args.args[0].wb_user_id == idc.ext_to_int_user_id(
+        "u"
+    )
     assert start_req.project_id == "ent/proj"
+    assert start_req.wb_user_id == "u"
 
     status_req = tsi.ExportStatusReq(project_id="ent/proj", job_id="job-1")
     status_res = adapter.export_status(status_req)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7384,6 +7384,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             req.project_id,
             req.targets,
             calls_read_table,
+            req.wb_user_id,
         )
         return tsi.ExportStartRes(job_id=job_id)
 

--- a/weave/trace_server/export.py
+++ b/weave/trace_server/export.py
@@ -18,6 +18,7 @@ from clickhouse_connect.driver.client import Client as CHClient
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server import environment as wf_env
+from weave.trace_server import export_rate_limit
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.export_targets import EXPORT_TARGET_NAMES, build_export_query
 from weave.trace_server.file_storage import (
@@ -52,37 +53,51 @@ def start_export(
     project_id: str,
     target_names: list[str],
     calls_read_table: ReadTable,
+    wb_user_id: str | None,
 ) -> str:
     """Write the job manifest, then run its targets serially off-thread."""
-    targets = _resolve_targets(target_names, calls_read_table)
-    if file_storage_client is None:
-        raise ExportError(
-            503,
-            "EXPORT_STORAGE_UNAVAILABLE",
-            "export storage is not configured",
+    try:
+        slot = (
+            export_rate_limit.acquire_export_slot(wb_user_id)
+            if wb_user_id is not None
+            else None
         )
-    # Fail closed before a job or artifact exists, so a rejected request cannot
-    # leave an object the status API might later discover.
-    targets_with_counts: list[tuple[str, int]] = []
-    cap = wf_env.wf_export_max_rows()
-    for target in targets:
-        rows = precount_rows(ch_client, project_id, target)
-        if rows > cap:
+    except export_rate_limit.ExportRateLimitError as exc:
+        raise ExportError(exc.http_status, exc.code, str(exc)) from exc
+    try:
+        targets = _resolve_targets(target_names, calls_read_table)
+        if file_storage_client is None:
             raise ExportError(
-                409,
-                "TOO_LARGE",
-                f"target {target.name!r} has {rows} rows > cap {cap}",
+                503,
+                "EXPORT_STORAGE_UNAVAILABLE",
+                "export storage is not configured",
             )
-        targets_with_counts.append((target.name, rows))
-    job_id = str(uuid.uuid4())
-    if not JOB_ID_RE.match(job_id):
-        raise ExportError(500, "BAD_JOB_ID", f"job_id {job_id!r} fails validation")
-    _write_manifest(file_storage_client, project_id, job_id, targets_with_counts)
-    threading.Thread(
-        target=_run_export,
-        args=(mint_client, project_id, job_id, targets),
-        daemon=True,
-    ).start()
+        # Fail closed before a job or artifact exists, so a rejected request
+        # cannot leave an object the status API might later discover.
+        targets_with_counts: list[tuple[str, int]] = []
+        cap = wf_env.wf_export_max_rows()
+        for target in targets:
+            rows = precount_rows(ch_client, project_id, target)
+            if rows > cap:
+                raise ExportError(
+                    409,
+                    "TOO_LARGE",
+                    f"target {target.name!r} has {rows} rows > cap {cap}",
+                )
+            targets_with_counts.append((target.name, rows))
+        job_id = str(uuid.uuid4())
+        if not JOB_ID_RE.match(job_id):
+            raise ExportError(500, "BAD_JOB_ID", f"job_id {job_id!r} fails validation")
+        _write_manifest(file_storage_client, project_id, job_id, targets_with_counts)
+        threading.Thread(
+            target=_run_export,
+            args=(mint_client, project_id, job_id, targets, slot),
+            daemon=True,
+        ).start()
+    except Exception:
+        if slot is not None:
+            export_rate_limit.release_export_slot(slot)
+        raise
     return job_id
 
 
@@ -290,11 +305,16 @@ def _run_export(
     project_id: str,
     job_id: str,
     targets: list[ResolvedExportTarget],
+    slot: export_rate_limit.ExportSlot | None,
 ) -> None:
     """Run one job's targets serially to bound its ClickHouse concurrency."""
-    client = mint_client()
-    for target in targets:
-        _run_target_insert(client, project_id, job_id, target)
+    try:
+        client = mint_client()
+        for target in targets:
+            _run_target_insert(client, project_id, job_id, target)
+    finally:
+        if slot is not None:
+            export_rate_limit.release_export_slot(slot)
 
 
 def _run_target_insert(

--- a/weave/trace_server/export_rate_limit.py
+++ b/weave/trace_server/export_rate_limit.py
@@ -1,0 +1,81 @@
+"""Redis-backed cross-worker concurrency guard for managed-bucket exports."""
+
+import hashlib
+import logging
+import uuid
+from dataclasses import dataclass
+
+from weave.trace_server.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+# A single job may serialize all three targets, each limited to five minutes.
+# The worker releases its lease on completion; this only bounds a crashed worker.
+EXPORT_LOCK_TTL_SECONDS = 1_200
+_LOCK_KEY_PREFIX = "weave:export:active:"
+_RELEASE_IF_OWNED = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+end
+return 0
+"""
+
+
+class ExportRateLimitError(Exception):
+    def __init__(self, http_status: int, code: str, message: str) -> None:
+        super().__init__(message)
+        self.http_status = http_status
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ExportSlot:
+    key: str
+    token: str
+
+
+def acquire_export_slot(wb_user_id: str) -> ExportSlot:
+    """Reserve a single bounded export slot for a user across all workers."""
+    client = get_redis_client()
+    if client is None:
+        raise ExportRateLimitError(
+            503,
+            "EXPORT_LIMIT_UNAVAILABLE",
+            "export concurrency limit is temporarily unavailable",
+        )
+
+    key = _export_lock_key(wb_user_id)
+    token = str(uuid.uuid4())
+    try:
+        acquired = client.set(key, token, nx=True, ex=EXPORT_LOCK_TTL_SECONDS)
+    except Exception as exc:
+        raise ExportRateLimitError(
+            503,
+            "EXPORT_LIMIT_UNAVAILABLE",
+            "export concurrency limit is temporarily unavailable",
+        ) from exc
+    if not acquired:
+        raise ExportRateLimitError(
+            409,
+            "EXPORT_ALREADY_RUNNING",
+            "an export is already running for this user",
+        )
+    return ExportSlot(key=key, token=token)
+
+
+def release_export_slot(slot: ExportSlot) -> None:
+    """Release an owned reservation without deleting a newer owner's lock."""
+    try:
+        client = get_redis_client()
+        if client is not None:
+            client.eval(  # type: ignore[no-untyped-call]
+                _RELEASE_IF_OWNED, 1, slot.key, slot.token
+            )
+    except Exception:
+        # The TTL bounds the lock if Redis is unavailable during cleanup.
+        logger.warning("failed to release export concurrency slot", exc_info=True)
+
+
+def _export_lock_key(wb_user_id: str) -> str:
+    user_hash = hashlib.sha256(wb_user_id.encode()).hexdigest()
+    return f"{_LOCK_KEY_PREFIX}{user_hash}"

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -689,6 +689,8 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     def export_start(self, req: tsi.ExportStartReq) -> tsi.ExportStartRes:
         req = req.model_copy(deep=True)
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        if req.wb_user_id is not None:
+            req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
         # Artifacts hold ref strings verbatim; no ext<->int ref conversion here.
         return self._internal_trace_server.export_start(req)
 


### PR DESCRIPTION
## Summary
- Redis is used only as a per-user cross-worker admission lease; it is not used as export/job metadata.
- The lease is acquired before preflight, compare-and-deleted on any preflight failure, and released in the detached worker `finally` after serial execution. Its 20-minute crash TTL covers three five-minute target limits.
- Redis outage fails closed with 503 and a second active export for the same authenticated user gets 409.

## Testing
- Same-user/different-user behavior, unavailable Redis, token-safe cleanup, preflight cleanup, and worker cleanup after both target failure and client-start failure.