### PR TITLE
feat(weave): support all-time provider cost stats

### DIFF
--- a/tests/trace_server/test_call_stats.py
+++ b/tests/trace_server/test_call_stats.py
@@ -16,6 +16,7 @@ from tests.trace.util import client_is_clickhouse
 from tests.trace_server.helpers import force_optimize_calls_merged
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.token_costs import build_model_prices_query
 from weave.trace_server.trace_server_interface import (
     AggregationType,
     CallMetricSpec,
@@ -163,11 +164,12 @@ def test_call_stats_usage_sum_aggregation(client: weave_client.WeaveClient):
     )
 
 
-def test_call_stats_date_range_limit_validation():
-    """Reject CallStatsReq with a date range exceeding 31 days."""
+def test_call_stats_all_time_cost_validation_and_provider_filter():
+    """Keep broad stats bounded while allowing the one-bucket provider cost use case."""
     end_time = _BASE_TIME
     start_time = end_time - datetime.timedelta(days=32)
 
+    # Normal requests remain limited to 31 days.
     with pytest.raises(ValidationError):
         tsi.CallStatsReq(
             project_id="entity/project",
@@ -176,6 +178,34 @@ def test_call_stats_date_range_limit_validation():
             granularity=3600,
             usage_metrics=[tsi.UsageMetricSpec(metric="total_tokens")],
         )
+
+    # All-time requests must collapse into one bucket.
+    with pytest.raises(ValidationError):
+        tsi.CallStatsReq(
+            project_id="entity/project",
+            start=start_time,
+            end=end_time,
+            granularity=3600,
+            usage_metrics=[tsi.UsageMetricSpec(metric="total_cost")],
+            allow_large_range=True,
+        )
+
+    req = tsi.CallStatsReq(
+        project_id="entity/project",
+        start=start_time,
+        end=end_time,
+        granularity=int((end_time - start_time).total_seconds()),
+        usage_metrics=[tsi.UsageMetricSpec(metric="total_cost")],
+        cost_provider_id="coreweave",
+        allow_large_range=True,
+    )
+    assert req.cost_provider_id == "coreweave"
+
+    sql, params = build_model_prices_query(
+        req.project_id, ["google/gemma-4-31B-it"], req.cost_provider_id
+    )
+    assert "provider_id = {provider_id:String}" in sql
+    assert params["provider_id"] == "coreweave"
 
 
 def test_call_stats_multiple_models(client: weave_client.WeaveClient):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1539,7 +1539,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
     def _get_prices_for_models(
-        self, models: set[str], project_id: str
+        self, models: set[str], project_id: str, provider_id: str | None = None
     ) -> dict[str, dict[str, float]]:
         """Query llm_token_prices for the given models and return best prices.
 
@@ -1550,7 +1550,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             return {}
 
         try:
-            sql, params = build_model_prices_query(project_id, list(models))
+            sql, params = build_model_prices_query(
+                project_id, list(models), provider_id
+            )
             settings = None
             if self.use_distributed_mode:
                 # Use patched settings for distributed bug (more info in ch_settings)
@@ -1588,6 +1590,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         usage_buckets: list[dict[str, Any]],
         project_id: str,
         requested_cost_metrics: set[str],
+        provider_id: str | None = None,
     ) -> None:
         """Compute cost metrics for usage buckets by multiplying tokens by prices.
 
@@ -1603,7 +1606,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         models = {b.get("model", "") for b in usage_buckets if b.get("model")}
 
         # Query prices for those models
-        prices = self._get_prices_for_models(models, project_id)
+        prices = self._get_prices_for_models(models, project_id, provider_id)
 
         # Compute costs for each bucket
         for bucket in usage_buckets:
@@ -1683,7 +1686,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # Compute costs post-query if cost metrics were requested
         if requested_cost_metrics and usage_buckets:
             self._compute_costs_for_buckets(
-                usage_buckets, req.project_id, requested_cost_metrics
+                usage_buckets,
+                req.project_id,
+                requested_cost_metrics,
+                req.cost_provider_id,
             )
 
         # Process call metrics (not grouped by model)

--- a/weave/trace_server/token_costs.py
+++ b/weave/trace_server/token_costs.py
@@ -69,7 +69,7 @@ LLM_TOKEN_PRICES_TABLE = Table(
 
 
 def build_model_prices_query(
-    project_id: str, models: list[str]
+    project_id: str, models: list[str], provider_id: str | None = None
 ) -> tuple[str, dict[str, Any]]:
     """Build SQL to get the current price per model.
 
@@ -78,6 +78,7 @@ def build_model_prices_query(
     Args:
         project_id: Project ID for project-level pricing.
         models: List of model/llm_id values to look up.
+        provider_id: Optional provider ID to restrict price resolution to.
 
     Returns:
         SQL string and parameters dict.
@@ -103,6 +104,7 @@ def build_model_prices_query(
             ) AS rank
         FROM {LLM_TOKEN_PRICES_TABLE_NAME}
         WHERE llm_id IN {{models:Array(String)}}
+          AND ({{provider_id:String}} = '' OR provider_id = {{provider_id:String}})
           AND (
               (pricing_level = '{PRICING_LEVELS["PROJECT"]}' AND pricing_level_id = {{project:String}})
               OR (pricing_level = '{PRICING_LEVELS["DEFAULT"]}' AND pricing_level_id = {{default:String}})
@@ -114,6 +116,7 @@ def build_model_prices_query(
         "models": models,
         "project": project_id,
         "default": DEFAULT_PRICING_LEVEL_ID,
+        "provider_id": provider_id or "",
     }
     return sql, params
 

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3856,6 +3856,14 @@ class CallStatsReq(BaseModelStrict):
         default="UTC",
         description="IANA timezone for bucket alignment (e.g., 'America/New_York')",
     )
+    cost_provider_id: str | None = Field(
+        default=None,
+        description="Optional provider ID used when resolving token prices for cost metrics.",
+    )
+    allow_large_range: bool = Field(
+        default=False,
+        description="Allow an all-time, single-bucket usage request. The granularity must cover the entire requested range.",
+    )
 
     @model_validator(mode="after")
     def validate_date_range(self) -> "CallStatsReq":
@@ -3863,9 +3871,17 @@ class CallStatsReq(BaseModelStrict):
         end = self.end or datetime.datetime.now(datetime.timezone.utc)
         if end < self.start:
             raise ValueError("CallStatsReq end must be after start")
-        if end - self.start > MAX_CALL_STATS_RANGE:
+        requested_range = end - self.start
+        if requested_range > MAX_CALL_STATS_RANGE and not self.allow_large_range:
             raise ValueError(
                 f"CallStatsReq date range cannot exceed {MAX_CALL_STATS_RANGE_DAYS} days"
+            )
+        if self.allow_large_range and (
+            self.granularity is None
+            or self.granularity < int(requested_range.total_seconds())
+        ):
+            raise ValueError(
+                "allow_large_range requires granularity to cover the entire requested range"
             )
         return self
 


### PR DESCRIPTION
## Summary
- support single-bucket all-time call usage statistics
- restrict dynamic cost resolution to a requested provider
- enable the project overview to identify CoreWeave serverless SDK calls

## Testing
- `uvx ruff check weave/trace_server/trace_server_interface.py weave/trace_server/token_costs.py weave/trace_server/clickhouse_trace_server_batched.py tests/trace_server/test_call_stats.py`
- `nox --no-install -e "tests-3.12(shard='trace_server')" -- tests/trace_server/test_call_stats.py::test_call_stats_all_time_cost_validation_and_provider_filter`