### PR TITLE
refactor(weave_ts): use canonical integration attributes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,14 @@ To run an example (e.g. the Claude Agent SDK demo), `dist/` must be built first
 pnpm exec tsx examples/claudeAgents.ts
 ```
 
+### TypeScript integration metadata
+
+- `sdks/node/src/integrations/integrationMetadata.ts` remains shared:
+  `asAttributes()` supplies nested provenance to Weave-call integrations, while
+  `asOtelAttributes()` supplies canonical `weave.integration.name` and
+  `weave.integration.version` identity to OTel integrations. Integration
+  `meta` remains call-only until it has a canonical OTel namespace.
+
 ## Code Review & PR Guidelines
 
 ### PR Requirements

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,8 +314,8 @@ pnpm exec tsx examples/claudeAgents.ts
   `asAttributes()` supplies nested provenance to Weave-call integrations, while
   `asOtelAttributes()` supplies canonical `weave.integration.name` and
   `weave.integration.version` identity to OTel integrations and preserves
-  flattened `integration.meta.*` provenance. OTel scalar metadata stays typed;
-  non-scalar values are stringified.
+  flattened `weave.integration.meta.*` provenance. OTel scalar metadata stays
+  typed; non-scalar values are stringified.
 
 ## Code Review & PR Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,8 +313,9 @@ pnpm exec tsx examples/claudeAgents.ts
 - `sdks/node/src/integrations/integrationMetadata.ts` remains shared:
   `asAttributes()` supplies nested provenance to Weave-call integrations, while
   `asOtelAttributes()` supplies canonical `weave.integration.name` and
-  `weave.integration.version` identity to OTel integrations. Integration
-  `meta` remains call-only until it has a canonical OTel namespace.
+  `weave.integration.version` identity to OTel integrations and preserves
+  flattened `integration.meta.*` provenance. OTel scalar metadata stays typed;
+  non-scalar values are stringified.
 
 ## Code Review & PR Guidelines
 

--- a/sdks/node/src/__tests__/integrationMetadata.test.ts
+++ b/sdks/node/src/__tests__/integrationMetadata.test.ts
@@ -42,17 +42,15 @@ describe('integration metadata builders', () => {
     expect(asAttributes(m).integration.meta.package_name).toBe('x');
   });
 
-  test('asOtelAttributes flattens to dotted keys', () => {
+  test('asOtelAttributes renders canonical Weave integration identity', () => {
     const m: IntegrationMetadata = {
       name: 'openai_agents',
       version: '1',
       meta: {package_name: 'p', package_version: '2'},
     };
     expect(asOtelAttributes(m)).toEqual({
-      'integration.name': 'openai_agents',
-      'integration.version': '1',
-      'integration.meta.package_name': 'p',
-      'integration.meta.package_version': '2',
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': '1',
     });
   });
 });

--- a/sdks/node/src/__tests__/integrationMetadata.test.ts
+++ b/sdks/node/src/__tests__/integrationMetadata.test.ts
@@ -42,15 +42,22 @@ describe('integration metadata builders', () => {
     expect(asAttributes(m).integration.meta.package_name).toBe('x');
   });
 
-  test('asOtelAttributes renders canonical Weave integration identity', () => {
+  test('asOtelAttributes renders canonical identity and flattened metadata', () => {
     const m: IntegrationMetadata = {
       name: 'openai_agents',
       version: '1',
-      meta: {package_name: 'p', package_version: '2'},
+      meta: {
+        package_name: 'p',
+        package_version: '2',
+        options: {debug: true},
+      },
     };
     expect(asOtelAttributes(m)).toEqual({
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': '1',
+      'integration.meta.package_name': 'p',
+      'integration.meta.package_version': '2',
+      'integration.meta.options': '[object Object]',
     });
   });
 });

--- a/sdks/node/src/__tests__/integrationMetadata.test.ts
+++ b/sdks/node/src/__tests__/integrationMetadata.test.ts
@@ -55,9 +55,9 @@ describe('integration metadata builders', () => {
     expect(asOtelAttributes(m)).toEqual({
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': '1',
-      'integration.meta.package_name': 'p',
-      'integration.meta.package_version': '2',
-      'integration.meta.options': '[object Object]',
+      'weave.integration.meta.package_name': 'p',
+      'weave.integration.meta.package_version': '2',
+      'weave.integration.meta.options': '[object Object]',
     });
   });
 });

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -422,9 +422,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.agent.handoffs': ['h1'],
       'weave.openai_agents.agent.output_type': 'text',
       'weave.openai_agents.span_id': 'span-agent',
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
 
     const executeToolSpan = spans.find(
@@ -438,9 +437,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.tool.call.arguments': '{"city":"Tokyo"}',
       'gen_ai.tool.call.result': 'sunny, 22C',
       'weave.openai_agents.span_id': 'span-function',
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
 
     const resp = spans.find(s => s.name === 'chat gpt-4o-mini')!;
@@ -457,9 +455,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.usage.output_tokens': 7,
       'gen_ai.usage.cache_read.input_tokens': 4,
       'gen_ai.usage.reasoning.output_tokens': 3,
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
     expect(resp.attributes['gen_ai.input.messages']).toMatchInlineSnapshot(
       `"[{"role":"user","parts":[{"type":"text","content":"What is the weather in Tokyo?"}]}]"`
@@ -488,9 +485,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.request.seed': 42,
       'gen_ai.request.stop_sequences': ['STOP'],
       'gen_ai.request.choice.count': 3,
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
     expect(gen.attributes['gen_ai.input.messages']).toMatchInlineSnapshot(
       `"[{"role":"user","parts":[{"type":"text","content":"hi"}]}]"`
@@ -507,9 +503,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.handoff.from_agent': 'Triage',
       'weave.openai_agents.handoff.to_agent': 'Specialist',
       'weave.openai_agents.span_id': 'span-handoff',
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
     expect(handoff.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -520,9 +515,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.guardrail.name': 'test-guardrail',
       'weave.openai_agents.guardrail.triggered': false,
       'weave.openai_agents.span_id': 'span-guardrail',
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
     expect(guard.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -535,9 +529,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.transcription.input_format': 'pcm',
       'weave.openai_agents.transcription.output': 'hello world',
       'weave.openai_agents.span_id': 'span-transcription',
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
     expect(transcription.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -550,9 +543,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.speech.output': 'base64audio',
       'weave.openai_agents.speech.output_format': 'pcm',
       'weave.openai_agents.span_id': 'span-speech',
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
     expect(speech.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -562,9 +554,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.conversation.id': 'some-conversation-id',
       'weave.openai_agents.speech_group.input': 'narration script',
       'weave.openai_agents.span_id': 'span-speech-group',
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
     expect(speechGroup.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -575,9 +566,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.mcp.server': 'http://localhost:9000',
       'weave.openai_agents.mcp.result': ['search', 'fetch'],
       'weave.openai_agents.span_id': 'span-mcp',
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
     expect(mcp.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -589,9 +579,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.custom.kind': 'cache_lookup',
       'weave.openai_agents.custom.hits': 3,
       'weave.openai_agents.span_id': 'span-custom',
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
     // Null values dropped — `miss: null` doesn't produce an attribute.
     expect(
@@ -666,9 +655,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.conversation.id': 'some-conversation-id',
       'gen_ai.provider.name': 'openai',
       'weave.openai_agents.agent.tools': ['get_weather'],
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
 
     const executeToolSpan = spans.find(
@@ -684,9 +672,8 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       // on the FunctionSpanData, which we lift straight to semconv.
       'gen_ai.tool.call.arguments': '{"city":"Tokyo"}',
       'gen_ai.tool.call.result': 'Tokyo: Sunny, 22°C',
-      'integration.meta.package_name': '@openai/agents',
-      'integration.name': 'openai_agents',
-      'integration.version': packageVersion,
+      'weave.integration.name': 'openai_agents',
+      'weave.integration.version': packageVersion,
     });
     // Span is a child of the agent span.
     expect(executeToolSpan.parentSpanId).toBe(agentSpan!.spanContext().spanId);

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -424,7 +424,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-agent',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
 
     const executeToolSpan = spans.find(
@@ -440,7 +440,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-function',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
 
     const resp = spans.find(s => s.name === 'chat gpt-4o-mini')!;
@@ -459,7 +459,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.usage.reasoning.output_tokens': 3,
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
     expect(resp.attributes['gen_ai.input.messages']).toMatchInlineSnapshot(
       `"[{"role":"user","parts":[{"type":"text","content":"What is the weather in Tokyo?"}]}]"`
@@ -490,7 +490,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.request.choice.count': 3,
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
     expect(gen.attributes['gen_ai.input.messages']).toMatchInlineSnapshot(
       `"[{"role":"user","parts":[{"type":"text","content":"hi"}]}]"`
@@ -509,7 +509,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-handoff',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
     expect(handoff.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -522,7 +522,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-guardrail',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
     expect(guard.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -537,7 +537,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-transcription',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
     expect(transcription.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -552,7 +552,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-speech',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
     expect(speech.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -564,7 +564,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-speech-group',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
     expect(speechGroup.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -577,7 +577,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-mcp',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
     expect(mcp.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -591,7 +591,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-custom',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
     // Null values dropped — `miss: null` doesn't produce an attribute.
     expect(
@@ -668,7 +668,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.agent.tools': ['get_weather'],
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
 
     const executeToolSpan = spans.find(
@@ -686,7 +686,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.tool.call.result': 'Tokyo: Sunny, 22°C',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
-      'integration.meta.package_name': '@openai/agents',
+      'weave.integration.meta.package_name': '@openai/agents',
     });
     // Span is a child of the agent span.
     expect(executeToolSpan.parentSpanId).toBe(agentSpan!.spanContext().spanId);

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -424,6 +424,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-agent',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
 
     const executeToolSpan = spans.find(
@@ -439,6 +440,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-function',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
 
     const resp = spans.find(s => s.name === 'chat gpt-4o-mini')!;
@@ -457,6 +459,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.usage.reasoning.output_tokens': 3,
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
     expect(resp.attributes['gen_ai.input.messages']).toMatchInlineSnapshot(
       `"[{"role":"user","parts":[{"type":"text","content":"What is the weather in Tokyo?"}]}]"`
@@ -487,6 +490,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.request.choice.count': 3,
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
     expect(gen.attributes['gen_ai.input.messages']).toMatchInlineSnapshot(
       `"[{"role":"user","parts":[{"type":"text","content":"hi"}]}]"`
@@ -505,6 +509,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-handoff',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
     expect(handoff.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -517,6 +522,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-guardrail',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
     expect(guard.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -531,6 +537,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-transcription',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
     expect(transcription.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -545,6 +552,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-speech',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
     expect(speech.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -556,6 +564,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-speech-group',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
     expect(speechGroup.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -568,6 +577,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-mcp',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
     expect(mcp.attributes['gen_ai.operation.name']).toBeUndefined();
 
@@ -581,6 +591,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.span_id': 'span-custom',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
     // Null values dropped — `miss: null` doesn't produce an attribute.
     expect(
@@ -657,6 +668,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.agent.tools': ['get_weather'],
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
 
     const executeToolSpan = spans.find(
@@ -674,6 +686,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.tool.call.result': 'Tokyo: Sunny, 22°C',
       'weave.integration.name': 'openai_agents',
       'weave.integration.version': packageVersion,
+      'integration.meta.package_name': '@openai/agents',
     });
     // Span is a child of the agent span.
     expect(executeToolSpan.parentSpanId).toBe(agentSpan!.spanContext().spanId);

--- a/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
@@ -10,6 +10,7 @@ import type {
   PiExtensionApi,
   PiExtensionContext,
 } from '../../integrations/piCodingAgent.types';
+import {packageVersion} from '../../utils/packageVersion';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -115,23 +116,18 @@ describe('PiCodingAgentOtelAdapter', () => {
         'test-session-id'
       );
       expect(span!.attributes['pi.session.cwd']).toBe('/home/user/project');
-      // Integration-tracking metadata is stamped on every span this
-      // integration emits. OTel attributes are scalars, so the nested
-      // `integration` shape is flattened to dotted keys.
       const stamped = exporter
         .getFinishedSpans()
-        .filter(s => s.attributes['integration.name'] !== undefined);
+        .filter(s => s.attributes['weave.integration.name'] !== undefined);
       expect(stamped.length).toBeGreaterThan(0);
       expect(
         stamped.every(
-          s => s.attributes['integration.name'] === 'pi_coding_agent'
+          s => s.attributes['weave.integration.name'] === 'pi_coding_agent'
         )
       ).toBe(true);
       expect(
         stamped.every(
-          s =>
-            s.attributes['integration.meta.package_name'] ===
-            '@pi-dev/coding-agent'
+          s => s.attributes['weave.integration.version'] === packageVersion
         )
       ).toBe(true);
     });

--- a/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
@@ -130,6 +130,13 @@ describe('PiCodingAgentOtelAdapter', () => {
           s => s.attributes['weave.integration.version'] === packageVersion
         )
       ).toBe(true);
+      expect(
+        stamped.every(
+          s =>
+            s.attributes['integration.meta.package_name'] ===
+            '@pi-dev/coding-agent'
+        )
+      ).toBe(true);
     });
 
     it('emits one trace per prompt, linked by conversation id', () => {

--- a/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
@@ -133,7 +133,7 @@ describe('PiCodingAgentOtelAdapter', () => {
       expect(
         stamped.every(
           s =>
-            s.attributes['integration.meta.package_name'] ===
+            s.attributes['weave.integration.meta.package_name'] ===
             '@pi-dev/coding-agent'
         )
       ).toBe(true);

--- a/sdks/node/src/genai/semconv.ts
+++ b/sdks/node/src/genai/semconv.ts
@@ -92,6 +92,10 @@ export const ATTR_GEN_AI_USAGE_TOTAL_TOKENS = 'gen_ai.usage.total_tokens';
  *  (e.g. on `gen_ai.system.message`). */
 export const ATTR_GEN_AI_EVENT_CONTENT = 'gen_ai.event.content';
 
+// Unlike gen_ai.agent.name, conversation-scoped integration identity is fixed and inherited by every span.
+export const WEAVE_INTEGRATION_NAME = 'weave.integration.name';
+export const WEAVE_INTEGRATION_VERSION = 'weave.integration.version';
+
 // ---------------------------------------------------------------------------
 // Emitter identity (Weave-specific, not a semconv constant)
 // ---------------------------------------------------------------------------

--- a/sdks/node/src/genai/semconv.ts
+++ b/sdks/node/src/genai/semconv.ts
@@ -93,6 +93,7 @@ export const ATTR_GEN_AI_USAGE_TOTAL_TOKENS = 'gen_ai.usage.total_tokens';
 export const ATTR_GEN_AI_EVENT_CONTENT = 'gen_ai.event.content';
 
 // Unlike gen_ai.agent.name, conversation-scoped integration identity is fixed and inherited by every span.
+export const WEAVE_INTEGRATION_META_PREFIX = 'weave.integration.meta';
 export const WEAVE_INTEGRATION_NAME = 'weave.integration.name';
 export const WEAVE_INTEGRATION_VERSION = 'weave.integration.version';
 

--- a/sdks/node/src/integrations/integrationMetadata.ts
+++ b/sdks/node/src/integrations/integrationMetadata.ts
@@ -13,6 +13,10 @@
  *     }
  *   }
  */
+import {
+  WEAVE_INTEGRATION_NAME,
+  WEAVE_INTEGRATION_VERSION,
+} from '../genai/semconv';
 import {packageVersion as weavePackageVersion} from '../utils/packageVersion';
 
 /** Top-level attribute key under which integration provenance is stored. */
@@ -85,27 +89,15 @@ export function asAttributes(
 }
 
 /**
- * Render the metadata as flattened OpenTelemetry span attributes. OTel
- * attributes must be scalars, so the nested shape is flattened to dotted keys
- * (`integration.name`, `integration.version`, `integration.meta.<key>`). Used
- * by the agent OTel integrations that emit spans instead of Weave calls. The
- * trace server reconstructs the nested `integration` dict on ingest.
+ * Render the canonical Weave integration identity for OpenTelemetry spans.
+ * Integration-specific metadata remains available to call-based integrations
+ * through `asAttributes()` until it has a canonical OTel attribute namespace.
  */
 export function asOtelAttributes(
   metadata: IntegrationMetadata
 ): Record<string, string | number | boolean> {
-  const attributes: Record<string, string | number | boolean> = {
-    [`${INTEGRATION_ATTRIBUTE_KEY}.name`]: metadata.name,
-    [`${INTEGRATION_ATTRIBUTE_KEY}.version`]: metadata.version,
+  return {
+    [WEAVE_INTEGRATION_NAME]: metadata.name,
+    [WEAVE_INTEGRATION_VERSION]: metadata.version,
   };
-  for (const [key, value] of Object.entries(metadata.meta)) {
-    const scalar =
-      typeof value === 'string' ||
-      typeof value === 'number' ||
-      typeof value === 'boolean';
-    attributes[`${INTEGRATION_ATTRIBUTE_KEY}.meta.${key}`] = scalar
-      ? value
-      : String(value);
-  }
-  return attributes;
 }

--- a/sdks/node/src/integrations/integrationMetadata.ts
+++ b/sdks/node/src/integrations/integrationMetadata.ts
@@ -89,15 +89,25 @@ export function asAttributes(
 }
 
 /**
- * Render the canonical Weave integration identity for OpenTelemetry spans.
- * Integration-specific metadata remains available to call-based integrations
- * through `asAttributes()` until it has a canonical OTel attribute namespace.
+ * Render canonical Weave integration identity plus flattened integration
+ * metadata for OpenTelemetry spans. OTel attributes must be scalars, so
+ * non-scalar metadata values are stringified.
  */
 export function asOtelAttributes(
   metadata: IntegrationMetadata
 ): Record<string, string | number | boolean> {
-  return {
+  const attributes: Record<string, string | number | boolean> = {
     [WEAVE_INTEGRATION_NAME]: metadata.name,
     [WEAVE_INTEGRATION_VERSION]: metadata.version,
   };
+  for (const [key, value] of Object.entries(metadata.meta)) {
+    const scalar =
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean';
+    attributes[`${INTEGRATION_ATTRIBUTE_KEY}.meta.${key}`] = scalar
+      ? value
+      : String(value);
+  }
+  return attributes;
 }

--- a/sdks/node/src/integrations/integrationMetadata.ts
+++ b/sdks/node/src/integrations/integrationMetadata.ts
@@ -14,6 +14,7 @@
  *   }
  */
 import {
+  WEAVE_INTEGRATION_META_PREFIX,
   WEAVE_INTEGRATION_NAME,
   WEAVE_INTEGRATION_VERSION,
 } from '../genai/semconv';
@@ -105,7 +106,7 @@ export function asOtelAttributes(
       typeof value === 'string' ||
       typeof value === 'number' ||
       typeof value === 'boolean';
-    attributes[`${INTEGRATION_ATTRIBUTE_KEY}.meta.${key}`] = scalar
+    attributes[`${WEAVE_INTEGRATION_META_PREFIX}.${key}`] = scalar
       ? value
       : String(value);
   }


### PR DESCRIPTION
## Summary

- render OTel integration identity with `weave.integration.name` and `weave.integration.version`
- emit flattened integration provenance under `weave.integration.meta.*`
- preserve typed scalar metadata values and stringify non-scalars
- define the shared canonical integration constants at the base of the stack
- update the shared helper and the OpenAI Agents and Pi Coding Agent expectations

## Testing

- targeted integration metadata, OpenAI Agents, and Pi Coding Agent Jest suites: 33 tests and 7 snapshots
- targeted ESLint and Prettier
- `pnpm run typecheck:esm`
- `pnpm run typecheck:cjs`

## Breaking changes

No public TypeScript API changes. Raw OTel consumers must migrate integration identity and metadata from `integration.*` to `weave.integration.*`.

## Related

Base of the stack for #7624 and #7620. Supersedes #7626, which GitHub marked merged while the branch ancestry was inverted.