### PR TITLE
fix(weave): expose cache rates in add_cost

### DIFF
--- a/sdks/node/src/generated/traceServerApi.ts
+++ b/sdks/node/src/generated/traceServerApi.ts
@@ -2675,6 +2675,10 @@ export interface CostQueryOutput {
   prompt_token_cost?: number | null;
   /** Completion Token Cost */
   completion_token_cost?: number | null;
+  /** Cache Read Input Token Cost */
+  cache_read_input_token_cost?: number | null;
+  /** Cache Creation Input Token Cost */
+  cache_creation_input_token_cost?: number | null;
   /** Prompt Token Cost Unit */
   prompt_token_cost_unit?: string | null;
   /** Completion Token Cost Unit */

--- a/sdks/node/weave.openapi.json
+++ b/sdks/node/weave.openapi.json
@@ -12431,6 +12431,34 @@
               1.0
             ]
           },
+          "cache_read_input_token_cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Read Input Token Cost",
+            "examples": [
+              1.0
+            ]
+          },
+          "cache_creation_input_token_cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Creation Input Token Cost",
+            "examples": [
+              1.0
+            ]
+          },
           "prompt_token_cost_unit": {
             "anyOf": [
               {

--- a/tests/trace/test_client_cost.py
+++ b/tests/trace/test_client_cost.py
@@ -81,6 +81,8 @@ def test_cost_apis(client):
         prompt_token_cost=500,
         completion_token_cost=1000,
         effective_date=datetime.datetime(1998, 10, 3),
+        cache_read_input_token_cost=250,
+        cache_creation_input_token_cost=750,
     )
 
     assert len(res.ids) == 1
@@ -94,6 +96,9 @@ def test_cost_apis(client):
     else:
         assert res[1].effective_date.year == 2021
         assert res[0].effective_date.year == 1998
+    added_cost = next(cost for cost in res if cost.effective_date.year == 1998)
+    assert added_cost.cache_read_input_token_cost == 250
+    assert added_cost.cache_creation_input_token_cost == 750
 
     # query with limit and offset
     res = client.query_costs(llm_ids=["my_model_to_delete3"], limit=1)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -2297,6 +2297,8 @@ class WeaveClient:
         prompt_token_cost_unit: str | None = "USD",
         completion_token_cost_unit: str | None = "USD",
         provider_id: str | None = "default",
+        cache_read_input_token_cost: float = 0,
+        cache_creation_input_token_cost: float = 0,
     ) -> CostCreateRes:
         """Add a cost to the current project.
 
@@ -2314,6 +2316,8 @@ class WeaveClient:
             provider_id: The provider of the LLM. Defaults to "default". eg "openai"
             prompt_token_cost_unit: The unit of the cost for the prompt tokens. Defaults to "USD". (Currently unused, will be used in the future to specify the currency type for the cost eg "tokens" or "time")
             completion_token_cost_unit: The unit of the cost for the completion tokens. Defaults to "USD". (Currently unused, will be used in the future to specify the currency type for the cost eg "tokens" or "time")
+            cache_read_input_token_cost: The cost per cache-read input token. Defaults to 0.
+            cache_creation_input_token_cost: The cost per cache-creation input token. Defaults to 0.
 
         Returns:
             A CostCreateRes object.
@@ -2325,6 +2329,8 @@ class WeaveClient:
         cost = CostCreateInput(
             prompt_token_cost=prompt_token_cost,
             completion_token_cost=completion_token_cost,
+            cache_read_input_token_cost=cache_read_input_token_cost,
+            cache_creation_input_token_cost=cache_creation_input_token_cost,
             effective_date=effective_date,
             prompt_token_cost_unit=prompt_token_cost_unit,
             completion_token_cost_unit=completion_token_cost_unit,

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -4133,6 +4133,8 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                     ),
                     "prompt_token_cost": cost.prompt_token_cost,
                     "completion_token_cost": cost.completion_token_cost,
+                    "cache_read_input_token_cost": cost.cache_read_input_token_cost,
+                    "cache_creation_input_token_cost": cost.cache_creation_input_token_cost,
                     "prompt_token_cost_unit": cost.prompt_token_cost_unit or "USD",
                     "completion_token_cost_unit": cost.completion_token_cost_unit
                     or "USD",

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1838,6 +1838,8 @@ class CostQueryOutput(BaseModel):
     llm_id: str | None = Field(default=None, examples=["gpt4"])
     prompt_token_cost: float | None = Field(default=None, examples=[1.0])
     completion_token_cost: float | None = Field(default=None, examples=[1.0])
+    cache_read_input_token_cost: float | None = Field(default=None, examples=[1.0])
+    cache_creation_input_token_cost: float | None = Field(default=None, examples=[1.0])
     prompt_token_cost_unit: str | None = Field(default=None, examples=["USD"])
     completion_token_cost_unit: str | None = Field(default=None, examples=["USD"])
     effective_date: datetime.datetime | None = Field(


### PR DESCRIPTION
## Summary
- Let `WeaveClient.add_cost` configure cache-read and cache-creation token pricing.
- Return those rates from `query_costs`, including the in-memory trace server.
- Regenerate the tracked OpenAPI and Node SDK response types for both cache-rate fields.
- Jira: [WB-37571](https://coreweave.atlassian.net/browse/WB-37571)

## End-to-end cost path

This PR closes the public SDK configuration/readback gap. Agent-span cost calculation already happens at query time; [core #48415](https://github.com/wandb/core/pull/48415) loads that authoritative conversation aggregate into the Agents → Spans drill-in.

```mermaid
flowchart LR
  Agent["Agent/provider emits OTel GenAI span"] --> Spans["spans table<br/>model + input/output/cache tokens"]

  Catalog["Built-in price catalog"] --> Prices["llm_token_prices"]
  SDK["WeaveClient.add_cost<br/>weave #7592"] --> Create["cost/create API"] --> Prices
  Prices --> QueryCosts["query_costs<br/>configuration readback"]

  Spans --> Join["Read-time model-price join"]
  Prices --> Join
  Join --> Formula["regular input × prompt rate<br/>+ cache read × cache-read rate<br/>+ cache creation × cache-creation rate<br/>+ output × completion rate"]
  Formula --> Aggregate["agentSpansQuery<br/>filter + group by conversation_id<br/>include_costs=true"]
  Aggregate --> Rail["Conversation token/cache/cost aggregate<br/>Agents → Spans meta rail<br/>core #48415"]
```

Price selection currently matches `response_model` (falling back to `request_model`), prefers project pricing over default pricing, and then chooses the latest `effective_date`. `provider_id` is stored on the price row but is not part of this agent-span join key.

## Production and UI evidence
[<img src="https://github.com/user-attachments/assets/720fe594-f585-480c-b705-125003af92cd" width="900">](https://wandb.ai/weave-team/gclaude-codex-evidence-20260717/weave/agents/spans/7b9b61939fc6402df98dc63b4184b24f?span=d2ef74d5cdebbcbd&chatTab=spans&convTurn=1)

The linked production trace records `1.0K` input tokens, `800` cache-read tokens, and the expected `$0.0056` cache-aware total. The screenshot is a production-versus-FeatureBee proof for core #48415: #7592 supplies the project cache pricing; #48415 projects the same conversation aggregate into the Agents → Spans right rail. Click the screenshot to open the live trace.

## Testing
- `uv run --group test python -m pytest tests/trace/test_client_cost.py::test_cost_apis -v --trace-server=fake`
- `uv run --group test python -m pytest tests/trace_server/test_genai_agent_costs.py::test_spans_query_cost_subtracts_cache_tokens -v`
- `pnpm exec prettier --check src/generated/traceServerApi.ts`
- `pnpm run typecheck:cjs`
- `pnpm run typecheck:esm`
- `pnpm run lint`
- `nox -e lint`

[WB-37571]: https://coreweave.atlassian.net/browse/WB-37571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
