### PR TITLE
fix(weave): preserve object read error context

### DIFF
--- a/tests/trace/test_errors.py
+++ b/tests/trace/test_errors.py
@@ -1,0 +1,52 @@
+import httpx
+
+from weave.trace.errors import format_http_error, response_error_message
+
+
+def test_response_error_message_prefers_common_json_fields_and_falls_back_to_body():
+    request = httpx.Request("POST", "https://trace.wandb.ai/obj/read")
+
+    # Structured API errors use different message field names.
+    assert (
+        response_error_message(
+            httpx.Response(
+                403,
+                json={"reason": "reason", "detail": "detail", "message": "message"},
+                request=request,
+            )
+        )
+        == "reason"
+    )
+    assert (
+        response_error_message(
+            httpx.Response(403, json={"detail": "Project not found"}, request=request)
+        )
+        == "Project not found"
+    )
+    assert (
+        response_error_message(
+            httpx.Response(403, json={"message": "Forbidden"}, request=request)
+        )
+        == "Forbidden"
+    )
+
+    # Unstructured and empty responses preserve useful diagnostic context.
+    assert (
+        response_error_message(
+            httpx.Response(502, content=b"upstream unavailable", request=request)
+        )
+        == "upstream unavailable"
+    )
+    assert (
+        response_error_message(httpx.Response(500, request=request))
+        == "<empty response body>"
+    )
+
+    assert format_http_error(
+        httpx.Response(403, json={"detail": "Project not found"}, request=request),
+        "Unable to read object for ref uri: weave:///test/test-project/object/frozen-dataset:abc123",
+    ) == (
+        "Unable to read object for ref uri: "
+        "weave:///test/test-project/object/frozen-dataset:abc123 "
+        "(status 403): Project not found"
+    )

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -74,22 +74,6 @@ from weave.trace_server.trace_server_interface import (
 from weave.trace_server_bindings.http_utils import _ENDPOINT_CACHE
 
 
-def test_obj_read_error_message_includes_ref_status_and_json_detail():
-    response = httpx.Response(
-        403,
-        json={"detail": "Project not found"},
-        request=httpx.Request("POST", "https://trace.wandb.ai/obj/read"),
-    )
-
-    assert weave_client._obj_read_error_message(
-        response, "weave:///test/test-project/object/frozen-dataset:abc123"
-    ) == (
-        "Unable to read object for ref uri: "
-        "weave:///test/test-project/object/frozen-dataset:abc123 "
-        "(status 403): Project not found"
-    )
-
-
 @pytest.mark.flaky(reruns=3, reruns_delay=0.2)
 def test_table_create(client):
     res = client.server.table_create(

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -74,6 +74,22 @@ from weave.trace_server.trace_server_interface import (
 from weave.trace_server_bindings.http_utils import _ENDPOINT_CACHE
 
 
+def test_obj_read_error_message_includes_ref_status_and_json_detail():
+    response = httpx.Response(
+        403,
+        json={"detail": "Project not found"},
+        request=httpx.Request("POST", "https://trace.wandb.ai/obj/read"),
+    )
+
+    assert weave_client._obj_read_error_message(
+        response, "weave:///test/test-project/object/frozen-dataset:abc123"
+    ) == (
+        "Unable to read object for ref uri: "
+        "weave:///test/test-project/object/frozen-dataset:abc123 "
+        "(status 403): Project not found"
+    )
+
+
 @pytest.mark.flaky(reruns=3, reruns_delay=0.2)
 def test_table_create(client):
     res = client.server.table_create(

--- a/weave/trace/errors.py
+++ b/weave/trace/errors.py
@@ -1,0 +1,27 @@
+"""Shared helpers for client-side error reporting."""
+
+from typing import Any
+
+import httpx
+
+
+def response_error_message(response: httpx.Response) -> str:
+    """Extract the most actionable message from an HTTP error response."""
+    body: Any = response.text or "<empty response body>"
+    try:
+        parsed_body = response.json()
+    except (UnicodeDecodeError, ValueError):
+        return str(body)
+
+    if isinstance(parsed_body, dict):
+        for key in ("reason", "detail", "message"):
+            if message := parsed_body.get(key):
+                return str(message)
+    return str(parsed_body)
+
+
+def format_http_error(response: httpx.Response, context: str) -> str:
+    """Add request context and status to an HTTP error response message."""
+    return (
+        f"{context} (status {response.status_code}): {response_error_message(response)}"
+    )

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import copy
 import dataclasses
 import datetime
-import json
 import logging
 import os
 import re
@@ -15,7 +14,6 @@ from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, cast
 
 import pydantic
 from httpx import HTTPStatusError as HTTPError
-from httpx import Response
 
 from weave.chat.chat import Chat
 from weave.chat.inference_models import InferenceModels
@@ -41,6 +39,7 @@ from weave.trace.casting import CallsFilterLike, QueryLike, SortByLike
 from weave.trace.concurrent.futures import FutureExecutor
 from weave.trace.constants import TRACE_CALL_EMOJI
 from weave.trace.context import call_context
+from weave.trace.errors import format_http_error
 from weave.trace.feedback import FeedbackQuery, RefFeedbackQuery
 from weave.trace.interface_query_builder import (
     exists_expr,
@@ -364,30 +363,6 @@ def _remove_empty_ref(obj: ObjectRecord) -> ObjectRecord:
     return obj
 
 
-def _obj_read_error_message(response: Response, ref_uri: str) -> str:
-    """Return actionable context for an object-read HTTP failure."""
-    body: Any = response.text or "<empty response body>"
-    try:
-        parsed_body = json.loads(response.content)
-    except json.JSONDecodeError:
-        pass
-    else:
-        if isinstance(parsed_body, dict):
-            body = (
-                parsed_body.get("reason")
-                or parsed_body.get("detail")
-                or parsed_body.get("message")
-                or parsed_body
-            )
-        else:
-            body = parsed_body
-
-    return (
-        f"Unable to read object for ref uri: {ref_uri} "
-        f"(status {response.status_code}): {body}"
-    )
-
-
 def map_to_refs(obj: Any) -> Any:
     if isinstance(obj, Ref):
         return obj
@@ -609,7 +584,12 @@ class WeaveClient:
             )
         except HTTPError as e:
             if e.response is not None:
-                raise ValueError(_obj_read_error_message(e.response, ref.uri)) from None
+                raise ValueError(
+                    format_http_error(
+                        e.response,
+                        f"Unable to read object for ref uri: {ref.uri}",
+                    )
+                ) from None
             raise
 
         # At this point, `ref.digest` is one of three things:

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, cast
 
 import pydantic
 from httpx import HTTPStatusError as HTTPError
+from httpx import Response
 
 from weave.chat.chat import Chat
 from weave.chat.inference_models import InferenceModels
@@ -363,6 +364,30 @@ def _remove_empty_ref(obj: ObjectRecord) -> ObjectRecord:
     return obj
 
 
+def _obj_read_error_message(response: Response, ref_uri: str) -> str:
+    """Return actionable context for an object-read HTTP failure."""
+    body: Any = response.text or "<empty response body>"
+    try:
+        parsed_body = json.loads(response.content)
+    except json.JSONDecodeError:
+        pass
+    else:
+        if isinstance(parsed_body, dict):
+            body = (
+                parsed_body.get("reason")
+                or parsed_body.get("detail")
+                or parsed_body.get("message")
+                or parsed_body
+            )
+        else:
+            body = parsed_body
+
+    return (
+        f"Unable to read object for ref uri: {ref_uri} "
+        f"(status {response.status_code}): {body}"
+    )
+
+
 def map_to_refs(obj: Any) -> Any:
     if isinstance(obj, Ref):
         return obj
@@ -584,16 +609,7 @@ class WeaveClient:
             )
         except HTTPError as e:
             if e.response is not None:
-                if e.response.content:
-                    try:
-                        reason = json.loads(e.response.content).get("reason")
-                        raise ValueError(reason) from None
-                    except json.JSONDecodeError:
-                        raise ValueError(e.response.content) from None
-                if e.response.status_code == 404:
-                    raise ValueError(
-                        f"Unable to find object for ref uri: {ref.uri}"
-                    ) from e
+                raise ValueError(_obj_read_error_message(e.response, ref.uri)) from None
             raise
 
         # At this point, `ref.digest` is one of three things:


### PR DESCRIPTION
## Problem

A failed read of the frozen weakness-eval dataset returned a meaningful server response, but the SDK discarded it:

```text
HTTP 403
{"detail":"Project not found"}

ValueError: None
```

`WeaveClient.get()` only read the JSON `reason` key, so a common FastAPI-style `detail` response became an opaque exception.

## After

The same failure now preserves the actionable context:

```text
ValueError: Unable to read object for ref uri: weave:///wb-agent-team/weakness-evals/object/jira-weakness-recall-2026-07-15:... (status 403): Project not found
```

The fallback order is `reason`, `detail`, `message`, then the raw response body.

## Validation

- `uv run --group test python -m pytest tests/trace/test_weave_client.py::test_obj_read_error_message_includes_ref_status_and_json_detail -v`
- `uvx ruff check weave/trace/weave_client.py tests/trace/test_weave_client.py`
- `uvx ruff format --check weave/trace/weave_client.py tests/trace/test_weave_client.py`
- Pre-push type and import checks passed.