### PR TITLE
fix(weave): map openai cached_tokens to cache_read on otel ingest

### DIFF
--- a/tests/trace_server/test_genai_extraction.py
+++ b/tests/trace_server/test_genai_extraction.py
@@ -436,12 +436,7 @@ def test_multi_alias_extraction_canonical_weave_key_wins() -> None:
     ["prompt_tokens_details", "input_tokens_details"],
 )
 def test_openai_shaped_cached_tokens_map_to_cache_read(details_key: str) -> None:
-    """OpenAI-compatible / LiteLLM-bridged exporters nest cached tokens under
-    ``gen_ai.usage.prompt_tokens_details.cached_tokens`` (Chat Completions) or
-    ``gen_ai.usage.input_tokens_details.cached_tokens`` (Responses API) rather
-    than the Anthropic-style ``gen_ai.usage.cache_read.input_tokens``. Without
-    this mapping those tokens were silently dropped, overstating cost.
-    """
+    """Maps OpenAI-shaped cached tokens to cache reads."""
     span = _make_span(
         attrs={
             "gen_ai": {

--- a/tests/trace_server/test_genai_extraction.py
+++ b/tests/trace_server/test_genai_extraction.py
@@ -13,6 +13,8 @@ import json
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from weave.trace_server.agents import semconv
 from weave.trace_server.opentelemetry.genai_extraction import (
     extract_genai_span,
@@ -427,6 +429,54 @@ def test_multi_alias_extraction_canonical_weave_key_wins() -> None:
         project_id="p1",
     )
     assert result.reasoning_tokens == 99
+
+
+@pytest.mark.parametrize(
+    "details_key",
+    ["prompt_tokens_details", "input_tokens_details"],
+)
+def test_openai_shaped_cached_tokens_map_to_cache_read(details_key: str) -> None:
+    """OpenAI-compatible / LiteLLM-bridged exporters nest cached tokens under
+    ``gen_ai.usage.prompt_tokens_details.cached_tokens`` (Chat Completions) or
+    ``gen_ai.usage.input_tokens_details.cached_tokens`` (Responses API) rather
+    than the Anthropic-style ``gen_ai.usage.cache_read.input_tokens``. Without
+    this mapping those tokens were silently dropped, overstating cost.
+    """
+    span = _make_span(
+        attrs={
+            "gen_ai": {
+                "usage": {
+                    "input_tokens": 1000,
+                    "output_tokens": 50,
+                    details_key: {"cached_tokens": 640},
+                }
+            }
+        }
+    )
+    result = extract_genai_span(span, project_id="p1")
+    assert result.input_tokens == 1000
+    assert result.output_tokens == 50
+    assert result.cache_creation_input_tokens == 0
+    assert result.cache_read_input_tokens == 640
+
+
+def test_anthropic_style_cache_read_wins_over_openai_shaped() -> None:
+    """When both the canonical Anthropic-style key and the OpenAI-shaped
+    fallback keys are present, the canonical value must win.
+    """
+    span = _make_span(
+        attrs={
+            "gen_ai": {
+                "usage": {
+                    "cache_read": {"input_tokens": 99},
+                    "prompt_tokens_details": {"cached_tokens": 10},
+                    "input_tokens_details": {"cached_tokens": 20},
+                }
+            }
+        }
+    )
+    result = extract_genai_span(span, project_id="p1")
+    assert result.cache_read_input_tokens == 99
 
 
 def test_extract_custom_attrs_skips_non_finite_floats() -> None:

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -1469,6 +1469,17 @@ class TestSemanticConventionParsing:
         assert usage.get("cache_read_input_tokens") == 20
         assert usage.get("total_tokens") == 150
 
+        # An explicit canonical zero beats an OpenAI-shaped fallback.
+        usage = get_weave_usage(
+            create_attributes(
+                {
+                    "gen_ai.usage.cache_read.input_tokens": 0,
+                    "gen_ai.usage.prompt_tokens_details.cached_tokens": 640,
+                }
+            )
+        )
+        assert usage.get("cache_read_input_tokens") == 0
+
     def test_genai_semconv_conversation_id_as_thread_and_turn(self):
         """Test that gen_ai.conversation.id maps to both thread_id and is_turn."""
         test_conversation_id = "conv-abc-123"

--- a/weave/trace_server/agents/semconv.py
+++ b/weave/trace_server/agents/semconv.py
@@ -157,10 +157,7 @@ USAGE_CACHE_READ_INPUT_TOKENS = Attribute(
     "int",
     "Tokens served from cache",
     [
-        # Canonical Anthropic-style key; wins over the OpenAI-shaped forms below.
         "gen_ai.usage.cache_read.input_tokens",
-        # OpenAI Chat Completions / Responses API usage shapes, as emitted by
-        # OpenAI-compatible and LiteLLM-bridged OTel exporters.
         "gen_ai.usage.prompt_tokens_details.cached_tokens",
         "gen_ai.usage.input_tokens_details.cached_tokens",
         "prompt_tokens_details.cached_tokens",

--- a/weave/trace_server/agents/semconv.py
+++ b/weave/trace_server/agents/semconv.py
@@ -156,7 +156,15 @@ USAGE_CACHE_READ_INPUT_TOKENS = Attribute(
     "weave.usage.cache_read.input_tokens",
     "int",
     "Tokens served from cache",
-    ["gen_ai.usage.cache_read.input_tokens"],
+    [
+        # Canonical Anthropic-style key; wins over the OpenAI-shaped forms below.
+        "gen_ai.usage.cache_read.input_tokens",
+        # OpenAI Chat Completions / Responses API usage shapes, as emitted by
+        # OpenAI-compatible and LiteLLM-bridged OTel exporters.
+        "gen_ai.usage.prompt_tokens_details.cached_tokens",
+        "gen_ai.usage.input_tokens_details.cached_tokens",
+        "prompt_tokens_details.cached_tokens",
+    ],
 )
 CONVERSATION_ID = Attribute(
     "weave.conversation.id",

--- a/weave/trace_server/opentelemetry/attributes.py
+++ b/weave/trace_server/opentelemetry/attributes.py
@@ -24,12 +24,22 @@ class SpanEvent(dict):
     dropped_attributes_count: int
 
 
+def _has_value(value: Any, allow_numeric_zero: bool) -> bool:
+    return bool(value) or (
+        allow_numeric_zero
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+        and value == 0
+    )
+
+
 def parse_weave_values(
     attributes: dict[str, Any],
     key_mapping: list[str]
     | dict[str, list[str]]
     | list[tuple[str, Callable[..., Any]]]
     | dict[str, list[tuple[str, Callable[..., Any]]]],
+    allow_numeric_zero: bool = False,
 ) -> dict[str, Any]:
     result = {}
     # If list use the attribute as the key - Prevents synthetic attributes under input and output
@@ -42,7 +52,7 @@ def parse_weave_values(
             else:
                 attribute_key = attribute_key_or_tuple
             value = get_attribute(attributes, attribute_key)
-            if value:
+            if _has_value(value, allow_numeric_zero):
                 # Handler should never raise - Always use a try in handler and default to passed in value
                 if handler:
                     value = handler(value)
@@ -62,7 +72,7 @@ def parse_weave_values(
                 attribute_key = attribute_key_or_tuple
 
             value = get_attribute(attributes, attribute_key)
-            if value:
+            if _has_value(value, allow_numeric_zero):
                 if handler:
                     # Handler should never raise - Always use a try in handler and default to passed in value
                     value = handler(value)
@@ -81,7 +91,7 @@ def get_weave_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
 
 
 def get_weave_usage(attributes: dict[str, Any]) -> dict[str, Any]:
-    usage = parse_weave_values(attributes, USAGE_KEYS)
+    usage = parse_weave_values(attributes, USAGE_KEYS, allow_numeric_zero=True)
     if (
         "prompt_tokens" in usage
         and "completion_tokens" in usage

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -112,6 +112,11 @@ USAGE_KEYS = {
     ],
     "cache_read_input_tokens": [
         ("gen_ai.usage.cache_read.input_tokens", try_parse_int),
+        # OpenAI Chat Completions / Responses API usage shapes, as emitted by
+        # OpenAI-compatible and LiteLLM-bridged OTel exporters.
+        ("gen_ai.usage.prompt_tokens_details.cached_tokens", try_parse_int),
+        ("gen_ai.usage.input_tokens_details.cached_tokens", try_parse_int),
+        ("prompt_tokens_details.cached_tokens", try_parse_int),
     ],
 }
 

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -112,8 +112,6 @@ USAGE_KEYS = {
     ],
     "cache_read_input_tokens": [
         ("gen_ai.usage.cache_read.input_tokens", try_parse_int),
-        # OpenAI Chat Completions / Responses API usage shapes, as emitted by
-        # OpenAI-compatible and LiteLLM-bridged OTel exporters.
         ("gen_ai.usage.prompt_tokens_details.cached_tokens", try_parse_int),
         ("gen_ai.usage.input_tokens_details.cached_tokens", try_parse_int),
         ("prompt_tokens_details.cached_tokens", try_parse_int),


### PR DESCRIPTION
## Summary
- OTel agent-span ingest only recognized the Anthropic-style `gen_ai.usage.cache_read.input_tokens` key, so OpenAI-compatible / LiteLLM-bridged harnesses reporting cached tokens under `prompt_tokens_details`/`input_tokens_details` had them silently dropped, overstating cost
- Adds the OpenAI-shaped keys as fallback lookups in both the agent-span extraction path (`semconv.py`) and the raw-OTLP calls path (`constants.py`), with the canonical Anthropic key kept highest priority
- Jira: [WB-37554](https://coreweave.atlassian.net/browse/WB-37554)

## Testing
unit test: openai-shaped cached_tokens (both prompt_tokens_details and input_tokens_details shapes) now populate cache_read_input_tokens; anthropic key still preferred when both present

## QA validation (zoo-qa)

| Master `89e03dc` | Candidate `8596b92` |
| --- | --- |
| ![master: Cache read 0](https://github.com/user-attachments/assets/e6230414-18f3-4f6b-8919-c2e8040c1610) | ![candidate: Cache read 640](https://github.com/user-attachments/assets/7138e46a-d911-4dba-9911-51ae77182434) |

Identical live Agent-OTLP `chat` spans, with `gen_ai.usage.prompt_tokens_details.cached_tokens=640`, input `1000`, output `50`, and provider `openai`.

| build | persisted `cache_read_input_tokens` | evidence |
| --- | ---: | --- |
| master `89e03dc` | 0 | [Weave trace](https://app.qa.wandb.ai/weave-team/weave-codex-cache-read-7590-zoo-qa-master-20260717-104520/weave/agents?dashConv=zoo-qa-master-openai-cache-probe-7590-20260717-104520&convTurn=1&chatTrace=01c9dbcb9946b487da284085224bdec2) |
| candidate `8596b92` | 640 | [Weave trace](https://app.qa.wandb.ai/weave-team/weave-codex-cache-read-7590-zoo-qa-candidate-20260717-105120/weave/agents?dashConv=zoo-qa-candidate-openai-cache-probe-7590-20260717-105120&convTurn=1&chatTrace=edb15436cfb1d6f8550066ee4af0d7a0) |

### Exact Agent-OTLP logging probe

This inline logger was run unchanged against master and candidate. The runner supplied only `WANDB_BASE_URL`, `WANDB_API_KEY`, `PROBE_PROJECT`, and `PROBE_CONVERSATION` as environment variables; no credentials are embedded here.

```bash
node --input-type=module -e '
  import {context, SpanKind, trace} from "@opentelemetry/api";
  import {buildTracer} from "./node_modules/weave-codex/dist/spans/tracer.js";

  const config = {
    baseUrl: process.env.WANDB_BASE_URL,
    apiKey: process.env.WANDB_API_KEY,
    projectId: process.env.PROBE_PROJECT,
    entity: process.env.PROBE_PROJECT.split("/")[0],
    project: process.env.PROBE_PROJECT.split("/")[1],
    captureContent: false,
    debug: false,
  };
  const {tracer, shutdown} = buildTracer(config);
  const now = Date.now();

  const root = tracer.startSpan("invoke_agent codex", {
    kind: SpanKind.INTERNAL,
    startTime: new Date(now),
    attributes: {
      "gen_ai.operation.name": "invoke_agent",
      "gen_ai.provider.name": "openai",
      "gen_ai.conversation.id": process.env.PROBE_CONVERSATION,
      "gen_ai.agent.name": "codex",
      "gen_ai.request.model": "zai-org/GLM-5.2",
    },
  });

  const parent = trace.setSpan(context.active(), root);
  const chat = tracer.startSpan("chat zai-org/GLM-5.2", {
    kind: SpanKind.CLIENT,
    startTime: new Date(now + 1),
    attributes: {
      "gen_ai.operation.name": "chat",
      "gen_ai.provider.name": "openai",
      "gen_ai.conversation.id": process.env.PROBE_CONVERSATION,
      "gen_ai.request.model": "zai-org/GLM-5.2",
      "gen_ai.response.model": "zai-org/GLM-5.2",
      "gen_ai.usage.input_tokens": 1000,
      "gen_ai.usage.output_tokens": 50,
      "gen_ai.usage.prompt_tokens_details.cached_tokens": 640,
    },
  });

  chat.end(new Date(now + 2));
  root.end(new Date(now + 3));
  await shutdown();
  console.log(JSON.stringify({
    project: process.env.PROBE_PROJECT,
    conversation_id: process.env.PROBE_CONVERSATION,
    trace_id: root.spanContext().traceId,
    source_cached_tokens: 640,
  }));
'
```

[WB-37554]: https://coreweave.atlassian.net/browse/WB-37554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
