### PR TITLE
feat(trace-server): add paginated agent signals query

### DIFF
--- a/tests/trace_server/query_builder/test_agent_signals_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_signals_query_builder.py
@@ -1,0 +1,111 @@
+"""Exact SQL assertions for the server-paginated agent Signals query."""
+
+import sqlparse
+
+from weave.trace_server.agents.types import AgentSignalsQueryReq
+from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.query_builder.agent_signals_query_builder import (
+    make_agent_signals_count_query,
+    make_agent_signals_list_query,
+)
+
+
+def test_count_query_reuses_aggregate_filter_semantics() -> None:
+    pb = ParamBuilder("signals")
+    query = make_agent_signals_count_query(
+        pb,
+        AgentSignalsQueryReq(
+            project_id="entity/project",
+            after_ms=1_000,
+            before_ms=2_000,
+            feedback_types=["wandb.agent_monitor"],
+            tags=["unsafe"],
+            rating_min=0.25,
+            rating_max=0.75,
+            scorer_ids=["judge"],
+            span_agent_names=["support-bot"],
+            span_types=["agent_turn"],
+        ),
+    )
+
+    expected = """
+        SELECT count()
+        FROM feedback
+        WHERE (
+          project_id = {signals_0:String}
+          AND created_at >= fromUnixTimestamp64Milli({signals_1:Int64})
+          AND created_at < fromUnixTimestamp64Milli({signals_2:Int64})
+          AND (startsWith(feedback_type, {signals_3:String}))
+          AND (
+            splitByChar(':', splitByChar('/', ifNull(runnable_ref, ''))[-1])[1]
+              = {signals_4:String}
+          )
+          AND span_agent_name IN {signals_5:Array(String)}
+          AND (splitByChar('/', weave_ref)[-2] = {signals_6:String})
+          AND hasAny(scorer_tags, {signals_7:Array(String)})
+          AND mapContains(scorer_ratings, {signals_8:String})
+          AND scorer_ratings[{signals_8:String}] >= {signals_9:Float64}
+          AND scorer_ratings[{signals_8:String}] <= {signals_10:Float64}
+        )
+        AND (notEmpty(scorer_tags) OR notEmpty(scorer_ratings))
+    """
+    assert (
+        query == sqlparse.format(expected, reindent=True, keyword_case="upper").strip()
+    )
+    assert pb.get_params() == {
+        "signals_0": "entity/project",
+        "signals_1": 1_000,
+        "signals_2": 2_000,
+        "signals_3": "wandb.agent_monitor",
+        "signals_4": "judge",
+        "signals_5": ["support-bot"],
+        "signals_6": "agent_turn",
+        "signals_7": ["unsafe"],
+        "signals_8": "_rating_",
+        "signals_9": 0.25,
+        "signals_10": 0.75,
+    }
+
+
+def test_created_at_sort_pages_before_pricing() -> None:
+    pb = ParamBuilder("signals")
+    query = make_agent_signals_list_query(
+        pb,
+        AgentSignalsQueryReq(
+            project_id="entity/project",
+            after_ms=1_000,
+            before_ms=2_000,
+            limit=50,
+            offset=100,
+        ),
+    )
+    compact = " ".join(query.split())
+
+    assert "page_feedback AS" in compact
+    assert "FROM page_feedback" in compact
+    assert "ORDER BY f.created_at DESC, f.id DESC" in compact
+    assert query.index("page_feedback AS") < query.index("scorer_costs AS")
+
+
+def test_cost_sort_prices_filtered_set_before_stable_page() -> None:
+    pb = ParamBuilder("signals")
+    query = make_agent_signals_list_query(
+        pb,
+        AgentSignalsQueryReq(
+            project_id="entity/project",
+            after_ms=1_000,
+            before_ms=2_000,
+            sort_by={"field": "total_cost_usd", "direction": "asc"},
+            limit=50,
+            offset=100,
+        ),
+    )
+    compact = " ".join(query.split())
+
+    assert "page_feedback AS" not in compact
+    assert "FROM filtered_feedback" in compact
+    assert "LEFT ANY JOIN scorer_costs" in compact
+    assert (
+        "ORDER BY c.total_cost_usd ASC NULLS LAST, f.created_at DESC, f.id DESC"
+        in compact
+    )

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -32,6 +32,7 @@ from weave.trace_server.agents.types import (
     AgentGroupByRef,
     AgentSearchReq,
     AgentSignalFilter,
+    AgentSignalsQueryReq,
     AgentSortBy,
     AgentSpanGroupDistributionSpec,
     AgentSpanGroupFilter,
@@ -3263,6 +3264,53 @@ def test_genai_otel_export_ref_boundary_internal_in_db_external_out(
 # ---------------------------------------------------------------------------
 # Tests: agent target IDs persisted on feedback create
 # ---------------------------------------------------------------------------
+
+
+def test_agent_signals_query_filters_counts_and_pages(ch_server):
+    project_id = _make_project_id("signals-page")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    created_ids: list[str] = []
+    for index, tags in enumerate((["unsafe"], ["safe"], ["unsafe"])):
+        trace_id = uuid.uuid4().hex
+        created = ch_server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=ri.InternalAgentTurnRef(
+                    project_id=project_id, trace_id=trace_id
+                ).uri,
+                feedback_type=AGENT_USER_FEEDBACK_TYPE,
+                payload={},
+                scorer_tags=tags,
+                span_agent_name=f"agent-{index}",
+                span_trace_id=trace_id,
+                wb_user_id=f"user-{index}",
+            )
+        )
+        created_ids.append(created.id)
+
+    request = AgentSignalsQueryReq(
+        project_id=project_id,
+        after_ms=int((now - datetime.timedelta(minutes=1)).timestamp() * 1000),
+        before_ms=int((now + datetime.timedelta(minutes=1)).timestamp() * 1000),
+        feedback_types=[AGENT_USER_FEEDBACK_TYPE],
+        tags=["unsafe"],
+        limit=1,
+    )
+    first = ch_server.agent_signals_query(request)
+    second = ch_server.agent_signals_query(request.model_copy(update={"offset": 1}))
+
+    assert first.total_count == 2
+    assert second.total_count == 2
+    assert len(first.signals) == 1
+    assert len(second.signals) == 1
+    assert {first.signals[0].id, second.signals[0].id} == {
+        created_ids[0],
+        created_ids[2],
+    }
+    assert first.signals[0].scorer_tags == ["unsafe"]
+    assert second.signals[0].scorer_tags == ["unsafe"]
+    assert first.signals[0].total_cost_usd is None
+    assert second.signals[0].total_cost_usd is None
 
 
 def test_feedback_create_derives_conversation_target_id_from_ref(ch_server):

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -61,6 +61,9 @@ from weave.trace_server.agents.types import (
     AgentSearchMatchedMessage,
     AgentSearchReq,
     AgentSearchRes,
+    AgentSignalSchema,
+    AgentSignalsQueryReq,
+    AgentSignalsQueryRes,
     AgentSpanGroupDistributionBin,
     AgentSpanGroupDistributionItem,
     AgentSpanGroupDistributionValue,
@@ -82,7 +85,10 @@ from weave.trace_server.agents.types import (
     GenAIOTelExportRes,
     group_by_ref_alias,
 )
-from weave.trace_server.clickhouse.utilities import insert_with_empty_query_retry
+from weave.trace_server.clickhouse.utilities import (
+    ensure_datetimes_have_tz,
+    insert_with_empty_query_retry,
+)
 from weave.trace_server.datadog import record_db_insert, set_root_span_dd_tags
 from weave.trace_server.interface.query import Query
 from weave.trace_server.opentelemetry.genai_extraction import (
@@ -113,6 +119,10 @@ from weave.trace_server.query_builder.agent_query_builder import (
     safe_int,
     safe_str,
     span_group_distribution_key,
+)
+from weave.trace_server.query_builder.agent_signals_query_builder import (
+    make_agent_signals_count_query,
+    make_agent_signals_list_query,
 )
 from weave.trace_server.query_builder.agent_stats_query_builder import (
     build_agent_span_stats_query,
@@ -148,6 +158,7 @@ PaginatedReqT = TypeVar(
     AgentSpansQueryReq,
     AgentsQueryReq,
     AgentVersionsQueryReq,
+    AgentSignalsQueryReq,
     AgentConversationChatReq,
 )
 PARAM_NAMESPACE = "genai"
@@ -202,6 +213,17 @@ class AgentQueryHandler:
         if _is_conversation_grouping(req.group_by):
             self._hydrate_conversation_previews(req, groups, aliases[0])
         return AgentSpansQueryRes(groups=groups, total_count=total)
+
+    def signals_query(self, req: AgentSignalsQueryReq) -> AgentSignalsQueryRes:
+        """Query one filtered Signals page and its authoritative total."""
+        total, rows = self._run_paginated(
+            make_agent_signals_count_query, make_agent_signals_list_query, req
+        )
+        signals: list[AgentSignalSchema] = []
+        for row in rows:
+            row["created_at"] = ensure_datetimes_have_tz(row.get("created_at"))
+            signals.append(AgentSignalSchema.model_validate(row))
+        return AgentSignalsQueryRes(signals=signals, total_count=total)
 
     def _hydrate_conversation_previews(
         self,

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -8,7 +8,7 @@ endpoints (services/weave-trace) and the ClickHouse query handlers
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Annotated, Any, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal, get_args
 
 from pydantic import (
     AwareDatetime,
@@ -789,6 +789,76 @@ class AgentSignalFilter(BaseModel):
 
     def is_empty(self) -> bool:
         return not self.tags and not self.ratings
+
+
+AgentSignalSpanType = Literal["agent_turn", "agent_conversation"]
+AgentSignalSortField = Literal["created_at", "rating", "total_cost_usd"]
+
+
+class AgentSignalsQueryReq(BaseModel):
+    """Request one filtered, globally sorted page of agent Signals feedback."""
+
+    project_id: str
+    after_ms: int = Field(ge=0)
+    before_ms: int = Field(ge=0)
+    feedback_types: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    rating_min: float | None = Field(default=None, ge=0.0, le=1.0)
+    rating_max: float | None = Field(default=None, ge=0.0, le=1.0)
+    monitor_ids: list[str] = Field(default_factory=list)
+    scorer_ids: list[str] = Field(default_factory=list)
+    span_agent_names: list[str] = Field(default_factory=list)
+    span_types: list[AgentSignalSpanType] = Field(default_factory=list)
+    sort_by: AgentSortBy = Field(
+        default_factory=lambda: AgentSortBy(field="created_at", direction="desc")
+    )
+    limit: int = Field(
+        default=DEFAULT_AGENT_QUERY_LIMIT, ge=0, le=MAX_AGENT_QUERY_LIMIT
+    )
+    offset: int = Field(default=0, ge=0)
+
+    @model_validator(mode="after")
+    def validate_signals_query_request(self) -> AgentSignalsQueryReq:
+        if self.before_ms <= self.after_ms:
+            raise ValueError("before_ms must be greater than after_ms")
+        if self.sort_by.field not in get_args(AgentSignalSortField):
+            raise ValueError(f"unsupported Signals sort field: {self.sort_by.field!r}")
+        if (
+            self.rating_min is not None
+            and self.rating_max is not None
+            and self.rating_max < self.rating_min
+        ):
+            raise ValueError("rating_max must be greater than or equal to rating_min")
+        return self
+
+
+class AgentSignalSchema(BaseModel):
+    """One agent Signals feedback row with its query-time scorer cost."""
+
+    id: str
+    project_id: str
+    weave_ref: str
+    wb_user_id: str
+    creator: str | None = None
+    created_at: datetime.datetime
+    feedback_type: str
+    runnable_ref: str | None = None
+    scorer_tags: list[str] = Field(default_factory=list)
+    scorer_tag_reasons: dict[str, str] = Field(default_factory=dict)
+    scorer_tag_confidences: dict[str, float] = Field(default_factory=dict)
+    scorer_ratings: dict[str, float] = Field(default_factory=dict)
+    scorer_rating_reasons: dict[str, str] = Field(default_factory=dict)
+    scorer_rating_confidences: dict[str, float] = Field(default_factory=dict)
+    span_agent_name: str = ""
+    span_conversation_id: str = ""
+    span_trace_id: str = ""
+    scorer_trace_id: str = ""
+    total_cost_usd: float | None = None
+
+
+class AgentSignalsQueryRes(BaseModel):
+    signals: list[AgentSignalSchema] = Field(default_factory=list)
+    total_count: int = 0
 
 
 class AgentSpansQueryReq(BaseModel):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -70,6 +70,8 @@ from weave.trace_server.agents.types import (
     AgentCustomAttrsSchemaRes,
     AgentSearchReq,
     AgentSearchRes,
+    AgentSignalsQueryReq,
+    AgentSignalsQueryRes,
     AgentSpansQueryReq,
     AgentSpansQueryRes,
     AgentSpanStatsReq,
@@ -7308,6 +7310,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     def agent_spans_query(self, req: AgentSpansQueryReq) -> AgentSpansQueryRes:
         return AgentQueryHandler(self._query, self.feedback_query).spans_query(req)
+
+    def agent_signals_query(self, req: AgentSignalsQueryReq) -> AgentSignalsQueryRes:
+        return AgentQueryHandler(self._query, self.feedback_query).signals_query(req)
 
     def agent_spans_stats(self, req: AgentSpanStatsReq) -> AgentSpanStatsRes:
         return AgentQueryHandler(self._query, self.feedback_query).spans_stats(req)

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1480,6 +1480,23 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             span.project_id = original_project_id
         return res
 
+    def agent_signals_query(
+        self, req: tsi.agent_types.AgentSignalsQueryReq
+    ) -> tsi.agent_types.AgentSignalsQueryRes:
+        original_project_id = req.project_id
+        req.project_id = self._idc.ext_to_int_project_id(original_project_id)
+        res = self._ref_apply(
+            self._internal_trace_server.agent_signals_query,
+            req,
+            req.project_id,
+            tolerate_external_refs=True,
+        )
+        for signal in res.signals:
+            if signal.project_id != req.project_id:
+                raise ValueError("Internal Error - Project Mismatch")
+            signal.project_id = original_project_id
+        return res
+
     def agent_spans_stats(
         self, req: tsi.agent_types.AgentSpanStatsReq
     ) -> tsi.agent_types.AgentSpanStatsRes:

--- a/weave/trace_server/feedback_agg_query_builder.py
+++ b/weave/trace_server/feedback_agg_query_builder.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
 from weave.trace_server.calls_query_builder.utils import param_slot, safely_format_sql
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.trace_server_interface import FeedbackAggregateReq
+
+if TYPE_CHECKING:
+    from weave.trace_server.agents.types import AgentSignalsQueryReq
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +83,9 @@ def build_feedback_aggregate_query(
         f"{_SCORED_COUNT_SQL} AS scored_count",
     ]
     select_sql = ",\n      ".join(select_parts)
-    where_sql = _build_where_sql(req, project_param, after_param, before_param, pb)
+    where_sql = build_feedback_filter_sql(
+        req, project_param, after_param, before_param, pb
+    )
 
     raw_sql = f"SELECT {select_sql} FROM feedback WHERE {where_sql}"
     if group_keys:
@@ -160,8 +165,8 @@ def _object_id_match_clause(column: str, values: list[str], pb: ParamBuilder) ->
     return f"({' OR '.join(ors)})"
 
 
-def _build_where_sql(
-    req: FeedbackAggregateReq,
+def build_feedback_filter_sql(
+    req: FeedbackAggregateReq | AgentSignalsQueryReq,
     project_param: str,
     after_param: str,
     before_param: str,

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -51,6 +51,9 @@ from weave.trace_server import eval_results_helpers as eval_helpers
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents.completion_spans import build_completion_span
 from weave.trace_server.agents.types import (
+    AgentSignalSchema,
+    AgentSignalsQueryReq,
+    AgentSignalsQueryRes,
     AgentSpanSchema,
     AgentSpansQueryReq,
     AgentSpansQueryRes,
@@ -4262,6 +4265,80 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             }
             results.append(AgentSpanSchema(**data))
         return AgentSpansQueryRes(spans=results, total_count=total)
+
+    def agent_signals_query(self, req: AgentSignalsQueryReq) -> AgentSignalsQueryRes:
+        """In-memory parity for filtered, server-paginated Signals rows."""
+
+        def ref_object_id(ref: str | None) -> str:
+            return (ref or "").rsplit("/", 1)[-1].split(":", 1)[0]
+
+        def matches(row: dict[str, Any]) -> bool:
+            if row["project_id"] != req.project_id:
+                return False
+            created_ms = int(_ensure_tz(row["created_at"]).timestamp() * 1000)
+            if created_ms < req.after_ms or created_ms >= req.before_ms:
+                return False
+            tags = row.get("scorer_tags") or []
+            ratings = row.get("scorer_ratings") or {}
+            if not tags and not ratings:
+                return False
+            if req.feedback_types and not any(
+                row["feedback_type"].startswith(value.rstrip("*"))
+                for value in req.feedback_types
+            ):
+                return False
+            if req.tags and not set(tags).intersection(req.tags):
+                return False
+            if (
+                req.monitor_ids
+                and ref_object_id(row.get("trigger_ref")) not in req.monitor_ids
+            ):
+                return False
+            if (
+                req.scorer_ids
+                and ref_object_id(row.get("runnable_ref")) not in req.scorer_ids
+            ):
+                return False
+            if (
+                req.span_agent_names
+                and row.get("span_agent_name", "") not in req.span_agent_names
+            ):
+                return False
+            span_type = row["weave_ref"].split("/")[-2]
+            if req.span_types and span_type not in req.span_types:
+                return False
+            rating = ratings.get("_rating_")
+            if req.rating_min is not None and (
+                rating is None or rating < req.rating_min
+            ):
+                return False
+            if req.rating_max is not None and (
+                rating is None or rating > req.rating_max
+            ):
+                return False
+            return True
+
+        with self.lock:
+            rows = [dict(row) for row in self._feedback if matches(row)]
+        rows.sort(key=lambda row: (row["created_at"], row["id"]), reverse=True)
+        if req.sort_by.field == "created_at" and req.sort_by.direction == "asc":
+            rows.reverse()
+        elif req.sort_by.field == "rating":
+            present = [
+                row for row in rows if "_rating_" in (row.get("scorer_ratings") or {})
+            ]
+            missing = [row for row in rows if row not in present]
+            present.sort(
+                key=lambda row: row["scorer_ratings"]["_rating_"],
+                reverse=req.sort_by.direction == "desc",
+            )
+            rows = present + missing
+        page = rows[req.offset : req.offset + req.limit]
+        signals = [
+            AgentSignalSchema.model_validate({**row, "total_cost_usd": None})
+            for row in page
+        ]
+        return AgentSignalsQueryRes(signals=signals, total_count=len(rows))
 
     def _prepare_completion_request(
         self, req: tsi.CompletionsCreateReq

--- a/weave/trace_server/query_builder/agent_signals_query_builder.py
+++ b/weave/trace_server/query_builder/agent_signals_query_builder.py
@@ -1,0 +1,136 @@
+"""ClickHouse list/count queries for server-paginated agent Signals."""
+
+from __future__ import annotations
+
+import logging
+
+from weave.trace_server.agents.span_costs import cost_augmented_source_sql
+from weave.trace_server.agents.types import AgentSignalsQueryReq
+from weave.trace_server.calls_query_builder.utils import param_slot, safely_format_sql
+from weave.trace_server.feedback_agg_query_builder import build_feedback_filter_sql
+from weave.trace_server.orm import ParamBuilder
+
+logger = logging.getLogger(__name__)
+
+_RATING_KEY = "_rating_"
+_SIGNAL_COLUMNS: tuple[str, ...] = (
+    "id",
+    "project_id",
+    "weave_ref",
+    "wb_user_id",
+    "creator",
+    "created_at",
+    "feedback_type",
+    "runnable_ref",
+    "scorer_tags",
+    "scorer_tag_reasons",
+    "scorer_tag_confidences",
+    "scorer_ratings",
+    "scorer_rating_reasons",
+    "scorer_rating_confidences",
+    "span_agent_name",
+    "span_conversation_id",
+    "span_trace_id",
+    "scorer_trace_id",
+)
+
+
+def _where_sql(req: AgentSignalsQueryReq, pb: ParamBuilder) -> str:
+    project_param = pb.add_param(req.project_id)
+    after_param = pb.add_param(req.after_ms)
+    before_param = pb.add_param(req.before_ms)
+    filters = build_feedback_filter_sql(
+        req, project_param, after_param, before_param, pb
+    )
+    return f"({filters}) AND (notEmpty(scorer_tags) OR notEmpty(scorer_ratings))"
+
+
+def make_agent_signals_count_query(pb: ParamBuilder, req: AgentSignalsQueryReq) -> str:
+    """Count exactly the signal rows eligible for the requested page."""
+    raw_sql = f"SELECT count() FROM feedback WHERE {_where_sql(req, pb)}"
+    return safely_format_sql(raw_sql, logger)
+
+
+def make_agent_signals_list_query(pb: ParamBuilder, req: AgentSignalsQueryReq) -> str:
+    """Return one stable page, pricing each scorer trace at query time."""
+    rating_key = param_slot(pb.add_param(_RATING_KEY), "String")
+    feedback_columns = ",\n          ".join(_SIGNAL_COLUMNS)
+    filtered_feedback = f"""
+        SELECT
+          {feedback_columns},
+          if(
+            mapContains(scorer_ratings, {rating_key}),
+            scorer_ratings[{rating_key}],
+            NULL
+          ) AS rating
+        FROM feedback
+        WHERE {_where_sql(req, pb)}
+    """
+
+    direction = req.sort_by.direction.upper()
+    if req.sort_by.field == "created_at":
+        order_sql = f"f.created_at {direction}, f.id {direction}"
+    elif req.sort_by.field == "rating":
+        order_sql = f"f.rating {direction} NULLS LAST, f.created_at DESC, f.id DESC"
+    elif req.sort_by.field == "total_cost_usd":
+        order_sql = (
+            f"c.total_cost_usd {direction} NULLS LAST, f.created_at DESC, f.id DESC"
+        )
+    else:
+        raise ValueError(f"unsupported Signals sort field: {req.sort_by.field!r}")
+
+    limit_slot = param_slot(pb.add_param(req.limit), "UInt64")
+    offset_slot = param_slot(pb.add_param(req.offset), "UInt64")
+    cost_sort = req.sort_by.field == "total_cost_usd"
+    page_cte = ""
+    cost_scope = "filtered_feedback"
+    result_relation = "filtered_feedback"
+    final_pagination = f"LIMIT {limit_slot}\n    OFFSET {offset_slot}"
+    if not cost_sort:
+        page_cte = f""",
+      page_feedback AS (
+        SELECT * FROM filtered_feedback f
+        ORDER BY {order_sql}
+        LIMIT {limit_slot}
+        OFFSET {offset_slot}
+      )"""
+        cost_scope = "page_feedback"
+        result_relation = "page_feedback"
+        final_pagination = ""
+
+    project_slot = param_slot(pb.add_param(req.project_id), "String")
+    scoped_spans = f"""(
+        SELECT *
+        FROM spans
+        WHERE project_id = {project_slot}
+          AND trace_id IN (
+            SELECT scorer_trace_id
+            FROM {cost_scope}
+            WHERE scorer_trace_id != ''
+          )
+    )"""
+    cost_source = cost_augmented_source_sql(
+        pb, req.project_id, base_relation=scoped_spans
+    )
+    scorer_costs = f"""
+        SELECT
+          s.trace_id,
+          sumOrNull(s.total_cost_usd) AS total_cost_usd
+        FROM {cost_source} s
+        GROUP BY s.trace_id
+    """
+
+    output_columns = ",\n      ".join(f"f.{column}" for column in _SIGNAL_COLUMNS)
+    raw_sql = f"""
+    WITH
+      filtered_feedback AS ({filtered_feedback}){page_cte},
+      scorer_costs AS ({scorer_costs})
+    SELECT
+      {output_columns},
+      c.total_cost_usd
+    FROM {result_relation} f
+    LEFT ANY JOIN scorer_costs c ON c.trace_id = f.scorer_trace_id
+    ORDER BY {order_sql}
+    {final_pagination}
+    """
+    return safely_format_sql(raw_sql, logger)

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3523,6 +3523,9 @@ class TraceServerInterface(Protocol):
     def agent_spans_query(
         self, req: agent_types.AgentSpansQueryReq
     ) -> agent_types.AgentSpansQueryRes: ...
+    def agent_signals_query(
+        self, req: agent_types.AgentSignalsQueryReq
+    ) -> agent_types.AgentSignalsQueryRes: ...
     def agent_spans_stats(
         self, req: agent_types.AgentSpanStatsReq
     ) -> agent_types.AgentSpanStatsRes: ...

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -641,6 +641,17 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         )
 
     @validate_call
+    def agent_signals_query(
+        self, req: agent_types.AgentSignalsQueryReq
+    ) -> agent_types.AgentSignalsQueryRes:
+        return self._generic_request(
+            "/agents/signals/query",
+            req,
+            agent_types.AgentSignalsQueryReq,
+            agent_types.AgentSignalsQueryRes,
+        )
+
+    @validate_call
     def agent_traces_chat(
         self, req: agent_types.AgentTraceChatReq
     ) -> agent_types.AgentTraceChatRes:


### PR DESCRIPTION
Adds a typed /agents/signals/query contract with shared feedback filters, authoritative counts, stable pagination, and query-time scorer cost. Normal sorts price only the visible page; global cost sorting prices the filtered candidate set. Includes ClickHouse query-builder and integration coverage.\n\nThis is the Weave half of wandb/core task t-b1dd2; the dependent core draft updates the trace-server route and Signals UI.