### PR TITLE
fix(weave): normalize Claude Agent SDK cached token usage

### DIFF
--- a/tests/integrations/claude_agent_sdk/cassettes/cache_usage_response.json
+++ b/tests/integrations/claude_agent_sdk/cassettes/cache_usage_response.json
@@ -1,0 +1,36 @@
+[
+  {
+    "type": "system",
+    "subtype": "init",
+    "session_id": "s-cache789"
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "content": [
+        {
+          "type": "text",
+          "text": "The cached response."
+        }
+      ],
+      "model": "claude-sonnet-4-6"
+    }
+  },
+  {
+    "type": "result",
+    "subtype": "result",
+    "duration_ms": 1200,
+    "duration_api_ms": 900,
+    "is_error": false,
+    "num_turns": 1,
+    "session_id": "s-cache789",
+    "total_cost_usd": 0.003,
+    "usage": {
+      "input_tokens": 10,
+      "output_tokens": 75,
+      "cache_read_input_tokens": 19447,
+      "cache_creation_input_tokens": 1024
+    },
+    "result": "The cached response."
+  }
+]

--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
@@ -158,6 +158,27 @@ async def test_simple_text_query_otel(otel_spans: InMemorySpanExporter) -> None:
     assert chat_span.parent.span_id == agent_span.context.span_id
 
 
+@pytest.mark.asyncio
+async def test_cached_usage_is_normalized_in_otel_span(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    await run_query("cache_usage_response", "Use the cache")
+
+    chat_spans = get_spans_by_op(otel_spans.get_finished_spans(), "chat")
+    assert len(chat_spans) == 1
+    usage_attrs = {
+        key: value
+        for key, value in get_attrs(chat_spans[0]).items()
+        if key.startswith("gen_ai.usage.")
+    }
+    assert usage_attrs == {
+        "gen_ai.usage.input_tokens": 20481,
+        "gen_ai.usage.output_tokens": 75,
+        "gen_ai.usage.cache_read.input_tokens": 19447,
+        "gen_ai.usage.cache_creation.input_tokens": 1024,
+    }
+
+
 # --- query(): tool use ------------------------------------------------------
 
 

--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_test.py
@@ -100,6 +100,44 @@ async def test_simple_text_query(
     assert model_usage["output_tokens"] == 10
 
 
+@pytest.mark.asyncio
+async def test_cached_usage_is_normalized_in_call_and_summary(
+    client: weave.trace.weave_client.WeaveClient,
+) -> None:
+    async for _ in query(
+        prompt="Use the cache",
+        options=ClaudeAgentOptions(),
+        transport=ReplayTransport(load_cassette("cache_usage_response")),
+    ):
+        pass
+
+    calls = list(client.get_calls())
+    root_calls = [
+        call for call in calls if op_name_from_call(call) == "claude_agent_sdk.query"
+    ]
+    assert len(root_calls) == 1
+    root_call = root_calls[0]
+    raw_usage = {
+        "input_tokens": 10,
+        "output_tokens": 75,
+        "cache_read_input_tokens": 19447,
+        "cache_creation_input_tokens": 1024,
+    }
+    expected_summary_usage = {
+        "input_tokens": 20481,
+        "output_tokens": 75,
+        "cache_read_input_tokens": 19447,
+        "cache_creation_input_tokens": 1024,
+    }
+    assert root_call.output["usage"] == raw_usage
+    assert root_call.summary["usage"] == {
+        "claude-sonnet-4-6": {
+            "requests": 1,
+            **expected_summary_usage,
+        }
+    }
+
+
 # =====================================================================
 # query() — tool use
 # =====================================================================

--- a/weave/integrations/claude_agent_sdk/claude_agent_sdk_integration.py
+++ b/weave/integrations/claude_agent_sdk/claude_agent_sdk_integration.py
@@ -14,6 +14,7 @@ from weave.integrations.claude_agent_sdk.display_utils import (
     tool_use_display_name,
     turn_display_name,
 )
+from weave.integrations.claude_agent_sdk.usage import total_input_tokens
 from weave.integrations.integration_metadata import library_integration
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings
@@ -210,11 +211,13 @@ def _finalize_stream(
             # Set summary directly so usage propagates even when tool
             # call children exist (children path skips output-based summary).
             if state["root_model"]:
+                summary_usage = dict(result_msg.usage)
+                summary_usage["input_tokens"] = total_input_tokens(summary_usage)
                 root_call.summary = {
                     "usage": {
                         state["root_model"]: {
                             "requests": 1,
-                            **result_msg.usage,
+                            **summary_usage,
                         }
                     }
                 }

--- a/weave/integrations/claude_agent_sdk/otel_integration.py
+++ b/weave/integrations/claude_agent_sdk/otel_integration.py
@@ -47,6 +47,7 @@ from weave.conversation.conversation_otel import (
     llm_attributes,
 )
 from weave.conversation.types import Message, Reasoning, ToolCallPart, Usage
+from weave.integrations.claude_agent_sdk.usage import total_input_tokens
 from weave.integrations.integration_metadata import library_integration
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings
@@ -109,7 +110,7 @@ def _usage_from_result(usage: dict[str, Any] | None) -> Usage:
     """Build a Usage from a ResultMessage's aggregate usage dict."""
     raw = usage or {}
     return Usage(
-        input_tokens=int(raw.get("input_tokens", 0) or 0),
+        input_tokens=total_input_tokens(raw),
         output_tokens=int(raw.get("output_tokens", 0) or 0),
         cache_creation_input_tokens=int(raw.get("cache_creation_input_tokens", 0) or 0),
         cache_read_input_tokens=int(raw.get("cache_read_input_tokens", 0) or 0),

--- a/weave/integrations/claude_agent_sdk/usage.py
+++ b/weave/integrations/claude_agent_sdk/usage.py
@@ -1,0 +1,21 @@
+"""Usage normalization shared by Claude Agent SDK tracing variants."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def total_input_tokens(usage: Mapping[str, Any] | None) -> int:
+    """Return Weave's gross prompt count for an Anthropic usage payload.
+
+    Anthropic reports fresh input tokens separately from cache-read and
+    cache-creation tokens. Weave records those cache counts as subsets of the
+    full prompt, so its input token count must include all three values.
+    """
+    raw = usage or {}
+    return (
+        int(raw.get("input_tokens", 0) or 0)
+        + int(raw.get("cache_read_input_tokens", 0) or 0)
+        + int(raw.get("cache_creation_input_tokens", 0) or 0)
+    )


### PR DESCRIPTION
## Description

- Fixes [WB-37897](https://coreweave.atlassian.net/browse/WB-37897)

The Python Claude Agent SDK reported Anthropic fresh input tokens directly, even though Weave treats cache-read and cache-creation counts as subsets of the full prompt. This caused cached tokens to be subtracted twice by cost calculations and let cache-hit rates exceed 100%.

Jira ticket has an incredible breakdown. whoever made that ticket must be SOOO good.

- Normalize Python Claude Agent SDK usage as fresh + cache_read + cache_creation at both dashboard reporting boundaries: legacy call summaries and OTel span attributes.
- Preserve the provider-native raw usage in legacy call output.
- Add a cache-heavy replay regression covering both tracing paths.
- Confirm Node parity: its Claude Agent SDK tracer already folds the same three values and has an existing OTel contract test asserting the inclusive count and cache fields; no Node change is required.

## Testing

- Added deterministic replay tests that send a cache-heavy Claude Agent SDK result through the legacy and OTel integrations and assert the inclusive input count plus preserved cache counts.

[WB-37897]: https://coreweave.atlassian.net/browse/WB-37897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