### PR TITLE
fix(weave): label serverless inference traces by model

### DIFF
--- a/tests/integrations/openai/test_openai_sdk.py
+++ b/tests/integrations/openai/test_openai_sdk.py
@@ -8,6 +8,7 @@ from weave.integrations.openai.openai_sdk import (
     create_wrapper_async,
     create_wrapper_sync,
     openai_on_input_handler,
+    serverless_inference_call_display_name,
 )
 from weave.trace.autopatch import OpSettings
 
@@ -33,6 +34,37 @@ class NonCompletion:
 
     def __init__(self):
         self.data = "not a completion"
+
+
+def test_serverless_inference_call_display_name():
+    display_name = serverless_inference_call_display_name(
+        "openai.chat.completions.create"
+    )
+
+    # W&B's OpenAI-compatible endpoint should show the actual provider and model.
+    call = Mock(
+        inputs={
+            "self": {"client": {"base_url": "https://api.inference.wandb.ai/v1/"}},
+            "model": "google/gemma-4-31B-it",
+        }
+    )
+    assert display_name(call) == "Serverless Inference: google/gemma-4-31B-it"
+
+    # Missing model metadata still identifies Serverless Inference accurately.
+    call.inputs = {
+        "self": {"client": {"base_url": "https://api.inference.wandb.ai/v1"}}
+    }
+    assert display_name(call) == "Serverless Inference"
+
+    # OpenAI and other compatible endpoints retain the integration's op label.
+    call.inputs = {
+        "self": {"client": {"base_url": "https://api.openai.com/v1/"}},
+        "model": "gpt-5",
+    }
+    assert display_name(call) == "openai.chat.completions.create"
+
+    call.inputs = {}
+    assert display_name(call) == "openai.chat.completions.create"
 
 
 def test_openai_on_input_handler_with_completion_instance():

--- a/tests/integrations/openai/test_openai_sdk.py
+++ b/tests/integrations/openai/test_openai_sdk.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from functools import partial
 from unittest.mock import Mock
 
 import pytest
@@ -37,8 +38,8 @@ class NonCompletion:
 
 
 def test_serverless_inference_call_display_name():
