### PR TITLE
perf(weave): split top-level $or calls queries into UNION DISTINCT so skip indexes prune

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -27,6 +27,7 @@ from tests.trace.util import (
     DatetimeMatcher,
     FuzzyDateTimeMatcher,
     MaybeStringMatcher,
+    client_is_clickhouse,
     get_info_loglines,
 )
 from tests.trace_server.conftest_lib.trace_server_external_adapter import (
@@ -55,6 +56,7 @@ from weave.trace_server.clickhouse_trace_server_settings import ENTITY_TOO_LARGE
 from weave.trace_server.common_interface import SortBy
 from weave.trace_server.errors import InsertTooLarge, InvalidFieldError, InvalidRequest
 from weave.trace_server.ids import generate_id
+from weave.trace_server.project_version.types import CallsStorageServerMode
 from weave.trace_server.token_costs import COST_OBJECT_NAME
 from weave.trace_server.validation_util import CHValidationError
 from weave.utils.project_id import from_project_id, to_project_id
@@ -4526,8 +4528,18 @@ def test_call_stream_query_heavy_query_batch(client):
         assert call.attributes["empty"] == ""
 
 
-def test_calls_query_or_union_rewrite_equivalence_and_pagination(client):
+@pytest.mark.parametrize(
+    "force_calls_merged", [False, True], ids=["calls_complete", "calls_merged"]
+)
+def test_calls_query_or_union_rewrite_equivalence_and_pagination(
+    client, force_calls_merged
+):
     """The $or -> UNION DISTINCT rewrite returns the same rows as a brute-force filter.
+
+    Runs on both calls_complete (default routing, also covers --trace-server=fake)
+    and calls_merged (FORCE_LEGACY routing, real ClickHouse only) so the
+    per-arm GROUP BY + UNION DISTINCT dedup path is exercised, not just the
+    single-row calls_complete path.
 
     Exercises id `$in` lowering (branch A) unioned with a heavy JSON `$eq`
     (branch B). One call matches both branches, two match branch B only, one
@@ -4535,6 +4547,12 @@ def test_calls_query_or_union_rewrite_equivalence_and_pagination(client):
     Also asserts paginated pages partition the full ordered result with no
     duplicates or misses.
     """
+    if force_calls_merged:
+        if not client_is_clickhouse(client):
+            pytest.skip("calls_merged routing requires a real ClickHouse backend")
+        ch_server = find_server_layer(client.server, ClickHouseTraceServer)
+        ch_server.table_routing_resolver._mode = CallsStorageServerMode.FORCE_LEGACY
+
     project_id = client.project_id
     turn_target = f"root_turn_{generate_id()}"
     base_time = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -4582,6 +4600,9 @@ def test_calls_query_or_union_rewrite_equivalence_and_pagination(client):
     assert set(full_ordered) == expected_ids
     assert call_neither not in full_ordered
     assert full_ordered == [call_a_only, call_both, call_b_only_1, call_b_only_2]
+    # call_both matches BOTH arms (id `$in` and heavy JSON `$eq`); UNION
+    # DISTINCT must still yield it exactly once, not once per matching arm.
+    assert full_ordered.count(call_both) == 1
 
     # Pagination: pages must partition the full ordered set with no dup/miss.
     page_size = 2
@@ -4769,6 +4790,83 @@ def test_calls_query_or_union_kill_switch_and_guardrails_functional(
         )
     )
     assert {c.id for c in res} == {call_match}
+
+
+def test_calls_query_or_union_calls_merged_started_at_tie_pagination_functional(
+    client, ch_server
+):
+    """A started_at tie spanning both UNION arms on calls_merged paginates cleanly.
+
+    Four calls share one `started_at` value: two match branch A (id `$in`),
+    two match branch B (heavy JSON `$eq`). With only the started_at tie to
+    resolve, ordering falls entirely on the id ASC tiebreak appended by the
+    rewrite. Forces calls_merged (real ClickHouse only, via `ch_server`) so
+    this exercises the per-arm GROUP BY + UNION DISTINCT path, not the
+    single-row calls_complete path. LIMIT (2) is smaller than the match count
+    (4), so pagination must partition the full ordered set with no
+    duplicates or misses.
+    """
+    ch_server.table_routing_resolver._mode = CallsStorageServerMode.FORCE_LEGACY
+
+    project_id = client.project_id
+    turn_target = f"root_turn_{generate_id()}"
+    tied_time = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    id_branch_ids = [
+        _make_or_union_test_call(client, base_time=tied_time, offset_seconds=0)
+        for _ in range(2)
+    ]
+    turn_branch_ids = [
+        _make_or_union_test_call(
+            client, base_time=tied_time, offset_seconds=0, turn_value=turn_target
+        )
+        for _ in range(2)
+    ]
+    call_neither = _make_or_union_test_call(
+        client, base_time=tied_time, offset_seconds=1
+    )
+
+    query = {
+        "$or": [
+            {"$in": [{"$getField": "id"}, [{"$literal": i} for i in id_branch_ids]]},
+            {
+                "$eq": [
+                    {"$getField": "inputs.turn.root_turn_id"},
+                    {"$literal": turn_target},
+                ]
+            },
+        ]
+    }
+    base_req = {
+        "project_id": project_id,
+        "query": {"$expr": query},
+        "sort_by": [{"field": "started_at", "direction": "asc"}],
+    }
+
+    expected_ids = set(id_branch_ids) | set(turn_branch_ids)
+    full_ordered = [
+        call.id
+        for call in client.server.calls_query_stream(
+            tsi.CallsQueryReq.model_validate(base_req)
+        )
+    ]
+    assert set(full_ordered) == expected_ids
+    assert call_neither not in full_ordered
+    # All four share started_at, so the id ASC tiebreak alone determines order.
+    assert full_ordered == sorted(expected_ids)
+
+    # Pagination: LIMIT (2) < match count (4) must still partition cleanly.
+    page_size = 2
+    paged_ids: list[str] = []
+    for offset in range(0, len(full_ordered), page_size):
+        page_req = {**base_req, "limit": page_size, "offset": offset}
+        paged_ids.extend(
+            call.id
+            for call in client.server.calls_query_stream(
+                tsi.CallsQueryReq.model_validate(page_req)
+            )
+        )
+    assert paged_ids == full_ordered
 
 
 @pytest.fixture

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -98,6 +98,49 @@ def get_client_project_id(client: weave_client.WeaveClient) -> str:
 ## End hacky interface compatibility helpers
 
 
+def _make_or_union_test_call(
+    client: weave_client.WeaveClient,
+    *,
+    base_time: datetime.datetime,
+    offset_seconds: float,
+    turn_value: str | None = None,
+    thread_id: str | None = None,
+) -> str:
+    """Create a completed call for $or -> UNION DISTINCT rewrite functional tests.
+
+    `started_at` is deterministically offset from `base_time` so ordering
+    assertions never depend on wall-clock timing.
+    """
+    call_id = generate_id()
+    started_at = base_time + datetime.timedelta(seconds=offset_seconds)
+    client.server.call_start(
+        tsi.CallStartReq(
+            start=tsi.StartedCallSchemaForInsert(
+                project_id=client.project_id,
+                id=call_id,
+                op_name="test_or_union",
+                trace_id=generate_id(),
+                thread_id=thread_id,
+                started_at=started_at,
+                attributes={},
+                inputs={"turn": {"root_turn_id": turn_value or "no_match"}},
+            )
+        )
+    )
+    client.server.call_end(
+        tsi.CallEndReq(
+            end=tsi.EndedCallSchemaForInsert(
+                project_id=client.project_id,
+                id=call_id,
+                ended_at=started_at + datetime.timedelta(seconds=1),
+                summary={},
+                output={},
+            )
+        )
+    )
+    return call_id
+
+
 @pytest.mark.flaky(reruns=2, reruns_delay=0.2)
 def test_simple_op(client):
     @weave.op
@@ -4481,6 +4524,246 @@ def test_call_stream_query_heavy_query_batch(client):
     assert len(list(res)) == 10
     for call in res:
         assert call.attributes["empty"] == ""
