### PR TITLE
feat(weave): add custom runtime SDK wrapper

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -28,7 +28,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"examples/**/*.ts\"",
     "run": "tsx",
     "prettier-check": "prettier --check \"src/**/*.ts\" \"examples/**/*.ts\"",
-    "generate-api": "swagger-typescript-api generate -o ./src/generated -n traceServerApi.ts --p ./weave.openapi.json ",
+    "generate-api": "swagger-typescript-api generate -o ./src/generated -n traceServerApi.ts --p ./weave.openapi.json --custom-config ./swagger-typescript-api.config.mjs",
     "dev": "nodemon",
     "lint": "eslint .",
     "typecheck:cjs": "tsc --noEmit -p tsconfig.cjs.json",

--- a/sdks/node/src/__tests__/generatedTraceServerApi.test.ts
+++ b/sdks/node/src/__tests__/generatedTraceServerApi.test.ts
@@ -1,0 +1,29 @@
+import {Api as TraceServerApi} from '../generated/traceServerApi';
+
+test('encodes custom runtime names in request paths', async () => {
+  let requestedUrl: string | undefined;
+  const api = new TraceServerApi({
+    baseUrl: 'https://trace.example',
+    customFetch: async input => {
+      requestedUrl = input.toString();
+      return new Response('{}', {
+        status: 200,
+        headers: {'Content-Type': 'application/json'},
+      });
+    },
+  });
+
+  await api.v2.customRuntimeApplyV2EntityProjectRuntimesRuntimeNamePut(
+    'entity',
+    'project',
+    'support/agent?canary',
+    {
+      base_url: 'https://runtime.example/v1',
+      runtime_ids: [],
+    }
+  );
+
+  expect(requestedUrl).toBe(
+    'https://trace.example/v2/entity/project/runtimes/support%2Fagent%3Fcanary'
+  );
+});

--- a/sdks/node/src/generated/traceServerApi.ts
+++ b/sdks/node/src/generated/traceServerApi.ts
@@ -9217,11 +9217,11 @@ export class Api<
      * @description Create or replace a custom runtime configuration.
      *
      * @tags Custom Runtimes
-     * @name CustomRuntimeApplyV2EntityProjectCustomRuntimesRuntimeNamePut
+     * @name CustomRuntimeApplyV2EntityProjectRuntimesRuntimeNamePut
      * @summary Custom Runtime Apply
-     * @request PUT:/v2/{entity}/{project}/custom-runtimes/{runtime_name}
+     * @request PUT:/v2/{entity}/{project}/runtimes/{runtime_name}
      */
-    customRuntimeApplyV2EntityProjectCustomRuntimesRuntimeNamePut: (
+    customRuntimeApplyV2EntityProjectRuntimesRuntimeNamePut: (
       entity: string,
       project: string,
       runtimeName: string,
@@ -9229,7 +9229,7 @@ export class Api<
       params: RequestParams = {}
     ) =>
       this.request<CustomRuntimeApplyRes, HTTPValidationError>({
-        path: `/v2/${entity}/${project}/custom-runtimes/${runtimeName}`,
+        path: `/v2/${entity}/${project}/runtimes/${encodeURIComponent(runtimeName)}`,
         method: 'PUT',
         body: data,
         type: ContentType.Json,

--- a/sdks/node/swagger-typescript-api.config.mjs
+++ b/sdks/node/swagger-typescript-api.config.mjs
@@ -1,0 +1,8 @@
+export default {
+  hooks: {
+    onInsertPathParam: paramName =>
+      paramName === 'runtimeName'
+        ? `encodeURIComponent(${paramName})`
+        : undefined,
+  },
+};

--- a/sdks/node/weave.openapi.json
+++ b/sdks/node/weave.openapi.json
@@ -5875,14 +5875,14 @@
         }
       }
     },