-    display_name = serverless_inference_call_display_name(
-        "openai.chat.completions.create"
+    display_name = partial(
+        serverless_inference_call_display_name, "openai.chat.completions.create"
     )
 
     # W&B's OpenAI-compatible endpoint should show the actual provider and model.

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import wraps
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -32,6 +32,7 @@ from weave.integrations.integration_metadata import (
 )
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
+from weave.trace.call import Call
 from weave.trace.op import (
     _add_accumulator,
     _default_on_input_handler,
@@ -51,8 +52,35 @@ if TYPE_CHECKING:
 _openai_patcher: MultiPatcher | None = None
 
 OPENAI_INTEGRATION = library_integration("openai")
+SERVERLESS_INFERENCE_HOST = "api.inference.wandb.ai"
 
 logger = logging.getLogger(__name__)
+
+
+def serverless_inference_call_display_name(
+    default_display_name: str,
+) -> Callable[[Call], str]:
+    """Label OpenAI-compatible W&B Inference calls by their requested model."""
+
+    def display_name(call: Call) -> str:
+        self_input = call.inputs.get("self")
+        if not isinstance(self_input, Mapping):
+            return default_display_name
+        client = self_input.get("client")
+        if not isinstance(client, Mapping):
+            return default_display_name
+        base_url = client.get("base_url")
+        if (
+            isinstance(base_url, str)
+            and urlparse(base_url).hostname == SERVERLESS_INFERENCE_HOST
+        ):
+            model = call.inputs.get("model")
+            if isinstance(model, str) and model:
+                return f"Serverless Inference: {model}"
+            return "Serverless Inference"
+        return default_display_name
+
+    return display_name
 
 
 def _parse_api_response(value: LegacyAPIResponse | APIResponse) -> Any:
@@ -414,9 +442,14 @@ def _normalize_openai_cache_tokens(usage: dict[str, Any]) -> None:
     and the Responses API nests them under input_tokens_details. This extracts
     them to the top-level canonical field `cache_read_input_tokens`.
     """
-    ptd = usage.get("prompt_tokens_details")
-    if isinstance(ptd, dict) and ptd.get("cached_tokens") is not None:
-        usage.setdefault("cache_read_input_tokens", ptd["cached_tokens"])
+    prompt_tokens_details = usage.get("prompt_tokens_details")
+    if (
+        isinstance(prompt_tokens_details, dict)
+        and prompt_tokens_details.get("cached_tokens") is not None
+    ):
+        usage.setdefault(
+            "cache_read_input_tokens", prompt_tokens_details["cached_tokens"]
+        )
     itd = usage.get("input_tokens_details")
     if isinstance(itd, dict) and itd.get("cached_tokens") is not None:
         usage.setdefault("cache_read_input_tokens", itd["cached_tokens"])
@@ -793,28 +826,43 @@ def get_openai_patcher(
         return _openai_patcher
 
     base = with_integration_metadata(settings.op_settings, OPENAI_INTEGRATION)
+    completions_create_name = base.name or "openai.chat.completions.create"
+    completions_parse_name = base.name or "openai.chat.completions.parse"
+    completions_create_display_name = base.call_display_name
+    completions_parse_display_name = base.call_display_name
+    if base.name is None and base.call_display_name is None:
+        completions_create_display_name = serverless_inference_call_display_name(
+            completions_create_name
+        )
+        completions_parse_display_name = serverless_inference_call_display_name(
+            completions_parse_name
+        )
 
     completions_create_settings = base.model_copy(
         update={
-            "name": base.name or "openai.chat.completions.create",
+            "name": completions_create_name,
+            "call_display_name": completions_create_display_name,
             "kind": base.kind or "llm",
         }
     )
     async_completions_create_settings = base.model_copy(
         update={
-            "name": base.name or "openai.chat.completions.create",
+            "name": completions_create_name,
+            "call_display_name": completions_create_display_name,
             "kind": base.kind or "llm",
         }
     )
     completions_parse_settings = base.model_copy(
         update={
-            "name": base.name or "openai.chat.completions.parse",
+            "name": completions_parse_name,
+            "call_display_name": completions_parse_display_name,
             "kind": base.kind or "llm",
         }
     )
     async_completions_parse_settings = base.model_copy(
         update={
-            "name": base.name or "openai.chat.completions.parse",
+            "name": completions_parse_name,
+            "call_display_name": completions_parse_display_name,
             "kind": base.kind or "llm",
         }
     )

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -4,7 +4,7 @@ import importlib
 import logging
 import time
 from collections.abc import Callable, Mapping
-from functools import wraps
+from functools import partial, wraps
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -52,35 +52,31 @@ if TYPE_CHECKING:
 _openai_patcher: MultiPatcher | None = None
 
 OPENAI_INTEGRATION = library_integration("openai")
+OPENAI_HOST = "api.openai.com"
 SERVERLESS_INFERENCE_HOST = "api.inference.wandb.ai"
+SERVERLESS_INFERENCE_LABEL = "Serverless Inference"
+CHAT_COMPLETIONS_CREATE_OP = "openai.chat.completions.create"
+CHAT_COMPLETIONS_PARSE_OP = "openai.chat.completions.parse"
 
 logger = logging.getLogger(__name__)
 
 
 def serverless_inference_call_display_name(
-    default_display_name: str,
-) -> Callable[[Call], str]:
+    default_display_name: str, call: Call
+) -> str:
     """Label OpenAI-compatible W&B Inference calls by their requested model."""
-
-    def display_name(call: Call) -> str:
-        self_input = call.inputs.get("self")
-        if not isinstance(self_input, Mapping):
-            return default_display_name
-        client = self_input.get("client")
-        if not isinstance(client, Mapping):
-            return default_display_name
-        base_url = client.get("base_url")
-        if (
-            isinstance(base_url, str)
-            and urlparse(base_url).hostname == SERVERLESS_INFERENCE_HOST
-        ):
-            model = call.inputs.get("model")
-            if isinstance(model, str) and model:
-                return f"Serverless Inference: {model}"
-            return "Serverless Inference"
+    self_input = call.inputs.get("self")
+    client = self_input.get("client") if isinstance(self_input, Mapping) else None
+    base_url = client.get("base_url") if isinstance(client, Mapping) else None
+    if (
+        not isinstance(base_url, str)
+        or urlparse(base_url).hostname != SERVERLESS_INFERENCE_HOST
+    ):
         return default_display_name
-
-    return display_name
+    model = call.inputs.get("model")
+    if isinstance(model, str) and model:
+        return f"{SERVERLESS_INFERENCE_LABEL}: {model}"
+    return SERVERLESS_INFERENCE_LABEL
 
 
 def _parse_api_response(value: LegacyAPIResponse | APIResponse) -> Any:
@@ -450,9 +446,14 @@ def _normalize_openai_cache_tokens(usage: dict[str, Any]) -> None:
         usage.setdefault(
             "cache_read_input_tokens", prompt_tokens_details["cached_tokens"]
         )
-    itd = usage.get("input_tokens_details")
-    if isinstance(itd, dict) and itd.get("cached_tokens") is not None:
-        usage.setdefault("cache_read_input_tokens", itd["cached_tokens"])
+    input_tokens_details = usage.get("input_tokens_details")
+    if (
+        isinstance(input_tokens_details, dict)
+        and input_tokens_details.get("cached_tokens") is not None
+    ):
+        usage.setdefault(
+            "cache_read_input_tokens", input_tokens_details["cached_tokens"]
+        )
 
 
 def openai_on_finish(
@@ -480,7 +481,7 @@ def create_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
                     completion = self
                     base_url = str(completion._client._base_url)
                     # Only set stream_options if it targets the OpenAI endpoints
-                    if urlparse(base_url).hostname == "api.openai.com":
+                    if urlparse(base_url).hostname == OPENAI_HOST:
                         kwargs["stream_options"] = {"include_usage": True}
 
                 return fn(self, *args, **kwargs)
@@ -528,7 +529,7 @@ def create_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]
                     completion = self
                     base_url = str(completion._client._base_url)
                     # Only set stream_options if it targets the OpenAI endpoints
-                    if urlparse(base_url).hostname == "api.openai.com":
+                    if urlparse(base_url).hostname == OPENAI_HOST:
                         kwargs["stream_options"] = {"include_usage": True}
 
                 return await fn(self, *args, **kwargs)
@@ -826,16 +827,17 @@ def get_openai_patcher(
         return _openai_patcher
 
     base = with_integration_metadata(settings.op_settings, OPENAI_INTEGRATION)
-    completions_create_name = base.name or "openai.chat.completions.create"
-    completions_parse_name = base.name or "openai.chat.completions.parse"
+    completions_create_name = base.name or CHAT_COMPLETIONS_CREATE_OP
+    completions_parse_name = base.name or CHAT_COMPLETIONS_PARSE_OP
+    # Only label by serverless model when the user hasn't set their own name/display.
     completions_create_display_name = base.call_display_name
     completions_parse_display_name = base.call_display_name
     if base.name is None and base.call_display_name is None:
-        completions_create_display_name = serverless_inference_call_display_name(
-            completions_create_name
+        completions_create_display_name = partial(
+            serverless_inference_call_display_name, completions_create_name
         )
-        completions_parse_display_name = serverless_inference_call_display_name(
-            completions_parse_name
+        completions_parse_display_name = partial(
+            serverless_inference_call_display_name, completions_parse_name
         )
 
     completions_create_settings = base.model_copy(


### PR DESCRIPTION
## Summary
- identify OpenAI-compatible W&B Serverless Inference calls by endpoint
- display the requested model in traces while preserving the underlying OpenAI SDK op name
- preserve custom OpenAI integration names and display-name overrides

## Testing

Master: [link](https://wandb.ai/weave-team/serverless-trace-naming-repro/weave/traces?view=traces_default&peekPath=%2Fweave-team%2Fserverless-trace-naming-repro%2Fcalls%2F019f8b84-3811-7b5d-8189-a9177ada6590%3FhideTraceTree%3D0%26traceRootStartedAt%3D2026-07-22T20%253A28%253A45.969627Z)
<img width="1540" height="818" alt="image" src="https://github.com/user-attachments/assets/d49f7004-676d-4368-9d53-e0c646ad8136" />

Branch: [link](https://wandb.ai/weave-team/serverless-trace-naming-repro/weave/traces?view=traces_default&peekPath=%2Fweave-team%2Fserverless-trace-naming-repro%2Fcalls%2F019f8b88-2b18-71e7-b804-455f9b387a33%3FhideTraceTree%3D0%26traceRootStartedAt%3D2026-07-22T20%253A33%253A04.797277Z)
<img width="1537" height="840" alt="image" src="https://github.com/user-attachments/assets/2fb15743-ed1f-4ded-acd6-466dff94c17a" />