+
+
+def test_calls_query_or_union_rewrite_equivalence_and_pagination(client):
+    """The $or -> UNION DISTINCT rewrite returns the same rows as a brute-force filter.
+
+    Exercises id `$in` lowering (branch A) unioned with a heavy JSON `$eq`
+    (branch B). One call matches both branches, two match branch B only, one
+    matches branch A only, and one matches neither (and must be excluded).
+    Also asserts paginated pages partition the full ordered result with no
+    duplicates or misses.
+    """
+    project_id = client.project_id
+    turn_target = f"root_turn_{generate_id()}"
+    base_time = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    def _make_call(turn_value: str, offset_seconds: float) -> str:
+        return _make_or_union_test_call(
+            client,
+            base_time=base_time,
+            offset_seconds=offset_seconds,
+            turn_value=turn_value,
+        )
+
+    call_a_only = _make_call("not_the_marker", 1)
+    call_both = _make_call(turn_target, 2)
+    call_b_only_1 = _make_call(turn_target, 3)
+    call_b_only_2 = _make_call(turn_target, 4)
+    call_neither = _make_call("also_not_the_marker", 5)
+
+    id_list = [call_a_only, call_both]
+    expected_ids = {call_a_only, call_both, call_b_only_1, call_b_only_2}
+
+    query = {
+        "$or": [
+            {"$in": [{"$getField": "id"}, [{"$literal": i} for i in id_list]]},
+            {
+                "$eq": [
+                    {"$getField": "inputs.turn.root_turn_id"},
+                    {"$literal": turn_target},
+                ]
+            },
+        ]
+    }
+    base_req = {
+        "project_id": project_id,
+        "query": {"$expr": query},
+        "sort_by": [{"field": "started_at", "direction": "asc"}],
+    }
+
+    full_ordered = [
+        call.id
+        for call in client.server.calls_query_stream(
+            tsi.CallsQueryReq.model_validate(base_req)
+        )
+    ]
+    assert set(full_ordered) == expected_ids
+    assert call_neither not in full_ordered
+    assert full_ordered == [call_a_only, call_both, call_b_only_1, call_b_only_2]
+
+    # Pagination: pages must partition the full ordered set with no dup/miss.
+    page_size = 2
+    paged_ids: list[str] = []
+    for offset in range(0, len(full_ordered), page_size):
+        page_req = {**base_req, "limit": page_size, "offset": offset}
+        paged_ids.extend(
+            call.id
+            for call in client.server.calls_query_stream(
+                tsi.CallsQueryReq.model_validate(page_req)
+            )
+        )
+    assert paged_ids == full_ordered
+
+
+def test_calls_query_or_union_trace_id_and_thread_id_lowering_functional(client):
+    """trace_id and thread_id `$or` branches functionally match only their own calls.
+
+    Exercises the ID_MASK-adjacent lowering paths (TRACE_IDS via `$eq`,
+    THREAD_IDS via `$in`) end to end against a real backend, each unioned
+    with a heavy JSON branch that a *different* call satisfies.
+    """
+    base_time = datetime.datetime.now(tz=datetime.timezone.utc)
+    turn_target = f"root_turn_{generate_id()}"
+    trace_id = generate_id()
+    call_trace_match = generate_id()
+
+    client.server.call_start(
+        tsi.CallStartReq(
+            start=tsi.StartedCallSchemaForInsert(
+                project_id=client.project_id,
+                id=call_trace_match,
+                op_name="test_or_union",
+                trace_id=trace_id,
+                started_at=base_time + datetime.timedelta(seconds=1),
+                attributes={},
+                inputs={"turn": {"root_turn_id": "not_the_marker"}},
+            )
+        )
+    )
+    call_turn_match = _make_or_union_test_call(
+        client, base_time=base_time, offset_seconds=2, turn_value=turn_target
+    )
+    call_neither = _make_or_union_test_call(client, base_time=base_time, offset_seconds=3)
+
+    trace_query = {
+        "$or": [
+            {"$eq": [{"$getField": "trace_id"}, {"$literal": trace_id}]},
+            {
+                "$eq": [
+                    {"$getField": "inputs.turn.root_turn_id"},
+                    {"$literal": turn_target},
+                ]
+            },
+        ]
+    }
+    res = list(
+        client.server.calls_query_stream(
+            tsi.CallsQueryReq.model_validate(
+                {"project_id": client.project_id, "query": {"$expr": trace_query}}
+            )
+        )
+    )
+    assert {c.id for c in res} == {call_trace_match, call_turn_match}
+    assert call_neither not in {c.id for c in res}
+
+    thread_a = f"thread_{generate_id()}"
+    thread_b = f"thread_{generate_id()}"
+    call_thread_a = _make_or_union_test_call(
+        client, base_time=base_time, offset_seconds=4, thread_id=thread_a
+    )
+    call_thread_b = _make_or_union_test_call(
+        client, base_time=base_time, offset_seconds=5, thread_id=thread_b
+    )
+    call_thread_other = _make_or_union_test_call(
+        client, base_time=base_time, offset_seconds=6, thread_id=f"thread_{generate_id()}"
+    )
+
+    thread_query = {
+        "$or": [
+            {
+                "$in": [
+                    {"$getField": "thread_id"},
+                    [{"$literal": thread_a}, {"$literal": thread_b}],
+                ]
+            },
+            {
+                "$eq": [
+                    {"$getField": "inputs.turn.root_turn_id"},
+                    {"$literal": turn_target},
+                ]
+            },
+        ]
+    }
+    res = list(
+        client.server.calls_query_stream(
+            tsi.CallsQueryReq.model_validate(
+                {"project_id": client.project_id, "query": {"$expr": thread_query}}
+            )
+        )
+    )
+    got_ids = {c.id for c in res}
+    assert got_ids == {call_thread_a, call_thread_b, call_turn_match}
+    assert call_thread_other not in got_ids
+
+
+def test_calls_query_or_union_kill_switch_and_guardrails_functional(
+    client, monkeypatch
+) -> None:
+    """The rewrite is transparent: results are identical with it on, off, and never-firing.
+
+    Covers three edge cases end to end: (1) the env kill-switch must not
+    change results, only the SQL shape; (2) a 6-branch $or (over
+    MAX_OR_UNION_ARMS) never qualifies but must still filter correctly via
+    the fallback path; (3) a $or with a non-eq/in branch (a `$gt`, which
+    never classifies) must likewise still filter correctly.
+    """
+    base_time = datetime.datetime.now(tz=datetime.timezone.utc)
+    turn_target = f"root_turn_{generate_id()}"
+    call_match = _make_or_union_test_call(
+        client, base_time=base_time, offset_seconds=1, turn_value=turn_target
+    )
+    call_other = _make_or_union_test_call(client, base_time=base_time, offset_seconds=2)
+
+    query = {
+        "$or": [
+            {"$eq": [{"$getField": "id"}, {"$literal": call_match}]},
+            {
+                "$eq": [
+                    {"$getField": "inputs.turn.root_turn_id"},
+                    {"$literal": turn_target},
+                ]
+            },
+        ]
+    }
+    req = tsi.CallsQueryReq.model_validate(
+        {"project_id": client.project_id, "query": {"$expr": query}}
+    )
+
+    baseline_ids = {c.id for c in client.server.calls_query_stream(req)}
+    assert baseline_ids == {call_match}
+    assert call_other not in baseline_ids
+
+    monkeypatch.setenv("WEAVE_CALLS_OR_UNION_REWRITE", "0")
+    kill_switch_ids = {c.id for c in client.server.calls_query_stream(req)}
+    assert kill_switch_ids == baseline_ids
+    monkeypatch.delenv("WEAVE_CALLS_OR_UNION_REWRITE")
+
+    # Guardrail: > MAX_OR_UNION_ARMS branches never qualifies.
+    six_arm_query = {
+        "$or": [
+            {"$eq": [{"$getField": "id"}, {"$literal": call_match}]},
+            *[
+                {"$eq": [{"$getField": "id"}, {"$literal": generate_id()}]}
+                for _ in range(5)
+            ],
+        ]
+    }
+    res = list(
+        client.server.calls_query_stream(
+            tsi.CallsQueryReq.model_validate(
+                {"project_id": client.project_id, "query": {"$expr": six_arm_query}}
+            )
+        )
+    )
+    assert {c.id for c in res} == {call_match}
+
+    # Guardrail: a $gt branch never classifies.
+    gt_query = {
+        "$or": [
+            {"$eq": [{"$getField": "id"}, {"$literal": call_match}]},
+            {"$gt": [{"$getField": "inputs.turn.missing_count"}, {"$literal": 999999}]},
+        ]
+    }
+    res = list(
+        client.server.calls_query_stream(
+            tsi.CallsQueryReq.model_validate(
+                {"project_id": client.project_id, "query": {"$expr": gt_query}}
+            )
+        )
+    )
+    assert {c.id for c in res} == {call_match}
 
 
 @pytest.fixture

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -4625,7 +4625,9 @@ def test_calls_query_or_union_trace_id_and_thread_id_lowering_functional(client)
     call_turn_match = _make_or_union_test_call(
         client, base_time=base_time, offset_seconds=2, turn_value=turn_target
     )
