### PR TITLE
feat(weave): add totals to feedback queries

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -1162,6 +1162,48 @@ def test_agent_monitor_feedback_sort_by_map_column(client: WeaveClient) -> None:
     ]
 
 
+def test_feedback_query_total_count_precedes_pagination(client: WeaveClient) -> None:
+    project_id = client.project_id
+    for index, feedback_type in enumerate(["keep", "skip", "keep"]):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=f"weave:///{project_id}/call/{index}",
+                feedback_type=feedback_type,
+                payload={},
+            )
+        )
+
+    without_total = client.server.feedback_query(
+        tsi.FeedbackQueryReq(project_id=project_id, fields=["id"], limit=1)
+    )
+    assert without_total.total_count is None
+
+    result = client.server.feedback_query(
+        tsi.FeedbackQueryReq(
+            project_id=project_id,
+            fields=["weave_ref"],
+            query=Query(
+                **{
+                    "$expr": {
+                        "$eq": [
+                            {"$getField": "feedback_type"},
+                            {"$literal": "keep"},
+                        ]
+                    }
+                }
+            ),
+            sort_by=[SortBy(field="weave_ref", direction="asc")],
+            limit=1,
+            offset=1,
+            include_total=True,
+        )
+    )
+
+    assert result.total_count == 2
+    assert result.result == [{"weave_ref": f"weave:///{project_id}/call/2"}]
+
+
 async def populate_feedback(client: WeaveClient) -> None:
     @weave.op
     def my_scorer(x: int, output: int) -> int:

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -1174,11 +1174,6 @@ def test_feedback_query_total_count_precedes_pagination(client: WeaveClient) -> 
             )
         )
 
-    without_total = client.server.feedback_query(
-        tsi.FeedbackQueryReq(project_id=project_id, fields=["id"], limit=1)
-    )
-    assert without_total.total_count is None
-
     result = client.server.feedback_query(
         tsi.FeedbackQueryReq(
             project_id=project_id,
@@ -1196,7 +1191,6 @@ def test_feedback_query_total_count_precedes_pagination(client: WeaveClient) -> 
             sort_by=[SortBy(field="weave_ref", direction="asc")],
             limit=1,
             offset=1,
-            include_total=True,
         )
     )
 

--- a/tests/trace_server/test_agent_feedback_helpers.py
+++ b/tests/trace_server/test_agent_feedback_helpers.py
@@ -58,6 +58,7 @@ def test_make_agent_feedback_query_req_unions_arbitrary_ref_kinds():
 
 def test_group_agent_feedback_by_target_separates_kinds_and_skips_non_agent_refs():
     feedback = tsi.FeedbackQueryRes(
+        total_count=4,
         result=[
             {
                 "id": "f1",
@@ -81,7 +82,7 @@ def test_group_agent_feedback_by_target_separates_kinds_and_skips_non_agent_refs
                 "id": "f5",
                 "weave_ref": ri.InternalCallRef(project_id="p", id="call-xyz").uri,
             },
-        ]
+        ],
     )
 
     groups = group_agent_feedback_by_target(feedback)

--- a/tests/trace_server/test_genai_agent_query_handler.py
+++ b/tests/trace_server/test_genai_agent_query_handler.py
@@ -129,7 +129,9 @@ def test_group_distributions_are_hydrated_with_batched_queries() -> None:
         calls.append((sql, params))
         return results.pop(0)
 
-    handler = AgentQueryHandler(query, lambda req: FeedbackQueryRes(result=[]))
+    handler = AgentQueryHandler(
+        query, lambda req: FeedbackQueryRes(result=[], total_count=0)
+    )
 
     res = handler.spans_query(req)
 
@@ -224,7 +226,9 @@ def test_grouped_rows_hydrate_message_previews() -> None:
         calls.append(sql)
         return results.pop(0)
 
-    handler = AgentQueryHandler(query, lambda req: FeedbackQueryRes(result=[]))
+    handler = AgentQueryHandler(
+        query, lambda req: FeedbackQueryRes(result=[], total_count=0)
+    )
     res = handler.spans_query(req)
 
     # 3 queries: count, grouped list, bounded preview. The grouped list query

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6773,15 +6773,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return tsi.FeedbackCreateBatchRes(res=results)
 
     def feedback_query(self, req: tsi.FeedbackQueryReq) -> tsi.FeedbackQueryRes:
-        total_count = None
-        if req.include_total:
-            count_query = TABLE_FEEDBACK.select()
-            count_query = count_query.project_id(req.project_id)
-            count_query = count_query.fields(["count(*)"])
-            count_query = count_query.where(req.query)
-            prepared_count = count_query.prepare()
-            count_result = self._query(prepared_count.sql, prepared_count.parameters)
-            total_count = int(count_result.result_rows[0][0])
+        count_query = TABLE_FEEDBACK.select()
+        count_query = count_query.project_id(req.project_id)
+        count_query = count_query.fields(["count(*)"])
+        count_query = count_query.where(req.query)
+        prepared_count = count_query.prepare()
+        count_result = self._query(prepared_count.sql, prepared_count.parameters)
+        total_count = int(count_result.result_rows[0][0])
 
         query = TABLE_FEEDBACK.select()
         query = query.project_id(req.project_id)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6773,6 +6773,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return tsi.FeedbackCreateBatchRes(res=results)
 
     def feedback_query(self, req: tsi.FeedbackQueryReq) -> tsi.FeedbackQueryRes:
