### PR TITLE
feat(weave): link stamped agent spans to eval results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,12 @@ When trace-server request/response models or route schemas change, refresh the A
 2. Copy that schema into the tracked Node SDK schema: `cp ../../weave-trace/openapi.json sdks/node/weave.openapi.json`.
 3. Regenerate the TypeScript client from `sdks/node`: `pnpm run generate-api`.
 
+Evaluation result rows merge agent span links from two sources: legacy
+`weave.genai_span_ref` call attributes and OTel spans whose promoted
+`eval_run_id` plus `eval_predict_and_score_call_id` columns identify the
+trial. Keep the promoted-column hydration best-effort so eval results remain
+available during rolling deploys.
+
 If `sdks/node/node_modules` is missing, run `pnpm install --frozen-lockfile` in `sdks/node` first. Do not use `npm install`; this SDK is pinned to pnpm.
 
 ## Python Testing Guidelines

--- a/tests/trace_server/test_eval_results_genai_span_ref.py
+++ b/tests/trace_server/test_eval_results_genai_span_ref.py
@@ -1,9 +1,16 @@
 import datetime
 from typing import Any
 
+from tests.trace_server.helpers import make_project_id
 from weave.trace_server import constants
 from weave.trace_server import eval_results_helpers as eval_helpers
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.agents.helpers import genai_span_to_row
+from weave.trace_server.agents.schema import (
+    ALL_SPAN_INSERT_COLUMNS,
+    AgentSpanCHInsertable,
+)
+from weave.trace_server.agents.types import AgentSpanSchema
 
 
 def _call(
@@ -147,4 +154,130 @@ def test_extract_genai_span_refs_skips_invalid_items() -> None:
 
     assert eval_helpers.extract_genai_span_refs(call) == [
         tsi.GenAISpanRef.model_validate(_genai_span_ref("valid-trace"))
+    ]
+
+
+def test_merge_eval_agent_span_refs_links_stamped_span_tree_root() -> None:
+    rows = [
+        tsi.EvalResultsRow(
+            row_digest="row-1",
+            evaluations=[
+                tsi.EvalResultsRowEvaluation(
+                    evaluation_call_id="eval-1",
+                    trials=[tsi.EvalResultsTrial(predict_and_score_call_id="pas-1")],
+                )
+            ],
+        )
+    ]
+    now = datetime.datetime.now(datetime.timezone.utc)
+    spans = [
+        AgentSpanSchema(
+            project_id="project-1",
+            trace_id="agent-trace-1",
+            span_id="child",
+            parent_span_id="root",
+            started_at=now + datetime.timedelta(seconds=1),
+            eval_run_id="eval-1",
+            eval_predict_and_score_call_id="pas-1",
+        ),
+        AgentSpanSchema(
+            project_id="project-1",
+            trace_id="agent-trace-1",
+            span_id="root",
+            started_at=now,
+            eval_run_id="eval-1",
+            eval_predict_and_score_call_id="pas-1",
+        ),
+        AgentSpanSchema(
+            project_id="project-1",
+            trace_id="unrelated-trace",
+            span_id="unrelated",
+            eval_run_id="eval-2",
+            eval_predict_and_score_call_id="pas-2",
+        ),
+    ]
+
+    eval_helpers.merge_eval_agent_span_refs(rows, spans)
+
+    assert rows[0].evaluations[0].trials[0].genai_span_ref == [
+        tsi.GenAISpanRef(trace_id="agent-trace-1", span_id="root")
+    ]
+
+
+def test_merge_eval_agent_span_refs_preserves_explicit_ref_for_same_trace() -> None:
+    explicit_ref = tsi.GenAISpanRef(trace_id="agent-trace-1", span_id="model-span")
+    rows = [
+        tsi.EvalResultsRow(
+            row_digest="row-1",
+            evaluations=[
+                tsi.EvalResultsRowEvaluation(
+                    evaluation_call_id="eval-1",
+                    trials=[
+                        tsi.EvalResultsTrial(
+                            predict_and_score_call_id="pas-1",
+                            genai_span_ref=[explicit_ref],
+                        )
+                    ],
+                )
+            ],
+        )
+    ]
+    spans = [
+        AgentSpanSchema(
+            project_id="project-1",
+            trace_id="agent-trace-1",
+            span_id="root",
+            eval_run_id="eval-1",
+            eval_predict_and_score_call_id="pas-1",
+        ),
+        AgentSpanSchema(
+            project_id="project-1",
+            trace_id="agent-trace-2",
+            span_id="other-root",
+            eval_run_id="eval-1",
+            eval_predict_and_score_call_id="pas-1",
+        ),
+    ]
+
+    eval_helpers.merge_eval_agent_span_refs(rows, spans)
+
+    assert rows[0].evaluations[0].trials[0].genai_span_ref == [
+        explicit_ref,
+        tsi.GenAISpanRef(trace_id="agent-trace-2", span_id="other-root"),
+    ]
+
+
+def test_hydrate_eval_agent_span_refs_queries_promoted_columns(ch_server) -> None:
+    project_id = make_project_id("eval_results_agent_spans")
+    span = AgentSpanCHInsertable(
+        project_id=project_id,
+        trace_id="agent-trace-1",
+        span_id="agent-span-1",
+        span_name="agent-run",
+        started_at=datetime.datetime.now(datetime.timezone.utc),
+        eval_run_id="eval-1",
+        eval_predict_and_score_call_id="pas-1",
+    )
+    ch_server.ch_client.insert(
+        "spans",
+        data=[genai_span_to_row(span)],
+        column_names=ALL_SPAN_INSERT_COLUMNS,
+    )
+    rows = [
+        tsi.EvalResultsRow(
+            row_digest="row-1",
+            evaluations=[
+                tsi.EvalResultsRowEvaluation(
+                    evaluation_call_id="eval-1",
+                    trials=[tsi.EvalResultsTrial(predict_and_score_call_id="pas-1")],
+                )
+            ],
+        )
+    ]
+
+    warnings = eval_helpers.hydrate_eval_agent_span_refs(ch_server, project_id, rows)
+
+    assert warnings == []
+    assert rows[0].evaluations[0].trials[0].genai_span_ref == [
+        tsi.GenAISpanRef(trace_id="agent-trace-1", span_id="agent-span-1")
     ]

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5895,7 +5895,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             return tsi.EvalResultsQueryRes(
                 rows=[], total_rows=0, summary=empty_summary, warnings=[]
             )
-        return self._eval_results_via_cte(req, eval_root_ids)
+        result = self._eval_results_via_cte(req, eval_root_ids)
+        result.warnings.extend(
+            eval_helpers.hydrate_eval_agent_span_refs(self, req.project_id, result.rows)
+        )
+        return result
 
     def _eval_results_via_cte(
         self,

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -19,7 +19,10 @@ from weave.shared.digest import str_digest
 from weave.trace_server import constants
 from weave.trace_server import trace_server_common as tsc
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.agents import types as agent_types
+from weave.trace_server.agents.constants import MAX_AGENT_QUERY_LIMIT
 from weave.trace_server.errors import InvalidRequest
+from weave.trace_server.interface.query import Query
 from weave.trace_server.tracing import traced
 
 _SUPPORTED_SORT_PREFIXES = (
@@ -28,8 +31,6 @@ _SUPPORTED_SORT_PREFIXES = (
     "output.",
 )
 _NUMERIC_SORT_PREFIXES = ("scores.",)
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -409,6 +410,166 @@ def _combine_genai_span_refs(
                 refs.append(ref)
                 seen.add(key)
     return refs or None
+
+
+def _span_order_key(span: agent_types.AgentSpanSchema) -> tuple[float, str]:
+    started_at = span.started_at
+    return (
+        started_at.timestamp() if started_at is not None else float("inf"),
+        span.span_id,
+    )
+
+
+def merge_eval_agent_span_refs(
+    rows: list[tsi.EvalResultsRow],
+    spans: Iterable[agent_types.AgentSpanSchema],
+) -> None:
+    """Merge one representative stamped span ref per trace into each trial.
+
+    Evaluation-linked OTel spans are stamped with both the evaluation run ID
+    and predict-and-score call ID. A prediction can produce an entire span tree,
+    but ``genai_span_ref`` is a trace link, so use the root of the stamped
+    subtree as the representative instead of returning every child span.
+    Explicit refs already recorded on calls win for their trace.
+    """
+    spans_by_trial_and_trace: dict[
+        tuple[str, str], dict[str, list[agent_types.AgentSpanSchema]]
+    ] = defaultdict(lambda: defaultdict(list))
+    for span in spans:
+        if not span.eval_run_id or not span.eval_predict_and_score_call_id:
+            continue
+        spans_by_trial_and_trace[span.eval_run_id, span.eval_predict_and_score_call_id][
+            span.trace_id
+        ].append(span)
+
+    for row in rows:
+        for evaluation in row.evaluations:
+            for trial in evaluation.trials:
+                spans_by_trace = spans_by_trial_and_trace.get(
+                    (evaluation.evaluation_call_id, trial.predict_and_score_call_id)
+                )
+                if not spans_by_trace:
+                    continue
+
+                refs = list(trial.genai_span_ref or [])
+                linked_trace_ids = {ref.trace_id for ref in refs}
+                representatives: list[agent_types.AgentSpanSchema] = []
+                for trace_spans in spans_by_trace.values():
+                    span_ids = {span.span_id for span in trace_spans}
+                    roots = [
+                        span
+                        for span in trace_spans
+                        if span.parent_span_id not in span_ids
+                    ]
+                    representatives.append(
+                        min(roots or trace_spans, key=_span_order_key)
+                    )
+
+                for span in sorted(representatives, key=_span_order_key):
+                    if span.trace_id in linked_trace_ids:
+                        continue
+                    refs.append(
+                        tsi.GenAISpanRef(trace_id=span.trace_id, span_id=span.span_id)
+                    )
+                    linked_trace_ids.add(span.trace_id)
+                trial.genai_span_ref = refs or None
+
+
+def _query_eval_agent_spans(
+    server: tsi.TraceServerInterface,
+    project_id: str,
+    eval_call_ids: set[str],
+    predict_and_score_call_ids: list[str],
+) -> list[agent_types.AgentSpanSchema]:
+    linked_spans: list[agent_types.AgentSpanSchema] = []
+    for batch_start in range(
+        0,
+        len(predict_and_score_call_ids),
+        tsc.MAX_FILTER_LENGTH,
+    ):
+        call_id_batch = predict_and_score_call_ids[
+            batch_start : batch_start + tsc.MAX_FILTER_LENGTH
+        ]
+        query = Query.model_validate(
+            {
+                "$expr": {
+                    "$and": [
+                        {
+                            "$in": [
+                                {"$getField": "eval_run_id"},
+                                [
+                                    {"$literal": eval_call_id}
+                                    for eval_call_id in sorted(eval_call_ids)
+                                ],
+                            ]
+                        },
+                        {
+                            "$in": [
+                                {"$getField": "eval_predict_and_score_call_id"},
+                                [{"$literal": call_id} for call_id in call_id_batch],
+                            ]
+                        },
+                    ]
+                }
+            }
+        )
+        offset = 0
+        while True:
+            result = server.agent_spans_query(
+                agent_types.AgentSpansQueryReq(
+                    project_id=project_id,
+                    query=query,
+                    limit=MAX_AGENT_QUERY_LIMIT,
+                    offset=offset,
+                )
+            )
+            linked_spans.extend(
+                span
+                for span in result.spans
+                if span.eval_run_id in eval_call_ids
+                and span.eval_predict_and_score_call_id in call_id_batch
+            )
+            offset += len(result.spans)
+            if not result.spans or offset >= result.total_count:
+                break
+    return linked_spans
+
+
+def hydrate_eval_agent_span_refs(
+    server: tsi.TraceServerInterface,
+    project_id: str,
+    rows: list[tsi.EvalResultsRow],
+) -> list[str]:
+    """Load stamped OTel spans for returned trials and merge them as trace refs.
+
+    This is deliberately best-effort. Eval results remain useful during rolling
+    deploys or if the agent span query fails; callers receive a non-fatal warning
+    rather than losing the evaluation response.
+    """
+    eval_call_ids: set[str] = set()
+    predict_and_score_call_ids: list[str] = []
+    for row in rows:
+        for evaluation in row.evaluations:
+            eval_call_ids.add(evaluation.evaluation_call_id)
+            predict_and_score_call_ids.extend(
+                trial.predict_and_score_call_id for trial in evaluation.trials
+            )
+    predict_and_score_call_ids = list(dict.fromkeys(predict_and_score_call_ids))
+    if not eval_call_ids or not predict_and_score_call_ids:
+        return []
+
+    try:
+        linked_spans = _query_eval_agent_spans(
+            server, project_id, eval_call_ids, predict_and_score_call_ids
+        )
+        merge_eval_agent_span_refs(rows, linked_spans)
+    except Exception:
+        logger.warning(
+            "Failed to load evaluation-linked agent spans",
+            exc_info=True,
+        )
+        return ["Failed to load evaluation-linked agent spans"]
+    return []
 
 
 def _build_trial(

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -6832,8 +6832,17 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             )
             eval_helpers.resolve_eval_inputs(all_calls, eval_root_ids, reader)
         if not req.filters and not req.sort_by:
-            return eval_helpers.eval_results_query(self, req, eval_root_ids, all_calls)
-        return self._eval_results_query_sorted_filtered(req, eval_root_ids, all_calls)
+            result = eval_helpers.eval_results_query(
+                self, req, eval_root_ids, all_calls
+            )
+        else:
+            result = self._eval_results_query_sorted_filtered(
+                req, eval_root_ids, all_calls
+            )
+        result.warnings.extend(
+            eval_helpers.hydrate_eval_agent_span_refs(self, req.project_id, result.rows)
+        )
+        return result
 
     @staticmethod
     def _eval_row_field_values(


### PR DESCRIPTION
## Summary

- Hydrates evaluation result trials from spans stamped with the evaluation run and predict-and-score call IDs.
- Links one root stamped span per trace while preserving explicit `genai_span_ref` values.
- Keeps hydration best-effort and batches/paginates agent span queries using existing trace-server limits.
- Covers merge behavior and the ClickHouse query path.

Companion UI PR: wandb/core#48399.

## Validation

- `uv run --group test python -m pytest tests/trace_server/test_eval_results_genai_span_ref.py` (7 passed)
- `uvx ruff check weave/trace_server/eval_results_helpers.py tests/trace_server/test_eval_results_genai_span_ref.py`
- Seeded local eval run `019f7155-0e31-785c-9b4c-270060511eab`; `eval_results/query` returned 3 linked root span refs.