### PR TITLE
feat(weave): emit agent events for insights

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1995,18 +1995,28 @@ def _turn_ended_span_row() -> AgentSpanCHInsertable:
 
 
 @pytest.mark.parametrize(
-    ("online_eval", "scoring", "should_emit"),
+    ("online_eval", "scoring", "insights", "should_emit"),
     [
-        (True, True, True),
-        (True, False, False),  # scoring off -> skip
-        (False, True, False),  # online eval off -> skip
+        (True, True, False, True),
+        (True, False, True, True),
+        (False, False, True, True),
+        (False, True, False, False),
+        (True, False, False, False),
+        (False, False, False, False),
     ],
-    ids=["both-on", "scoring-off", "online-eval-off"],
+    ids=[
+        "legacy-scoring",
+        "online-eval-and-insights",
+        "insights-only",
+        "scoring-without-online-eval",
+        "online-eval-without-consumer",
+        "all-disabled",
+    ],
 )
-def test_genai_otel_export_emit_gate(monkeypatch, online_eval, scoring, should_emit):
-    """OTel ingest emits turn-ended events only when online eval and agent scoring
-    are both enabled; otherwise the kafka emit is skipped.
-    """
+def test_genai_otel_export_emit_gate(
+    monkeypatch, online_eval, scoring, insights, should_emit
+):
+    """OTel ingest emits for legacy scoring or independently enabled Insights."""
     mock_producer = MagicMock()
     monkeypatch.setattr(
         chts.ClickHouseTraceServer, "_mint_client", lambda self: MagicMock()
@@ -2027,6 +2037,9 @@ def test_genai_otel_export_emit_gate(monkeypatch, online_eval, scoring, should_e
     )
     monkeypatch.setattr(
         "weave.trace_server.environment.wf_enable_agent_scoring", lambda: scoring
+    )
+    monkeypatch.setattr(
+        "weave.trace_server.environment.wf_enable_agent_insights", lambda: insights
     )
 
     res = server.genai_otel_export(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -544,8 +544,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @property
     def kafka_producer(self) -> KafkaProducer | None:
-        """Lazily initialize the Kafka producer, only if online eval is enabled."""
-        if not wf_env.wf_enable_online_eval():
+        """Lazily initialize the Kafka producer when an agent consumer needs it."""
+        if not wf_env.wf_enable_agent_event_producer():
             return None
         if self._kafka_producer is not None:
             return self._kafka_producer
@@ -7353,8 +7353,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self.ch_client, self._async_insert_settings(), self
         ).insert_otel_spans(req)
 
-        # Return early without emitting kafka events if online eval or agent scoring are disabled
-        if not wf_env.wf_enable_online_eval() or not wf_env.wf_enable_agent_scoring():
+        if not wf_env.wf_enable_agent_event_producer():
             return res
 
         # Emit for each row that produces a valid event type

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -79,6 +79,18 @@ def wf_enable_agent_scoring() -> bool:
     return os.environ.get("WEAVE_ENABLE_AGENT_SCORING", "false").lower() == "true"
 
 
+def wf_enable_agent_insights() -> bool:
+    """Whether to emit agent span events for the Insights worker."""
+    return os.environ.get("WEAVE_ENABLE_AGENT_INSIGHTS", "false").lower() == "true"
+
+
+def wf_enable_agent_event_producer() -> bool:
+    """Whether to initialize Kafka and emit agent span events."""
+    return wf_enable_agent_insights() or (
+        wf_enable_online_eval() and wf_enable_agent_scoring()
+    )
+
+
 def wf_scoring_worker_batch_size() -> int:
     """The batch size for the scoring worker."""
     return int(


### PR DESCRIPTION
## Summary

- add `WEAVE_ENABLE_AGENT_INSIGHTS` environment handling for the trace-server producer
- initialize Kafka and emit shared agent-span events when Insights is enabled independently
- preserve the legacy scoring gate: online evaluation and agent scoring must both be enabled
- cover the producer truth table, including Insights-only mode

This is the producer-side follow-up to wandb/helm-charts#656 and the Insights worker in wandb/core#48537.

## Testing

- `uv run --group test python -m pytest tests/trace_server/test_clickhouse_trace_server_batched.py::test_genai_otel_export_emit_gate -q` (6 passed)
- `uvx ruff check weave/trace_server/environment.py tests/trace_server/test_clickhouse_trace_server_batched.py`
- `uvx ruff format --check weave/trace_server/environment.py weave/trace_server/clickhouse_trace_server_batched.py tests/trace_server/test_clickhouse_trace_server_batched.py`
- `git diff --check`

## Breaking changes

None. The event schema and Kafka topic are unchanged.