-    call_neither = _make_or_union_test_call(client, base_time=base_time, offset_seconds=3)
+    call_neither = _make_or_union_test_call(
+        client, base_time=base_time, offset_seconds=3
+    )
 
     trace_query = {
         "$or": [
@@ -4657,7 +4659,10 @@ def test_calls_query_or_union_trace_id_and_thread_id_lowering_functional(client)
         client, base_time=base_time, offset_seconds=5, thread_id=thread_b
     )
     call_thread_other = _make_or_union_test_call(
-        client, base_time=base_time, offset_seconds=6, thread_id=f"thread_{generate_id()}"
+        client,
+        base_time=base_time,
+        offset_seconds=6,
+        thread_id=f"thread_{generate_id()}",
     )
 
     thread_query = {

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -1071,7 +1071,11 @@ def test_calls_query_with_predicate_filters_multiple_heavy_conditions() -> None:
 
 
 def test_calls_query_with_or_between_start_and_end_fields() -> None:
-    """Test that we create predicate filters when there's an OR between start and end fields."""
+    """Test that a top-level OR between two optimizable heavy fields splits into a UNION DISTINCT.
+
+    Each branch becomes its own pass-1 arm so its LIKE prefilter runs as a
+    top-level conjunct (see the $or -> UNION DISTINCT rewrite).
+    """
     cq = CallsQuery(project_id="project")
     cq.add_field("id")
     cq.add_field("inputs")
@@ -1099,30 +1103,47 @@ def test_calls_query_with_or_between_start_and_end_fields() -> None:
     assert_sql(
         cq,
         """
+        WITH filtered_calls AS (
+            SELECT id FROM (
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_3:String}
+                WHERE ((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump IS NULL))
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING (((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+                    AND ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_1:String})))
+                ORDER BY calls_merged.id ASC
+                UNION DISTINCT
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_3:String}
+                WHERE ((calls_merged.output_dump LIKE {pb_6:String} OR calls_merged.output_dump IS NULL))
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING (((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+                    AND ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.output_dump, {pb_4:String}), calls_merged.output_dump IS NOT NULL), 'null'), '') = {pb_5:String})))
+                ORDER BY calls_merged.id ASC
+            )
+            ORDER BY id ASC
+        )
         SELECT
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump,
             any(calls_merged.output_dump) AS output_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_6:String}
-        WHERE (((calls_merged.inputs_dump LIKE {pb_4:String} OR calls_merged.inputs_dump IS NULL)
-                OR (calls_merged.output_dump LIKE {pb_5:String} OR calls_merged.output_dump IS NULL)))
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        WHERE (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id, calls_merged.id)
-        HAVING ((
-            ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_1:String})
-            OR
-            (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.output_dump, {pb_2:String}), calls_merged.output_dump IS NOT NULL), 'null'), '') = {pb_3:String})))
-            AND ((any(calls_merged.deleted_at) IS NULL))
-            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
         """,
         {
             "pb_0": '$."param"."val"',
             "pb_1": "hello",
-            "pb_2": '$."result"',
-            "pb_3": "success",
-            "pb_4": '%"hello"%',
-            "pb_5": '%"success"%',
-            "pb_6": "project",
+            "pb_2": '%"hello"%',
+            "pb_3": "project",
+            "pb_4": '$."result"',
+            "pb_5": "success",
+            "pb_6": '%"success"%',
         },
     )
 
@@ -5429,5 +5450,864 @@ def test_query_with_annotation_filter_still_uses_anyif() -> None:
             "pb_1": '$."value"',
             "pb_2": "good",
             "pb_3": "project",
+        },
+    )
+
+
+######### $or -> UNION DISTINCT REWRITE ##########
+# A qualifying top-level `$or` (id/trace_id/thread_id `$eq`/`$in` lowered into a
+# hardcoded filter, or a heavy-JSON `$eq`/`$in`/`$contains` kept as the arm's sole
+# condition) forces the two-pass CTE and splits pass 1 into a UNION DISTINCT of
+# per-branch arms, so each branch's skip index applies as a top-level conjunct.
+
+
+def _turn_id_or_condition(id_value: str = "call_1") -> tsi_query.OrOperation:
+    """The prod shape: `id == X OR inputs.turn.root_turn_id == X`."""
+    return tsi_query.OrOperation.model_validate(
+        {
+            "$or": [
+                {"$eq": [{"$getField": "id"}, {"$literal": id_value}]},
+                {
+                    "$eq": [
+                        {"$getField": "inputs.turn.root_turn_id"},
+                        {"$literal": id_value},
+                    ]
+                },
+            ]
+        }
+    )
+
+
+def test_or_union_calls_complete_prod_shape() -> None:
+    """The prod query (id==X OR inputs.turn.root_turn_id==X) splits into a UNION DISTINCT on calls_complete.
+
+    The id branch lowers to `id IN {Array}` (idx_id_bloom); the heavy branch
+    keeps its LIKE prefilter as a top-level conjunct (idx_inputs_dump). Pass 2
+    bounds on the page's started_at range (page_started_at_bound).
+    """
+    cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(_turn_id_or_condition())
+    cq.add_order("started_at", "desc")
+    cq.set_limit(40)
+
+    assert_sql(
+        cq,
+        """
+        WITH filtered_calls AS (
+            SELECT id, started_at FROM (
+                SELECT calls_complete.id AS id, calls_complete.started_at AS started_at
+                FROM calls_complete
+                PREWHERE calls_complete.project_id = {pb_2:String}
+                WHERE (calls_complete.id IN {pb_1:Array(String)})
+                  AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
+                ORDER BY calls_complete.started_at DESC, calls_complete.id ASC
+                LIMIT 40
+                UNION DISTINCT
+                SELECT calls_complete.id AS id, calls_complete.started_at AS started_at
+                FROM calls_complete
+                PREWHERE calls_complete.project_id = {pb_2:String}
+                WHERE (calls_complete.inputs_dump LIKE {pb_6:String})
+                  AND (((calls_complete.deleted_at = {pb_3:DateTime64(3)}))
+                    AND ((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_4:String}), 'null'), '') = {pb_5:String})))
+                ORDER BY calls_complete.started_at DESC, calls_complete.id ASC
+                LIMIT 40
+            )
+            ORDER BY started_at DESC, id ASC
+            LIMIT 40
+        )
+        SELECT
+            calls_complete.id AS id,
+            calls_complete.inputs_dump AS inputs_dump
+        FROM calls_complete
+        PREWHERE calls_complete.project_id = {pb_2:String}
+        WHERE (calls_complete.id IN (SELECT id FROM filtered_calls))
+          AND (calls_complete.started_at >= (SELECT min(started_at) FROM filtered_calls))
+          AND (calls_complete.started_at <= (SELECT max(started_at) FROM filtered_calls))
+        ORDER BY calls_complete.started_at DESC
+        """,
+        {
+            "pb_0": SENTINEL_EPOCH,
+            "pb_1": ["call_1"],
+            "pb_2": "project",
+            "pb_3": SENTINEL_EPOCH,
+            "pb_4": '$."turn"."root_turn_id"',
+            "pb_5": "call_1",
+            "pb_6": '%"call_1"%',
+        },
+    )
+
+
+def test_or_union_calls_merged_shape() -> None:
+    """The same prod query splits into a UNION DISTINCT on calls_merged, each arm keeping GROUP BY/HAVING."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(_turn_id_or_condition())
+    cq.add_order("started_at", "desc")
+    cq.set_limit(40)
+
+    assert_sql(
+        cq,
+        """
+        WITH filtered_calls AS (
+            SELECT id FROM (
+                SELECT calls_merged.id AS id, any(calls_merged.started_at) AS started_at
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_1:String}
+                WHERE (calls_merged.id IN {pb_0:Array(String)})
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING (((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+                ORDER BY any(calls_merged.started_at) DESC, calls_merged.id ASC
+                LIMIT 40
+                UNION DISTINCT
+                SELECT calls_merged.id AS id, any(calls_merged.started_at) AS started_at
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_1:String}
+                WHERE ((calls_merged.inputs_dump LIKE {pb_4:String} OR calls_merged.inputs_dump IS NULL))
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING (((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+                    AND ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_2:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_3:String})))
+                ORDER BY any(calls_merged.started_at) DESC, calls_merged.id ASC
+                LIMIT 40
+            )
+            ORDER BY started_at DESC, id ASC
+            LIMIT 40
+        )
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_1:String}
+        WHERE (calls_merged.id IN filtered_calls)
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        ORDER BY any(calls_merged.started_at) DESC
+        """,
+        {
+            "pb_0": ["call_1"],
+            "pb_1": "project",
+            "pb_2": '$."turn"."root_turn_id"',
+            "pb_3": "call_1",
+            "pb_4": '%"call_1"%',
+        },
+    )
+
+
+def test_or_union_composes_with_light_conjunct() -> None:
+    """A light conjunct (op_name eq) alongside the $or rides along in every arm."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(
+        tsi_query.AndOperation.model_validate(
+            {
+                "$and": [
+                    {"$eq": [{"$getField": "op_name"}, {"$literal": "my_op"}]},
+                    _turn_id_or_condition().model_dump(by_alias=True),
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        WITH filtered_calls AS (
+            SELECT id FROM (
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_2:String}
+                WHERE (calls_merged.id IN {pb_1:Array(String)})
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING (((any(calls_merged.op_name) = {pb_0:String}))
+                    AND ((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+                ORDER BY calls_merged.id ASC
+                UNION DISTINCT
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_2:String}
+                WHERE ((calls_merged.inputs_dump LIKE {pb_5:String} OR calls_merged.inputs_dump IS NULL))
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING (((any(calls_merged.op_name) = {pb_0:String}))
+                    AND ((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+                    AND ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_3:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_4:String})))
+                ORDER BY calls_merged.id ASC
+            )
+            ORDER BY id ASC
+        )
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_2:String}
+        WHERE (calls_merged.id IN filtered_calls)
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        """,
+        {
+            "pb_0": "my_op",
+            "pb_1": ["call_1"],
+            "pb_2": "project",
+            "pb_3": '$."turn"."root_turn_id"',
+            "pb_4": "call_1",
+            "pb_5": '%"call_1"%',
+        },
+    )
+
+
+def test_or_union_limit_offset_arithmetic() -> None:
+    """Each arm gets LIMIT limit+offset; the outer wrapper gets LIMIT limit OFFSET offset."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(_turn_id_or_condition())
+    cq.set_limit(10)
+    cq.set_offset(20)
+
+    assert_sql(
+        cq,
+        """
+        WITH filtered_calls AS (
+            SELECT id FROM (
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_1:String}
+                WHERE (calls_merged.id IN {pb_0:Array(String)})
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING (((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+                ORDER BY calls_merged.id ASC
+                LIMIT 30
+                UNION DISTINCT
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_1:String}
+                WHERE ((calls_merged.inputs_dump LIKE {pb_4:String} OR calls_merged.inputs_dump IS NULL))
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING (((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+                    AND ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_2:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_3:String})))
+                ORDER BY calls_merged.id ASC
+                LIMIT 30
+            )
+            ORDER BY id ASC
+            LIMIT 10
+            OFFSET 20
+        )
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_1:String}
+        WHERE (calls_merged.id IN filtered_calls)
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        """,
+        {
+            "pb_0": ["call_1"],
+            "pb_1": "project",
+            "pb_2": '$."turn"."root_turn_id"',
+            "pb_3": "call_1",
+            "pb_4": '%"call_1"%',
+        },
+    )
+
+
+def test_or_union_trace_id_eq_lowering() -> None:
+    """A `trace_id == X` branch lowers into the arm's hardcoded trace_ids filter."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(
+        tsi_query.OrOperation.model_validate(
+            {
+                "$or": [
+                    {"$eq": [{"$getField": "trace_id"}, {"$literal": "trace_1"}]},
+                    {
+                        "$eq": [
+                            {"$getField": "inputs.turn.root_turn_id"},
+                            {"$literal": "call_1"},
+                        ]
+                    },
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        WITH filtered_calls AS (
+            SELECT id FROM (
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_1:String}
+                WHERE (ifNull(calls_merged.trace_id, '') = {pb_0:String} OR calls_merged.trace_id IS NULL)
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING (((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+                ORDER BY calls_merged.id ASC
+                UNION DISTINCT
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_1:String}
+                WHERE ((calls_merged.inputs_dump LIKE {pb_4:String} OR calls_merged.inputs_dump IS NULL))
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING (((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+                    AND ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_2:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_3:String})))
+                ORDER BY calls_merged.id ASC
+            )
+            ORDER BY id ASC
+        )
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_1:String}
+        WHERE (calls_merged.id IN filtered_calls)
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        """,
+        {
+            "pb_0": "trace_1",
+            "pb_1": "project",
+            "pb_2": '$."turn"."root_turn_id"',
+            "pb_3": "call_1",
+            "pb_4": '%"call_1"%',
+        },
+    )
+
+
+def test_or_union_thread_id_in_lowering() -> None:
+    """A `thread_id IN [...]` branch lowers into the arm's hardcoded thread_ids filter.
+
+    thread_ids double-renders (unchanged from today's non-union behavior): the
+    WHERE-level OR-IS-NULL pushdown AND the HAVING-level exact `IN` match.
+    """
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(
+        tsi_query.OrOperation.model_validate(
+            {
+                "$or": [
+                    {
+                        "$in": [
+                            {"$getField": "thread_id"},
+                            [{"$literal": "thread_1"}, {"$literal": "thread_2"}],
+                        ]
+                    },
+                    {
+                        "$eq": [
+                            {"$getField": "inputs.turn.root_turn_id"},
+                            {"$literal": "call_1"},
+                        ]
+                    },
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        WITH filtered_calls AS (
+            SELECT id FROM (
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_2:String}
+                WHERE (calls_merged.thread_id IN {pb_1:Array(String)} OR calls_merged.thread_id IS NULL)
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING (((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+                    AND (any(calls_merged.thread_id) IN {pb_0:Array(String)}))
+                ORDER BY calls_merged.id ASC
+                UNION DISTINCT
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_2:String}
+                WHERE ((calls_merged.inputs_dump LIKE {pb_5:String} OR calls_merged.inputs_dump IS NULL))
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING (((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+                    AND ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_3:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_4:String})))
+                ORDER BY calls_merged.id ASC
+            )
+            ORDER BY id ASC
+        )
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_2:String}
+        WHERE (calls_merged.id IN filtered_calls)
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        """,
+        {
+            "pb_0": ["thread_1", "thread_2"],
+            "pb_1": ["thread_1", "thread_2"],
+            "pb_2": "project",
+            "pb_3": '$."turn"."root_turn_id"',
+            "pb_4": "call_1",
+            "pb_5": '%"call_1"%',
+        },
+    )
+
+
+def test_or_union_kill_switch_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WEAVE_CALLS_OR_UNION_REWRITE=0 disables the rewrite; SQL matches today's (A OR B) shape."""
+    monkeypatch.setenv("WEAVE_CALLS_OR_UNION_REWRITE", "0")
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(_turn_id_or_condition())
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_2:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING ((((calls_merged.id = {pb_0:String})
+            OR (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_1:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_0:String})))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        """,
+        {
+            "pb_0": "call_1",
+            "pb_1": '$."turn"."root_turn_id"',
+            "pb_2": "project",
+        },
+    )
+
+
+######### $or -> UNION DISTINCT GUARDRAILS (negative cases: today's SQL unchanged) ##########
+
+
+def test_or_union_guardrail_single_branch_unchanged() -> None:
+    """A single-element `$or` (len < 2) never qualifies; SQL is the plain single-pass OR."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(
+        tsi_query.OrOperation.model_validate(
+            {
+                "$or": [
+                    {
+                        "$eq": [
+                            {"$getField": "inputs.turn.root_turn_id"},
+                            {"$literal": "call_1"},
+                        ]
+                    },
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        WHERE (((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump IS NULL)))
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_0:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_1:String}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        """,
+        {
+            "pb_0": '$."turn"."root_turn_id"',
+            "pb_1": "call_1",
+            "pb_2": '%"call_1"%',
+            "pb_3": "project",
+        },
+    )
+
+
+def test_or_union_guardrail_six_arms_unchanged() -> None:
+    """A 6-branch `$or` (> MAX_OR_UNION_ARMS) never qualifies; SQL is the plain single-pass OR."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    branches = [
+        {"$eq": [{"$getField": "id"}, {"$literal": f"call_{i}"}]} for i in range(3)
+    ]
+    branches += [
+        {
+            "$eq": [
+                {"$getField": "inputs.turn.root_turn_id"},
+                {"$literal": f"call_{i}"},
+            ]
+        }
+        for i in range(3)
+    ]
+    cq.add_condition(tsi_query.OrOperation.model_validate({"$or": branches}))
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_4:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING ((((calls_merged.id = {pb_0:String})
+            OR (calls_merged.id = {pb_1:String})
+            OR (calls_merged.id = {pb_2:String})
+            OR (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_3:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_0:String})
+            OR (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_3:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_1:String})
+            OR (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_3:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_2:String})))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        """,
+        {
+            "pb_0": "call_0",
+            "pb_1": "call_1",
+            "pb_2": "call_2",
+            "pb_3": '$."turn"."root_turn_id"',
+            "pb_4": "project",
+        },
+    )
+
+
+def test_or_union_guardrail_gt_branch_unchanged() -> None:
+    """A `$gt` branch never classifies (only $eq/$in/$contains do); SQL is unchanged."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(
+        tsi_query.OrOperation.model_validate(
+            {
+                "$or": [
+                    {"$eq": [{"$getField": "id"}, {"$literal": "call_1"}]},
+                    {"$gt": [{"$getField": "inputs.turn.count"}, {"$literal": 5}]},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING ((((calls_merged.id = {pb_0:String})
+            OR (toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_1:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '')) > {pb_2:Int64})))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        """,
+        {
+            "pb_0": "call_1",
+            "pb_1": '$."turn"."count"',
+            "pb_2": 5,
+            "pb_3": "project",
+        },
+    )
+
+
+def test_or_union_guardrail_nested_or_unchanged() -> None:
+    """A branch that is itself an `$or` never classifies; SQL is unchanged."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(
+        tsi_query.OrOperation.model_validate(
+            {
+                "$or": [
+                    {"$eq": [{"$getField": "id"}, {"$literal": "call_1"}]},
+                    {
+                        "$or": [
+                            {
+                                "$eq": [
+                                    {"$getField": "inputs.turn.root_turn_id"},
+                                    {"$literal": "call_1"},
+                                ]
+                            },
+                            {
+                                "$eq": [
+                                    {"$getField": "inputs.turn.root_turn_id"},
+                                    {"$literal": "call_2"},
+                                ]
+                            },
+                        ]
+                    },
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING ((((calls_merged.id = {pb_0:String})
+            OR ((coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_1:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_0:String})
+                OR (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_1:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_2:String}))))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        """,
+        {
+            "pb_0": "call_1",
+            "pb_1": '$."turn"."root_turn_id"',
+            "pb_2": "call_2",
+            "pb_3": "project",
+        },
+    )
+
+
+def test_or_union_guardrail_not_or_unchanged() -> None:
+    """`$not($or)` is a top-level NotOperation, not an OrOperation condition; SQL is unchanged."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(
+        tsi_query.NotOperation.model_validate(
+            {"$not": [_turn_id_or_condition().model_dump(by_alias=True)]}
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_2:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (((NOT (((calls_merged.id = {pb_0:String})
+            OR (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_1:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_0:String})))))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        """,
+        {
+            "pb_0": "call_1",
+            "pb_1": '$."turn"."root_turn_id"',
+            "pb_2": "project",
+        },
+    )
+
+
+def test_or_union_guardrail_feedback_branch_unchanged() -> None:
+    """A feedback-payload branch never classifies (not id/trace_id/thread_id/heavy JSON); SQL is unchanged."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(
+        tsi_query.OrOperation.model_validate(
+            {
+                "$or": [
+                    {"$eq": [{"$getField": "id"}, {"$literal": "call_1"}]},
+                    {
+                        "$eq": [
+                            {
+                                "$getField": "feedback.[wandb.runnable.my_op].payload.output.score"
+                            },
+                            {"$literal": 5},
+                        ]
+                    },
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        LEFT JOIN (
+            SELECT * FROM feedback WHERE feedback.project_id = {pb_4:String}
+        ) AS feedback ON (
+            feedback.weave_ref = concat('weave-trace-internal:///', {pb_4:String}, '/call/', calls_merged.id))
+        PREWHERE calls_merged.project_id = {pb_4:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING ((((calls_merged.id = {pb_0:String})
+            OR (toInt64OrNull(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_1:String}), {pb_2:String}), 'null'), '')) = {pb_3:Int64})))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        """,
+        {
+            "pb_0": "call_1",
+            "pb_1": "wandb.runnable.my_op",
+            "pb_2": '$."output"."score"',
+            "pb_3": 5,
+            "pb_4": "project",
+        },
+    )
+
+
+def test_or_union_guardrail_non_optimizable_heavy_branch_unchanged() -> None:
+    """An empty-string heavy-field literal never classifies (LIKE optimization rejects it); SQL is unchanged."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(
+        tsi_query.OrOperation.model_validate(
+            {
+                "$or": [
+                    {"$eq": [{"$getField": "id"}, {"$literal": "call_1"}]},
+                    {
+                        "$eq": [
+                            {"$getField": "inputs.turn.root_turn_id"},
+                            {"$literal": ""},
+                        ]
+                    },
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING ((((calls_merged.id = {pb_0:String})
+            OR (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_1:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_2:String})))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        """,
+        {
+            "pb_0": "call_1",
+            "pb_1": '$."turn"."root_turn_id"',
+            "pb_2": "",
+            "pb_3": "project",
+        },
+    )
+
+
+def test_or_union_guardrail_existing_call_ids_filter_unchanged() -> None:
+    """An id branch never lowers onto an already-set hardcoded call_ids filter; SQL is unchanged."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.hardcoded_filter = HardCodedFilter(filter={"call_ids": ["existing_id"]})
+    cq.add_condition(_turn_id_or_condition())
+
+    assert_sql(
+        cq,
+        """
+        WITH filtered_calls AS (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_3:String}
+            WHERE (calls_merged.id IN {pb_2:Array(String)})
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING ((((calls_merged.id = {pb_0:String})
+                OR (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_1:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_0:String})))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        )
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        WHERE (calls_merged.id IN filtered_calls)
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        """,
+        {
+            "pb_0": "call_1",
+            "pb_1": '$."turn"."root_turn_id"',
+            "pb_2": ["existing_id"],
+            "pb_3": "project",
+        },
+    )
+
+
+def test_or_union_guardrail_object_ref_expand_columns_unchanged() -> None:
+    """An object-ref expand-columns condition alongside the $or disqualifies the whole rewrite."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.set_expand_columns(["inputs.model"])
+    cq.add_condition(
+        tsi_query.AndOperation.model_validate(
+            {
+                "$and": [
+                    {
+                        "$eq": [
+                            {"$getField": "inputs.model.id"},
+                            {
+                                "$literal": "weave-trace-internal:///project/object/Model:abc"
+                            },
+                        ]
+                    },
+                    _turn_id_or_condition().model_dump(by_alias=True),
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        WITH obj_filter_0 AS (
+            SELECT digest, concat('weave-trace-internal:///', project_id, '/object/', object_id, ':', digest) AS ref
+            FROM object_versions
+            WHERE project_id = {pb_0:String}
+              AND JSON_VALUE(val_dump, {pb_1:String}) = {pb_2:String}
+            GROUP BY project_id, object_id, digest
+            UNION ALL
+            SELECT digest, digest as ref
+            FROM table_rows
+            WHERE project_id = {pb_0:String}
+              AND JSON_VALUE(val_dump, {pb_1:String}) = {pb_2:String}
+            GROUP BY project_id, digest
+        ),
+        filtered_calls AS (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_0:String}
+            WHERE (length(calls_merged.input_refs) > 0 OR calls_merged.op_name IS NULL)
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_3:String}), 'null'), '') GLOBAL IN (SELECT ref FROM obj_filter_0)
+                OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN (SELECT ref FROM obj_filter_0)))
+                AND (((calls_merged.id = {pb_4:String})
+                    OR (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_5:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_4:String})))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        )
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_0:String}
+        WHERE (calls_merged.id IN filtered_calls)
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        """,
+        {
+            "pb_0": "project",
+            "pb_1": '$."id"',
+            "pb_2": "weave-trace-internal:///project/object/Model:abc",
+            "pb_3": '$."model"',
+            "pb_4": "call_1",
+            "pb_5": '$."turn"."root_turn_id"',
         },
     )

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -6241,6 +6241,106 @@ def test_or_union_guardrail_existing_call_ids_filter_unchanged() -> None:
     )
 
 
+def test_or_union_guardrail_heavy_order_field_unchanged() -> None:
+    """A qualifying $or with a heavy (summary) ORDER BY field disqualifies the rewrite; SQL is unchanged."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.add_condition(_turn_id_or_condition())
+    cq.add_order("summary.weave.status", "asc")
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_7:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING ((((calls_merged.id = {pb_0:String})
+            OR (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_1:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_0:String})))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        ORDER BY CASE
+            WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_3:String}
+            WHEN IFNULL(toInt64OrNull(coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.summary_dump, {pb_2:String}), calls_merged.summary_dump IS NOT NULL), 'null'), '')), 0) > 0 THEN {pb_6:String}
+            WHEN any(calls_merged.ended_at) IS NULL THEN {pb_4:String}
+            ELSE {pb_5:String}
+        END ASC
+        """,
+        {
+            "pb_0": "call_1",
+            "pb_1": '$."turn"."root_turn_id"',
+            "pb_2": '$."status_counts"."error"',
+            "pb_3": "error",
+            "pb_4": "running",
+            "pb_5": "success",
+            "pb_6": "descendant_error",
+            "pb_7": "project",
+        },
+    )
+
+
+def test_or_union_guardrail_existing_trace_ids_filter_unchanged() -> None:
+    """A trace_id branch never lowers onto an already-set hardcoded trace_ids filter; SQL is unchanged."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_field("inputs")
+    cq.hardcoded_filter = HardCodedFilter(filter={"trace_ids": ["existing_trace"]})
+    cq.add_condition(
+        tsi_query.OrOperation.model_validate(
+            {
+                "$or": [
+                    {"$eq": [{"$getField": "trace_id"}, {"$literal": "trace_1"}]},
+                    {
+                        "$eq": [
+                            {"$getField": "inputs.turn.root_turn_id"},
+                            {"$literal": "call_1"},
+                        ]
+                    },
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        WITH filter_candidate_ids AS (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_1:String}
+            WHERE ifNull(calls_merged.trace_id, '') = {pb_0:String}),
+        filtered_calls AS (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_1:String}
+            WHERE (calls_merged.id IN filter_candidate_ids)
+                AND (ifNull(calls_merged.trace_id, '') = {pb_0:String} OR calls_merged.trace_id IS NULL)
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING ((((any(calls_merged.trace_id) = {pb_2:String})
+                OR (coalesce(nullIf(anyIf(JSON_VALUE(calls_merged.inputs_dump, {pb_3:String}), calls_merged.inputs_dump IS NOT NULL), 'null'), '') = {pb_4:String})))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))))
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.inputs_dump) AS inputs_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_1:String}
+        WHERE (calls_merged.id IN filtered_calls)
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        """,
+        {
+            "pb_0": "existing_trace",
+            "pb_1": "project",
+            "pb_2": "trace_1",
+            "pb_3": '$."turn"."root_turn_id"',
+            "pb_4": "call_1",
+        },
+    )
+
+
 def test_or_union_guardrail_object_ref_expand_columns_unchanged() -> None:
     """An object-ref expand-columns condition alongside the $or disqualifies the whole rewrite."""
     cq = CallsQuery(project_id="project")

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -26,9 +26,11 @@ Outstanding Optimizations/Work:
 """
 
 import logging
+import os
 import re
 from collections.abc import Callable, Collection, KeysView, Sequence
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Literal, cast
 
 from pydantic import BaseModel, Field
@@ -54,6 +56,8 @@ from weave.trace_server.calls_query_builder.object_ref_query_builder import (
 )
 from weave.trace_server.calls_query_builder.optimization_builder import (
     DATETIME_BUFFER_TIME_SECONDS,
+    HeavyFieldOptimizationProcessor,
+    apply_processor,
     process_query_to_optimization_sql,
 )
 from weave.trace_server.calls_query_builder.utils import (
@@ -91,6 +95,10 @@ CTE_FILTERED_CALLS = "filtered_calls"
 CTE_ALL_CALLS = "all_calls"
 CTE_FILTER_CANDIDATE_IDS = "filter_candidate_ids"
 CTE_STORAGE_SCOPE_IDS = "storage_scope_ids"
+
+# Cap on the number of `$or` branches the UNION DISTINCT rewrite will plan for.
+# Beyond this, per-arm overhead outweighs the skip-index win.
+MAX_OR_UNION_ARMS = 5
 
 # Deferred: server-side defense-in-depth cap for unfiltered calls_merged stats.
 # Wired up in `build_calls_stats_query` but currently commented out; callers
@@ -139,6 +147,29 @@ class QueryBodyResult:
 
     sql: str
     needs_feedback_join: bool
+
+
+class _UnionBranchKind(Enum):
+    """How a single `$or` branch is planned into a UNION DISTINCT arm."""
+
+    ID_MASK = "id_mask"
+    TRACE_IDS = "trace_ids"
+    THREAD_IDS = "thread_ids"
+    HEAVY_JSON = "heavy_json"
+
+
+@dataclass(frozen=True, slots=True)
+class _OrUnionArmSpec:
+    """One arm of a top-level `$or` rewritten as a UNION DISTINCT branch.
+
+    `lowered_values` is set for ID_MASK/TRACE_IDS/THREAD_IDS branches (the
+    literal values pushed into the arm's hardcoded filter) and None for
+    HEAVY_JSON branches, which keep `operand` as the arm's sole condition.
+    """
+
+    branch_kind: _UnionBranchKind
+    operand: "tsi_query.Operand"
+    lowered_values: list[str] | None
 
 
 def maybe_agg(expr: str, use_agg_fn: bool) -> str:
@@ -1075,6 +1106,101 @@ class CallsQuery(BaseModel):
         # No predicate pushdown possible
         return False
 
+    def _plan_or_union_arms(self, table_alias: str) -> list[_OrUnionArmSpec] | None:
+        """Plan a top-level `$or` as UNION DISTINCT arms, or None if it can't fire.
+
+        Must be called BEFORE the deleted_at/op_name conditions are injected
+        into `self.query_conditions`, so only user conditions are inspected.
+        Returns None unless: there is exactly one top-level `$or` condition
+        with 2-`MAX_OR_UNION_ARMS` branches, every branch classifies via
+        `_classify_or_union_branch`, every other condition and order field is
+        light, and each id/trace_id/thread_id branch can be lowered onto a
+        currently-unset hardcoded filter field.
+        """
+        if os.getenv("WEAVE_CALLS_OR_UNION_REWRITE", "1") == "0":
+            return None
+
+        or_conditions = [
+            condition
+            for condition in self.query_conditions
+            if isinstance(condition.operand, tsi_query.OrOperation)
+        ]
+        if len(or_conditions) != 1:
+            return None
+        or_operand = or_conditions[0].operand
+        assert isinstance(or_operand, tsi_query.OrOperation)
+        branches = or_operand.or_
+        if not (2 <= len(branches) <= MAX_OR_UNION_ARMS):
+            return None
+
+        table_name = get_calls_table_name(self.read_table)
+        other_conditions = [c for c in self.query_conditions if c is not or_conditions[0]]
+        for condition in other_conditions:
+            if (
+                condition.is_heavy(table_name)
+                or condition.is_feedback(table_name)
+                or condition.is_queue_item(table_name)
+                or is_object_ref_operand(condition.operand, self.expand_columns)
+            ):
+                return None
+
+        for order_field in self.order_fields:
+            if isinstance(
+                order_field.field,
+                (
+                    CallsMergedDynamicField,
+                    CallsMergedSummaryField,
+                    CallsMergedFeedbackPayloadField,
+                    CallsMergedQueueItemField,
+                ),
+            ):
+                return None
+
+        already_has_call_ids = bool(
+            self.hardcoded_filter and self.hardcoded_filter.filter.call_ids
+        )
+        already_has_trace_ids = bool(
+            self.hardcoded_filter and self.hardcoded_filter.filter.trace_ids
+        )
+        already_has_thread_ids = bool(
+            self.hardcoded_filter and self.hardcoded_filter.filter.thread_ids is not None
+        )
+
+        arm_specs: list[_OrUnionArmSpec] = []
+        for branch in branches:
+            kind = _classify_or_union_branch(branch, table_alias)
+            if kind is None:
+                return None
+
+            lowered_values: list[str] | None = None
+            if kind == _UnionBranchKind.HEAVY_JSON:
+                pass
+            elif kind in {
+                _UnionBranchKind.ID_MASK,
+                _UnionBranchKind.TRACE_IDS,
+                _UnionBranchKind.THREAD_IDS,
+            }:
+                extracted = _extract_eq_or_in_literal_field(branch)
+                if extracted is None:
+                    return None
+                _, lowered_values = extracted
+                if kind == _UnionBranchKind.ID_MASK and already_has_call_ids:
+                    return None
+                if kind == _UnionBranchKind.TRACE_IDS and already_has_trace_ids:
+                    return None
+                if kind == _UnionBranchKind.THREAD_IDS and already_has_thread_ids:
+                    return None
+            else:
+                raise ValueError(f"Unhandled _UnionBranchKind: {kind}")
+
+            arm_specs.append(
+                _OrUnionArmSpec(
+                    branch_kind=kind, operand=branch, lowered_values=lowered_values
+                )
+            )
+
+        return arm_specs
+
     def as_sql(self, pb: ParamBuilder, table_alias: str | None = None) -> str:
         """This is the main entry point for building the query.
 
@@ -1153,6 +1279,12 @@ class CallsQuery(BaseModel):
         # Determine if we should use the two-step filtered_calls CTE pattern.
         should_use_filter_cte = self._should_use_filter_cte()
 
+        table_alias_resolved = table_alias or get_calls_table_name(self.read_table)
+
+        # Plan the $or -> UNION DISTINCT rewrite before deleted_at/op_name are
+        # injected below, so only user conditions are inspected.
+        or_union_arms = self._plan_or_union_arms(table_alias_resolved)
+
         # Important: Always inject deleted_at into the query.
         # We use None as the literal for both table types. The sentinel handling
         # in process_operation converts None to the correct sentinel value with
@@ -1187,14 +1319,15 @@ class CallsQuery(BaseModel):
                 )
             )
 
-        table_alias_resolved = table_alias or get_calls_table_name(self.read_table)
-
         object_ref_conditions = get_all_object_ref_conditions(
             self.query_conditions,
             self.order_fields,
             self.expand_columns,
             table_alias_resolved,
         )
+        if object_ref_conditions:
+            # A qualifying $or never coexists with object-ref conditions.
+            or_union_arms = None
 
         # Build object-ref and candidate-id CTEs up front so all downstream
         # code paths (early-return, single-pass, two-pass) can reference them.
@@ -1227,9 +1360,13 @@ class CallsQuery(BaseModel):
         # the page's payloads instead of every scanned row's (prod: 28 GiB -> 1.7 GiB
         # on a fat-payload list read). calls_merged additionally uses it for costs /
         # object-ref pushdown ahead of its GROUP BY.
-        use_filter_cte = should_use_filter_cte or (
-            self.read_table != ReadTable.CALLS_COMPLETE
-            and (self.include_costs or bool(object_ref_conditions))
+        use_filter_cte = (
+            should_use_filter_cte
+            or or_union_arms is not None
+            or (
+                self.read_table != ReadTable.CALLS_COMPLETE
+                and (self.include_costs or bool(object_ref_conditions))
+            )
         )
 
         # On calls_complete the total-storage rollup otherwise aggregates the
@@ -1248,6 +1385,7 @@ class CallsQuery(BaseModel):
 
         if (
             not should_use_filter_cte
+            and or_union_arms is None
             and not self.include_costs
             and not object_ref_conditions
         ):
@@ -1265,9 +1403,6 @@ class CallsQuery(BaseModel):
             # Build two queries: a filter CTE that narrows rows by light
             # conditions first, then a select query that loads heavy columns
             # only for the matched ids.
-            filter_query = CallsQuery(
-                project_id=self.project_id, read_table=self.read_table
-            )
             select_query = CallsQuery(
                 project_id=self.project_id,
                 include_storage_size=self.include_storage_size,
@@ -1285,27 +1420,8 @@ class CallsQuery(BaseModel):
                 and not self.include_total_storage_size
             )
 
-            filter_query.add_field("id")
-            if page_started_at_bound:
-                filter_query.add_field("started_at")
             for field in self.select_fields:
                 select_query.select_fields.append(field)
-
-            for condition in self.query_conditions:
-                filter_query.query_conditions.append(condition)
-
-            filter_query.hardcoded_filter = self.hardcoded_filter
-            # Total-order pass 1 with an id tiebreaker so the min/max started_at
-            # bound and the id set derive from the identical LIMIT cut.
-            if page_started_at_bound:
-                filter_query.order_fields = [
-                    *self.order_fields,
-                    OrderField(field=get_field_by_name("id"), direction="ASC"),
-                ]
-            else:
-                filter_query.order_fields = self.order_fields
-            filter_query.limit = self.limit
-            filter_query.offset = self.offset
             # SUPER IMPORTANT: still need to re-sort the final query
             select_query.order_fields = self.order_fields
 
@@ -1315,13 +1431,41 @@ class CallsQuery(BaseModel):
             if self.include_costs:
                 self._ensure_order_fields_selected(select_query.select_fields)
 
-            filtered_calls_sql = filter_query._as_sql_base_format(
-                pb,
-                table_alias_resolved,
-                id_subquery_name=candidate_cte_name,
-                field_to_object_join_alias_map=field_to_object_join_alias_map,
-                expand_columns=self.expand_columns,
-            )
+            if or_union_arms is not None:
+                filtered_calls_sql = self._build_or_union_filtered_calls_sql(
+                    pb, table_alias_resolved, or_union_arms, page_started_at_bound
+                )
+            else:
+                filter_query = CallsQuery(
+                    project_id=self.project_id, read_table=self.read_table
+                )
+                filter_query.add_field("id")
+                if page_started_at_bound:
+                    filter_query.add_field("started_at")
+
+                for condition in self.query_conditions:
+                    filter_query.query_conditions.append(condition)
+
+                filter_query.hardcoded_filter = self.hardcoded_filter
+                # Total-order pass 1 with an id tiebreaker so the min/max started_at
+                # bound and the id set derive from the identical LIMIT cut.
+                if page_started_at_bound:
+                    filter_query.order_fields = [
+                        *self.order_fields,
+                        OrderField(field=get_field_by_name("id"), direction="ASC"),
+                    ]
+                else:
+                    filter_query.order_fields = self.order_fields
+                filter_query.limit = self.limit
+                filter_query.offset = self.offset
+
+                filtered_calls_sql = filter_query._as_sql_base_format(
+                    pb,
+                    table_alias_resolved,
+                    id_subquery_name=candidate_cte_name,
+                    field_to_object_join_alias_map=field_to_object_join_alias_map,
+                    expand_columns=self.expand_columns,
+                )
             ctes.add_cte(CTE_FILTERED_CALLS, filtered_calls_sql)
 
             base_sql = select_query._as_sql_base_format(
@@ -1919,6 +2063,92 @@ class CallsQuery(BaseModel):
             field_to_object_join_alias_map=field_to_object_join_alias_map,
             expand_columns=self.expand_columns,
         )
+
+    def _build_or_union_filtered_calls_sql(
+        self,
+        pb: ParamBuilder,
+        table_alias: str,
+        arms: list[_OrUnionArmSpec],
+        page_started_at_bound: bool,
+    ) -> str:
+        """Build the `filtered_calls` CTE body as a UNION DISTINCT of per-branch arms.
+
+        Each arm is a child `CallsQuery` carrying every other light conjunct
+        plus its own branch condition (kept as-is for HEAVY_JSON so the LIKE
+        prefilter fires as a top-level conjunct, or lowered into the arm's
+        hardcoded filter for ID_MASK/TRACE_IDS/THREAD_IDS). Arms share `pb` so
+        params never collide. The union is wrapped in one outer
+        `ORDER BY ... LIMIT ... OFFSET ...` re-sort on the arms' own aliases.
+        """
+        or_condition = next(
+            c
+            for c in self.query_conditions
+            if isinstance(c.operand, tsi_query.OrOperation)
+        )
+        other_conditions = [c for c in self.query_conditions if c is not or_condition]
+
+        already_ordered_by_id = any(
+            of.field.field == "id" for of in self.order_fields
+        )
+        if already_ordered_by_id:
+            total_order_fields = list(self.order_fields)
+        else:
+            total_order_fields = [
+                *self.order_fields,
+                OrderField(field=get_field_by_name("id"), direction="ASC"),
+            ]
+
+        arm_limit = self.limit + (self.offset or 0) if self.limit is not None else None
+
+        arm_sqls = []
+        for arm in arms:
+            arm_query = CallsQuery(project_id=self.project_id, read_table=self.read_table)
+            arm_query.add_field("id")
+            if page_started_at_bound:
+                arm_query.add_field("started_at")
+            for order_field in self.order_fields:
+                arm_query.add_field(order_field.field.field)
+
+            for condition in other_conditions:
+                arm_query.query_conditions.append(condition)
+
+            if arm.branch_kind == _UnionBranchKind.HEAVY_JSON:
+                arm_query.query_conditions.append(Condition(operand=arm.operand))
+                arm_query.hardcoded_filter = self.hardcoded_filter
+            elif arm.branch_kind in {
+                _UnionBranchKind.ID_MASK,
+                _UnionBranchKind.TRACE_IDS,
+                _UnionBranchKind.THREAD_IDS,
+            }:
+                arm_query.hardcoded_filter = _lower_or_union_branch_filter(
+                    self.hardcoded_filter, arm
+                )
+            else:
+                raise ValueError(f"Unhandled _UnionBranchKind: {arm.branch_kind}")
+
+            arm_query.order_fields = total_order_fields
+            arm_query.limit = arm_limit
+            arm_query.offset = None
+
+            arm_sqls.append(arm_query._as_sql_base_format(pb, table_alias))
+
+        union_sql = "\nUNION DISTINCT\n".join(arm_sqls)
+
+        outer_select_cols = ["id"]
+        if page_started_at_bound:
+            outer_select_cols.append("started_at")
+        outer_order_sql = ", ".join(
+            f"{of.field.field} {of.direction}" for of in total_order_fields
+        )
+        limit_sql = f"LIMIT {self.limit}" if self.limit is not None else ""
+        offset_sql = f"OFFSET {self.offset}" if self.offset is not None else ""
+
+        return f"""SELECT {", ".join(outer_select_cols)} FROM (
+        {union_sql}
+        )
+        ORDER BY {outer_order_sql}
+        {limit_sql}
+        {offset_sql}"""
 
     def _as_sql_base_format(
         self,
@@ -2701,6 +2931,116 @@ def process_thread_id_filter_to_sql(
         param_builder, table_alias, read_table, use_agg_fn=False
     )
     return f" AND ({thread_cond} OR {thread_null})"
+
+
+# Fields whose `$eq`/`$in` branches lower into a hardcoded-filter pushdown;
+# maps field name -> the _UnionBranchKind that branch classifies as.
+_OR_UNION_LOWERABLE_FIELDS = {
+    "id": _UnionBranchKind.ID_MASK,
+    "trace_id": _UnionBranchKind.TRACE_IDS,
+    "thread_id": _UnionBranchKind.THREAD_IDS,
+}
+
+
+def _extract_eq_or_in_literal_field(
+    operand: "tsi_query.Operand",
+) -> tuple[str, list[str]] | None:
+    """Extract (field name, string literal values) from a plain `$eq`/`$in` operand.
+
+    Returns None for anything else: wrong arity, non-GetField operand, or a
+    literal that isn't a string (id/trace_id/thread_id are all string columns).
+    """
+    if isinstance(operand, tsi_query.EqOperation):
+        if len(operand.eq_) != 2:
+            return None
+        lhs, rhs = operand.eq_
+        if isinstance(lhs, tsi_query.GetFieldOperator) and isinstance(
+            rhs, tsi_query.LiteralOperation
+        ):
+            field, literal = lhs.get_field_, rhs.literal_
+        elif isinstance(rhs, tsi_query.GetFieldOperator) and isinstance(
+            lhs, tsi_query.LiteralOperation
+        ):
+            field, literal = rhs.get_field_, lhs.literal_
+        else:
+            return None
+        if not isinstance(literal, str):
+            return None
+        return field, [literal]
+
+    if isinstance(operand, tsi_query.InOperation):
+        lhs, values = operand.in_
+        if not isinstance(lhs, tsi_query.GetFieldOperator):
+            return None
+        literals: list[str] = []
+        for value_operand in values:
+            if not isinstance(
+                value_operand, tsi_query.LiteralOperation
+            ) or not isinstance(value_operand.literal_, str):
+                return None
+            literals.append(value_operand.literal_)
+        if not literals:
+            return None
+        return lhs.get_field_, literals
+
+    return None
+
+
+def _classify_or_union_branch(
+    operand: "tsi_query.Operand", table_alias: str
+) -> _UnionBranchKind | None:
+    """Classify a single `$or` branch for the UNION DISTINCT rewrite, or None.
+
+    `$eq`/`$in` on id/trace_id/thread_id lower into a hardcoded-filter pushdown.
+    `$eq`/`$in`/`$contains` on a heavy JSON field qualify when
+    `HeavyFieldOptimizationProcessor` can emit a LIKE prefilter for them (the
+    same probe `process_query_to_optimization_sql` uses). Anything else (gt/lt,
+    nested and/or/not, non-literal operands, feedback/summary/object-ref
+    fields) disqualifies the branch.
+    """
+    extracted = _extract_eq_or_in_literal_field(operand)
+    if extracted is not None:
+        field, _ = extracted
+        lowered_kind = _OR_UNION_LOWERABLE_FIELDS.get(field)
+        if lowered_kind is not None:
+            return lowered_kind
+
+    if isinstance(
+        operand,
+        (tsi_query.EqOperation, tsi_query.InOperation, tsi_query.ContainsOperation),
+    ):
+        probe = apply_processor(
+            HeavyFieldOptimizationProcessor(ParamBuilder(), table_alias),
+            operand,
+        )
+        if probe is not None:
+            return _UnionBranchKind.HEAVY_JSON
+
+    return None
+
+
+def _lower_or_union_branch_filter(
+    base_filter: HardCodedFilter | None, arm: _OrUnionArmSpec
+) -> HardCodedFilter:
+    """Build the arm's hardcoded filter for an ID_MASK/TRACE_IDS/THREAD_IDS branch.
+
+    Copies `base_filter` (if any) with the branch's literal values set on the
+    matching field, reusing existing index-shaped pushdowns for that field.
+    """
+    if arm.lowered_values is None:
+        raise ValueError(f"Branch {arm.branch_kind} has no lowered_values to apply")
+
+    if arm.branch_kind == _UnionBranchKind.ID_MASK:
+        update = {"call_ids": arm.lowered_values}
+    elif arm.branch_kind == _UnionBranchKind.TRACE_IDS:
+        update = {"trace_ids": arm.lowered_values}
+    elif arm.branch_kind == _UnionBranchKind.THREAD_IDS:
+        update = {"thread_ids": arm.lowered_values}
+    else:
+        raise ValueError(f"Unhandled lowered branch kind: {arm.branch_kind}")
+
+    base = base_filter.filter if base_filter is not None else tsi.CallsFilter()
+    return HardCodedFilter(filter=base.model_copy(update=update))
 
 
 def process_turn_id_filter_to_sql(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1134,7 +1134,9 @@ class CallsQuery(BaseModel):
             return None
 
         table_name = get_calls_table_name(self.read_table)
-        other_conditions = [c for c in self.query_conditions if c is not or_conditions[0]]
+        other_conditions = [
+            c for c in self.query_conditions if c is not or_conditions[0]
+        ]
         for condition in other_conditions:
             if (
                 condition.is_heavy(table_name)
@@ -1163,7 +1165,8 @@ class CallsQuery(BaseModel):
             self.hardcoded_filter and self.hardcoded_filter.filter.trace_ids
         )
         already_has_thread_ids = bool(
-            self.hardcoded_filter and self.hardcoded_filter.filter.thread_ids is not None
+            self.hardcoded_filter
+            and self.hardcoded_filter.filter.thread_ids is not None
         )
 
         arm_specs: list[_OrUnionArmSpec] = []
@@ -2087,9 +2090,7 @@ class CallsQuery(BaseModel):
         )
         other_conditions = [c for c in self.query_conditions if c is not or_condition]
 
-        already_ordered_by_id = any(
-            of.field.field == "id" for of in self.order_fields
-        )
+        already_ordered_by_id = any(of.field.field == "id" for of in self.order_fields)
         if already_ordered_by_id:
             total_order_fields = list(self.order_fields)
         else:
@@ -2102,7 +2103,9 @@ class CallsQuery(BaseModel):
 
         arm_sqls = []
         for arm in arms:
-            arm_query = CallsQuery(project_id=self.project_id, read_table=self.read_table)
+            arm_query = CallsQuery(
+                project_id=self.project_id, read_table=self.read_table
+            )
             arm_query.add_field("id")
             if page_started_at_bound:
                 arm_query.add_field("started_at")


### PR DESCRIPTION
## Summary
- ClickHouse skip indexes (tokenbf on `inputs_dump`, bloom on `id`/`trace_id`) only prune inside top-level AND conjuncts, never inside an OR, so calls queries with a top-level `$or` (e.g. an internal agent session-resolution query matching by id or turn root id) fall back to full scans.
- Rewrites the pass-1 `filtered_calls` CTE as a `UNION DISTINCT` of per-branch child queries when a query has exactly one qualifying top-level `$or` (2-5 branches, no feedback/queue-item/object-ref conditions, no incompatible ordering). `id`/`trace_id`/`thread_id` `$eq`/`$in` branches lower into `HardCodedFilter`; heavy-JSON branches keep their LIKE/tokenbf optimization. Pass-2 hydration is untouched.
- Guarded by `WEAVE_CALLS_OR_UNION_REWRITE` (default on) and falls back to the existing path for any non-qualifying shape.

## Before / after example (simplified)

Say we need to find either the call itself or a child call that points to it:

```text
id = "call_123" OR inputs.turn.root_turn_id = "call_123"
```

**Before:** both checks live inside one `OR`.

```sql
SELECT id
FROM calls_complete
WHERE id = 'call_123'
   OR JSON_VALUE(inputs_dump, '$.turn.root_turn_id') = 'call_123';
```

ClickHouse cannot use either skip index to prune this query, so it scans the table.

**After:** each check gets its own branch.

```sql
SELECT id
FROM calls_complete
WHERE id IN ('call_123')  -- id bloom index can prune

UNION DISTINCT

SELECT id
FROM calls_complete
WHERE inputs_dump LIKE '%"call_123"%'  -- token index can prune
  AND JSON_VALUE(inputs_dump, '$.turn.root_turn_id') = 'call_123';
```

Each branch can now prune independently, and `UNION DISTINCT` removes a duplicate if one row matches both. Shared project/deleted/order/limit clauses are omitted here for readability; this rewrite only changes pass 1, and final row hydration stays the same.

## Testing
Full-SQL unit tests for each union shape, composition, limit/offset, id-field lowering, and 9 guardrail negative cases; real-ClickHouse equivalence + pagination tests (branch-A-only/B-only/both/neither, dup/miss check) also runnable under `--trace-server=fake`.