### PR TITLE
feat(weave_ts): separate turn input and output messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,8 @@ pnpm exec tsx examples/claudeAgents.ts
 
 ### TypeScript GenAI Turn output
 
+- The existing `Turn.record({messages: [...]})` path records input messages;
+  Turn stores these separately from terminal `outputMessages`.
 - Record a terminal agent result with
   `Turn.record({outputMessages: [...]})`; `Turn.end()` serializes it onto the
   `invoke_agent` span as `gen_ai.output.messages`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,6 +317,12 @@ pnpm exec tsx examples/claudeAgents.ts
   flattened `weave.integration.meta.*` provenance. OTel scalar metadata stays
   typed; non-scalar values are stringified.
 
+### TypeScript GenAI Turn output
+
+- Record a terminal agent result with
+  `Turn.record({outputMessages: [...]})`; `Turn.end()` serializes it onto the
+  `invoke_agent` span as `gen_ai.output.messages`.
+
 ## Code Review & PR Guidelines
 
 ### PR Requirements
@@ -468,4 +474,7 @@ If there is something that doesn't make sense architecturally, devex-wise, or pr
 Think of this as the reverse-task assignment - a place where you can communicate back to us.
 
 - [ ] Add TypeScript testing guidelines
+- [ ] Add `output_messages` to Python `Turn.record()` for parity with
+      TypeScript `Turn.record({outputMessages: ...})`; the lower-level Python
+      `invoke_agent_attributes()` builder already supports agent output.
 - [ ] ...

--- a/sdks/node/src/__tests__/genai/turn.test.ts
+++ b/sdks/node/src/__tests__/genai/turn.test.ts
@@ -65,6 +65,7 @@ describe('Turn', () => {
   it('record() updates fields, which are emitted at end()', () => {
     const turn = Turn.create({agentName: 'weather-bot'});
     turn.record({
+      outputMessages: [{role: 'assistant', content: 'It is sunny.'}],
       agentId: 'weather-bot-prod',
       agentDescription: 'Looks up the weather',
       agentVersion: '1.4.2',
@@ -81,6 +82,7 @@ describe('Turn', () => {
           "gen_ai.agent.name": "weather-bot",
           "gen_ai.agent.version": "1.4.2",
           "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.output.messages": "[{"role":"assistant","content":"It is sunny."}]",
           "gen_ai.system_instructions": "[{"type":"text","content":"Be helpful"}]",
         },
         "endTime": "<timestamp>",

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -103,7 +103,7 @@ export class Turn extends SpanBase {
   private _agentDescription: string;
   private _agentVersion: string;
   private _model: string;
-  private _messages: Message[];
+  private _inputMessages: Message[];
   private _outputMessages: Message[] = [];
   private _systemInstructions: string[];
   private _attributes: Attributes;
@@ -124,7 +124,7 @@ export class Turn extends SpanBase {
     this._agentName = opts.agentName;
     this._agentDescription = opts.agentDescription;
     this._agentVersion = opts.agentVersion;
-    this._messages = opts.messages;
+    this._inputMessages = opts.messages;
     this._model = opts.model;
     this._systemInstructions = opts.systemInstructions;
     this._attributes = opts.attributes;
@@ -223,7 +223,7 @@ export class Turn extends SpanBase {
     if (this._warnIfEnded('record')) return this;
 
     if (opts.messages !== undefined) {
-      this._messages = opts.messages;
+      this._inputMessages = opts.messages;
     }
     if (opts.outputMessages !== undefined) {
       this._outputMessages = opts.outputMessages;
@@ -281,10 +281,10 @@ export class Turn extends SpanBase {
     if (this._agentVersion) {
       this.span.setAttribute(ATTR_GEN_AI_AGENT_VERSION, this._agentVersion);
     }
-    if (this._messages.length > 0) {
+    if (this._inputMessages.length > 0) {
       this.span.setAttribute(
         ATTR_GEN_AI_INPUT_MESSAGES,
-        JSON.stringify(this._messages)
+        JSON.stringify(this._inputMessages)
       );
     }
     if (this._outputMessages.length > 0) {

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -20,6 +20,7 @@ import {
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_INPUT_MESSAGES,
   ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_OUTPUT_MESSAGES,
   ATTR_GEN_AI_REQUEST_MODEL,
   ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   WEAVE_GENAI_TRACER_NAME,
@@ -103,6 +104,7 @@ export class Turn extends SpanBase {
   private _agentVersion: string;
   private _model: string;
   private _messages: Message[];
+  private _outputMessages: Message[] = [];
   private _systemInstructions: string[];
   private _attributes: Attributes;
 
@@ -210,6 +212,7 @@ export class Turn extends SpanBase {
    */
   record(opts: {
     messages?: Message[];
+    outputMessages?: Message[];
     model?: string;
     systemInstructions?: string[];
     agentId?: string;
@@ -221,6 +224,9 @@ export class Turn extends SpanBase {
 
     if (opts.messages !== undefined) {
       this._messages = opts.messages;
+    }
+    if (opts.outputMessages !== undefined) {
+      this._outputMessages = opts.outputMessages;
     }
     if (opts.model !== undefined) {
       this._model = opts.model;
@@ -279,6 +285,12 @@ export class Turn extends SpanBase {
       this.span.setAttribute(
         ATTR_GEN_AI_INPUT_MESSAGES,
         JSON.stringify(this._messages)
+      );
+    }
+    if (this._outputMessages.length > 0) {
+      this.span.setAttribute(
+        ATTR_GEN_AI_OUTPUT_MESSAGES,
+        JSON.stringify(this._outputMessages)
       );
     }
     if (this._systemInstructions.length > 0) {


### PR DESCRIPTION
## Summary

- Add `outputMessages` to `Turn.record()` for terminal agent responses.
- Keep input and output messages distinct: `messages` continues to populate `gen_ai.input.messages`, while `outputMessages` populates `gen_ai.output.messages` when the Turn ends.
- Rename the private `_messages` field to `_inputMessages` to make that distinction explicit without changing the public `record({messages})` API.
- Document the TypeScript behavior and note the follow-up needed for Python parity.

This allows an `invoke_agent` span to capture both the messages supplied to the agent and its final response instead of overloading a single message field.

## Testing

- `pnpm exec prettier --check src/genai/turn.ts src/__tests__/genai/turn.test.ts`
- `pnpm exec eslint src/genai/turn.ts src/__tests__/genai/turn.test.ts`
- `pnpm exec jest --runInBand src/__tests__/genai/turn.test.ts` (17 passed)
- `pnpm run typecheck:cjs`
- `pnpm run typecheck:esm`

## Breaking changes

None. The field rename is private, and the existing `Turn.record({messages})` API is unchanged.

## Related

Extracted from #7620 so this generic Turn capability can land first.