### PR TITLE
fix(weave): regenerate trace server API bindings

### DIFF
--- a/sdks/node/src/generated/traceServerApi.ts
+++ b/sdks/node/src/generated/traceServerApi.ts
@@ -246,11 +246,8 @@ export interface AgentConversationChatRes {
  * chat view; `text` is the trimmed, length-capped preview content.
  */
 export interface AgentConversationMessagePreview {
-  /**
-   * Role
-   * @default ""
-   */
-  role?: string;
+  /** Role */
+  role: 'user_message' | 'assistant_message';
   /**
    * Text
    * @default ""
@@ -530,7 +527,8 @@ export interface AgentSearchMatchedMessage {
     | 'system'
     | 'tool'
     | 'tool_call'
-    | 'tool_result';
+    | 'tool_result'
+    | string;
   /** Content Preview */
   content_preview: string;
   /** Content Digest */
@@ -912,6 +910,20 @@ export interface AgentSpanSchema {
   agent_description?: string | null;
   /** Agent Version */
   agent_version?: string | null;
+  /** Eval Run Id */
+  eval_run_id?: string | null;
+  /** Eval Predict And Score Call Id */
+  eval_predict_and_score_call_id?: string | null;
+  /** Eval Kind */
+  eval_kind?: string | null;
+  /** Eval Row Digest */
+  eval_row_digest?: string | null;
+  /** Eval Example Id */
+  eval_example_id?: string | null;
+  /** Eval Trial Index */
+  eval_trial_index?: number | null;
+  /** Eval Evaluation Name */
+  eval_evaluation_name?: string | null;
   /** Request Model */
   request_model?: string | null;
   /** Response Model */
@@ -1147,6 +1159,7 @@ export interface AgentSpanStatsReq {
     | null;
   /** Group Filters */
   group_filters?: AgentSpanGroupFilter[];
+  signal_filters?: AgentSignalFilter | null;
 }
 
 /**
@@ -1489,6 +1502,7 @@ export interface AndOperation {
     | LiteralOperation
     | GetFieldOperator
     | ConvertOperation
+    | SizeOperation
     | AndOperation
     | OrOperation
     | NotOperation
@@ -2471,6 +2485,7 @@ export interface ContainsSpec {
     | LiteralOperation
     | GetFieldOperator
     | ConvertOperation
+    | SizeOperation
     | AndOperation
     | OrOperation
     | NotOperation
@@ -2486,6 +2501,7 @@ export interface ContainsSpec {
     | LiteralOperation
     | GetFieldOperator
     | ConvertOperation
+    | SizeOperation
     | AndOperation
     | OrOperation
     | NotOperation
@@ -2540,6 +2556,7 @@ export interface ConvertSpec {
     | LiteralOperation
     | GetFieldOperator
     | ConvertOperation
+    | SizeOperation
     | AndOperation
     | OrOperation
     | NotOperation
@@ -3742,6 +3759,12 @@ export interface FeedbackCreateReq {
    */
   span_trace_id?: string;
   /**
+   * Scorer Trace Id
+   * Trace of the scorer (judge) invocation that produced this feedback (spans.trace_id of the judge call). Distinct from span_trace_id, which is the scored turn. Lets signals price the invocation off the judge span without joining the calls model.
+   * @default ""
+   */
+  scorer_trace_id?: string;
+  /**
    * Wb User Id
    * Do not set directly. Server will automatically populate this field.
    */
@@ -3888,6 +3911,11 @@ export interface FeedbackQueryReq {
 export interface FeedbackQueryRes {
   /** Result */
   result: Record<string, any>[];
+  /**
+   * Total Count
+   * @min 0
+   */
+  total_count: number;
 }
 
 /** FeedbackReplaceReq */
@@ -3980,6 +4008,12 @@ export interface FeedbackReplaceReq {
    * @default ""
    */
   span_trace_id?: string;
+  /**
+   * Scorer Trace Id
+   * Trace of the scorer (judge) invocation that produced this feedback (spans.trace_id of the judge call). Distinct from span_trace_id, which is the scored turn. Lets signals price the invocation off the judge span without joining the calls model.
+   * @default ""
+   */
+  scorer_trace_id?: string;
   /**
    * Wb User Id
    * Do not set directly. Server will automatically populate this field.
@@ -5257,6 +5291,7 @@ export interface OrOperation {
     | LiteralOperation
     | GetFieldOperator
     | ConvertOperation
+    | SizeOperation
     | AndOperation
     | OrOperation
     | NotOperation
@@ -5790,6 +5825,34 @@ export interface ServerInfoRes {
   min_required_weave_python_version: string;
   /** Trace Server Version */
   trace_server_version: string;
+}
+
+/**
+ * SizeOperation
+ * Return the number of elements in a collection or characters in a string.
+ *
+ * Example:
+ *     ```
+ *     {"$size": {"$getField": "scorer_tags"}}
+ *     ```
+ */
+export interface SizeOperation {
+  /** $Size */
+  $size:
+    | LiteralOperation
+    | GetFieldOperator
+    | ConvertOperation
+    | SizeOperation
+    | AndOperation
+    | OrOperation
+    | NotOperation
+    | EqOperation
+    | GtOperation
+    | LtOperation
+    | GteOperation
+    | LteOperation
+    | InOperation
+    | ContainsOperation;
 }
 
 /** SortBy */

--- a/sdks/node/weave.openapi.json
+++ b/sdks/node/weave.openapi.json
@@ -6479,8 +6479,11 @@
         "properties": {
           "role": {
             "type": "string",
-            "title": "Role",
-            "default": ""
+            "enum": [
+              "user_message",
+              "assistant_message"
+            ],
+            "title": "Role"
           },
           "text": {
             "type": "string",
@@ -6489,6 +6492,9 @@
           }
         },
         "type": "object",
+        "required": [
+          "role"
+        ],
         "title": "AgentConversationMessagePreview",
         "description": "A truncated first/last message snippet for a grouped conversation row.\n\n`role` is the chat-timeline message type (e.g. \"user_message\",\n\"assistant_message\") so clients can style it consistently with the full\nchat view; `text` is the trimmed, length-capped preview content."
       },
@@ -7017,15 +7023,22 @@
             "title": "Trace Id"
           },
           "role": {
-            "type": "string",
-            "enum": [
-              "",
-              "user",
-              "assistant",
-              "system",
-              "tool",
-              "tool_call",
-              "tool_result"
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "",
+                  "user",
+                  "assistant",
+                  "system",
+                  "tool",
+                  "tool_call",
+                  "tool_result"
+                ]
+              },
+              {
+                "type": "string"
+              }
             ],
             "title": "Role"
           },
