### PR TITLE
feat(weave): support membership filters in grouped agent stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,11 @@ with an untyped dictionary. After changing the model, run
 `make synchronize-base-object-schemas` from the repository root so the Python
 schema and the dependent Core frontend types stay aligned.
 
+Agent span stats `group_filters` are membership filters and may group by a
+different key than the result's `group_by`. For example, qualify conversations
+where any span matches an attribute, retain every span in those conversations,
+then display the resulting cost grouped by model.
+
 ### Trace Server API / Node SDK Schema
 
 When trace-server request/response models or route schemas change, refresh the API schema used by the Node SDK:

--- a/tests/trace_server/query_builder/test_agent_stats_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_stats_query_builder.py
@@ -749,6 +749,107 @@ def test_group_by_custom_attr_and_metric_custom_attr() -> None:
     assert result.columns == ["timestamp", "env", "avg_score", "count_score"]
 
 
+def test_grouped_time_stats_apply_conversation_membership_filters() -> None:
+    pb = ParamBuilder("genai")
+    req = _req(
+        group_by=[
+            AgentGroupByRef(
+                source="custom_attrs_string",
+                key="env",
+                alias="env",
+            )
+        ],
+        group_filters=[
+            AgentSpanGroupFilter(
+                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+                measure=AgentSpanMeasureSpec(
+                    alias="matched",
+                    aggregation="count",
+                    filter=Query.model_validate(
+                        {
+                            "$expr": {
+                                "$eq": [
+                                    {"$getField": "status_code"},
+                                    {"$literal": "ERROR"},
+                                ]
+                            }
+                        }
+                    ),
+                ),
+                min=1,
+            )
+        ],
+    )
+
+    result = build_agent_span_stats_query(req, pb)
+
+    start = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    end = datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc)
+    src_sql, src_params = _attr_src(3, started_after=start, started_before=end)
+    expected_sql = """
+        WITH all_buckets AS
+          (SELECT toStartOfInterval(toDateTime({genai_9:Float64}, {genai_11:String}), INTERVAL 3600 SECOND, {genai_11:String}) + toIntervalSecond(number * {genai_12:Int64}) AS bucket
+           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({genai_10:Float64}, {genai_11:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({genai_9:Float64}, {genai_11:String}), INTERVAL 3600 SECOND, {genai_11:String}))) / {genai_12:Float64})))
+           WHERE bucket < toDateTime({genai_10:Float64}, {genai_11:String}) ),
+             filtered_spans AS
+          (SELECT *
+           FROM {_ATTR_SRC} s
+           WHERE s.project_id = {genai_0:String}
+             AND s.started_at >= {genai_1:DateTime64(6)}
+             AND s.started_at < {genai_2:DateTime64(6)} ),
+             qualified_groups_0 AS
+          (SELECT s.conversation_id AS conversation_id
+           FROM filtered_spans s
+           GROUP BY conversation_id
+           HAVING countIf(((s.status_code = {genai_14:String}))) >= {genai_15:Float64}),
+             filtered_metric_spans AS
+          (SELECT s.*
+           FROM filtered_spans s
+           INNER JOIN qualified_groups_0 q ON s.conversation_id = q.conversation_id),
+             top_groups AS
+          (SELECT if(mapContains(s.custom_attrs_string, {genai_8:String}), s.custom_attrs_string[{genai_8:String}], NULL) AS env
+           FROM filtered_metric_spans s
+           GROUP BY env
+           ORDER BY count() DESC
+           LIMIT {genai_13:UInt64}),
+             aggregated_data AS
+          (SELECT bucket,
+                  env,
+                  sumOrNull(if(v_input_tokens, m_input_tokens, NULL)) AS sum_input_tokens
+           FROM
+             (SELECT toStartOfInterval(s.started_at, INTERVAL 3600 SECOND, {genai_11:String}) AS bucket,
+                     if(mapContains(s.custom_attrs_string, {genai_8:String}), s.custom_attrs_string[{genai_8:String}], NULL) AS env,
+                     toFloat64(s.input_tokens) AS m_input_tokens,
+                     toUInt8(1) AS v_input_tokens
+              FROM filtered_metric_spans s)
+           GROUP BY bucket,
+                    env)
+        SELECT all_buckets.bucket AS timestamp,
+               top_groups.env AS env,
+               COALESCE(aggregated_data.sum_input_tokens, 0) AS sum_input_tokens
+        FROM all_buckets
+        CROSS JOIN top_groups
+        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+        AND top_groups.env = aggregated_data.env
+        ORDER BY timestamp, env
+    """.replace("{_ATTR_SRC}", src_sql)
+    expected_params = {
+        "genai_0": "p1",
+        "genai_1": start,
+        "genai_2": end,
+        "genai_8": "env",
+        "genai_9": 1767225600,
+        "genai_10": 1767312000,
+        "genai_11": "UTC",
+        "genai_12": 3600,
+        "genai_13": 50,
+        "genai_14": "ERROR",
+        "genai_15": 1.0,
+        **src_params,
+    }
+    assert_sql(expected_sql, expected_params, result.sql, result.parameters)
+
+
 def test_time_stats_apply_group_filters() -> None:
     pb = ParamBuilder("genai")
     req = _req(

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -414,14 +414,15 @@ class AgentSpanStatsReq(BaseModel):
             raise ValueError(
                 "grouped numeric bucket stats do not support explicit metrics"
             )
-        if self.group_filters:
-            if self.group_by:
-                raise ValueError("group_filters do not support group_by")
-            if numeric_bucket is not None and not numeric_bucket.group_by:
-                raise ValueError(
-                    "group_filters are only supported for time stats or "
-                    "grouped numeric bucket stats"
-                )
+        if (
+            self.group_filters
+            and numeric_bucket is not None
+            and not numeric_bucket.group_by
+        ):
+            raise ValueError(
+                "group_filters are only supported for time stats or "
+                "grouped numeric bucket stats"
+            )
         return self
 
 

--- a/weave/trace_server/query_builder/agent_stats_query_builder.py
+++ b/weave/trace_server/query_builder/agent_stats_query_builder.py
@@ -780,6 +780,8 @@ def _build_stats_query(
         resolved_groups=resolved_groups,
         group_limit_slot=group_limit_slot,
         parts=parts,
+        group_filters=group_filters,
+        pb=pb,
     )
 
 
@@ -1051,8 +1053,17 @@ def _build_grouped_stats_query(
     resolved_groups: list[tuple[str, str]],
     group_limit_slot: str,
     parts: _StatsQuerySQLParts,
+    group_filters: list[AgentSpanGroupFilter],
+    pb: ParamBuilder,
 ) -> str:
-    """Render one row per time bucket and selected top group."""
+    """Render one row per time bucket and selected top display group.
+
+    Membership group filters may use a different grouping (for example,
+    conversation_id) from the display group (for example, model). They first
+    qualify containers and retain all of their spans; top-N selection and
+    metric aggregation then run over that complete qualified span set.
+    """
+    group_filter_ctes, stats_source_cte = _group_filter_ctes(pb, group_filters)
     select_group_cols = ", ".join(
         f"{expr} AS {alias}" for expr, alias in resolved_groups
     )
@@ -1078,10 +1089,10 @@ def _build_grouped_stats_query(
         SELECT *
         FROM {source_filter.source} {_SPAN_ALIAS}
         {source_filter.clause}
-      ),
+      ){group_filter_ctes},
       {_CTE_TOP_GROUPS} AS (
         SELECT {select_group_cols}
-        FROM {_CTE_FILTERED_SPANS} {_SPAN_ALIAS}
+        FROM {stats_source_cte} {_SPAN_ALIAS}
         GROUP BY {group_by_clause}
         ORDER BY count() DESC
         LIMIT {group_limit_slot}
@@ -1096,7 +1107,7 @@ def _build_grouped_stats_query(
             {parts.bucket_expr} AS {_BUCKET_COLUMN},
             {inner_group_select_sql},
             {parts.metric_select_sql}
-          FROM {_CTE_FILTERED_SPANS} {_SPAN_ALIAS}
+          FROM {stats_source_cte} {_SPAN_ALIAS}
         )
         GROUP BY {_BUCKET_COLUMN}, {group_by_clause}
       )


### PR DESCRIPTION
## Summary

- allow agent-span stats requests to combine membership `group_filters` with a result `group_by`
- qualify containers first, retain all sibling spans, then select and aggregate top display groups
- support different membership and display keys (for example: qualify conversations by a custom span attribute, then group their complete cost by model)
- keep the request schema closed and typed; this enables an existing representable combination without adding an API field

This completes the exact grouped-breakdown semantics used by wandb/core#48595. The Core frontend retains a production-compatible fallback during rolling deployment.

## Validation

- `uvx ruff check weave/trace_server/agents/types.py weave/trace_server/query_builder/agent_stats_query_builder.py tests/trace_server/query_builder/test_agent_stats_query_builder.py`
- `uvx ruff format --check weave/trace_server/agents/types.py weave/trace_server/query_builder/agent_stats_query_builder.py tests/trace_server/query_builder/test_agent_stats_query_builder.py`
- `uv run --group test python -m pytest tests/trace_server/query_builder/test_agent_stats_query_builder.py -q` (20 passed)