### PR TITLE
feat(weave): emit agent events for insights

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,14 +93,6 @@ Evaluation result rows merge agent span links from two sources: legacy
 trial. Keep the promoted-column hydration best-effort so eval results remain
 available during rolling deploys.
 
-Kafka event production uses independent feature gates. Online eval publishes
-call completions to `weave.call_ended`, agent scoring publishes agent spans to
-`weave.score_agent_spans`, and Agent Insights publishes the same agent-span
-payload to `weave.embed_agent_spans`. Completed root spans carry the event type
-`weave.genai.turn_ended`; when scoring and Insights are both enabled, publish
-distinct `ScoreAgentSpansEvent` and `EmbedAgentSpansEvent` instances to their
-respective topics.
-
 If `sdks/node/node_modules` is missing, run `pnpm install --frozen-lockfile` in `sdks/node` first. Do not use `npm install`; this SDK is pinned to pnpm.
 
 ## Python Testing Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,8 @@ call completions to `weave.call_ended`, agent scoring publishes agent spans to
 `weave.score_agent_spans`, and Agent Insights publishes the same agent-span
 payload to `weave.embed_agent_spans`. Completed root spans carry the event type
 `weave.genai.turn_ended`; when scoring and Insights are both enabled, publish
-the event to both agent-span topics.
+distinct `ScoreAgentSpansEvent` and `EmbedAgentSpansEvent` instances to their
+respective topics.
 
 If `sdks/node/node_modules` is missing, run `pnpm install --frozen-lockfile` in `sdks/node` first. Do not use `npm install`; this SDK is pinned to pnpm.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,13 @@ Evaluation result rows merge agent span links from two sources: legacy
 trial. Keep the promoted-column hydration best-effort so eval results remain
 available during rolling deploys.
 
+Kafka event production uses independent feature gates. Online eval publishes
+call completions to `weave.call_ended`, agent scoring publishes agent spans to
+`weave.score_agent_spans`, and Agent Insights publishes the same agent-span
+payload to `weave.embed_agent_spans`. Completed root spans carry the event type
+`weave.genai.turn_ended`; when scoring and Insights are both enabled, publish
+the event to both agent-span topics.
+
 If `sdks/node/node_modules` is missing, run `pnpm install --frozen-lockfile` in `sdks/node` first. Do not use `npm install`; this SDK is pinned to pnpm.
 
 ## Python Testing Guidelines

--- a/tests/trace_server/test_agent_scorer_event_producer.py
+++ b/tests/trace_server/test_agent_scorer_event_producer.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from weave.trace_server.agents.kafka_events import (
+    EMBED_AGENT_SPANS_TOPIC,
     SCORE_AGENT_SPANS_TOPIC,
     ScoreAgentSpansEvent,
 )
@@ -29,8 +30,9 @@ def _make_event(**overrides) -> ScoreAgentSpansEvent:
     return ScoreAgentSpansEvent(**base)
 
 
-def test_topic_constant_value() -> None:
+def test_topic_constant_values() -> None:
     assert SCORE_AGENT_SPANS_TOPIC == "weave.score_agent_spans"
+    assert EMBED_AGENT_SPANS_TOPIC == "weave.embed_agent_spans"
 
 
 def test_event_round_trip() -> None:
@@ -52,29 +54,43 @@ def _bind_real_methods(producer: MagicMock, *names: str) -> None:
         setattr(producer, name, getattr(KafkaProducer, name).__get__(producer))
 
 
+@pytest.mark.parametrize(
+    "method_name", ["produce_score_agent_spans", "produce_embed_agent_spans"]
+)
 @pytest.mark.disable_logging_error_check
-def test_producer_drops_when_buffer_full() -> None:
+def test_producer_drops_when_buffer_full(method_name: str) -> None:
     producer = MagicMock(spec=KafkaProducer)
     producer.max_buffer_size = 2
     producer.__len__ = MagicMock(return_value=5)  # buffer full
-    _bind_real_methods(producer, "produce_score_agent_spans", "_check_buffer_pressure")
+    _bind_real_methods(
+        producer, method_name, "_produce_agent_spans", "_check_buffer_pressure"
+    )
 
-    producer.produce_score_agent_spans(_make_event())
+    getattr(producer, method_name)(_make_event())
 
     producer.produce.assert_not_called()
 
 
-def test_producer_publishes_under_buffer_limit() -> None:
+@pytest.mark.parametrize(
+    ("method_name", "topic"),
+    [
+        ("produce_score_agent_spans", "weave.score_agent_spans"),
+        ("produce_embed_agent_spans", "weave.embed_agent_spans"),
+    ],
+)
+def test_producer_publishes_under_buffer_limit(method_name: str, topic: str) -> None:
     producer = MagicMock(spec=KafkaProducer)
     producer.max_buffer_size = 100
     producer.__len__ = MagicMock(return_value=0)
