### PR TITLE
fix(weave_ts): trace Claude Agent SDK multi-turn queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,8 @@ pnpm exec tsx examples/claudeAgents.ts
   without typed `record()` methods.
 - The Claude Agent SDK integration keeps each `Tool` open until its matching
   `tool_result`.
+- For streamed sessions, queue observed user inputs in FIFO order and close one
+  `Turn` for each matching SDK `result`.
 
 ## Code Review & PR Guidelines
 

--- a/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
+++ b/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
@@ -150,6 +150,18 @@ function userToolResult(opts: {
   };
 }
 
+function userPrompt(opts: {
+  content: string;
+  sessionId?: string;
+}): SDKUserMessage {
+  return {
+    type: 'user',
+    session_id: opts.sessionId,
+    parent_tool_use_id: null,
+    message: {role: 'user', content: opts.content},
+  };
+}
+
 // Build one model's usage; the tracer only reads the four token fields, so the
 // rest (cost, context window, …) default to 0.
 const modelUsage = (u: Partial<ModelUsage>): ModelUsage => ({
@@ -385,6 +397,86 @@ describe('Claude Agent SDK — OTel tracer', () => {
     const traceId = invoke.spanContext().traceId;
     expect(chat.spanContext().traceId).toBe(traceId);
     expect(tool.spanContext().traceId).toBe(traceId);
+  });
+
+  test('emits one invoke_agent root per streaming-input turn', () => {
+    const tracer = new ClaudeAgentOtelTracer();
+
+    tracer.processInput(userPrompt({content: 'first question'}));
+    tracer.processInput(userPrompt({content: 'second question'}));
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-multi',
+        model: 'claude-first',
+        content: [textBlock('first response')],
+      })
+    );
+    tracer.processMessage(
+      resultSuccess({
+        sessionId: 'sess-multi',
+        result: 'first result',
+        modelUsage: {
+          'claude-first': modelUsage({inputTokens: 2, outputTokens: 3}),
+        },
+      })
+    );
+
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-multi',
+        model: 'claude-second',
+        content: [textBlock('second response')],
+      })
+    );
+    tracer.processMessage(
+      resultSuccess({
+        sessionId: 'sess-multi',
+        result: 'second result',
+        modelUsage: {
+          'claude-second': modelUsage({inputTokens: 5, outputTokens: 7}),
+        },
+      })
+    );
+    tracer.finalize();
+
+    const spans = getExporter().getFinishedSpans();
+    const roots = spans.filter(span => span.name === INVOKE);
+    expect(roots).toHaveLength(2);
+    expect(
+      roots.map(root => ({
+        conversationId: root.attributes[ATTR_GEN_AI_CONVERSATION_ID],
+        input: JSON.parse(
+          root.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string
+        ),
+        output: JSON.parse(
+          root.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string
+        ),
+      }))
+    ).toEqual([
+      {
+        conversationId: 'sess-multi',
+        input: [{role: 'user', content: 'first question'}],
+        output: [{role: 'assistant', content: 'first result'}],
+      },
+      {
+        conversationId: 'sess-multi',
+        input: [{role: 'user', content: 'second question'}],
+        output: [{role: 'assistant', content: 'second result'}],
+      },
+    ]);
+    expect(roots[0].spanContext().traceId).not.toBe(
+      roots[1].spanContext().traceId
+    );
+
+    const contentChats = spans.filter(
+      span =>
+        span.name === 'chat' &&
+        span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] !== undefined
+    );
+    expect(contentChats.map(span => span.parentSpanId)).toEqual([
+      roots[0].spanContext().spanId,
+      roots[1].spanContext().spanId,
+    ]);
   });
 
   test('emits one usage chat span per model, preserving the per-model split', () => {

--- a/sdks/node/src/__tests__/integrations/claudeAgentSdk.test.ts
+++ b/sdks/node/src/__tests__/integrations/claudeAgentSdk.test.ts
@@ -129,6 +129,159 @@ describe('Claude Agent SDK — query() patch', () => {
     expect(spans.some(s => s.name === 'chat')).toBe(true);
   });
 
+  test('streaming input emits one root per user turn', async () => {
+    async function* prompts() {
+      yield {
+        type: 'user',
+        message: {role: 'user', content: 'first question'},
+        parent_tool_use_id: null,
+      };
+      yield {
+        type: 'user',
+        message: {role: 'user', content: 'second question'},
+        parent_tool_use_id: null,
+      };
+    }
+
+    const sdk = {
+      query: ({prompt}: {prompt: AsyncIterable<any>}) => {
+        async function* gen() {
+          let turn = 0;
+          for await (const _input of prompt) {
+            turn += 1;
+            yield {
+              type: 'assistant',
+              session_id: 'sess-multi',
+              message: {
+                model: `claude-${turn}`,
+                content: [{type: 'text', text: `response-${turn}`}],
+              },
+            };
+            yield {
+              type: 'result',
+              subtype: 'success',
+              session_id: 'sess-multi',
+              is_error: false,
+              result: `result-${turn}`,
+              total_cost_usd: turn / 100,
+              modelUsage: {
+                [`claude-${turn}`]: {
+                  inputTokens: turn,
+                  outputTokens: turn + 1,
+                  cacheReadInputTokens: 0,
+                  cacheCreationInputTokens: 0,
+                },
+              },
+            };
+          }
+        }
+        return gen() as any;
+      },
+    };
+    patchClaudeAgentSdk(sdk);
+
+    const query = sdk.query({prompt: prompts()});
+    await expect(query.next()).resolves.toMatchObject({
+      value: {type: 'assistant'},
+      done: false,
+    });
+    await expect(query.next()).resolves.toMatchObject({
+      value: {type: 'result', result: 'result-1'},
+      done: false,
+    });
+    expect(
+      getExporter()
+        .getFinishedSpans()
+        .filter(span => span.name === INVOKE)
+    ).toHaveLength(1);
+
+    for await (const _message of query) {
+      void _message;
+    }
+
+    const roots = getExporter()
+      .getFinishedSpans()
+      .filter(span => span.name === INVOKE);
+    expect(roots).toHaveLength(2);
+    expect(
+      roots.map(root => ({
+        conversationId: root.attributes[ATTR_GEN_AI_CONVERSATION_ID],
+        input: JSON.parse(
+          root.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string
+        ),
+        output: JSON.parse(
+          root.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string
+        ),
+      }))
+    ).toEqual([
+      {
+        conversationId: 'sess-multi',
+        input: [{role: 'user', content: 'first question'}],
+        output: [{role: 'assistant', content: 'result-1'}],
+      },
+      {
+        conversationId: 'sess-multi',
+        input: [{role: 'user', content: 'second question'}],
+        output: [{role: 'assistant', content: 'result-2'}],
+      },
+    ]);
+  });
+
+  test('traces user messages sent through Query.streamInput()', async () => {
+    const streamInput = jest.fn(async (stream: AsyncIterable<any>) => {
+      for await (const _message of stream) {
+        void _message;
+      }
+    });
+    const sdk = fakeSdk(
+      [
+        {
+          type: 'assistant',
+          session_id: 'sess-stream-input',
+          message: {
+            model: 'claude-x',
+            content: [{type: 'text', text: 'response'}],
+          },
+        },
+        {
+          type: 'result',
+          subtype: 'success',
+          session_id: 'sess-stream-input',
+          is_error: false,
+          result: 'done',
+          modelUsage: {},
+        },
+      ],
+      {streamInput}
+    );
+    patchClaudeAgentSdk(sdk);
+
+    const emptyPrompt: AsyncIterable<any> = {
+      [Symbol.asyncIterator]: () => ({
+        next: async () => ({done: true, value: undefined}),
+      }),
+    };
+    async function* nextTurn() {
+      yield {
+        type: 'user',
+        message: {role: 'user', content: 'sent later'},
+        parent_tool_use_id: null,
+      };
+    }
+
+    const query = sdk.query({prompt: emptyPrompt});
+    await query.streamInput(nextTurn());
+    for await (const _message of query) {
+      void _message;
+    }
+
+    expect(streamInput).toHaveBeenCalledTimes(1);
+    const root = findSpan(getExporter().getFinishedSpans(), INVOKE);
+    expect(
+      JSON.parse(root.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string)
+    ).toEqual([{role: 'user', content: 'sent later'}]);
+  });
+
   test('forwards Query interface methods (e.g. interrupt) to the underlying query', async () => {
     const interrupt = jest.fn(async () => {});
     const sdk = fakeSdk(

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -1,6 +1,7 @@
 import {
   Conversation,
   runIsolated,
+  type Message,
   type MessagePart,
   type Tool,
   type Turn,
@@ -80,6 +81,33 @@ function toolResultText(content: ToolResultBlock['content']): string {
   return text || JSON.stringify(content);
 }
 
+function userInputMessage(msg: SDKUserMessage): Message {
+  const content = msg.message.content;
+  if (typeof content === 'string') {
+    return {role: 'user', content};
+  }
+
+  const parts: MessagePart[] = [];
+  for (const block of content) {
+    if (block.type === 'text') {
+      parts.push({type: 'text', content: block.text});
+    } else if (block.type === 'tool_result') {
+      parts.push({
+        type: 'tool_result',
+        toolCallId: block.tool_use_id,
+        result: toolResultText(block.content),
+      });
+    } else {
+      return {role: 'user', content: JSON.stringify(content)};
+    }
+  }
+
+  if (parts.length === 1 && parts[0].type === 'text') {
+    return {role: 'user', content: parts[0].content};
+  }
+  return {role: 'user', parts};
+}
+
 type NormalizedUsage = {
   usage: Usage;
   totalTokens: number;
@@ -131,31 +159,72 @@ type ClaudeAgentOtelTracerOptions = {
   agent?: string;
 };
 
+type PendingTurn = {
+  inputMessages: Message[];
+  startedAt: Date;
+};
+
 /** Emits Claude Agent SDK traces through Weave GenAI handles. */
 export class ClaudeAgentOtelTracer {
   private readonly agentName: string;
-  private readonly prompt: string | undefined;
   private readonly startedAt = new Date();
   private readonly openTools = new Map<string, Tool>();
+  private readonly pendingTurns: PendingTurn[] = [];
 
-  private turn: Turn | null = null;
+  private conversation: Conversation | null = null;
+  private conversationId: string | undefined;
+  private activeTurn: Turn | null = null;
+  private bufferedInputMessages: Message[] = [];
+  private bufferedTurnStartedAt: Date | null = null;
+  private completedTurns = 0;
   private rootModel: string | null = null;
   private finished = false;
 
   constructor(opts: ClaudeAgentOtelTracerOptions = {}) {
     this.agentName = opts.agent || AGENT_NAME;
-    this.prompt = opts.prompt;
+    if (opts.prompt != null) {
+      this.pendingTurns.push({
+        inputMessages: [{role: 'user', content: opts.prompt}],
+        startedAt: this.startedAt,
+      });
+    }
+  }
+
+  processInput(msg: SDKUserMessage): void {
+    if (this.finished) {
+      return;
+    }
+    this.rememberConversationId(msg.session_id);
+    if (this.bufferedTurnStartedAt == null) {
+      this.bufferedTurnStartedAt = new Date();
+    }
+    this.bufferedInputMessages.push(userInputMessage(msg));
+
+    if (msg.shouldQuery !== false) {
+      this.pendingTurns.push({
+        inputMessages: this.bufferedInputMessages,
+        startedAt: this.bufferedTurnStartedAt,
+      });
+      this.bufferedInputMessages = [];
+      this.bufferedTurnStartedAt = null;
+    }
   }
 
   processMessage(msg: SDKMessage): void {
-    const turn = this.getOrCreateTurn(msg.session_id);
+    if (this.finished) {
+      return;
+    }
+    this.rememberConversationId(msg.session_id);
 
     switch (msg.type) {
       case 'assistant':
-        this.processAssistant(msg, turn);
+        this.processAssistant(msg, this.getOrCreateTurn());
         break;
       case 'user':
         this.processUser(msg);
+        break;
+      case 'result':
+        this.endTurn(msg);
         break;
       default:
         break;
@@ -166,10 +235,24 @@ export class ClaudeAgentOtelTracer {
     if (this.finished) {
       return;
     }
+
+    if (result) {
+      this.processMessage(result);
+    }
     this.finished = true;
 
-    const turn = this.getOrCreateTurn(result?.session_id);
+    if (
+      this.activeTurn ||
+      this.pendingTurns.length > 0 ||
+      this.bufferedInputMessages.length > 0 ||
+      this.completedTurns === 0
+    ) {
+      this.endTurn(undefined, error);
+    }
+  }
 
+  private endTurn(result?: SDKResultMessage, error?: unknown): void {
+    const turn = this.getOrCreateTurn();
     for (const tool of this.openTools.values()) {
       tool.setAttributes({[ATTR_ERROR_TYPE]: 'aborted'});
       tool.end({error: new Error('Agent ended with open tool span')});
@@ -198,33 +281,74 @@ export class ClaudeAgentOtelTracer {
     } else {
       turn.end();
     }
+
+    this.activeTurn = null;
+    this.rootModel = null;
+    this.completedTurns += 1;
   }
 
-  private getOrCreateTurn(conversationId: string | undefined): Turn {
-    if (this.turn) {
-      return this.turn;
+  private rememberConversationId(conversationId: string | undefined): void {
+    if (this.conversationId == null && conversationId) {
+      this.conversationId = conversationId;
+    }
+  }
+
+  private getOrCreateConversation(): Conversation {
+    if (this.conversation) {
+      return this.conversation;
     }
 
-    // Defer conversation creation without losing the query start time.
-    this.turn = runIsolated(() => {
-      const conversation = Conversation.create({
+    this.conversation = runIsolated(() =>
+      Conversation.create({
         agentName: this.agentName,
-        conversationId: conversationId ?? '',
+        conversationId: this.conversationId ?? '',
         attributes: CLAUDE_AGENT_SDK_ATTRIBUTES,
-      });
-      return conversation.startTurn({
-        startTime: this.startedAt,
-      });
-    });
-    this.turn.setAttributes({
+      })
+    );
+    return this.conversation;
+  }
+
+  private nextPendingTurn(): PendingTurn {
+    const pending = this.pendingTurns.shift();
+    if (pending) {
+      return pending;
+    }
+    if (this.bufferedTurnStartedAt) {
+      const buffered = {
+        inputMessages: this.bufferedInputMessages,
+        startedAt: this.bufferedTurnStartedAt,
+      };
+      this.bufferedInputMessages = [];
+      this.bufferedTurnStartedAt = null;
+      return buffered;
+    }
+    return {
+      inputMessages: [],
+      startedAt: this.completedTurns === 0 ? this.startedAt : new Date(),
+    };
+  }
+
+  private getOrCreateTurn(): Turn {
+    if (this.activeTurn) {
+      return this.activeTurn;
+    }
+
+    const pending = this.nextPendingTurn();
+    const conversation = this.getOrCreateConversation();
+    this.activeTurn = runIsolated(() =>
+      conversation.startTurn({
+        startTime: pending.startedAt,
+      })
+    );
+    this.activeTurn.setAttributes({
       [ATTR_GEN_AI_PROVIDER_NAME]: PROVIDER_NAME,
     });
-    if (this.prompt != null) {
-      this.turn.record({
-        messages: [{role: 'user', content: this.prompt}],
+    if (pending.inputMessages.length > 0) {
+      this.activeTurn.record({
+        messages: pending.inputMessages,
       });
     }
-    return this.turn;
+    return this.activeTurn;
   }
 
   private emitModelUsageSpans(result: SDKResultMessage, turn: Turn): void {

--- a/sdks/node/src/integrations/claudeAgentSdk.ts
+++ b/sdks/node/src/integrations/claudeAgentSdk.ts
@@ -13,10 +13,6 @@
  *
  * Instrumentation is automatic via the CJS/ESM module hooks (registered from
  * `integrations/hooks.ts`), the same mechanism used by the other integrations.
- *
- * Out of scope for now (tracked as a follow-up): multi-turn / streaming-input
- * sessions (`query({prompt: <AsyncIterable>})` / `Query.streamInput`) get a
- * single root turn rather than one per turn.
  */
 import {getGlobalClient} from '../clientApi';
 import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
@@ -41,6 +37,20 @@ const GENERATOR_MEMBERS = new Set<PropertyKey>([
   'throw',
 ]);
 
+async function* tracedInput(
+  stream: AsyncIterable<ClaudeAgentSdk.SDKUserMessage>,
+  tracer: ClaudeAgentOtelTracer
+): AsyncGenerator<ClaudeAgentSdk.SDKUserMessage> {
+  for await (const message of stream) {
+    try {
+      tracer.processInput(message);
+    } catch (err) {
+      console.warn('weave: claude_agent_sdk tracing error (ignored)', err);
+    }
+    yield message;
+  }
+}
+
 /**
  * Wrap a `query()` so that iterating its result drives a {@link ClaudeAgentOtelTracer}.
  * The returned object preserves the full `Query` interface: iteration is traced,
@@ -49,35 +59,37 @@ const GENERATOR_MEMBERS = new Set<PropertyKey>([
  */
 function wrapQuery(originalQuery: QueryFn): QueryFn {
   return function patchedQuery(args) {
-    const realQuery = originalQuery(args);
     const client = getGlobalClient();
-    if (!client || realQuery == null) {
-      return realQuery;
+    if (!client) {
+      return originalQuery(args);
     }
 
     const prompt = typeof args?.prompt === 'string' ? args.prompt : undefined;
     // gen_ai.agent.name follows the caller's main-thread agent when named.
     const agent = args?.options?.agent;
     const tracer = new ClaudeAgentOtelTracer({prompt, agent});
+    const tracedArgs =
+      typeof args.prompt === 'string'
+        ? args
+        : {...args, prompt: tracedInput(args.prompt, tracer)};
+    const realQuery = originalQuery(tracedArgs);
+    if (realQuery == null) {
+      return realQuery;
+    }
 
     async function* traced(): AsyncGenerator<unknown, void> {
-      let result: ClaudeAgentSdk.SDKResultMessage | undefined;
       let streamError: unknown;
       try {
         for await (const msg of realQuery) {
-          if (msg && msg.type === 'result') {
-            result = msg;
-          } else {
-            // Tracing must never break the caller's stream: swallow any
-            // mapping error (the message is still yielded below).
-            try {
-              tracer.processMessage(msg);
-            } catch (err) {
-              console.warn(
-                'weave: claude_agent_sdk tracing error (ignored)',
-                err
-              );
-            }
+          // Tracing must never break the caller's stream: swallow any
+          // mapping error (the message is still yielded below).
+          try {
+            tracer.processMessage(msg);
+          } catch (err) {
+            console.warn(
+              'weave: claude_agent_sdk tracing error (ignored)',
+              err
+            );
           }
           yield msg;
         }
@@ -91,7 +103,7 @@ function wrapQuery(originalQuery: QueryFn): QueryFn {
         // Guard finalize too, so a tracing failure can't mask the real stream
         // error being re-thrown from the catch above.
         try {
-          tracer.finalize(result, streamError);
+          tracer.finalize(undefined, streamError);
         } catch (err) {
           console.warn('weave: claude_agent_sdk finalize error (ignored)', err);
         }
@@ -101,6 +113,13 @@ function wrapQuery(originalQuery: QueryFn): QueryFn {
     const wrapped = traced();
     return new Proxy(wrapped, {
       get(target, prop, receiver) {
+        if (prop === 'streamInput') {
+          const value = Reflect.get(realQuery, prop, realQuery);
+          return typeof value === 'function'
+            ? (stream: AsyncIterable<ClaudeAgentSdk.SDKUserMessage>) =>
+                value.call(realQuery, tracedInput(stream, tracer))
+            : value;
+        }
         if (GENERATOR_MEMBERS.has(prop)) {
           const value = Reflect.get(target, prop, receiver);
           return typeof value === 'function' ? value.bind(target) : value;


### PR DESCRIPTION
## Summary

- Trace one Claude Agent SDK `Conversation` per query session and one `Turn` per user-to-result cycle.
- Capture initial async prompts and streamed follow-ups in FIFO order, closing each turn with its output, usage, cost, tools, and model state while preserving single-turn behavior.

## Testing

- `pnpm test -- --runInBand src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts src/__tests__/integrations/claudeAgentSdk.test.ts` (21 tests)
- `pnpm run lint`
- `pnpm run prettier-check`
- `pnpm run typecheck:cjs`
- `pnpm run typecheck:esm`