### PR TITLE
chore(weave_ts): label serverless inference traces by model

### DIFF
--- a/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
+++ b/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
@@ -21,6 +21,7 @@ describe('OpenAI Integration', () => {
     }));
 
     mockOpenAI = {
+      baseURL: 'https://api.openai.com/v1/',
       chat: {
         completions: {create: mockOpenAIChat},
       },
@@ -73,6 +74,7 @@ describe('OpenAI Integration', () => {
     const calls = await traceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(1);
     expect(calls[0].op_name).toContain('openai.chat.completions.create');
+    expect(calls[0].display_name).toBeUndefined();
     // Integration-tracking metadata is stamped on every patched call.
     expect(calls[0].attributes?.integration?.name).toBe('openai');
     expect(calls[0].attributes?.integration?.meta?.package_name).toBe('openai');
@@ -98,6 +100,38 @@ describe('OpenAI Integration', () => {
     });
     // Ensure stream_options is not present in the logged call for non-streaming requests
     expect(calls[0].inputs).not.toHaveProperty('stream_options');
+  });
+
+  test('labels serverless inference calls by their requested model', async () => {
+    mockOpenAI.baseURL = 'https://api.inference.wandb.ai/v1/';
+    mockOpenAI.beta.chat.completions.parse = mockOpenAI.chat.completions.create;
+    patchedOpenAI = wrapOpenAI(mockOpenAI);
+    const messages = [{role: 'user', content: 'Hello!'}];
+
+    await patchedOpenAI.chat.completions.create({
+      model: 'google/gemma-4-31b-it',
+      messages,
+    });
+    await patchedOpenAI.chat.completions.create({messages});
+    await patchedOpenAI.beta.chat.completions.parse({
+      model: 'meta-llama/Llama-3.3-70B-Instruct',
+      messages,
+    });
+
+    await wait(300);
+
+    const calls = await traceServer.getCalls(testProjectName);
+    expect(calls).toHaveLength(3);
+    expect(calls[0].op_name).toContain('openai.chat.completions.create');
+    expect(calls[0].display_name).toBe(
+      'Serverless Inference: google/gemma-4-31b-it'
+    );
+    expect(calls[1].op_name).toContain('openai.chat.completions.create');
+    expect(calls[1].display_name).toBe('Serverless Inference');
+    expect(calls[2].op_name).toContain('openai.beta.chat.completions.parse');
+    expect(calls[2].display_name).toBe(
+      'Serverless Inference: meta-llama/Llama-3.3-70B-Instruct'
+    );
   });
 
   test('streaming chat completion basic', async () => {

--- a/sdks/node/src/integrations/openai.ts
+++ b/sdks/node/src/integrations/openai.ts
@@ -21,10 +21,10 @@ const CHAT_COMPLETIONS_CREATE_OP = 'openai.chat.completions.create';
 const CHAT_COMPLETIONS_PARSE_OP = 'openai.beta.chat.completions.parse';
 
 function serverlessInferenceCallDisplayName(
-  baseURL: unknown,
+  baseURL: string | undefined,
   model: unknown
 ): string | undefined {
-  if (typeof baseURL !== 'string') {
+  if (baseURL == null) {
     return undefined;
   }
 
@@ -137,7 +137,7 @@ export const openAIStreamReducer = {
 export function wrapOpenAIChatCompletionsCreate(
   originalCreate: any,
   name: string,
-  baseURL?: unknown
+  baseURL?: string
 ) {
   const opRef = {
     __isOp: true as const,

--- a/sdks/node/src/integrations/openai.ts
+++ b/sdks/node/src/integrations/openai.ts
@@ -15,6 +15,33 @@ import {defaultSettings} from '../settings';
 
 // Integration provenance stamped onto every call this integration produces.
 const OPENAI_INTEGRATION = libraryIntegration('openai');
+const SERVERLESS_INFERENCE_HOST = 'api.inference.wandb.ai';
+const SERVERLESS_INFERENCE_LABEL = 'Serverless Inference';
+const CHAT_COMPLETIONS_CREATE_OP = 'openai.chat.completions.create';
+const CHAT_COMPLETIONS_PARSE_OP = 'openai.beta.chat.completions.parse';
+
+function serverlessInferenceCallDisplayName(
+  baseURL: unknown,
+  model: unknown
+): string | undefined {
+  if (typeof baseURL !== 'string') {
+    return undefined;
+  }
+
+  let hostname: string;
+  try {
+    hostname = new URL(baseURL).hostname;
+  } catch {
+    return undefined;
+  }
+
+  if (hostname !== SERVERLESS_INFERENCE_HOST) {
+    return undefined;
+  }
+  return typeof model === 'string' && model.length > 0
+    ? `${SERVERLESS_INFERENCE_LABEL}: ${model}`
+    : SERVERLESS_INFERENCE_LABEL;
+}
 
 /**
  * Wraps a function to run with OpenAI Agents call stack if available.
@@ -109,7 +136,8 @@ export const openAIStreamReducer = {
 
 export function wrapOpenAIChatCompletionsCreate(
   originalCreate: any,
-  name: string
+  name: string,
+  baseURL?: unknown
 ) {
   const opRef = {
     __isOp: true as const,
@@ -154,6 +182,10 @@ export function wrapOpenAIChatCompletionsCreate(
         originalCreate,
         summarize,
         streamReducer: openAIStreamReducer,
+        displayName: serverlessInferenceCallDisplayName(
+          baseURL,
+          originalParams?.model
+        ),
       })
     );
   };
@@ -529,6 +561,7 @@ function traceOpenAICall(args: {
   summarize: (result: any) => any;
   streamReducer: any;
   thisArg?: any;
+  displayName?: string;
 }) {
   const {
     client,
@@ -539,6 +572,7 @@ function traceOpenAICall(args: {
     summarize,
     streamReducer,
     thisArg,
+    displayName,
   } = args;
 
   const apiPromise = originalCreate(...callArgs);
@@ -570,7 +604,7 @@ function traceOpenAICall(args: {
     currentCall,
     parentCall,
     startTime,
-    undefined,
+    displayName,
     {kind: 'llm', ...asAttributes(OPENAI_INTEGRATION)}
   );
 
@@ -690,6 +724,7 @@ function wrapStreamForTracing(args: {
 }
 
 interface OpenAIAPI {
+  baseURL?: string;
   chat: {
     completions: {
       create: any;
@@ -727,7 +762,8 @@ export function wrapOpenAI<T extends OpenAIAPI>(openai: T): T {
       if (p === 'create') {
         return wrapOpenAIChatCompletionsCreate(
           targetVal.bind(target),
-          'openai.chat.completions.create'
+          CHAT_COMPLETIONS_CREATE_OP,
+          openai.baseURL
         );
       }
       return targetVal;
@@ -763,7 +799,8 @@ export function wrapOpenAI<T extends OpenAIAPI>(openai: T): T {
         if (p === 'parse') {
           return wrapOpenAIChatCompletionsCreate(
             targetVal.bind(target),
-            'openai.beta.chat.completions.parse'
+            CHAT_COMPLETIONS_PARSE_OP,
+            openai.baseURL
           );
         }
         return targetVal;


### PR DESCRIPTION
## Summary

TypeScript counterpart to #7611.

- identify OpenAI-compatible W&B Serverless Inference calls by endpoint
- display the requested model in traces while preserving the underlying OpenAI SDK op name
- preserve existing trace naming for OpenAI and other compatible endpoints

## Proof

Both calls use `microsoft/Phi-4-mini-instruct` through the TypeScript SDK and retain `openai.chat.completions.create` as the underlying op.

- [Master: no display name](https://wandb.ai/weave-team/serverless-trace-naming-repro/weave/traces?view=traces_default&peekPath=%2Fweave-team%2Fserverless-trace-naming-repro%2Fcalls%2F019f8bba-bd14-7911-a6f0-2786cc0cc7ba%3FhideTraceTree%3D0%26traceRootStartedAt%3D2026-07-22T21%253A28%253A18.964000Z)
- [Branch: Serverless Inference: microsoft/Phi-4-mini-instruct](https://wandb.ai/weave-team/serverless-trace-naming-repro/weave/traces?view=traces_default&peekPath=%2Fweave-team%2Fserverless-trace-naming-repro%2Fcalls%2F019f8bba-a15a-75f9-8880-bb8231c8114b%3FhideTraceTree%3D0%26traceRootStartedAt%3D2026-07-22T21%253A28%253A11.866000Z)

## Testing

<img width="1540" height="463" alt="image" src="https://github.com/user-attachments/assets/4d289670-45d5-4016-acd2-8d84f46f908e" />