@@ -7930,6 +7943,83 @@
             ],
             "title": "Agent Version"
           },
+          "eval_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eval Run Id"
+          },
+          "eval_predict_and_score_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eval Predict And Score Call Id"
+          },
+          "eval_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eval Kind"
+          },
+          "eval_row_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eval Row Digest"
+          },
+          "eval_example_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eval Example Id"
+          },
+          "eval_trial_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eval Trial Index"
+          },
+          "eval_evaluation_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eval Evaluation Name"
+          },
           "request_model": {
             "anyOf": [
               {
@@ -8775,6 +8865,16 @@
             },
             "type": "array",
             "title": "Group Filters"
+          },
+          "signal_filters": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentSignalFilter"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -9518,6 +9618,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ConvertOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/SizeOperation"
                 },
                 {
                   "$ref": "#/components/schemas/AndOperation"
@@ -11947,6 +12050,9 @@
                 "$ref": "#/components/schemas/ConvertOperation"
               },
               {
+                "$ref": "#/components/schemas/SizeOperation"
+              },
+              {
                 "$ref": "#/components/schemas/AndOperation"
               },
               {
@@ -11989,6 +12095,9 @@
               },
               {
                 "$ref": "#/components/schemas/ConvertOperation"
+              },
+              {
+                "$ref": "#/components/schemas/SizeOperation"
               },
               {
                 "$ref": "#/components/schemas/AndOperation"
@@ -12069,6 +12178,9 @@
               },
               {
                 "$ref": "#/components/schemas/ConvertOperation"
+              },
+              {
+                "$ref": "#/components/schemas/SizeOperation"
               },
               {
                 "$ref": "#/components/schemas/AndOperation"
@@ -12996,6 +13108,9 @@
                     "$ref": "#/components/schemas/ConvertOperation"
                   },
                   {
+                    "$ref": "#/components/schemas/SizeOperation"
+                  },
+                  {
                     "$ref": "#/components/schemas/AndOperation"
                   },
                   {
@@ -13037,6 +13152,9 @@
                   },
                   {
                     "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SizeOperation"
                   },
                   {
                     "$ref": "#/components/schemas/AndOperation"
@@ -14836,6 +14954,12 @@
             "description": "Turn the feedback belongs to (from spans.trace_id)",
             "default": ""
           },
+          "scorer_trace_id": {
+            "type": "string",
+            "title": "Scorer Trace Id",
+            "description": "Trace of the scorer (judge) invocation that produced this feedback (spans.trace_id of the judge call). Distinct from span_trace_id, which is the scored turn. Lets signals price the invocation off the judge span without joining the calls model.",
+            "default": ""
+          },
           "wb_user_id": {
             "anyOf": [
               {
@@ -15166,11 +15290,17 @@
             },
             "type": "array",
             "title": "Result"
+          },
+          "total_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Total Count"
           }
         },
         "type": "object",
         "required": [
-          "result"
+          "result",
+          "total_count"
         ],
         "title": "FeedbackQueryRes"
       },
@@ -15423,6 +15553,12 @@
             "type": "string",
             "title": "Span Trace Id",
             "description": "Turn the feedback belongs to (from spans.trace_id)",