+        total_count = None
+        if req.include_total:
+            count_query = TABLE_FEEDBACK.select()
+            count_query = count_query.project_id(req.project_id)
+            count_query = count_query.fields(["count(*)"])
+            count_query = count_query.where(req.query)
+            prepared_count = count_query.prepare()
+            count_result = self._query(prepared_count.sql, prepared_count.parameters)
+            total_count = int(count_result.result_rows[0][0])
+
         query = TABLE_FEEDBACK.select()
         query = query.project_id(req.project_id)
         query = query.fields(req.fields)
@@ -6788,7 +6798,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         for row in result:
             if "created_at" in row and isinstance(row["created_at"], datetime.datetime):
                 row["created_at"] = ensure_datetimes_have_tz(row["created_at"])
-        return tsi.FeedbackQueryRes(result=result)
+        return tsi.FeedbackQueryRes(result=result, total_count=total_count)
 
     def feedback_purge(self, req: tsi.FeedbackPurgeReq) -> tsi.FeedbackPurgeRes:
         # TODO: Instead of passing conditions to DELETE FROM,

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -3803,19 +3803,17 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
     def feedback_query(self, req: tsi.FeedbackQueryReq) -> tsi.FeedbackQueryRes:
         with self.lock:
             rows = list(self._feedback)
-        total_count = None
-        if req.include_total:
-            count_result = _orm_select(
-                TABLE_FEEDBACK,
-                rows,
-                project_id=req.project_id,
-                fields=["count(*)"],
-                query=req.query,
-                sort_by=None,
-                limit=None,
-                offset=None,
-            )
-            total_count = int(count_result[0]["count(*)"])
+        count_result = _orm_select(
+            TABLE_FEEDBACK,
+            rows,
+            project_id=req.project_id,
+            fields=["count(*)"],
+            query=req.query,
+            sort_by=None,
+            limit=None,
+            offset=None,
+        )
+        total_count = int(count_result[0]["count(*)"])
         result = _orm_select(
             TABLE_FEEDBACK,
             rows,

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -3803,6 +3803,19 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
     def feedback_query(self, req: tsi.FeedbackQueryReq) -> tsi.FeedbackQueryRes:
         with self.lock:
             rows = list(self._feedback)
+        total_count = None
+        if req.include_total:
+            count_result = _orm_select(
+                TABLE_FEEDBACK,
+                rows,
+                project_id=req.project_id,
+                fields=["count(*)"],
+                query=req.query,
+                sort_by=None,
+                limit=None,
+                offset=None,
+            )
+            total_count = int(count_result[0]["count(*)"])
         result = _orm_select(
             TABLE_FEEDBACK,
             rows,
@@ -3813,7 +3826,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             limit=req.limit,
             offset=req.offset,
         )
-        return tsi.FeedbackQueryRes(result=result)
+        return tsi.FeedbackQueryRes(result=result, total_count=total_count)
 
     def feedback_purge(self, req: tsi.FeedbackPurgeReq) -> tsi.FeedbackPurgeRes:
         validate_feedback_purge_req(req)

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1323,13 +1323,12 @@ class FeedbackQueryReq(BaseModelStrict):
     sort_by: list[SortBy] | None = None
     limit: int | None = Field(default=None, examples=[10])
     offset: int | None = Field(default=None, examples=[0])
-    include_total: bool = False
 
 
 class FeedbackQueryRes(BaseModel):
     # Note: this is not a list of Feedback because user can request any fields.
     result: list[dict[str, Any]]
-    total_count: int | None = Field(default=None, ge=0)
+    total_count: int = Field(ge=0)
 
 
 class FeedbackPurgeReq(BaseModelStrict):

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1323,11 +1323,13 @@ class FeedbackQueryReq(BaseModelStrict):
     sort_by: list[SortBy] | None = None
     limit: int | None = Field(default=None, examples=[10])
     offset: int | None = Field(default=None, examples=[0])
+    include_total: bool = False
 
 
 class FeedbackQueryRes(BaseModel):
     # Note: this is not a list of Feedback because user can request any fields.
     result: list[dict[str, Any]]
+    total_count: int | None = Field(default=None, ge=0)
 
 
 class FeedbackPurgeReq(BaseModelStrict):


### PR DESCRIPTION
## Summary

To unlock server-side pagination for the Signals tab we first need to return the page size for every FeedbackQueryRes. Blocks https://github.com/wandb/core/pull/48768.

- return `total_count` from every existing `/feedback/query` response
- compute the filtered count before `limit` and `offset`
- match the behavior in ClickHouse and the in-memory trace server

## Testing

- [x] Tested locally


