### PR TITLE
fix(weave): include agent spans in feedback aggregates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,9 @@ Evaluation result rows merge agent span links from two sources: legacy
 trial. Keep the promoted-column hydration best-effort so eval results remain
 available during rolling deploys.
 
+Feedback aggregate `span_types` filters support all agent feedback target refs:
+`agent_turn`, individual-message `agent_span`, and `agent_conversation`.
+
 If `sdks/node/node_modules` is missing, run `pnpm install --frozen-lockfile` in `sdks/node` first. Do not use `npm install`; this SDK is pinned to pnpm.
 
 ## Python Testing Guidelines

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -1453,9 +1453,10 @@ def test_feedback_aggregate_filter_matching_functional(client: WeaveClient) -> N
             )
         )
 
-    # Two monitors whose ids share a prefix ("mon" vs "monday"), one scoring an
-    # agent_turn ref and one an agent_conversation ref.
+    # Monitors whose ids share a prefix ("mon" vs "monday"), covering every
+    # supported agent feedback target ref.
     _monitor("t1", "mon", f"weave:///{project_id}/agent_turn/trace_t1")
+    _monitor("s1", "mon", f"weave:///{project_id}/agent_span/span_s1")
     _monitor("c1", "monday", f"weave:///{project_id}/agent_conversation/conv_c1")
 
     # feedback_create (via the external adapter) stores the internal project_id and
@@ -1481,20 +1482,21 @@ def test_feedback_aggregate_filter_matching_functional(client: WeaveClient) -> N
         ]
         return sum(int(r["total_count"]) for r in rows)
 
-    # Sanity: both rows are present absent any id/type filter.
-    assert _total() == 2
+    # Sanity: all rows are present absent any id/type filter.
+    assert _total() == 3
 
     # monitor_ids: exact by default, so "mon" must NOT match "monday".
-    assert _total(monitor_ids=["mon"]) == 1
+    assert _total(monitor_ids=["mon"]) == 2
     assert _total(monitor_ids=["monday"]) == 1
     assert _total(monitor_ids=["mond"]) == 0  # no partial match without '*'
-    # A trailing '*' opts into prefix matching -> matches both ids.
-    assert _total(monitor_ids=["mon*"]) == 2
+    # A trailing '*' opts into prefix matching -> matches all three rows.
+    assert _total(monitor_ids=["mon*"]) == 3
 
     # span_types: matches the exact span-type segment of the ref, not a substring.
     assert _total(span_types=["agent_turn"]) == 1
+    assert _total(span_types=["agent_span"]) == 1
     assert _total(span_types=["agent_conversation"]) == 1
-    assert _total(span_types=["agent_turn", "agent_conversation"]) == 2
+    assert _total(span_types=["agent_turn", "agent_span", "agent_conversation"]) == 3
 
 
 class MatchAnyDatetime:  # noqa: PLW1641

--- a/tests/trace_server/query_builder/test_feedback_aggregate.py
+++ b/tests/trace_server/query_builder/test_feedback_aggregate.py
@@ -332,6 +332,9 @@ def test_feedback_aggregate_req_validation():
     """The request model validates the window, bucket count, and group_by allowlist."""
     # Happy path: a sane request constructs cleanly.
     assert _make_req().time_bucket_seconds == _BUCKET_SECONDS
+    assert _make_req(span_types=["agent_span"]).span_types == ["agent_span"]
+    with pytest.raises(ValidationError):
+        _make_req(span_types=["call"])
 
     # before_ms must be strictly after after_ms.
     with pytest.raises(ValidationError):

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1513,7 +1513,7 @@ FEEDBACK_AGGREGATE_GROUP_BY_COLUMNS: frozenset[FeedbackAggregateGroupByColumn] =
 )
 
 # Span types, matched on the feedback's weave_ref path segment
-FeedbackSpanType: TypeAlias = Literal["agent_turn", "agent_conversation"]
+FeedbackSpanType: TypeAlias = Literal["agent_turn", "agent_span", "agent_conversation"]
 
 # Limit aggregate feedback request time range and time bucket count
 MAX_FEEDBACK_AGG_TIME_RANGE_DAYS = 31
@@ -1572,7 +1572,7 @@ class FeedbackAggregateReq(BaseModelStrict):
     )
     span_types: list[FeedbackSpanType] = Field(
         default_factory=list,
-        description="Filter by span type (turn vs conversation).",
+        description="Filter by span type (turn, message span, or conversation).",
     )
     group_by: list[FeedbackAggregateGroupByColumn] = Field(
         default_factory=list,


### PR DESCRIPTION
## Summary

- allow feedback aggregates to filter individual-message `agent_span` targets
- preserve exact ref-segment matching in ClickHouse and the in-memory backend
- cover request validation and all supported agent feedback target refs

This is required by wandb/core#48768 so the Signals `turn_ended` filter includes both turn-level monitor feedback and per-message user feedback.

## Testing

- `uv run --group test python -m pytest tests/trace_server/query_builder/test_feedback_aggregate.py -q` (6 passed)
- `git diff --check`

## Breaking changes

None. This widens an existing request enum.