### PR TITLE
fix(weave): resolve Bedrock inference profile region from ARN for cost tracking

### DIFF
--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -10,6 +10,9 @@ from moto import mock_aws
 
 import weave
 from weave.integrations.bedrock import patch_client
+from weave.integrations.bedrock.bedrock_sdk import (
+    extract_model_name_from_inference_profile_arn,
+)
 
 model_id = "anthropic.claude-3-5-sonnet-20240620-v1:0"
 inference_profile_id = "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0"
@@ -1049,3 +1052,27 @@ def test_bedrock_agent_invoke_agent(
     summary = call.summary
     assert summary is not None, "Summary should not be None"
     assert "usage" in summary
+
+
+def test_bedrock_inference_profile_resolved_using_arn_region() -> None:
+    # Resolving an inference profile to its model name calls the Bedrock control
+    # plane, which must run in the profile's own region -- encoded in the ARN, not
+    # read from an ambient env var (WB-29454). Otherwise resolution fails, the
+    # stored name matches no price row, and the call shows tokens but no cost.
+    profile_arn = "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/abc123def456"
+    resolved_model = "anthropic.claude-sonnet-4-20250514-v1:0"
+
+    with patch(
+        "weave.integrations.bedrock.bedrock_sdk.boto3.client"
+    ) as mock_boto3_client:
+        mock_boto3_client.return_value.get_inference_profile.return_value = {
+            "models": [
+                {
+                    "modelArn": f"arn:aws:bedrock:eu-west-1::foundation-model/{resolved_model}"
+                }
+            ]
+        }
+        model_name = extract_model_name_from_inference_profile_arn(profile_arn)
+
+    mock_boto3_client.assert_called_once_with("bedrock", region_name="eu-west-1")
+    assert model_name == resolved_model

--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -1055,10 +1055,13 @@ def test_bedrock_agent_invoke_agent(
 
 
 def test_bedrock_inference_profile_resolved_using_arn_region() -> None:
-    # Resolving an inference profile to its model name calls the Bedrock control
-    # plane, which must run in the profile's own region -- encoded in the ARN, not
-    # read from an ambient env var (WB-29454). Otherwise resolution fails, the
-    # stored name matches no price row, and the call shows tokens but no cost.
+    """Resolve an inference profile to its model name using the region in its ARN.
+
+    The Bedrock control-plane lookup must run in the profile's own region, which is
+    taken from the ARN and not an ambient env var (WB-29454); otherwise resolution
+    fails and the call shows tokens but no cost. boto3.client is patched directly
+    because moto does not implement get_inference_profile.
+    """
     profile_arn = "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/abc123def456"
     resolved_model = "anthropic.claude-sonnet-4-20250514-v1:0"
 

--- a/weave/integrations/bedrock/bedrock_sdk.py
+++ b/weave/integrations/bedrock/bedrock_sdk.py
@@ -1,7 +1,6 @@
 import copy
 import io
 import json
-import os
 import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -120,9 +119,13 @@ def extract_model_name_from_inference_profile_arn(profile_arn: str) -> str:
         The extracted model name (e.g. "amazon.nova-lite-v1:0")
     """
     try:
-        aws_region_name = os.environ.get("AWS_REGION_NAME")
         profile_id = profile_arn.rsplit("/", maxsplit=1)[-1]
-        bedrock_client = boto3.client("bedrock", region_name=aws_region_name)
+        # An inference profile is a regional resource and its ARN encodes the
+        # region (arn:aws:bedrock:<region>:...). Resolve it from that region so
+        # the call does not depend on the caller's ambient AWS region config
+        # (boto3 only reads AWS_DEFAULT_REGION, not AWS_REGION, by default).
+        region_name = profile_arn.split(":")[3]
+        bedrock_client = boto3.client("bedrock", region_name=region_name)
 
         response = bedrock_client.get_inference_profile(
             inferenceProfileIdentifier=profile_id


### PR DESCRIPTION
## Description

Bedrock calls made through an inference profile show tokens but no cost: https://coreweave.atlassian.net/browse/WB-29454 . It was reported as an async race — the slower of two concurrent calls loses its cost — but the handler has no shared state. It's a model-name problem.

Weave computes cost at read time by matching the stored model name against the price table. For an inference-profile modelId (an ARN), the integration first resolves the ARN to a real model name via `GetInferenceProfile`, which must run in the profile's region. That region came from `AWS_REGION_NAME`, which boto3 never reads — and it doesn't read `AWS_REGION` either, only `AWS_DEFAULT_REGION`. So with `AWS_REGION` or nothing set, the resolve failed, the stored name matched no price row, and the call kept its tokens but lost its cost.

The region is already in the ARN (`arn:aws:bedrock:<region>:...`), so we read it from there. This also handles the case where the caller's default region differs from the profile's.

## Testing

Verified the boto3 behavior directly (1.41.3): `AWS_REGION` alone raises `NoRegionError`, `AWS_DEFAULT_REGION` alone resolves, and botocore maps the region to `AWS_DEFAULT_REGION` only. Added a unit test asserting the control-plane client is built in the ARN's region and the model name resolves. Full Bedrock suite passes (16), plus ruff, mypy, and pyright.

