### PR TITLE
feat(weave): allow custom runtimes without API keys

### DIFF
--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -169,6 +169,47 @@ class TestGetCustomProviderInfo(unittest.TestCase):
         finally:
             _secret_fetcher_context.reset(token)
 
+    def test_provider_without_api_key_skips_secret_lookup(self):
+        """An empty API-key name allows headers or endpoint auth to be used."""
+        provider_without_api_key = self.provider_obj.model_copy(
+            update={
+                "val": {
+                    **self.provider_obj.val,
+                    "api_key_name": "",
+                    "extra_headers": {"Authorization": "Bearer header-token"},
+                }
+            }
+        )
+
+        def mock_obj_read(req):
+            if req.object_id == self.provider_id:
+                return tsi.ObjReadRes(obj=provider_without_api_key)
+            if req.object_id == self.model_name:
+                return tsi.ObjReadRes(obj=self.provider_model_obj)
+            raise NotFoundError(f"Unknown object_id: {req.object_id}")
+
+        self.mock_obj_read_func.side_effect = mock_obj_read
+        self.mock_secret_fetcher.fetch.side_effect = AssertionError(
+            "A runtime without an API key must not fetch a secret"
+        )
+
+        token = _secret_fetcher_context.set(self.mock_secret_fetcher)
+        try:
+            provider_info = get_custom_provider_info(
+                project_id=self.project_id,
+                provider_name=self.provider_id,
+                model_name=self.model_name,
+                obj_read_func=self.mock_obj_read_func,
+            )
+
+            assert provider_info.api_key == ""
+            assert provider_info.extra_headers == {
+                "Authorization": "Bearer header-token"
+            }
+            self.mock_secret_fetcher.fetch.assert_not_called()
+        finally:
+            _secret_fetcher_context.reset(token)
+
     def test_missing_secret_fetcher(self):
         """Test error handling when secret fetcher is not configured.
 

--- a/weave/trace_server/llm_completion.py
+++ b/weave/trace_server/llm_completion.py
@@ -608,17 +608,15 @@ def get_custom_provider_info(
 
     secret_name = provider_obj.api_key_name
 
-    # Get the API key
-    if not secret_name:
-        raise InvalidRequest(f"No secret name found for provider {provider_name}")
+    api_key = ""
+    if secret_name:
+        api_key = secret_fetcher.fetch(secret_name).get("secrets", {}).get(secret_name)
 
-    api_key = secret_fetcher.fetch(secret_name).get("secrets", {}).get(secret_name)
-
-    if not api_key:
-        raise MissingLLMApiKeyError(
-            f"No API key {secret_name} found for provider {provider_name}",
-            api_key_name=secret_name,
-        )
+        if not api_key:
+            raise MissingLLMApiKeyError(
+                f"No API key {secret_name} found for provider {provider_name}",
+                api_key_name=secret_name,
+            )
 
     info = CustomProviderInfo(
         base_url=provider_obj.base_url,


### PR DESCRIPTION
## Summary

- allow custom runtime endpoints to omit an API-key secret
- preserve configured custom headers, including alternate authentication headers
- keep existing secret lookup and missing-secret behavior unchanged when a secret is configured

Paired with wandb/core#48619.

## Validation

- `.venv/bin/python -m pytest -p no:rerunfailures tests/trace_server/test_llm_completion.py::TestGetCustomProviderInfo tests/trace_server/test_custom_provider.py::test_get_custom_provider_info -q` (7 passed)
- `.venv/bin/python -m compileall -q weave/trace_server/llm_completion.py tests/trace_server/test_llm_completion.py`
- `git diff --check`