+            "default": ""
+          },
+          "scorer_trace_id": {
+            "type": "string",
+            "title": "Scorer Trace Id",
+            "description": "Trace of the scorer (judge) invocation that produced this feedback (spans.trace_id of the judge call). Distinct from span_trace_id, which is the scored turn. Lets signals price the invocation off the judge span without joining the calls model.",
             "default": ""
           },
           "wb_user_id": {
@@ -15831,6 +15967,9 @@
                     "$ref": "#/components/schemas/ConvertOperation"
                   },
                   {
+                    "$ref": "#/components/schemas/SizeOperation"
+                  },
+                  {
                     "$ref": "#/components/schemas/AndOperation"
                   },
                   {
@@ -15872,6 +16011,9 @@
                   },
                   {
                     "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SizeOperation"
                   },
                   {
                     "$ref": "#/components/schemas/AndOperation"
@@ -15935,6 +16077,9 @@
                     "$ref": "#/components/schemas/ConvertOperation"
                   },
                   {
+                    "$ref": "#/components/schemas/SizeOperation"
+                  },
+                  {
                     "$ref": "#/components/schemas/AndOperation"
                   },
                   {
@@ -15976,6 +16121,9 @@
                   },
                   {
                     "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SizeOperation"
                   },
                   {
                     "$ref": "#/components/schemas/AndOperation"
@@ -16148,6 +16296,9 @@
                     "$ref": "#/components/schemas/ConvertOperation"
                   },
                   {
+                    "$ref": "#/components/schemas/SizeOperation"
+                  },
+                  {
                     "$ref": "#/components/schemas/AndOperation"
                   },
                   {
@@ -16190,6 +16341,9 @@
                     },
                     {
                       "$ref": "#/components/schemas/ConvertOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SizeOperation"
                     },
                     {
                       "$ref": "#/components/schemas/AndOperation"
@@ -16736,6 +16890,9 @@
                     "$ref": "#/components/schemas/ConvertOperation"
                   },
                   {
+                    "$ref": "#/components/schemas/SizeOperation"
+                  },
+                  {
                     "$ref": "#/components/schemas/AndOperation"
                   },
                   {
@@ -16777,6 +16934,9 @@
                   },
                   {
                     "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SizeOperation"
                   },
                   {
                     "$ref": "#/components/schemas/AndOperation"
@@ -16840,6 +17000,9 @@
                     "$ref": "#/components/schemas/ConvertOperation"
                   },
                   {
+                    "$ref": "#/components/schemas/SizeOperation"
+                  },
+                  {
                     "$ref": "#/components/schemas/AndOperation"
                   },
                   {
@@ -16881,6 +17044,9 @@
                   },
                   {
                     "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SizeOperation"
                   },
                   {
                     "$ref": "#/components/schemas/AndOperation"
@@ -17411,6 +17577,9 @@
                   },
                   {
                     "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SizeOperation"
                   },
                   {
                     "$ref": "#/components/schemas/AndOperation"
@@ -18453,6 +18622,9 @@
                   "$ref": "#/components/schemas/ConvertOperation"
                 },
                 {
+                  "$ref": "#/components/schemas/SizeOperation"
+                },
+                {
                   "$ref": "#/components/schemas/AndOperation"
                 },
                 {
@@ -19394,6 +19566,63 @@
           "trace_server_version"
         ],
         "title": "ServerInfoRes"
+      },
+      "SizeOperation": {
+        "properties": {
+          "$size": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LiteralOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GetFieldOperator"
+              },
+              {
+                "$ref": "#/components/schemas/ConvertOperation"
+              },
+              {
+                "$ref": "#/components/schemas/SizeOperation"
+              },
+              {
+                "$ref": "#/components/schemas/AndOperation"
+              },
+              {
+                "$ref": "#/components/schemas/OrOperation"
+              },
+              {
+                "$ref": "#/components/schemas/NotOperation"
+              },
+              {
+                "$ref": "#/components/schemas/EqOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GtOperation"
+              },
+              {
+                "$ref": "#/components/schemas/LtOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GteOperation"
+              },
+              {
+                "$ref": "#/components/schemas/LteOperation"
+              },
+              {
+                "$ref": "#/components/schemas/InOperation"
+              },
+              {
+                "$ref": "#/components/schemas/ContainsOperation"
+              }
+            ],
+            "title": "$Size"
+          }
+        },
+        "type": "object",
+        "required": [
+          "$size"
+        ],
+        "title": "SizeOperation",
+        "description": "Return the number of elements in a collection or characters in a string.\n\nExample:\n    ```\n    {\"$size\": {\"$getField\": \"scorer_tags\"}}\n    ```"
       },
       "SortBy": {
         "properties": {


### PR DESCRIPTION
## Summary

CI is failing for https://github.com/wandb/core/pull/48796 because my last PR didn't update the API bindings. We should really fix this so it's not possible to merge wandb/weave with stale bindings.

- regenerate the tracked Node SDK OpenAPI schema from the current trace-server API
- regenerate the TypeScript trace-server client, including the required feedback query total count from #7612
- preserve the documented manual output type override for EndedCallSchemaForInsert

## Testing

- pnpm run typecheck:cjs
- pnpm run typecheck:esm
- pnpm exec prettier --check src/generated/traceServerApi.ts
- git diff --check

## Context

Follow-up to #7612. The core Zod schema is generated and committed in wandb/core, not this repository; this PR refreshes the bindings owned by wandb/weave.