### PR TITLE
fix(weave): preserve user prompt in conversation previews

### DIFF
--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -18,6 +18,7 @@ from tests.trace_server.helpers import make_project_id as _make_project_id
 from weave.shared import refs_internal as ri
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents.clickhouse import AgentWriteHandler
+from weave.trace_server.agents.constants import CONVERSATION_PREVIEW_CHARS
 from weave.trace_server.agents.helpers import genai_span_to_row
 from weave.trace_server.agents.schema import (
     ALL_SPAN_INSERT_COLUMNS,
@@ -1166,6 +1167,76 @@ def test_group_by_conversation_id_message_previews(ch_server):
     assert row.last_message is not None
     assert row.last_message.role == "assistant_message"
     assert row.last_message.text == "final reply"
+
+
+def test_conversation_preview_strips_leading_json_before_truncation(ch_server):
+    project_id = _make_project_id("conv-preview-json")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    conv = f"conv-{uuid.uuid4().hex[:8]}"
+    question = "Which settings caused the most crashes?"
+    context_blob = json.dumps(
+        {
+            "url": "u",
+            "content": [
+                {
+                    "type": "workspace",
+                    "description": "x" * 16,
+                    "run_sets": [
+                        {
+                            "enabled": True,
+                            "filter": "a" * 20,
+                            "name": "first",
+                        },
+                        {
+                            "enabled": True,
+                            "filter": "b" * 100,
+                            "name": "second",
+                        },
+                    ],
+                }
+            ],
+        },
+        sort_keys=True,
+    )
+    assert len(context_blob) > CONVERSATION_PREVIEW_CHARS
+    # The production preview limit cuts the outer object after one
+    # complete nested run-set and its separator. Frontend cleanup then strips
+    # the nested JSON but misclassifies the remaining comma as user prose.
+    truncated = context_blob[:CONVERSATION_PREVIEW_CHARS]
+    assert '"name": "first"}, {' in truncated
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(truncated)
+
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                project_id,
+                conversation_id=conv,
+                operation_name="chat",
+                started_at=now,
+                input_messages=[
+                    NormalizedMessage(
+                        role="user",
+                        content=f'{context_blob}\n{{"request_id": "abc"}}\n{question}',
+                    )
+                ],
+            )
+        ],
+    )
+
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(
+            project_id=project_id,
+            group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+        )
+    )
+    by_conv = {group.group_keys["conversation_id"]: group for group in res.groups}
+    row = by_conv[conv]
+
+    assert row.first_message is not None
+    assert row.first_message.role == "user_message"
+    assert row.first_message.text == question
 
 
 def _create_feedback(

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -16,7 +16,9 @@ from weave.trace_server.agents.chat_view import (
     build_chat_messages,
     build_span_tree,
     build_trace_chat,
+    first_user_preview_text,
 )
+from weave.trace_server.agents.schema import NormalizedMessage
 from weave.trace_server.agents.types import (
     AgentChatAgentStart,
     AgentChatAssistantMessage,
@@ -120,6 +122,64 @@ def _context_compacted_payload(
 ) -> AgentChatContextCompacted:
     assert message.context_compacted is not None
     return message.context_compacted
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        (
+            "Which settings caused the most crashes?",
+            "Which settings caused the most crashes?",
+        ),
+        (
+            json.dumps(
+                {
+                    "content": [{"type": "report", "title": "Crash report"}],
+                }
+            )
+            + "\nWhich settings caused the most crashes?",
+            "Which settings caused the most crashes?",
+        ),
+        (
+            '{"ordinary": 1}\nExplain this object',
+            "Explain this object",
+        ),
+        ("[1, 2]\nCompare these values", "Compare these values"),
+        (
+            '{"context": 1}\n{"metadata": 2}\nWhat failed?',
+            "What failed?",
+        ),
+        (
+            '{"context": 1}\nCompare {"run": "a"} with [1, 2]',
+            "Compare [JSON] with [JSON]",
+        ),
+        (
+            'Before {"first": 1} middle {"second": 2} after',
+            "Before [JSON] middle [JSON] after",
+        ),
+        ('Explain {"broken":', 'Explain {"broken":'),
+        ('{"question": "What failed?"}', ""),
+        (
+            '{"context": 1}\n{"error": "asdf"}',
+            "",
+        ),
+        ("Compare {foo} with {bar}", "Compare {foo} with {bar}"),
+        (
+            '{"complete": true}\n{"incomplete":\nWhat failed?',
+            '{"complete": true}\n{"incomplete":\nWhat failed?',
+        ),
+        (
+            '{"first": 1}, {"second": 2}\nWhat failed?',
+            '{"first": 1}, {"second": 2}\nWhat failed?',
+        ),
+    ],
+)
+def test_first_user_preview_text_handles_json_values(
+    content: str, expected: str
+) -> None:
+    messages = [NormalizedMessage(role="user", content=content)]
+
+    assert first_user_preview_text(messages) == expected
 
 
 def test_empty() -> None:

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -788,14 +788,60 @@ def _extract_user_text(
 
 
 def first_user_preview_text(messages: list[NormalizedMessage]) -> str:
-    """Public: opening user-prompt text from a span's `input_messages`.
+    """Public: readable opening user-prompt text from `input_messages`.
 
     The opening user prompt is the first user entry of the earliest
     message-bearing span; that span's `input_messages` begins at the
     conversation opening.
     """
     texts = _user_prompt_texts(messages)
-    return texts[0] if texts else ""
+    return _json_aware_preview_text(texts[0]) if texts else ""
+
+
+def _json_aware_preview_text(text: str) -> str:
+    """Remove leading JSON and replace later values before preview truncation.
+
+    Conversation titles use prose, so JSON-only input produces no user preview.
+    Malformed leading JSON is left unchanged rather than partially stripped.
+    """
+    stripped = text.lstrip()
+    cursor = 0
+    parsed_json = False
+    decoder = json.JSONDecoder()
+    while cursor < len(stripped) and stripped[cursor] in "[{":
+        try:
+            _, cursor = decoder.raw_decode(stripped, cursor)
+        except json.JSONDecodeError:
+            return text
+        parsed_json = True
+        while cursor < len(stripped) and stripped[cursor].isspace():
+            cursor += 1
+        if cursor < len(stripped) and stripped[cursor] == ",":
+            return text
+
+    trailing = stripped[cursor:].strip() if parsed_json else text
+    return _replace_json_values(trailing)
+
+
+def _replace_json_values(text: str) -> str:
+    """Replace complete JSON objects/arrays in preview prose with `[JSON]`."""
+    parts: list[str] = []
+    cursor = 0
+    decoder = json.JSONDecoder()
+    while cursor < len(text):
+        if text[cursor] in "[{":
+            try:
+                value, end = decoder.raw_decode(text, cursor)
+            except json.JSONDecodeError:
+                pass
+            else:
+                if isinstance(value, (dict, list)):
+                    parts.append("[JSON]")
+                    cursor = end
+                    continue
+        parts.append(text[cursor])
+        cursor += 1
+    return "".join(parts).strip()
 
 
 def last_assistant_preview_text(messages: list[NormalizedMessage]) -> str:


### PR DESCRIPTION
## Description

- Fixes [WB-37420](https://coreweave.atlassian.net/browse/WB-37420), which is caused by WB-agent prepending logged content with JSON that includes info such as page context. After we truncate, we may parse this JSON incompletely, resulting in preview text being ","
- Core creates [one page-context part](https://github.com/wandb/core/blob/a2832038c8bd66b7b38a7bb90d517863317a047d/frontends/app/src/agentChat/pageContext/buildPromptContext.ts#L18-L33) and [prepends it to the customer's prompt parts](https://github.com/wandb/core/blob/a2832038c8bd66b7b38a7bb90d517863317a047d/frontends/app/src/agentChat/promptAssembly.ts#L44-L53). Conversation previews truncated that combined value before the frontend separated structured data from prose; at certain JSON boundaries, cleanup removed objects but left a separator comma as the title.
- Remove complete leading JSON objects or arrays before applying the preview limit. Complete JSON later in the prose is represented as `[JSON]`, preserving the fact that the customer referenced structured data without putting the full blob in the title.
- Plain text, malformed leading JSON, and comma-separated top-level JSON remain unchanged. JSON-only input produces no user preview, allowing the existing assistant, agent-name, or conversation-ID fallback to apply.

For example:

```text
Input:
{"page": "..."}
Compare {"run": "a"} with {"run": "b"}

Preview: Compare [JSON] with [JSON]
```

## Testing

- Unit coverage for plain text, one and multiple leading JSON values, JSON in the middle of prose, multiple embedded values, arrays, JSON-only input, malformed JSON, and comma-separated JSON.
- ClickHouse-backed regression reproducing the production preview cutoff and asserting the stored question becomes the conversation title.
- `106 passed, 1 xfailed`; Ruff check and format clean.

Local reproduction using the same conversation before and after the change:

| before (current behavior) | after (this PR) |
|---|---|
| <img src="https://github.com/user-attachments/assets/ed0d9219-4fb7-446c-805d-9cf3f87dda8c" width="420" alt="Conversation title shown as a comma before the fix"> | <img src="https://github.com/user-attachments/assets/39d7cf23-7295-4ff0-859d-26373a8a7f66" width="420" alt="Conversation title derived from the user question after the fix"> |

[WB-37420]: https://coreweave.atlassian.net/browse/WB-37420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
