### PR TITLE
fix(weave): skip annotation queue calls without start times

### DIFF
--- a/tests/trace/test_client_annotation_queues.py
+++ b/tests/trace/test_client_annotation_queues.py
@@ -478,6 +478,117 @@ def test_annotation_queue_add_calls(client):
     assert add_res.duplicates == 0
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND,
+    reason="ClickHouse-only: calls_merged can contain end-only rows",
+)
+def test_annotation_queue_add_calls_retries_end_only_calls(client):
+    project_id = client.project_id
+    complete_call_id = generate_id()
+    end_only_call_id = generate_id()
+    complete_started_at = datetime.datetime.now(datetime.timezone.utc).replace(
+        microsecond=0
+    )
+    complete_ended_at = complete_started_at + datetime.timedelta(seconds=1)
+    end_only_ended_at = complete_started_at + datetime.timedelta(seconds=3)
+
+    # One complete call and one end-only call reproduce the mixed production batch.
+    client.server.call_start(
+        tsi.CallStartReq(
+            start=tsi.StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=complete_call_id,
+                trace_id=complete_call_id,
+                started_at=complete_started_at,
+                op_name="complete_call",
+                attributes={},
+                inputs={},
+            )
+        )
+    )
+    client.server.call_end(
+        tsi.CallEndReq(
+            end=tsi.EndedCallSchemaForInsert(
+                project_id=project_id,
+                id=complete_call_id,
+                ended_at=complete_ended_at,
+                summary={},
+            )
+        )
+    )
+    client.server.call_end(
+        tsi.CallEndReq(
+            end=tsi.EndedCallSchemaForInsert(
+                project_id=project_id,
+                id=end_only_call_id,
+                ended_at=end_only_ended_at,
+                summary={},
+            )
+        )
+    )
+
+    queue_id = create_annotation_queue(client, name="End-only calls test queue")
+    add_res = client.server.annotation_queue_add_calls(
+        tsi.AnnotationQueueAddCallsReq(
+            project_id=project_id,
+            queue_id=queue_id,
+            call_ids=[complete_call_id, end_only_call_id],
+            display_fields=["input", "output"],
+            wb_user_id="test_user",
+        )
+    )
+
+    # The valid call is added with its separately ingested end event intact.
+    assert add_res.added_count == 1
+    assert add_res.duplicates == 0
+    items_res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=project_id,
+            queue_id=queue_id,
+        )
+    )
+    assert [item.call_id for item in items_res.items] == [complete_call_id]
+    assert items_res.items[0].call_ended_at is not None
+
+    # Once the missing start arrives, retrying adds the previously skipped call.
+    end_only_started_at = complete_started_at + datetime.timedelta(seconds=2)
+    client.server.call_start(
+        tsi.CallStartReq(
+            start=tsi.StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=end_only_call_id,
+                trace_id=end_only_call_id,
+                started_at=end_only_started_at,
+                op_name="end_only_call",
+                attributes={},
+                inputs={},
+            )
+        )
+    )
+    retry_res = client.server.annotation_queue_add_calls(
+        tsi.AnnotationQueueAddCallsReq(
+            project_id=project_id,
+            queue_id=queue_id,
+            call_ids=[end_only_call_id],
+            display_fields=["input", "output"],
+            wb_user_id="test_user",
+        )
+    )
+
+    assert retry_res.added_count == 1
+    assert retry_res.duplicates == 0
+    items_res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=project_id,
+            queue_id=queue_id,
+        )
+    )
+    items_by_call_id = {item.call_id: item for item in items_res.items}
+    assert set(items_by_call_id) == {complete_call_id, end_only_call_id}
+    assert items_by_call_id[end_only_call_id].call_started_at is not None
+    assert items_by_call_id[end_only_call_id].call_ended_at is not None
+
+
 def test_annotation_queue_add_calls_duplicate_prevention(client):
     """Test that adding duplicate calls is handled correctly."""
     project_id = client.project_id

--- a/tests/trace/test_client_annotation_queues.py
+++ b/tests/trace/test_client_annotation_queues.py
@@ -548,7 +548,11 @@ def test_annotation_queue_add_calls_retries_end_only_calls(client):
         )
     )
     assert [item.call_id for item in items_res.items] == [complete_call_id]
-    assert items_res.items[0].call_ended_at is not None
+    complete_item = items_res.items[0]
+    assert (
+        complete_item.call_ended_at
+        == complete_item.call_started_at + datetime.timedelta(seconds=1)
+    )
 
     # Once the missing start arrives, retrying adds the previously skipped call.
     end_only_started_at = complete_started_at + datetime.timedelta(seconds=2)
@@ -585,8 +589,15 @@ def test_annotation_queue_add_calls_retries_end_only_calls(client):
     )
     items_by_call_id = {item.call_id: item for item in items_res.items}
     assert set(items_by_call_id) == {complete_call_id, end_only_call_id}
-    assert items_by_call_id[end_only_call_id].call_started_at is not None
-    assert items_by_call_id[end_only_call_id].call_ended_at is not None
+    end_only_item = items_by_call_id[end_only_call_id]
+    assert (
+        end_only_item.call_started_at
+        == complete_item.call_started_at + datetime.timedelta(seconds=2)
+    )
+    assert (
+        end_only_item.call_ended_at
+        == complete_item.call_started_at + datetime.timedelta(seconds=3)
+    )
 
 
 def test_annotation_queue_add_calls_duplicate_prevention(client):