-    _bind_real_methods(producer, "produce_score_agent_spans", "_check_buffer_pressure")
+    _bind_real_methods(
+        producer, method_name, "_produce_agent_spans", "_check_buffer_pressure"
+    )
 
-    producer.produce_score_agent_spans(_make_event())
+    getattr(producer, method_name)(_make_event())
 
     producer.produce.assert_called_once()
     call_kwargs = producer.produce.call_args.kwargs
-    assert call_kwargs["topic"] == "weave.score_agent_spans"
+    assert call_kwargs["topic"] == topic
 
 
 @pytest.mark.disable_logging_error_check

--- a/tests/trace_server/test_agent_scorer_event_producer.py
+++ b/tests/trace_server/test_agent_scorer_event_producer.py
@@ -9,13 +9,17 @@ import pytest
 from weave.trace_server.agents.kafka_events import (
     EMBED_AGENT_SPANS_TOPIC,
     SCORE_AGENT_SPANS_TOPIC,
+    EmbedAgentSpansEvent,
     ScoreAgentSpansEvent,
 )
 from weave.trace_server.kafka import KafkaProducer, _bucketed_project_key
 
 
-def _make_event(**overrides) -> ScoreAgentSpansEvent:
-    """Minimal valid ScoreAgentSpansEvent for tests; override any field."""
+def _make_event(
+    event_class: type[ScoreAgentSpansEvent | EmbedAgentSpansEvent],
+    **overrides,
+) -> ScoreAgentSpansEvent | EmbedAgentSpansEvent:
+    """Build a minimal valid agent spans event; override any field."""
     base = {
         "event_type": "weave.genai.turn_ended",
         "status_code": "OK",
@@ -27,7 +31,7 @@ def _make_event(**overrides) -> ScoreAgentSpansEvent:
         "operation_name": None,
     }
     base.update(overrides)
-    return ScoreAgentSpansEvent(**base)
+    return event_class(**base)
 
 
 def test_topic_constant_values() -> None:
@@ -37,6 +41,7 @@ def test_topic_constant_values() -> None:
 
 def test_event_round_trip() -> None:
     event = _make_event(
+        ScoreAgentSpansEvent,
         project_id="proj-1",
         trace_id="trace-1",
         span_id="span-root",
@@ -47,6 +52,9 @@ def test_event_round_trip() -> None:
     parsed = ScoreAgentSpansEvent.model_validate_json(payload)
     assert parsed == event
 
+    embed_event = EmbedAgentSpansEvent.model_validate_json(payload)
+    assert embed_event == EmbedAgentSpansEvent(**event.model_dump())
+
 
 def _bind_real_methods(producer: MagicMock, *names: str) -> None:
     """Replace MagicMock auto-stubs with real `KafkaProducer` methods bound to the mock."""
@@ -55,10 +63,17 @@ def _bind_real_methods(producer: MagicMock, *names: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "method_name", ["produce_score_agent_spans", "produce_embed_agent_spans"]
+    ("method_name", "event_class"),
+    [
+        ("produce_score_agent_spans", ScoreAgentSpansEvent),
+        ("produce_embed_agent_spans", EmbedAgentSpansEvent),
+    ],
 )
 @pytest.mark.disable_logging_error_check
-def test_producer_drops_when_buffer_full(method_name: str) -> None:
+def test_producer_drops_when_buffer_full(
+    method_name: str,
+    event_class: type[ScoreAgentSpansEvent | EmbedAgentSpansEvent],
+) -> None:
     producer = MagicMock(spec=KafkaProducer)
     producer.max_buffer_size = 2
     producer.__len__ = MagicMock(return_value=5)  # buffer full
@@ -66,19 +81,31 @@ def test_producer_drops_when_buffer_full(method_name: str) -> None:
         producer, method_name, "_produce_agent_spans", "_check_buffer_pressure"
     )
 
-    getattr(producer, method_name)(_make_event())
+    getattr(producer, method_name)(_make_event(event_class))
 
     producer.produce.assert_not_called()
 
 
 @pytest.mark.parametrize(
-    ("method_name", "topic"),
+    ("method_name", "event_class", "topic"),
     [
-        ("produce_score_agent_spans", "weave.score_agent_spans"),
-        ("produce_embed_agent_spans", "weave.embed_agent_spans"),
+        (
+            "produce_score_agent_spans",
+            ScoreAgentSpansEvent,
+            "weave.score_agent_spans",
+        ),
+        (
+            "produce_embed_agent_spans",
+            EmbedAgentSpansEvent,
+            "weave.embed_agent_spans",
+        ),
     ],
 )