-    "/v2/{entity}/{project}/custom-runtimes/{runtime_name}": {
+    "/v2/{entity}/{project}/runtimes/{runtime_name}": {
       "put": {
         "tags": [
           "Custom Runtimes"
         ],
         "summary": "Custom Runtime Apply",
         "description": "Create or replace a custom runtime configuration.",
-        "operationId": "custom_runtime_apply_v2__entity___project__custom_runtimes__runtime_name__put",
+        "operationId": "custom_runtime_apply_v2__entity___project__runtimes__runtime_name__put",
         "parameters": [
           {
             "name": "entity",

--- a/tests/trace/test_custom_runtime_client.py
+++ b/tests/trace/test_custom_runtime_client.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock
+
+import weave
+from weave.trace.weave_client import WeaveClient
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server_bindings.client_interface import TraceServerClientInterface
+
+
+def test_register_custom_runtime_normalizes_string_and_explicit_runtime_ids() -> None:
+    server = MagicMock(spec=TraceServerClientInterface)
+    expected_result = tsi.CustomRuntimeApplyRes(
+        name="support-agent",
+        base_url="https://agent.example/v1",
+        api_key_secret="AGENT_API_KEY",
+        headers={"X-Tenant-ID": "customer-1"},
+        runtime_ids=[
+            tsi.CustomRuntimeIDRes(
+                id="support-v12",
+                max_tokens=4096,
+                playground_id="custom::support-agent::support-v12",
+            ),
+            tsi.CustomRuntimeIDRes(
+                id="support-canary",
+                max_tokens=8192,
+                playground_id="custom::support-agent::support-canary",
+            ),
+        ],
+    )
+    server.custom_runtime_apply.return_value = expected_result
+    client = WeaveClient(
+        "entity",
+        "project",
+        server,
+        ensure_project_exists=False,
+    )
+
+    result = client.register_custom_runtime(
+        name="support-agent",
+        base_url="https://agent.example/v1",
+        api_key_secret="AGENT_API_KEY",
+        headers={"X-Tenant-ID": "customer-1"},
+        runtime_ids=[
+            "support-v12",
+            weave.CustomRuntimeID(id="support-canary", max_tokens=8192),
+        ],
+    )
+
+    server.custom_runtime_apply.assert_called_once_with(
+        tsi.CustomRuntimeApplyReq(
+            project_id="entity/project",
+            runtime_name="support-agent",
+            base_url="https://agent.example/v1",
+            api_key_secret="AGENT_API_KEY",
+            headers={"X-Tenant-ID": "customer-1"},
+            runtime_ids=[
+                tsi.CustomRuntimeID(id="support-v12", max_tokens=4096),
+                tsi.CustomRuntimeID(id="support-canary", max_tokens=8192),
+            ],
+        )
+    )
+    assert result == expected_result

--- a/tests/trace_server_bindings/test_http_behavior_remote.py
+++ b/tests/trace_server_bindings/test_http_behavior_remote.py
@@ -80,6 +80,52 @@ def test_call_start_ok(mock_post, unbatched_server):
     mock_post.assert_called_once()
 
 
+@patch("weave.utils.http_requests.put")
+def test_custom_runtime_apply_sends_put_request(mock_put, unbatched_server):
+    expected = tsi.CustomRuntimeApplyRes(
+        name="support/agent?canary",
+        base_url="https://agent.example.com/v1",
+        api_key_secret=None,
+        headers={"X-Tenant-ID": "customer-1"},
+        runtime_ids=[
+            tsi.CustomRuntimeIDRes(
+                id="support-v12",
+                max_tokens=4096,
+                playground_id="custom::support/agent?canary::support-v12",
+            )
+        ],
+    )
+    mock_put.return_value = httpx.Response(
+        200,
+        json=expected.model_dump(),
+        request=httpx.Request("PUT", "http://example.com"),
+    )
+
+    result = unbatched_server.custom_runtime_apply(
+        tsi.CustomRuntimeApplyReq(
+            project_id="entity/project",
+            runtime_name="support/agent?canary",
+            base_url="https://agent.example.com/v1",
+            api_key_secret=None,
+            headers={"X-Tenant-ID": "customer-1"},
+            runtime_ids=[tsi.CustomRuntimeID(id="support-v12")],
+        )
+    )
+
+    assert result == expected
+    mock_put.assert_called_once()
+    call = mock_put.call_args
+    assert call.args[0] == (
+        "http://example.com/v2/entity/project/runtimes/support%2Fagent%3Fcanary"
+    )
+    assert json.loads(call.kwargs["data"]) == {
+        "base_url": "https://agent.example.com/v1",
+        "api_key_secret": None,
+        "headers": {"X-Tenant-ID": "customer-1"},
+        "runtime_ids": [{"id": "support-v12", "max_tokens": 4096}],
+    }
+
+
 @patch("weave.utils.http_requests.post")
 def test_400_no_retry(mock_post, unbatched_server):
     """Test that 400 errors are not retried."""

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -95,6 +95,7 @@ from weave.trace.log_call import log_call
 from weave.trace.urls import otel_traces_endpoint
 from weave.trace.util import Thread as Thread
 from weave.trace.util import ThreadPoolExecutor as ThreadPoolExecutor
+from weave.trace_server.trace_server_interface import CustomRuntimeID
 from weave.type_handlers.Audio.audio import Audio
 from weave.type_handlers.File.file import File
 from weave.type_handlers.Markdown.markdown import Markdown
@@ -112,6 +113,7 @@ __all__ = [
     "ClassifierMonitor",
     "Content",
     "Conversation",
+    "CustomRuntimeID",
     "Dataset",
     "EasyPrompt",
     "Evaluation",

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -7,7 +7,7 @@ import logging
 import os
 import re
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from concurrent.futures import Future
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, cast
@@ -146,6 +146,9 @@ from weave.trace_server.trace_server_interface import (
     CostPurgeReq,
     CostQueryOutput,
     CostQueryReq,
+    CustomRuntimeApplyReq,
+    CustomRuntimeApplyRes,
+    CustomRuntimeID,
     EndedCallSchemaForInsertWithStartedAt,
     FeedbackCreateReq,
     FileCreateReq,
@@ -538,6 +541,40 @@ class WeaveClient:
             pass
 
     ################ High Level Convenience Methods ################
+
+    @trace_sentry.global_trace_sentry.watch()
+    def register_custom_runtime(
+        self,
+        *,
+        name: str,
+        base_url: str,
+        runtime_ids: Iterable[str | CustomRuntimeID],
+        api_key_secret: str | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> CustomRuntimeApplyRes:
+        """Register a custom runtime, replacing its configuration if it exists.
+
+        Runtime IDs omitted from this call are removed. String IDs use the
+        default maximum token count; pass ``CustomRuntimeID`` to set it explicitly.
+        Inference may use a prior configuration for up to 60 seconds after an
+        update.
+        """
+        normalized_runtime_ids = [
+            CustomRuntimeID(id=runtime_id)
+            if isinstance(runtime_id, str)
+            else runtime_id
+            for runtime_id in runtime_ids
+        ]
+        return self.server.custom_runtime_apply(
+            CustomRuntimeApplyReq(
+                project_id=self.project_id,
+                runtime_name=name,
+                base_url=base_url,
+                api_key_secret=api_key_secret,
+                headers=headers or {},
+                runtime_ids=normalized_runtime_ids,
+            )
+        )
 
     @trace_sentry.global_trace_sentry.watch()
     def save(self, val: Any, name: str, branch: str = "latest") -> Any:

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -3,6 +3,7 @@ import io
 import logging
 from collections.abc import Iterator
 from typing import Any, cast
+from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
 import httpx
@@ -1471,6 +1472,24 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             tsi.DatasetDeleteRes,
             method="DELETE",
             params=params,
+        )
+
+    @validate_call
+    def custom_runtime_apply(
+        self, req: tsi.CustomRuntimeApplyReq
+    ) -> tsi.CustomRuntimeApplyRes:
+        entity, project = from_project_id(req.project_id)
+        runtime_name = quote(req.runtime_name, safe="")
+        url = f"/v2/{entity}/{project}/runtimes/{runtime_name}"
+        body = tsi.CustomRuntimeApplyBody.model_validate(
+            req.model_dump(exclude={"project_id", "runtime_name", "wb_user_id"})
+        )
+        return self._generic_request(
+            url,
+            body,
+            tsi.CustomRuntimeApplyBody,
+            tsi.CustomRuntimeApplyRes,
+            method="PUT",
         )
 
     @validate_call


### PR DESCRIPTION
## Summary

- Add `WeaveClient.register_custom_runtime(...)` for registering or replacing a Custom Runtime configuration.
- Accept string runtime IDs with the default token limit or `weave.CustomRuntimeID` values with explicit limits.
- Implement the manual HTTP transport against `PUT /v2/{entity}/{project}/runtimes/{runtime_name}`.
- Configure the generated Node client to URL-encode Custom Runtime names.

## Usage

```python
import weave

client = weave.init("entity/project")
client.register_custom_runtime(
    name="support-agent",
    base_url="https://agent.example/v1",
    api_key_secret="AGENT_API_KEY",
    headers={"X-Tenant-ID": "customer-1"},
    runtime_ids=[
        "support-v12",
        weave.CustomRuntimeID(id="support-canary", max_tokens=8192),
    ],
)
```

`runtime_ids` is the complete desired list. IDs omitted from a later successful call are removed.

## Related changes

- Runtime implementation: #7614
- Shared request validation: #7649
- Core HTTP route: [wandb/core#49011](https://github.com/wandb/core/pull/49011)

## Verification

- Python SDK and HTTP transport: `24 passed`.
- Generated Node client URL regression: `1 passed`.
- Node CJS/ESM typechecks, ESLint, Prettier, Ruff, and Python formatting passed.
