### PR TITLE
fix(weave): classify ClickHouse TOO_SLOW as QueryEstimatedTimeoutExceededError

### DIFF
--- a/tests/trace_server/test_errors.py
+++ b/tests/trace_server/test_errors.py
@@ -10,6 +10,7 @@ from weave.trace_server.errors import (
     InvalidFieldError,
     InvalidRequest,
     ObjectNameTypeCollision,
+    QueryEstimatedTimeoutExceededError,
     handle_clickhouse_query_error,
     handle_server_exception,
 )
@@ -57,6 +58,33 @@ def test_clickhouse_type_mismatch_returns_400() -> None:
 
     result = handle_server_exception(InvalidRequest(error_msg))
     assert result.status_code == 400
+
+
+def test_clickhouse_estimated_too_slow_maps_to_estimated_timeout() -> None:
+    """ClickHouse rejects an over-broad query up front with code 160 (TOO_SLOW) when
+    its *estimated* execution time exceeds the limit. That is a query-guard rejection
+    of the user's unbounded query, so it must surface as
+    QueryEstimatedTimeoutExceededError (504) -- a type distinct from
+    QueryTimeoutExceededError (a query that actually ran and timed out) -- with
+    actionable "limit the scope" guidance, not fall through to a generic DatabaseError
+    ("Temporary backend error", 502) that reads as an unexpected server fault and pages
+    on-call. WB-33068.
+    """
+    error_msg = (
+        "HTTPDriver for https://example.clickhouse.cloud:8443 received ClickHouse "
+        "error code 160\n Code: 160. DB::Exception: Estimated query execution time "
+        "(30917.60248 seconds) is too long. Maximum: 3600. Estimated rows to process: "
+        "692495231 (807143 read in 36.03624 seconds): While executing "
+        "MergeTreeSelect(pool: PrefetchedReadPool, algorithm: Thread). (TOO_SLOW) "
+        "(version 26.2.1.413 (official build))"
+    )
+    exc = CHDatabaseError(error_msg)
+
+    with pytest.raises(QueryEstimatedTimeoutExceededError, match="limit the scope"):
+        handle_clickhouse_query_error(exc)
+
+    result = handle_server_exception(QueryEstimatedTimeoutExceededError(error_msg))
+    assert result.status_code == 504
 
 
 def test_clickhouse_bad_query_parameter_returns_400_with_real_detail() -> None:

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -131,6 +131,19 @@ class QueryTimeoutExceededError(Error):
     pass
 
 
+class QueryEstimatedTimeoutExceededError(Error):
+    """Raised when ClickHouse rejects a query up front (error code 160, TOO_SLOW)
+    because its *estimated* execution time exceeds the configured maximum.
+
+    Distinct from QueryTimeoutExceededError, which is a query that actually ran and
+    hit the execution-time limit mid-flight. Both are query-too-heavy guards, but the
+    distinction is kept so the pre-execution rejection can be identified separately
+    (e.g. in tracing/alerting).
+    """
+
+    pass
+
+
 class InsertTooLarge(Error):
     """Raised when a single insert is too large."""
 
@@ -354,6 +367,7 @@ class ErrorRegistry:
 
         # 504
         self.register(QueryTimeoutExceededError, 504)
+        self.register(QueryEstimatedTimeoutExceededError, 504)
 
         # Validation errors
         self.register(CHValidationError, 400)
@@ -424,7 +438,9 @@ def handle_clickhouse_query_error(e: Exception) -> None:
     Raises:
         QueryMemoryLimitExceededError: When the query exceeds memory limits
         QueryNoCommonTypeError: When there's a type mismatch in the query
-        QueryTimeoutExceededError: When the query exceeds timeout limits
+        QueryTimeoutExceededError: When a running query exceeds its execution-time limit
+        QueryEstimatedTimeoutExceededError: When ClickHouse rejects a query up front
+            because its estimated execution time exceeds the limit
         Exception: Re-raises the original exception if no known pattern matches
     """
     error_str = str(e)
@@ -441,6 +457,20 @@ def handle_clickhouse_query_error(e: Exception) -> None:
     if "TIMEOUT_EXCEEDED" in error_str:
         raise QueryTimeoutExceededError(
             "Query timeout exceeded. " + limit_scope_message
+        ) from e
+    if "TOO_SLOW" in error_str:
+        # ClickHouse rejects a query up front (error code 160, TOO_SLOW) when its
+        # *estimated* execution time exceeds max_estimated_execution_time -- the
+        # planner declines to run it rather than timing out mid-flight. This is the
+        # same class of "query is too heavy" guard as TIMEOUT_EXCEEDED, so surface it
+        # with actionable guidance instead of letting it fall through to a generic
+        # DatabaseError ("Temporary backend error", 502), which reads as an unexpected
+        # server fault and pages on-call. It gets its own error type (distinct from
+        # QueryTimeoutExceededError) so the pre-execution rejection is identifiable in
+        # tracing/alerting. See WB-33068.
+        raise QueryEstimatedTimeoutExceededError(
+            "Query aborted because its estimated execution time exceeds the maximum "
+            "allowed. " + limit_scope_message
         ) from e
     if "NO_COMMON_TYPE" in error_str:
         raise QueryNoCommonTypeError(


### PR DESCRIPTION
## JIRA Issue(s)

[WB-37836](https://coreweave.atlassian.net/browse/WB-37836)

## Description

`TOO_SLOW` currently shows up as `(Unexpected error - investigate!)` in our alerts ([recent example](https://weightsandbiases.slack.com/archives/C05SL7KPZA9/p1784679549991719)). This raises unnecessary concern for a known-issue and creates alert fatigue. I'm adding a new error type that we can filter on, so we can have cleaner alerts. I'm keeping this distinct from QueryTimeoutExceededError, so that we can differentiate between timeouts and predicted timeouts.

## Testing

_How did you test your PR? What is the blast radius of your change? Provide a test plan._

- [x] _Unit tests_


[WB-37836]: https://coreweave.atlassian.net/browse/WB-37836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