-def test_producer_publishes_under_buffer_limit(method_name: str, topic: str) -> None:
+def test_producer_publishes_under_buffer_limit(
+    method_name: str,
+    event_class: type[ScoreAgentSpansEvent | EmbedAgentSpansEvent],
+    topic: str,
+) -> None:
     producer = MagicMock(spec=KafkaProducer)
     producer.max_buffer_size = 100
     producer.__len__ = MagicMock(return_value=0)
@@ -86,7 +113,7 @@ def test_producer_publishes_under_buffer_limit(method_name: str, topic: str) -> 
         producer, method_name, "_produce_agent_spans", "_check_buffer_pressure"
     )
 
-    getattr(producer, method_name)(_make_event())
+    getattr(producer, method_name)(_make_event(event_class))
 
     producer.produce.assert_called_once()
     call_kwargs = producer.produce.call_args.kwargs

--- a/tests/trace_server/test_agent_scorer_events.py
+++ b/tests/trace_server/test_agent_scorer_events.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import datetime
 
-from weave.trace_server.agents.kafka_events import ScoreAgentSpansEvent
+from weave.trace_server.agents.kafka_events import (
+    EmbedAgentSpansEvent,
+    ScoreAgentSpansEvent,
+)
 from weave.trace_server.agents.schema import AgentSpanCHInsertable
 
 _STARTED_AT = datetime.datetime(2024, 1, 1, 11, 0, 0)
@@ -36,6 +39,16 @@ def test_from_row() -> None:
         conversation_id="c",
         operation_name="invoke_agent",
     )
+    assert EmbedAgentSpansEvent.from_row(root_row) == EmbedAgentSpansEvent(
+        event_type="weave.genai.turn_ended",
+        status_code="OK",
+        project_id="p",
+        trace_id="tr",
+        span_id="root",
+        parent_span_id=None,
+        conversation_id="c",
+        operation_name="invoke_agent",
+    )
 
     child_row = AgentSpanCHInsertable(
         project_id="p",
@@ -47,3 +60,4 @@ def test_from_row() -> None:
         ended_at=_ENDED_AT,
     )
     assert ScoreAgentSpansEvent.from_row(child_row) is None
+    assert EmbedAgentSpansEvent.from_row(child_row) is None

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -2056,9 +2056,7 @@ def _turn_ended_span_row() -> AgentSpanCHInsertable:
         "all-consumers-off",
     ],
 )