--- a/tests/trace_server/query_builder/test_annotation_queues_query_builder.py
+++ b/tests/trace_server/query_builder/test_annotation_queues_query_builder.py
@@ -4,9 +4,11 @@ import sqlparse
 
 from weave.trace_server.common_interface import AnnotationQueueItemsFilter, SortBy
 from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.project_version.types import ReadTable
 from weave.trace_server.query_builder.annotation_queues_query_builder import (
     make_annotator_progress_insert_query,
     make_annotator_progress_state_check_query,
+    make_queue_add_calls_fetch_calls_query,
     make_queue_item_existence_query,
     make_queue_items_query,
     make_queues_query,
@@ -24,6 +26,70 @@ def assert_sql(
     )
     assert expected_params == params, (
         f"\nExpected params: {expected_params}\n\nGot params: {params}"
+    )
+
+
+def test_make_queue_add_calls_fetch_calls_query_skips_calls_without_start_time() -> (
+    None
+):
+    expected_params = {
+        "pb_0": "project",
+        "pb_1": ["call-1", "call-2"],
+    }
+
+    # calls_merged needs aggregation after excluding incomplete call rows.
+    merged_pb = ParamBuilder("pb")
+    merged_query = make_queue_add_calls_fetch_calls_query(
+        project_id="project",
+        call_ids=["call-1", "call-2"],
+        pb=merged_pb,
+        read_table=ReadTable.CALLS_MERGED,
+    )
+    expected_merged_query = """
+        SELECT
+            id,
+            any(started_at) as started_at,
+            any(ended_at) as ended_at,
+            any(op_name) as op_name,
+            any(trace_id) as trace_id
+        FROM calls_merged
+        WHERE project_id = {pb_0: String}
+            AND id IN {pb_1: Array(String)}
+        GROUP BY (project_id, id)
+        HAVING started_at IS NOT NULL
+    """
+    assert_sql(
+        expected_merged_query,
+        expected_params,
+        merged_query,
+        merged_pb.get_params(),
+    )
+
+    # calls_complete stores one already-aggregated row per call.
+    complete_pb = ParamBuilder("pb")
+    complete_query = make_queue_add_calls_fetch_calls_query(
+        project_id="project",
+        call_ids=["call-1", "call-2"],
+        pb=complete_pb,
+        read_table=ReadTable.CALLS_COMPLETE,
+    )
+    expected_complete_query = """
+        SELECT
+            id,
+            started_at,
+            ended_at,
+            op_name,
+            trace_id
+        FROM calls_complete
+        WHERE project_id = {pb_0: String}
+            AND id IN {pb_1: Array(String)}
+            AND started_at IS NOT NULL
+    """
+    assert_sql(
+        expected_complete_query,
+        expected_params,
+        complete_query,
+        complete_pb.get_params(),
     )
 
 

--- a/tests/trace_server/query_builder/test_annotation_queues_query_builder.py
+++ b/tests/trace_server/query_builder/test_annotation_queues_query_builder.py
@@ -37,7 +37,7 @@ def test_make_queue_add_calls_fetch_calls_query_skips_calls_without_start_time()
         "pb_1": ["call-1", "call-2"],
     }
 
-    # calls_merged needs aggregation after excluding incomplete call rows.
+    # calls_merged must filter after aggregation so a separate end row is preserved.
     merged_pb = ParamBuilder("pb")
     merged_query = make_queue_add_calls_fetch_calls_query(
         project_id="project",

--- a/weave/trace_server/query_builder/annotation_queues_query_builder.py
+++ b/weave/trace_server/query_builder/annotation_queues_query_builder.py
@@ -411,6 +411,7 @@ def make_queue_add_calls_fetch_calls_query(
         WHERE project_id = {{{project_id_param}: String}}
             AND id IN {{{call_ids_param}: Array(String)}}
         GROUP BY (project_id, id)
+        HAVING started_at IS NOT NULL
         """
     else:
         # For calls_complete, columns are already aggregated
@@ -424,6 +425,7 @@ def make_queue_add_calls_fetch_calls_query(
         FROM {table_name}
         WHERE project_id = {{{project_id_param}: String}}
             AND id IN {{{call_ids_param}: Array(String)}}
+            AND started_at IS NOT NULL
         """
 
     return query


### PR DESCRIPTION
## Summary

- exclude calls whose required `started_at` has not reached the read model yet before caching them in `annotation_queue_items`
- filter `calls_merged` after aggregation so a separate end-event row still contributes `ended_at`
- cover both query routing tables plus the production end-before-start client flow

## Root cause

[Datadog issue](https://us5.datadoghq.com/error-tracking?query=service%3Aweave-trace&fromUser=true&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22b231bd66-8179-11f1-aba7-da7ad0900000%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1784047638094&to_ts=1784652438094&live=true) captured two production requests failing in `annotation_queue_add_calls` on deployed core SHA `35d8434b76036d44a260de7cc366622b51a6803d`.

The request-side lookup returned partially ingested `calls_merged` rows with a null `started_at`. `annotation_queue_items.call_started_at` is non-nullable, so `clickhouse-connect` attempted `None.timestamp()` while serializing the batch and the entire POST failed.

Calls absent from the read model are already skipped by this API. This change treats rows without their required start event the same way, allowing callers to retry after ingestion catches up instead of returning a 500.

## Testing

- ClickHouse functional client test: mixed complete/end-only batch adds the complete call, skips the end-only call, then adds it after its start event arrives
- Query-builder regression coverage for `calls_merged` and `calls_complete`
- `uv run --group test --group trace_server pytest tests/trace/test_client_annotation_queues.py::test_annotation_queue_add_calls_retries_end_only_calls tests/trace_server/query_builder/test_annotation_queues_query_builder.py -q` (10 passed)
- `uvx ruff@0.15.5 format --check ...`
- `uvx ruff@0.15.5 check ...`
- `uv run --group dev ty check ...`
- `git diff --check`