-def test_genai_otel_export_emit_gate(
-    monkeypatch, online_eval, scoring, insights
-):
+def test_genai_otel_export_emit_gate(monkeypatch, online_eval, scoring, insights):
     """OTel ingest emits for scoring or Insights, independent of online eval."""
     mock_producer = MagicMock()
     monkeypatch.setattr(

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1999,14 +1999,18 @@ def _turn_ended_span_row() -> AgentSpanCHInsertable:
     [
         (True, True, False, True),
         (True, False, True, True),
-        (False, False, True, True),
+        (True, True, True, True),
+        (False, False, True, False),
+        (False, True, True, False),
         (False, True, False, False),
         (True, False, False, False),
     ],
     ids=[
         "online-eval-and-scoring",
         "online-eval-and-insights",
-        "insights-only",
+        "online-eval-with-both-consumers",
+        "insights-without-online-eval",
+        "both-consumers-without-online-eval",
         "scoring-without-online-eval",
         "all-consumers-off",
     ],
@@ -2014,7 +2018,7 @@ def _turn_ended_span_row() -> AgentSpanCHInsertable:
 def test_genai_otel_export_emit_gate(
     monkeypatch, online_eval, scoring, insights, should_emit
 ):
-    """OTel ingest emits when either configured consumer can use the event."""
+    """OTel ingest requires online eval and at least one event consumer."""
     mock_producer = MagicMock()
     monkeypatch.setattr(
         chts.ClickHouseTraceServer, "_mint_client", lambda self: MagicMock()

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1402,6 +1402,41 @@ def server_with_mock_kafka():
             yield server, mock_producer
 
 
+@pytest.mark.parametrize(
+    ("online_eval", "scoring", "insights", "should_enable"),
+    [
+        (True, False, False, True),
+        (False, True, False, True),
+        (False, False, True, True),
+        (True, True, True, True),
+        (False, False, False, False),
+    ],
+)
+def test_kafka_producer_feature_gate(
+    monkeypatch, online_eval, scoring, insights, should_enable
+):
+    mock_producer = MagicMock()
+    monkeypatch.setattr(
+        chts.ClickHouseTraceServer, "_mint_client", lambda self: MagicMock()
+    )
+    server = chts.ClickHouseTraceServer(host="test_host")
+    server._kafka_producer = mock_producer
+    monkeypatch.setattr(
+        "weave.trace_server.environment.wf_enable_online_eval", lambda: online_eval
+    )
+    monkeypatch.setattr(
+        "weave.trace_server.environment.wf_enable_agent_scoring", lambda: scoring
+    )
+    monkeypatch.setattr(
+        "weave.trace_server.environment.wf_enable_agent_insights", lambda: insights
+    )
+
+    if should_enable:
+        assert server.kafka_producer is mock_producer
+    else:
+        assert server.kafka_producer is None
+
+
 def _make_call_end_req() -> tsi.CallEndReq:
     return tsi.CallEndReq(
         end=tsi.EndedCallSchemaForInsert(
@@ -2001,15 +2036,15 @@ def _turn_ended_span_row() -> AgentSpanCHInsertable:
 
 
 @pytest.mark.parametrize(
-    ("online_eval", "scoring", "insights", "should_emit"),
+    ("online_eval", "scoring", "insights"),
     [
-        (True, True, False, True),
-        (True, False, True, True),
-        (True, True, True, True),
-        (False, False, True, False),
-        (False, True, True, False),
-        (False, True, False, False),
-        (True, False, False, False),
+        (True, True, False),
+        (True, False, True),
+        (True, True, True),
+        (False, False, True),
+        (False, True, True),
+        (False, True, False),
+        (True, False, False),
     ],
     ids=[
         "online-eval-and-scoring",
@@ -2022,9 +2057,9 @@ def _turn_ended_span_row() -> AgentSpanCHInsertable:
     ],
 )
 def test_genai_otel_export_emit_gate(
-    monkeypatch, online_eval, scoring, insights, should_emit
+    monkeypatch, online_eval, scoring, insights
 ):
-    """OTel ingest requires online eval and at least one event consumer."""
+    """OTel ingest emits for scoring or Insights, independent of online eval."""
     mock_producer = MagicMock()
     monkeypatch.setattr(
         chts.ClickHouseTraceServer, "_mint_client", lambda self: MagicMock()
@@ -2055,11 +2090,17 @@ def test_genai_otel_export_emit_gate(
     )
 
     assert res.accepted_spans == 1
-    if should_emit:
+    if scoring:
         mock_producer.produce_score_agent_spans.assert_called_once()
-        mock_producer.flush.assert_called_once_with(0)
     else:
         mock_producer.produce_score_agent_spans.assert_not_called()
+    if insights:
+        mock_producer.produce_embed_agent_spans.assert_called_once()
+    else:
+        mock_producer.produce_embed_agent_spans.assert_not_called()
+    if scoring or insights:
+        mock_producer.flush.assert_called_once_with(0)
+    else:
         mock_producer.flush.assert_not_called()
 
 

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1389,9 +1389,15 @@ def server_with_mock_kafka():
     ):
         server = chts.ClickHouseTraceServer(host="test_host")
         server._kafka_producer = mock_producer
-        with patch(
-            "weave.trace_server.environment.wf_enable_online_eval",
-            return_value=True,
+        with (
+            patch(
+                "weave.trace_server.environment.wf_enable_online_eval",
+                return_value=True,
+            ),
+            patch(
+                "weave.trace_server.environment.wf_enable_agent_scoring",
+                return_value=True,
+            ),
         ):
             yield server, mock_producer
 

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1995,18 +1995,26 @@ def _turn_ended_span_row() -> AgentSpanCHInsertable:
 
 
 @pytest.mark.parametrize(
-    ("online_eval", "scoring", "should_emit"),
+    ("online_eval", "scoring", "insights", "should_emit"),
     [
-        (True, True, True),
-        (True, False, False),  # scoring off -> skip
-        (False, True, False),  # online eval off -> skip
+        (True, True, False, True),
+        (True, False, True, True),
+        (False, False, True, True),
+        (False, True, False, False),
+        (True, False, False, False),
     ],
-    ids=["both-on", "scoring-off", "online-eval-off"],
+    ids=[
+        "online-eval-and-scoring",
+        "online-eval-and-insights",
+        "insights-only",
+        "scoring-without-online-eval",
+        "all-consumers-off",
+    ],
 )
-def test_genai_otel_export_emit_gate(monkeypatch, online_eval, scoring, should_emit):
-    """OTel ingest emits turn-ended events only when online eval and agent scoring
-    are both enabled; otherwise the kafka emit is skipped.
-    """
+def test_genai_otel_export_emit_gate(
+    monkeypatch, online_eval, scoring, insights, should_emit
+):
+    """OTel ingest emits when either configured consumer can use the event."""
     mock_producer = MagicMock()
     monkeypatch.setattr(
         chts.ClickHouseTraceServer, "_mint_client", lambda self: MagicMock()
@@ -2027,6 +2035,9 @@ def test_genai_otel_export_emit_gate(monkeypatch, online_eval, scoring, should_e
     )
     monkeypatch.setattr(
         "weave.trace_server.environment.wf_enable_agent_scoring", lambda: scoring
+    )
+    monkeypatch.setattr(
+        "weave.trace_server.environment.wf_enable_agent_insights", lambda: insights
     )
 
     res = server.genai_otel_export(

--- a/weave/trace_server/agents/kafka_events.py
+++ b/weave/trace_server/agents/kafka_events.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
+from typing_extensions import Self
 
 from weave.trace_server.agents.schema import (
     AgentSpanCHInsertable,

--- a/weave/trace_server/agents/kafka_events.py
+++ b/weave/trace_server/agents/kafka_events.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from pydantic import BaseModel
 
@@ -25,9 +25,7 @@ EMBED_AGENT_SPANS_TOPIC = "weave.embed_agent_spans"
 _SENTINEL_EPOCH_NAIVE = SENTINEL_EPOCH_UTC.replace(tzinfo=None)
 
 
-class ScoreAgentSpansEvent(BaseModel):
-    """Agent-span trigger shared by scoring and Insights."""
-
+class _AgentSpansEvent(BaseModel):
     event_type: AgentSpanOpName
     status_code: StatusCodeLiteral
     project_id: str
@@ -37,30 +35,9 @@ class ScoreAgentSpansEvent(BaseModel):
     parent_span_id: str | None
     conversation_id: str | None
 
-    def emit(
-        self,
-        producer: KafkaProducer | None,
-        *,
-        for_scoring: bool = True,
-        for_insights: bool = False,
-    ) -> None:
-        """Produce this event for each enabled consumer without raising."""
-        if producer is None:
-            return
-        if for_scoring:
-            try:
-                producer.produce_score_agent_spans(self)
-            except Exception:
-                logger.exception("Failed to emit ScoreAgentSpansEvent for scoring")
-        if for_insights:
-            try:
-                producer.produce_embed_agent_spans(self)
-            except Exception:
-                logger.exception("Failed to emit agent spans event for Insights")
-
-    @staticmethod
-    def from_row(row: AgentSpanCHInsertable) -> ScoreAgentSpansEvent | None:
-        """Return a ScoreAgentSpansEvent from a finished span row if it matches any event_type (else None).
+    @classmethod
+    def from_row(cls, row: AgentSpanCHInsertable) -> Self | None:
+        """Return an event from a finished span row if it matches an event type.
 
         Currently only "turn_ended" is supported, but the interface is designed to support multiple types.
         """
@@ -70,7 +47,7 @@ class ScoreAgentSpansEvent(BaseModel):
             event_type = "weave.genai.turn_ended"
         # Ignore in-progress spans
         if event_type and row.ended_at > _SENTINEL_EPOCH_NAIVE:
-            return ScoreAgentSpansEvent(
+            return cls(
                 event_type=event_type,
                 status_code=row.status_code,
                 project_id=row.project_id,
@@ -82,3 +59,29 @@ class ScoreAgentSpansEvent(BaseModel):
                 operation_name=row.operation_name or None,
             )
         return None
+
+
+class ScoreAgentSpansEvent(_AgentSpansEvent):
+    """Trigger event for agent scoring."""
+
+    def emit(self, producer: KafkaProducer | None) -> None:
+        """Produce this event for agent scoring without raising."""
+        if producer is None:
+            return
+        try:
+            producer.produce_score_agent_spans(self)
+        except Exception:
+            logger.exception("Failed to emit ScoreAgentSpansEvent")
+
+
+class EmbedAgentSpansEvent(_AgentSpansEvent):
+    """Trigger event for Agent Insights embedding."""
+
+    def emit(self, producer: KafkaProducer | None) -> None:
+        """Produce this event for Agent Insights without raising."""
+        if producer is None:
+            return
+        try:
+            producer.produce_embed_agent_spans(self)
+        except Exception:
+            logger.exception("Failed to emit EmbedAgentSpansEvent")

--- a/weave/trace_server/agents/kafka_events.py
+++ b/weave/trace_server/agents/kafka_events.py
@@ -20,12 +20,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 SCORE_AGENT_SPANS_TOPIC = "weave.score_agent_spans"
+EMBED_AGENT_SPANS_TOPIC = "weave.embed_agent_spans"
 
 _SENTINEL_EPOCH_NAIVE = SENTINEL_EPOCH_UTC.replace(tzinfo=None)
 
 
 class ScoreAgentSpansEvent(BaseModel):
-    """Trigger event for agent scoring."""
+    """Agent-span trigger shared by scoring and Insights."""
 
     event_type: AgentSpanOpName
     status_code: StatusCodeLiteral
@@ -36,14 +37,26 @@ class ScoreAgentSpansEvent(BaseModel):
     parent_span_id: str | None
     conversation_id: str | None
 
-    def emit(self, producer: KafkaProducer | None) -> None:
-        """Produce this event to Kafka. Logs failures without raising."""
+    def emit(
+        self,
+        producer: KafkaProducer | None,
+        *,
+        for_scoring: bool = True,
+        for_insights: bool = False,
+    ) -> None:
+        """Produce this event for each enabled consumer without raising."""
         if producer is None:
             return
-        try:
-            producer.produce_score_agent_spans(self)
-        except Exception:
-            logger.exception("Failed to emit ScoreAgentSpansEvent")
+        if for_scoring:
+            try:
+                producer.produce_score_agent_spans(self)
+            except Exception:
+                logger.exception("Failed to emit ScoreAgentSpansEvent for scoring")
+        if for_insights:
+            try:
+                producer.produce_embed_agent_spans(self)
+            except Exception:
+                logger.exception("Failed to emit agent spans event for Insights")
 
     @staticmethod
     def from_row(row: AgentSpanCHInsertable) -> ScoreAgentSpansEvent | None:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -337,6 +337,15 @@ from weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker impo
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _agent_event_producer_enabled() -> bool:
+    """Whether the online-eval event stream has an enabled consumer."""
+    return wf_env.wf_enable_online_eval() and (
+        wf_env.wf_enable_agent_scoring() or wf_env.wf_enable_agent_insights()
+    )
+
+
 logger.setLevel(logging.INFO)
 
 T = TypeVar("T")
@@ -545,7 +554,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     @property
     def kafka_producer(self) -> KafkaProducer | None:
         """Lazily initialize the producer when an event consumer is enabled."""
-        if not (wf_env.wf_enable_online_eval() or wf_env.wf_enable_agent_insights()):
+        if not _agent_event_producer_enabled():
             return None
         if self._kafka_producer is not None:
             return self._kafka_producer
@@ -7353,11 +7362,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self.ch_client, self._async_insert_settings(), self
         ).insert_otel_spans(req)
 
-        # Insights consumes these events independently; scoring additionally requires
-        # online eval to remain enabled, matching its existing rollout gate.
-        if not wf_env.wf_enable_agent_insights() and not (
-            wf_env.wf_enable_online_eval() and wf_env.wf_enable_agent_scoring()
-        ):
+        # Online eval is the top-level gate; scoring and Insights are consumers
+        # that can independently require the shared event stream beneath it.
+        if not _agent_event_producer_enabled():
             return res
 
         # Emit for each row that produces a valid event type

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -545,8 +545,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     @property
     def kafka_producer(self) -> KafkaProducer | None:
         """Lazily initialize the producer when an event consumer is enabled."""
-        if not wf_env.wf_enable_online_eval() or not (
-            wf_env.wf_enable_agent_scoring() or wf_env.wf_enable_agent_insights()
+        if not (
+            wf_env.wf_enable_online_eval()
+            or wf_env.wf_enable_agent_scoring()
+            or wf_env.wf_enable_agent_insights()
         ):
             return None
         if self._kafka_producer is not None:
@@ -7355,17 +7357,19 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self.ch_client, self._async_insert_settings(), self
         ).insert_otel_spans(req)
 
-        # Online eval is the top-level gate; scoring and Insights are consumers
-        # that can independently require the shared event stream beneath it.
-        if not wf_env.wf_enable_online_eval() or not (
-            wf_env.wf_enable_agent_scoring() or wf_env.wf_enable_agent_insights()
-        ):
+        scoring_enabled = wf_env.wf_enable_agent_scoring()
+        insights_enabled = wf_env.wf_enable_agent_insights()
+        if not (scoring_enabled or insights_enabled):
             return res
 
         # Emit for each row that produces a valid event type
         for row in span_rows:
             if event := ScoreAgentSpansEvent.from_row(row):
-                event.emit(self.kafka_producer)
+                event.emit(
+                    self.kafka_producer,
+                    for_scoring=scoring_enabled,
+                    for_insights=insights_enabled,
+                )
 
         # Flush kafka producer
         if span_rows and self.kafka_producer:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -544,8 +544,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @property
     def kafka_producer(self) -> KafkaProducer | None:
-        """Lazily initialize the Kafka producer, only if online eval is enabled."""
-        if not wf_env.wf_enable_online_eval():
+        """Lazily initialize the producer when an event consumer is enabled."""
+        if not (wf_env.wf_enable_online_eval() or wf_env.wf_enable_agent_insights()):
             return None
         if self._kafka_producer is not None:
             return self._kafka_producer
@@ -7353,8 +7353,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self.ch_client, self._async_insert_settings(), self
         ).insert_otel_spans(req)
 
-        # Return early without emitting kafka events if online eval or agent scoring are disabled
-        if not wf_env.wf_enable_online_eval() or not wf_env.wf_enable_agent_scoring():
+        # Insights consumes these events independently; scoring additionally requires
+        # online eval to remain enabled, matching its existing rollout gate.
+        if not wf_env.wf_enable_agent_insights() and not (
+            wf_env.wf_enable_online_eval() and wf_env.wf_enable_agent_scoring()
+        ):
             return res
 
         # Emit for each row that produces a valid event type

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -59,7 +59,10 @@ from weave.trace_server import trace_server_interface as tsi
 # GenAI / Agent observability imports
 from weave.trace_server.agents.clickhouse import AgentQueryHandler, AgentWriteHandler
 from weave.trace_server.agents.completion_spans import build_completion_span
-from weave.trace_server.agents.kafka_events import ScoreAgentSpansEvent
+from weave.trace_server.agents.kafka_events import (
+    EmbedAgentSpansEvent,
+    ScoreAgentSpansEvent,
+)
 from weave.trace_server.agents.schema import AgentSpanCHInsertable
 from weave.trace_server.agents.types import (
     AgentConversationChatReq,
@@ -7362,19 +7365,17 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if not (scoring_enabled or insights_enabled):
             return res
 
-        # Emit for each row that produces a valid event type
+        producer = self.kafka_producer
         for row in span_rows:
-            if event := ScoreAgentSpansEvent.from_row(row):
-                event.emit(
-                    self.kafka_producer,
-                    for_scoring=scoring_enabled,
-                    for_insights=insights_enabled,
-                )
+            if scoring_enabled and (event := ScoreAgentSpansEvent.from_row(row)):
+                event.emit(producer)
+            if insights_enabled and (event := EmbedAgentSpansEvent.from_row(row)):
+                event.emit(producer)
 
         # Flush kafka producer
-        if span_rows and self.kafka_producer:
+        if span_rows and producer:
             try:
-                self.kafka_producer.flush(0)
+                producer.flush(0)
             except Exception:
                 logger.exception(
                     "Failed to flush Kafka producer during OTel span ingest"

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -337,15 +337,6 @@ from weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker impo
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _agent_event_producer_enabled() -> bool:
-    """Whether the online-eval event stream has an enabled consumer."""
-    return wf_env.wf_enable_online_eval() and (
-        wf_env.wf_enable_agent_scoring() or wf_env.wf_enable_agent_insights()
-    )
-
-
 logger.setLevel(logging.INFO)
 
 T = TypeVar("T")
@@ -554,7 +545,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     @property
     def kafka_producer(self) -> KafkaProducer | None:
         """Lazily initialize the producer when an event consumer is enabled."""
-        if not _agent_event_producer_enabled():
+        if not wf_env.wf_enable_online_eval() or not (
+            wf_env.wf_enable_agent_scoring() or wf_env.wf_enable_agent_insights()
+        ):
             return None
         if self._kafka_producer is not None:
             return self._kafka_producer
@@ -7364,7 +7357,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # Online eval is the top-level gate; scoring and Insights are consumers
         # that can independently require the shared event stream beneath it.
-        if not _agent_event_producer_enabled():
+        if not wf_env.wf_enable_online_eval() or not (
+            wf_env.wf_enable_agent_scoring() or wf_env.wf_enable_agent_insights()
+        ):
             return res
 
         # Emit for each row that produces a valid event type

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -67,20 +67,17 @@ def wf_kafka_project_id_bucket_count() -> int:
 
 
 def wf_enable_online_eval() -> bool:
-    """Whether to enable online evaluation."""
+    """Enable the scoring worker and emit `weave.call_ended` events."""
     return os.environ.get("WEAVE_ENABLE_ONLINE_EVAL", "false").lower() == "true"
 
 
 def wf_enable_agent_scoring() -> bool:
-    """Whether to emit ScoreAgentSpansEvent triggers from the OTel ingest path.
-
-    In addition to `wf_enable_online_eval` so agent scoring can be toggled independently.
-    """
+    """Enable the agent scoring worker and emit `weave.score_agent_spans` events."""
     return os.environ.get("WEAVE_ENABLE_AGENT_SCORING", "false").lower() == "true"
 
 
 def wf_enable_agent_insights() -> bool:
-    """Whether to emit agent span events for the insights worker."""
+    """Enable the insights worker to emit `weave.embed_agent_spans` events."""
     return os.environ.get("WEAVE_ENABLE_AGENT_INSIGHTS", "false").lower() == "true"
 
 

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -79,6 +79,11 @@ def wf_enable_agent_scoring() -> bool:
     return os.environ.get("WEAVE_ENABLE_AGENT_SCORING", "false").lower() == "true"
 
 
+def wf_enable_agent_insights() -> bool:
+    """Whether to emit agent span events for the insights worker."""
+    return os.environ.get("WEAVE_ENABLE_AGENT_INSIGHTS", "false").lower() == "true"
+
+
 def wf_scoring_worker_batch_size() -> int:
     """The batch size for the scoring worker."""
     return int(

--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -15,6 +15,7 @@ from confluent_kafka import (
 
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents.kafka_events import (
+    EMBED_AGENT_SPANS_TOPIC,
     SCORE_AGENT_SPANS_TOPIC,
     ScoreAgentSpansEvent,
 )
@@ -154,8 +155,33 @@ class KafkaProducer(ConfluentKafkaProducer):
 
         Drops the message when the producer buffer is full (same policy as `produce_call_end`).
         """
-        if self._check_buffer_pressure(
+        self._produce_agent_spans(
+            event,
+            topic=SCORE_AGENT_SPANS_TOPIC,
             message_type="score_agent_spans",
+        )
+
+    @traced(name="kafka_producer.produce_embed_agent_spans")
+    def produce_embed_agent_spans(self, event: ScoreAgentSpansEvent) -> None:
+        """Produce a weave.embed_agent_spans event to Kafka.
+
+        Drops the message when the producer buffer is full (same policy as `produce_call_end`).
+        """
+        self._produce_agent_spans(
+            event,
+            topic=EMBED_AGENT_SPANS_TOPIC,
+            message_type="embed_agent_spans",
+        )
+
+    def _produce_agent_spans(
+        self,
+        event: ScoreAgentSpansEvent,
+        *,
+        topic: str,
+        message_type: str,
+    ) -> None:
+        if self._check_buffer_pressure(
+            message_type=message_type,
             logging_extra={
                 "event_type": event.event_type,
                 "status_code": event.status_code,
@@ -168,12 +194,12 @@ class KafkaProducer(ConfluentKafkaProducer):
 
         # Partition by conversation_id if available, falling back to trace_id.
         # This ensures spans for the same conversation or turn always route to
-        # the same worker, which allows for more efficient caching/querying in
-        # the scoring worker. We intentionally do NOT partition on project_id:
+        # the same worker, which allows for more efficient caching/querying.
+        # We intentionally do NOT partition on project_id:
         # that would send all spans for a project to a single worker instance.
         publish_key = event.conversation_id or event.trace_id
         self.produce(
-            topic=SCORE_AGENT_SPANS_TOPIC,
+            topic=topic,
             value=event.model_dump_json(),
             key=publish_key,
         )

--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -17,6 +17,7 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents.kafka_events import (
     EMBED_AGENT_SPANS_TOPIC,
     SCORE_AGENT_SPANS_TOPIC,
+    EmbedAgentSpansEvent,
     ScoreAgentSpansEvent,
 )
 from weave.trace_server.datadog import set_root_span_dd_tags
@@ -162,7 +163,7 @@ class KafkaProducer(ConfluentKafkaProducer):
         )
 
     @traced(name="kafka_producer.produce_embed_agent_spans")
-    def produce_embed_agent_spans(self, event: ScoreAgentSpansEvent) -> None:
+    def produce_embed_agent_spans(self, event: EmbedAgentSpansEvent) -> None:
         """Produce a weave.embed_agent_spans event to Kafka.
 
         Drops the message when the producer buffer is full (same policy as `produce_call_end`).
@@ -175,7 +176,7 @@ class KafkaProducer(ConfluentKafkaProducer):
 
     def _produce_agent_spans(
         self,
-        event: ScoreAgentSpansEvent,
+        event: ScoreAgentSpansEvent | EmbedAgentSpansEvent,
         *,
         topic: str,
         message_type: str,


### PR DESCRIPTION
## Summary

- Adds a new kafka event, `weave.embed_agent_span` that is consumed by the new insights worker.
- Decouples `ENABLE_ONLINE_EVAL` from `ENABLE_AGENT_SCORING` so that agent scoring can be enabled independently.
- Adds `ENABLE_AGENT_INSIGHTS` which, if enabled, will emit `weave.embed_agent_span`.