### PR TITLE
feat(weave_ts): trace Claude Agent SDK nested and background subagents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,9 +374,20 @@ deterministic.
   use an `AgentSpansQueryReq` with `include_details=True` when validating stored
   span details.
 - Parallel/background Claude Agent SDK `Agent` calls can emit an
-  `async_launched` tool result before forwarded child messages, then finish via
-  a `task_notification`. Keep one `SubAgent` keyed by tool-use ID across turn
-  boundaries until that notification arrives.
+  `async_launched` or `remote_launched` tool result before forwarded child
+  messages, then finish via a `task_notification`. Keep one `SubAgent` keyed by
+  tool-use ID across turn boundaries until that notification arrives.
+- Read a subagent's lifetime from the launch request (`run_in_background`, or
+  `isolation: 'remote'`, which is always backgrounded) rather than inferring it
+  from the result status — an unrecognized status must not downgrade it.
+- Surviving a turn boundary is transitive: a background `SubAgent`'s open
+  `Tool`s and nested `SubAgent`s survive with it. Closing a descendant early
+  also drops it from the open map, so the next forwarded message re-creates it
+  under the wrong `Turn`.
+- Buffer a subagent's terminal state (and the timestamp it was observed) instead
+  of ending the span on the spot: `SpanBase` only records an error through
+  `end()`, and the span must close after its children. Pass the timestamp as
+  `endTime` so the deferral doesn't inflate the duration.
 - For streamed sessions, queue observed user inputs in FIFO order and close one
   `Turn` for each matching SDK `result`.
 - Treat `Agent` and legacy `Task` tool calls as subagents keyed by tool-call ID,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,6 +360,9 @@ pnpm exec tsx examples/claudeAgents.ts
 - `Turn` and `SubAgent` are logical in-process `invoke_agent` spans: emit
   `SpanKind.INTERNAL` and do not set `gen_ai.provider.name`; provider identity
   belongs on child model spans.
+- Record `invoke_agent` inputs and outputs through `Turn.record()` or
+  `SubAgent.record()`. Keep `gen_ai.tool.*` attributes on `execute_tool` spans,
+  not agent spans.
 - The Claude Agent SDK integration keeps each `Tool` open until its matching
   `tool_result`.
 - Parallel/background Claude Agent SDK `Agent` calls can emit an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,11 @@ To run an example (e.g. the Claude Agent SDK demo), `dist/` must be built first
 pnpm exec tsx examples/claudeAgents.ts
 ```
 
+Pure ESM auto-instrumentation requires the `weave/instrument` loader. For
+one-off `tsx` live validation scripts where that loader is not installed, call
+`wrapClaudeAgentSdk()` and consume the returned module view so tracing is
+deterministic.
+
 ### TypeScript integration metadata
 
 - `sdks/node/src/integrations/integrationMetadata.ts` remains shared:
@@ -365,6 +370,9 @@ pnpm exec tsx examples/claudeAgents.ts
   not agent spans.
 - The Claude Agent SDK integration keeps each `Tool` open until its matching
   `tool_result`.
+- Agent span list queries omit heavy message, tool-payload, and raw-span fields;
+  use an `AgentSpansQueryReq` with `include_details=True` when validating stored
+  span details.
 - Parallel/background Claude Agent SDK `Agent` calls can emit an
   `async_launched` tool result before forwarded child messages, then finish via
   a `task_notification`. Keep one `SubAgent` keyed by tool-use ID across turn

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,8 +357,9 @@ pnpm exec tsx examples/claudeAgents.ts
   `Tool` and `SubAgent` do not use ambient state.
 - Keep response models on child `chat` spans; use `setAttributes()` for fields
   without typed `record()` methods.
-- Do not set `gen_ai.provider.name` on a `Turn`; one turn can use multiple
-  providers, so provider identity belongs on its child model spans.
+- `Turn` and `SubAgent` are logical in-process `invoke_agent` spans: emit
+  `SpanKind.INTERNAL` and do not set `gen_ai.provider.name`; provider identity
+  belongs on child model spans.
 - The Claude Agent SDK integration keeps each `Tool` open until its matching
   `tool_result`.
 - Parallel/background Claude Agent SDK `Agent` calls can emit an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,10 @@ pnpm exec tsx examples/claudeAgents.ts
   without typed `record()` methods.
 - The Claude Agent SDK integration keeps each `Tool` open until its matching
   `tool_result`.
+- Parallel/background Claude Agent SDK `Agent` calls can emit an
+  `async_launched` tool result before forwarded child messages, then finish via
+  a `task_notification`. Keep one `SubAgent` keyed by tool-use ID across turn
+  boundaries until that notification arrives.
 - For streamed sessions, queue observed user inputs in FIFO order and close one
   `Turn` for each matching SDK `result`.
 - Treat `Agent` and legacy `Task` tool calls as subagents keyed by tool-call ID,
@@ -584,4 +588,8 @@ Think of this as the reverse-task assignment - a place where you can communicate
 - [ ] Repair the existing `pnpm run typecheck:examples` failures caused by
       OpenAI type drift in `examples/agent.ts`, `classesWithOps.ts`,
       `imageGeneration.ts`, `quickstart*.ts`, and `streamFunctionCalls.ts`.
+- [ ] Isolate Node GenAI test exit hooks: a full in-band Jest run can register
+      more than ten `beforeExit` listeners and flush queued test calls to the
+      real trace server after teardown when developer W&B credentials are
+      present, turning an otherwise-green run into a post-test failure.
 - [ ] ...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,6 +357,8 @@ pnpm exec tsx examples/claudeAgents.ts
   `Tool` and `SubAgent` do not use ambient state.
 - Keep response models on child `chat` spans; use `setAttributes()` for fields
   without typed `record()` methods.
+- Do not set `gen_ai.provider.name` on a `Turn`; one turn can use multiple
+  providers, so provider identity belongs on its child model spans.
 - The Claude Agent SDK integration keeps each `Tool` open until its matching
   `tool_result`.
 - Parallel/background Claude Agent SDK `Agent` calls can emit an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,6 +361,8 @@ pnpm exec tsx examples/claudeAgents.ts
   `tool_result`.
 - For streamed sessions, queue observed user inputs in FIFO order and close one
   `Turn` for each matching SDK `result`.
+- Treat `Agent` and legacy `Task` tool calls as subagents keyed by tool-call ID,
+  and preserve the caller's `forwardSubagentText` option.
 
 ## Code Review & PR Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -545,6 +545,14 @@ deterministic.
 - SDK output can fail before the first message or between completed turns. Keep
   the submitted/pending input observable by ending its `Turn` through the
   exception path so the span records the error before the exception propagates.
+- The Agents conversation tree renders recognized GenAI operations. Generic
+  OTel spans with an empty `gen_ai.operation.name` remain stored and queryable
+  through `agent_spans_query`, but are omitted from that visual tree; use a
+  semantic marker span when a UI-visible trace regression is required.
+- Use the Trace tree view for parentage comparisons. The default flamegraph
+  collapses overlapping siblings into synthetic groups, which can make flat
+  and nested traces look deceptively similar; give live-example spans realistic
+  duration and verify their stored parent IDs with `agent_spans_query`.
 
 ### Claude Agent SDK token accounting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,6 +377,13 @@ deterministic.
   `async_launched` or `remote_launched` tool result before forwarded child
   messages, then finish via a `task_notification`. Keep one `SubAgent` keyed by
   tool-use ID across turn boundaries until that notification arrives.
+- Route a forwarded assistant message to an already-open `SubAgent` before
+  creating a `Turn`; background messages can arrive after the root result and
+  must not create an empty root turn or consume the next pending input.
+- For synchronous `Agent`/`Task` completion, read terminal output from the
+  structured `SDKUserMessage.tool_use_result.content`; use the model-facing
+  `tool_result` block content only as a compatibility fallback. Background
+  completion output continues to come from `task_notification.summary`.
 - Read a subagent's lifetime from the launch request (`run_in_background`, or
   `isolation: 'remote'`, which is always backgrounded) rather than inferring it
   from the result status — an unrecognized status must not downgrade it.

--- a/sdks/node/src/__tests__/genai/subagent.test.ts
+++ b/sdks/node/src/__tests__/genai/subagent.test.ts
@@ -1,3 +1,4 @@
+import {SpanKind} from '@opentelemetry/api';
 import type {ReadableSpan} from '@opentelemetry/sdk-trace-base';
 
 import {ATTR_GEN_AI_AGENT_NAME} from '../../genai/semconv';
@@ -38,6 +39,8 @@ describe('SubAgent', () => {
     );
     expect(subSpan).toBeDefined();
     expect(parentTurnSpan).toBeDefined();
+    expect(subSpan!.kind).toBe(SpanKind.INTERNAL);
+    expect(parentTurnSpan!.kind).toBe(SpanKind.INTERNAL);
     expect(subSpan!.parentSpanId).toBe(parentTurnSpan!.spanContext().spanId);
 
     expect(spanSnapshot(subSpan!)).toMatchInlineSnapshot(`

--- a/sdks/node/src/__tests__/genai/subagent.test.ts
+++ b/sdks/node/src/__tests__/genai/subagent.test.ts
@@ -113,6 +113,8 @@ describe('SubAgent', () => {
     const turn = Turn.create({});
     const subagent = turn.startSubagent({name: 'researcher'});
     subagent.record({
+      messages: [{role: 'user', content: 'Research the SDK'}],
+      outputMessages: [{role: 'assistant', content: 'The SDK supports agents'}],
       agentId: 'agent-9',
       agentDescription: 'A research bot',
       agentVersion: 'v4',
@@ -129,7 +131,9 @@ describe('SubAgent', () => {
           "gen_ai.agent.id": "agent-9",
           "gen_ai.agent.name": "researcher",
           "gen_ai.agent.version": "v4",
+          "gen_ai.input.messages": "[{"role":"user","content":"Research the SDK"}]",
           "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.output.messages": "[{"role":"assistant","content":"The SDK supports agents"}]",
           "gen_ai.system_instructions": "[{"type":"text","content":"Find authoritative sources"}]",
         },
         "endTime": "<timestamp>",

--- a/sdks/node/src/__tests__/genai/turn.test.ts
+++ b/sdks/node/src/__tests__/genai/turn.test.ts
@@ -1,4 +1,4 @@
-import {SpanStatusCode} from '@opentelemetry/api';
+import {SpanKind, SpanStatusCode} from '@opentelemetry/api';
 import {Turn} from '../../genai/turn';
 
 import {
@@ -27,6 +27,7 @@ describe('Turn', () => {
     turn.end();
 
     const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
+    expect(span.kind).toBe(SpanKind.INTERNAL);
     expect(spanSnapshot(span)).toMatchInlineSnapshot(`
       {
         "attributes": {

--- a/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
+++ b/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
@@ -10,6 +10,7 @@ import type {
 
 import {
   ATTR_ERROR_TYPE,
+  ATTR_GEN_AI_AGENT_DESCRIPTION,
   ATTR_GEN_AI_AGENT_NAME,
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_INPUT_MESSAGES,
@@ -102,11 +103,16 @@ function assistantMessage(opts: {
   model: string;
   content: AssistantContent[];
   stopReason?: SDKAssistantMessage['message']['stop_reason'];
+  parentToolUseId?: string | null;
+  subagentType?: string;
+  taskDescription?: string;
 }): SDKAssistantMessage {
   return {
     type: 'assistant',
     session_id: opts.sessionId,
-    parent_tool_use_id: null,
+    parent_tool_use_id: opts.parentToolUseId ?? null,
+    subagent_type: opts.subagentType,
+    task_description: opts.taskDescription,
     uuid: randomUUID(),
     message: {
       id: 'msg-1',
@@ -135,6 +141,9 @@ function userToolResult(opts: {
   toolUseId: string;
   content: string;
   isError?: boolean;
+  parentToolUseId?: string | null;
+  subagentType?: string;
+  taskDescription?: string;
 }): SDKUserMessage {
   const block: ToolResultBlock = {
     type: 'tool_result',
@@ -145,7 +154,9 @@ function userToolResult(opts: {
   return {
     type: 'user',
     session_id: opts.sessionId,
-    parent_tool_use_id: null,
+    parent_tool_use_id: opts.parentToolUseId ?? null,
+    subagent_type: opts.subagentType,
+    task_description: opts.taskDescription,
     message: {role: 'user', content: [block]},
   };
 }
@@ -476,6 +487,247 @@ describe('Claude Agent SDK — OTel tracer', () => {
     expect(contentChats.map(span => span.parentSpanId)).toEqual([
       roots[0].spanContext().spanId,
       roots[1].spanContext().spanId,
+    ]);
+  });
+
+  test('nests forwarded subagent text and tools under a SubAgent span', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'research the SDK'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-subagent',
+        model: 'claude-main',
+        stopReason: 'tool_use',
+        content: [
+          toolUseBlock('agent-1', 'Agent', {
+            description: 'Research the Agent SDK',
+            prompt: 'Find how subagent forwarding works.',
+            subagent_type: 'researcher',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-subagent',
+        parentToolUseId: 'agent-1',
+        subagentType: 'researcher',
+        taskDescription: 'Research the Agent SDK',
+        model: 'claude-subagent',
+        stopReason: 'tool_use',
+        content: [
+          thinkingBlock('I should inspect the source.'),
+          textBlock('I will read the relevant file.'),
+          toolUseBlock('read-1', 'Read', {file_path: 'sdk.d.ts'}),
+        ],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-subagent',
+        parentToolUseId: 'agent-1',
+        subagentType: 'researcher',
+        toolUseId: 'read-1',
+        content: 'forwardSubagentText?: boolean',
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-subagent',
+        toolUseId: 'agent-1',
+        content: 'Set forwardSubagentText to include nested text.',
+      })
+    );
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-subagent',
+        model: 'claude-main',
+        content: [textBlock('The option forwards nested text.')],
+      })
+    );
+    tracer.finalize(
+      resultSuccess({
+        sessionId: 'sess-subagent',
+        result: 'The option forwards nested text.',
+      })
+    );
+
+    const spans = getExporter().getFinishedSpans();
+    const root = spans.find(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'claude_agent_sdk'
+    )!;
+    const subagent = spans.find(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'researcher'
+    )!;
+    expect(subagent.parentSpanId).toBe(root.spanContext().spanId);
+    expect(subagent.attributes[ATTR_GEN_AI_AGENT_DESCRIPTION]).toBe(
+      'Research the Agent SDK'
+    );
+    expect(subagent.attributes[ATTR_GEN_AI_REQUEST_MODEL]).toBe(
+      'claude-subagent'
+    );
+    expect(
+      JSON.parse(subagent.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string)
+    ).toEqual([{role: 'user', content: 'Find how subagent forwarding works.'}]);
+    expect(
+      JSON.parse(subagent.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string)
+    ).toEqual([
+      {
+        role: 'assistant',
+        content: 'Set forwardSubagentText to include nested text.',
+      },
+    ]);
+
+    const nestedChat = spans.find(
+      span =>
+        span.name === 'chat' &&
+        span.attributes[ATTR_GEN_AI_REQUEST_MODEL] === 'claude-subagent'
+    )!;
+    expect(nestedChat.parentSpanId).toBe(subagent.spanContext().spanId);
+    expect(
+      JSON.parse(nestedChat.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string)
+    ).toEqual([
+      {
+        role: 'assistant',
+        parts: [
+          {type: 'reasoning', content: 'I should inspect the source.'},
+          {type: 'text', content: 'I will read the relevant file.'},
+          {
+            type: 'tool_call',
+            toolCallId: 'read-1',
+            toolName: 'Read',
+            arguments: '{"file_path":"sdk.d.ts"}',
+          },
+        ],
+      },
+    ]);
+
+    const nestedTool = spans.find(
+      span =>
+        span.name === 'execute_tool' &&
+        span.attributes[ATTR_GEN_AI_TOOL_CALL_ID] === 'read-1'
+    )!;
+    expect(nestedTool.parentSpanId).toBe(subagent.spanContext().spanId);
+    expect(nestedTool.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBe(
+      'forwardSubagentText?: boolean'
+    );
+    expect(
+      spans.some(
+        span =>
+          span.name === 'execute_tool' &&
+          span.attributes[ATTR_GEN_AI_TOOL_CALL_ID] === 'agent-1'
+      )
+    ).toBe(false);
+  });
+
+  test('traces parallel subagents when only their tool blocks are forwarded', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate both checks'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-parallel',
+        model: 'claude-main',
+        stopReason: 'tool_use',
+        content: [
+          toolUseBlock('agent-a', 'Agent', {
+            description: 'Inspect types',
+            prompt: 'Read the SDK types.',
+            subagent_type: 'type-reader',
+          }),
+          toolUseBlock('agent-b', 'Agent', {
+            description: 'Inspect docs',
+            prompt: 'Search the SDK docs.',
+            subagent_type: 'doc-reader',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-parallel',
+        parentToolUseId: 'agent-b',
+        subagentType: 'doc-reader',
+        model: 'claude-docs',
+        stopReason: 'tool_use',
+        content: [toolUseBlock('grep-b', 'Grep', {pattern: 'forward'})],
+      })
+    );
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-parallel',
+        parentToolUseId: 'agent-a',
+        subagentType: 'type-reader',
+        model: 'claude-types',
+        stopReason: 'tool_use',
+        content: [toolUseBlock('read-a', 'Read', {file_path: 'sdk.d.ts'})],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-parallel',
+        parentToolUseId: 'agent-a',
+        toolUseId: 'read-a',
+        content: 'types',
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-parallel',
+        parentToolUseId: 'agent-b',
+        toolUseId: 'grep-b',
+        content: 'docs',
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-parallel',
+        toolUseId: 'agent-b',
+        content: 'docs complete',
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-parallel',
+        toolUseId: 'agent-a',
+        content: 'types complete',
+      })
+    );
+    tracer.finalize(
+      resultSuccess({sessionId: 'sess-parallel', result: 'done'})
+    );
+
+    const spans = getExporter().getFinishedSpans();
+    const root = spans.find(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'claude_agent_sdk'
+    )!;
+    const subagents = spans.filter(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] !== 'claude_agent_sdk'
+    );
+    expect(
+      subagents.map(span => ({
+        name: span.attributes[ATTR_GEN_AI_AGENT_NAME],
+        output: JSON.parse(
+          span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string
+        ),
+        parentSpanId: span.parentSpanId,
+      }))
+    ).toEqual([
+      {
+        name: 'doc-reader',
+        output: [{role: 'assistant', content: 'docs complete'}],
+        parentSpanId: root.spanContext().spanId,
+      },
+      {
+        name: 'type-reader',
+        output: [{role: 'assistant', content: 'types complete'}],
+        parentSpanId: root.spanContext().spanId,
+      },
     ]);
   });
 

--- a/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
+++ b/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
@@ -8,6 +8,7 @@ import type {
   SDKTaskNotificationMessage,
   SDKUserMessage,
 } from '@anthropic-ai/claude-agent-sdk';
+import type {AgentOutput} from '@anthropic-ai/claude-agent-sdk/sdk-tools';
 
 import {
   ATTR_ERROR_TYPE,
@@ -162,6 +163,35 @@ function userToolResult(opts: {
     task_description: opts.taskDescription,
     tool_use_result: opts.toolUseResult,
     message: {role: 'user', content: [block]},
+  };
+}
+
+type CompletedAgentOutput = Extract<AgentOutput, {status: 'completed'}>;
+
+function completedAgentOutput(opts: {
+  agentId: string;
+  content: string[];
+  prompt: string;
+  resolvedModel?: string;
+}): CompletedAgentOutput {
+  return {
+    status: 'completed',
+    agentId: opts.agentId,
+    content: opts.content.map(text => ({type: 'text', text})),
+    ...(opts.resolvedModel ? {resolvedModel: opts.resolvedModel} : {}),
+    totalToolUseCount: 0,
+    totalDurationMs: 0,
+    totalTokens: 0,
+    usage: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      server_tool_use: null,
+      service_tier: null,
+      cache_creation: null,
+    },
+    prompt: opts.prompt,
   };
 }
 
@@ -957,6 +987,122 @@ describe('Claude Agent SDK — OTel tracer', () => {
     ]);
   });
 
+  test('routes a late background message without creating another root turn', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-late-background',
+        model: 'claude-main',
+        content: [
+          toolUseBlock('agent-late', 'Agent', {
+            prompt: 'Finish in the background',
+            run_in_background: true,
+            subagent_type: 'late-worker',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-late-background',
+        toolUseId: 'agent-late',
+        content: 'Async agent launched successfully',
+        toolUseResult: {
+          status: 'async_launched',
+          agentId: 'task-late',
+        },
+      })
+    );
+    tracer.processMessage(
+      resultSuccess({sessionId: 'sess-late-background', result: 'launched'})
+    );
+
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-late-background',
+        parentToolUseId: 'agent-late',
+        subagentType: 'late-worker',
+        model: 'claude-worker',
+        content: [textBlock('late child output')],
+      })
+    );
+    tracer.processMessage(
+      taskNotification({
+        sessionId: 'sess-late-background',
+        taskId: 'task-late',
+        toolUseId: 'agent-late',
+        status: 'completed',
+        summary: 'Background work finished',
+      })
+    );
+    tracer.finalize();
+
+    const spans = getExporter().getFinishedSpans();
+    const root = spans.find(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'claude_agent_sdk'
+    )!;
+    const subagent = spans.find(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'late-worker'
+    )!;
+    expect(
+      spans
+        .filter(span => span.name === INVOKE)
+        .map(span => ({
+          agentName: span.attributes[ATTR_GEN_AI_AGENT_NAME],
+          inputMessages: JSON.parse(
+            span.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string
+          ),
+          outputMessages: JSON.parse(
+            span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string
+          ),
+          parentSpanId: span.parentSpanId,
+        }))
+    ).toEqual([
+      {
+        agentName: 'claude_agent_sdk',
+        inputMessages: [{role: 'user', content: 'delegate'}],
+        outputMessages: [{role: 'assistant', content: 'launched'}],
+        parentSpanId: undefined,
+      },
+      {
+        agentName: 'late-worker',
+        inputMessages: [{role: 'user', content: 'Finish in the background'}],
+        outputMessages: [
+          {role: 'assistant', content: 'Background work finished'},
+        ],
+        parentSpanId: root.spanContext().spanId,
+      },
+    ]);
+    expect(
+      spans
+        .filter(
+          span =>
+            span.name === 'chat' &&
+            span.attributes[ATTR_GEN_AI_REQUEST_MODEL] === 'claude-worker'
+        )
+        .map(span => ({
+          outputMessages: JSON.parse(
+            span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string
+          ),
+          parentSpanId: span.parentSpanId,
+        }))
+    ).toEqual([
+      {
+        outputMessages: [
+          {
+            role: 'assistant',
+            parts: [{type: 'text', content: 'late child output'}],
+          },
+        ],
+        parentSpanId: subagent.spanContext().spanId,
+      },
+    ]);
+  });
+
   test('marks a failed background subagent from its task notification', () => {
     const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate'});
     tracer.processMessage(
@@ -1364,7 +1510,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
     ]);
   });
 
-  test('records the resolved model and agent id from a synchronous subagent result', () => {
+  test('records structured output and identity from a synchronous subagent result', () => {
     const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate once'});
     tracer.processMessage(
       assistantMessage({
@@ -1384,12 +1530,13 @@ describe('Claude Agent SDK — OTel tracer', () => {
       userToolResult({
         sessionId: 'sess-sync',
         toolUseId: 'agent-sync',
-        content: 'the answer',
-        toolUseResult: {
-          status: 'completed',
+        content: 'Agent completed successfully',
+        toolUseResult: completedAgentOutput({
           agentId: 'agent-sync-1',
+          content: ['the answer'],
+          prompt: 'Answer briefly',
           resolvedModel: 'claude-haiku-4-5',
-        },
+        }),
       })
     );
     tracer.finalize(resultSuccess({sessionId: 'sess-sync', result: 'done'}));

--- a/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
+++ b/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
@@ -605,6 +605,17 @@ describe('Claude Agent SDK — OTel tracer', () => {
         content: 'Set forwardSubagentText to include nested text.',
       },
     ]);
+    expect({
+      toolCallArguments: subagent.attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS],
+      toolCallId: subagent.attributes[ATTR_GEN_AI_TOOL_CALL_ID],
+      toolCallResult: subagent.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT],
+      toolName: subagent.attributes[ATTR_GEN_AI_TOOL_NAME],
+    }).toEqual({
+      toolCallArguments: undefined,
+      toolCallId: undefined,
+      toolCallResult: undefined,
+      toolName: undefined,
+    });
 
     const nestedChat = spans.find(
       span =>
@@ -912,7 +923,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
         outputMessages: undefined,
         providerName: undefined,
         statusCode: SpanStatusCode.UNSET,
-        toolCallId: 'agent-a',
+        toolCallId: undefined,
         toolCallResult: undefined,
       },
       {
@@ -933,7 +944,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
         outputMessages: undefined,
         providerName: undefined,
         statusCode: SpanStatusCode.UNSET,
-        toolCallId: 'agent-b',
+        toolCallId: undefined,
         toolCallResult: undefined,
       },
     ]);
@@ -1000,7 +1011,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
         errorType: 'subagent_error',
         statusCode: SpanStatusCode.ERROR,
         statusMessage: 'Subagent crashed',
-        toolCallId: 'agent-failed',
+        toolCallId: undefined,
       },
     ]);
   });
@@ -1060,7 +1071,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
         errorType: 'aborted',
         statusCode: SpanStatusCode.ERROR,
         statusMessage: 'Agent ended with open subagent span',
-        toolCallId: 'agent-unfinished',
+        toolCallId: undefined,
       },
     ]);
   });
@@ -1156,13 +1167,13 @@ describe('Claude Agent SDK — OTel tracer', () => {
           )!
           .spanContext().spanId,
         statusCode: SpanStatusCode.UNSET,
-        toolName: 'Agent',
+        toolName: undefined,
       },
       {
         name: 'worker',
         parentSpanId: coordinator.spanContext().spanId,
         statusCode: SpanStatusCode.UNSET,
-        toolName: 'Task',
+        toolName: undefined,
       },
     ]);
   });

--- a/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
+++ b/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
@@ -349,7 +349,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
     expect(invoke.kind).toBe(SpanKind.CLIENT);
     expect(invoke.attributes[ATTR_GEN_AI_OPERATION_NAME]).toBe('invoke_agent');
     expect(invoke.attributes[ATTR_GEN_AI_AGENT_NAME]).toBe('claude_agent_sdk');
-    expect(invoke.attributes[ATTR_GEN_AI_PROVIDER_NAME]).toBe('anthropic');
+    expect(invoke.attributes[ATTR_GEN_AI_PROVIDER_NAME]).toBeUndefined();
     expect(invoke.attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('sess-1');
     expect(invoke.attributes[ATTR_GEN_AI_RESPONSE_MODEL]).toBeUndefined();
     expect(invoke.parentSpanId).toBeUndefined();

--- a/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
+++ b/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
@@ -171,6 +171,7 @@ function taskNotification(opts: {
   summary: string;
   taskId: string;
   toolUseId?: string;
+  usage?: SDKTaskNotificationMessage['usage'];
 }): SDKTaskNotificationMessage {
   return {
     type: 'system',
@@ -181,9 +182,13 @@ function taskNotification(opts: {
     tool_use_id: opts.toolUseId,
     status: opts.status,
     summary: opts.summary,
+    usage: opts.usage,
     output_file: '',
   };
 }
+
+const outputMessagesJson = (content: string): string =>
+  JSON.stringify([{role: 'assistant', content}]);
 
 function userPrompt(opts: {
   content: string;
@@ -920,7 +925,9 @@ describe('Claude Agent SDK — OTel tracer', () => {
         kind: SpanKind.INTERNAL,
         model: 'claude-haiku',
         name: 'alpha-verifier',
-        outputMessages: undefined,
+        // A background subagent reports no tool_result, so the notification
+        // summary is its only output text.
+        outputMessages: outputMessagesJson('Alpha verification finished'),
         providerName: undefined,
         statusCode: SpanStatusCode.UNSET,
         toolCallId: undefined,
@@ -941,7 +948,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
         kind: SpanKind.INTERNAL,
         model: 'claude-haiku',
         name: 'beta-verifier',
-        outputMessages: undefined,
+        outputMessages: outputMessagesJson('Beta verification finished'),
         providerName: undefined,
         statusCode: SpanStatusCode.UNSET,
         toolCallId: undefined,
@@ -1074,6 +1081,490 @@ describe('Claude Agent SDK — OTel tracer', () => {
         toolCallId: undefined,
       },
     ]);
+  });
+
+  test('keeps a background subagent tool call open across a turn boundary', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-bg-tool',
+        model: 'claude-main',
+        content: [
+          toolUseBlock('agent-bg', 'Agent', {
+            prompt: 'Inspect the repo',
+            run_in_background: true,
+            subagent_type: 'inspector',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-bg-tool',
+        toolUseId: 'agent-bg',
+        content: 'Async agent launched successfully',
+        toolUseResult: {status: 'async_launched', agentId: 'task-bg'},
+      })
+    );
+    // The subagent starts a tool, then the main turn ends while it is still
+    // running — the tool must not be swept as aborted.
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-bg-tool',
+        parentToolUseId: 'agent-bg',
+        subagentType: 'inspector',
+        model: 'claude-haiku',
+        content: [toolUseBlock('read-bg', 'Read', {file_path: 'sdk.d.ts'})],
+      })
+    );
+    tracer.processMessage(
+      resultSuccess({sessionId: 'sess-bg-tool', result: 'launched'})
+    );
+    expect(
+      getExporter()
+        .getFinishedSpans()
+        .filter(span => span.name === 'execute_tool')
+    ).toEqual([]);
+
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-bg-tool',
+        parentToolUseId: 'agent-bg',
+        toolUseId: 'read-bg',
+        content: 'file contents',
+      })
+    );
+    tracer.processMessage(
+      taskNotification({
+        sessionId: 'sess-bg-tool',
+        taskId: 'task-bg',
+        toolUseId: 'agent-bg',
+        status: 'completed',
+        summary: 'Inspection finished',
+        usage: {total_tokens: 1234, tool_uses: 1, duration_ms: 50},
+      })
+    );
+    tracer.finalize(resultSuccess({sessionId: 'sess-bg-tool', result: 'done'}));
+
+    const spans = getExporter().getFinishedSpans();
+    const subagent = spans.find(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'inspector'
+    )!;
+    expect(
+      spans
+        .filter(span => span.name === 'execute_tool')
+        .map(span => ({
+          errorType: span.attributes[ATTR_ERROR_TYPE],
+          parentSpanId: span.parentSpanId,
+          result: span.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT],
+          statusCode: span.status.code,
+          toolCallId: span.attributes[ATTR_GEN_AI_TOOL_CALL_ID],
+        }))
+    ).toEqual([
+      {
+        errorType: undefined,
+        parentSpanId: subagent.spanContext().spanId,
+        result: 'file contents',
+        statusCode: SpanStatusCode.UNSET,
+        toolCallId: 'read-bg',
+      },
+    ]);
+    expect({
+      errorType: subagent.attributes[ATTR_ERROR_TYPE],
+      outputMessages: subagent.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES],
+      statusCode: subagent.status.code,
+      totalTokens: subagent.attributes[ATTR_GEN_AI_USAGE_TOTAL_TOKENS],
+    }).toEqual({
+      errorType: undefined,
+      outputMessages: outputMessagesJson('Inspection finished'),
+      statusCode: SpanStatusCode.UNSET,
+      totalTokens: 1234,
+    });
+  });
+
+  test('keeps a subagent nested in a background subagent open across a turn boundary', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate recursively'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-bg-nested',
+        model: 'claude-main',
+        content: [
+          toolUseBlock('agent-bg', 'Agent', {
+            prompt: 'Coordinate in the background',
+            run_in_background: true,
+            subagent_type: 'coordinator',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-bg-nested',
+        toolUseId: 'agent-bg',
+        content: 'Async agent launched successfully',
+        toolUseResult: {status: 'async_launched', agentId: 'task-bg'},
+      })
+    );
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-bg-nested',
+        parentToolUseId: 'agent-bg',
+        subagentType: 'coordinator',
+        model: 'claude-coordinator',
+        content: [
+          toolUseBlock('task-child', 'Task', {
+            prompt: 'Do the work',
+            subagent_type: 'worker',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      resultSuccess({sessionId: 'sess-bg-nested', result: 'launched'})
+    );
+    // The nested subagent inherits its background ancestor's lifetime, so the
+    // turn boundary must neither close nor forget it.
+    expect(
+      getExporter()
+        .getFinishedSpans()
+        .filter(span => span.name === INVOKE && span.parentSpanId != null)
+    ).toEqual([]);
+
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-bg-nested',
+        parentToolUseId: 'task-child',
+        subagentType: 'worker',
+        model: 'claude-worker',
+        content: [textBlock('done')],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-bg-nested',
+        parentToolUseId: 'agent-bg',
+        toolUseId: 'task-child',
+        content: 'worker complete',
+      })
+    );
+    tracer.processMessage(
+      taskNotification({
+        sessionId: 'sess-bg-nested',
+        taskId: 'task-bg',
+        toolUseId: 'agent-bg',
+        status: 'completed',
+        summary: 'Coordination finished',
+      })
+    );
+    tracer.finalize(
+      resultSuccess({sessionId: 'sess-bg-nested', result: 'done'})
+    );
+
+    const spans = getExporter().getFinishedSpans();
+    const coordinator = spans.find(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'coordinator'
+    )!;
+    // Exactly one span per subagent — no duplicate from the lazy-create path.
+    expect(
+      spans
+        .filter(
+          span =>
+            span.name === INVOKE &&
+            span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'worker'
+        )
+        .map(span => ({
+          errorType: span.attributes[ATTR_ERROR_TYPE],
+          parentSpanId: span.parentSpanId,
+          outputMessages: span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES],
+          statusCode: span.status.code,
+        }))
+    ).toEqual([
+      {
+        errorType: undefined,
+        outputMessages: outputMessagesJson('worker complete'),
+        parentSpanId: coordinator.spanContext().spanId,
+        statusCode: SpanStatusCode.UNSET,
+      },
+    ]);
+  });
+
+  test('treats a remote launch as a background subagent', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate remotely'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-remote',
+        model: 'claude-main',
+        content: [
+          toolUseBlock('agent-remote', 'Agent', {
+            prompt: 'Run in the cloud',
+            isolation: 'remote',
+            subagent_type: 'remote-worker',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-remote',
+        toolUseId: 'agent-remote',
+        content: 'Remote agent launched successfully',
+        toolUseResult: {
+          status: 'remote_launched',
+          taskId: 'task-remote',
+          sessionUrl: 'https://example.invalid/session',
+        },
+      })
+    );
+    tracer.processMessage(
+      resultSuccess({sessionId: 'sess-remote', result: 'launched'})
+    );
+    // A remote launch only acknowledges — the span stays open past the turn.
+    expect(
+      getExporter()
+        .getFinishedSpans()
+        .filter(span => span.name === INVOKE && span.parentSpanId != null)
+    ).toEqual([]);
+
+    tracer.processMessage(
+      taskNotification({
+        sessionId: 'sess-remote',
+        taskId: 'task-remote',
+        status: 'failed',
+        summary: 'Remote agent crashed',
+      })
+    );
+    tracer.finalize(resultSuccess({sessionId: 'sess-remote', result: 'done'}));
+
+    expect(
+      getExporter()
+        .getFinishedSpans()
+        .filter(
+          span =>
+            span.name === INVOKE &&
+            span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'remote-worker'
+        )
+        .map(span => ({
+          agentId: span.attributes[ATTR_GEN_AI_AGENT_ID],
+          errorType: span.attributes[ATTR_ERROR_TYPE],
+          statusCode: span.status.code,
+          statusMessage: span.status.message,
+        }))
+    ).toEqual([
+      {
+        // No `agentId` in a remote launch payload, so the task handle stands in.
+        agentId: 'task-remote',
+        errorType: 'subagent_error',
+        statusCode: SpanStatusCode.ERROR,
+        statusMessage: 'Remote agent crashed',
+      },
+    ]);
+  });
+
+  test('records the resolved model and agent id from a synchronous subagent result', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate once'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-sync',
+        model: 'claude-main',
+        content: [
+          toolUseBlock('agent-sync', 'Agent', {
+            prompt: 'Answer briefly',
+            // The input carries a model *alias*, not a model id.
+            model: 'haiku',
+            subagent_type: 'answerer',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-sync',
+        toolUseId: 'agent-sync',
+        content: 'the answer',
+        toolUseResult: {
+          status: 'completed',
+          agentId: 'agent-sync-1',
+          resolvedModel: 'claude-haiku-4-5',
+        },
+      })
+    );
+    tracer.finalize(resultSuccess({sessionId: 'sess-sync', result: 'done'}));
+
+    expect(
+      getExporter()
+        .getFinishedSpans()
+        .filter(
+          span =>
+            span.name === INVOKE &&
+            span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'answerer'
+        )
+        .map(span => ({
+          agentId: span.attributes[ATTR_GEN_AI_AGENT_ID],
+          model: span.attributes[ATTR_GEN_AI_REQUEST_MODEL],
+          outputMessages: span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES],
+          statusCode: span.status.code,
+        }))
+    ).toEqual([
+      {
+        agentId: 'agent-sync-1',
+        model: 'claude-haiku-4-5',
+        outputMessages: outputMessagesJson('the answer'),
+        statusCode: SpanStatusCode.UNSET,
+      },
+    ]);
+  });
+
+  test('marks a stopped background subagent as aborted', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-stopped',
+        model: 'claude-main',
+        content: [
+          toolUseBlock('agent-stopped', 'Agent', {
+            prompt: 'Run until stopped',
+            run_in_background: true,
+            subagent_type: 'stoppable',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-stopped',
+        toolUseId: 'agent-stopped',
+        content: 'Async agent launched successfully',
+        toolUseResult: {status: 'async_launched', agentId: 'task-stopped'},
+      })
+    );
+    tracer.processMessage(
+      taskNotification({
+        sessionId: 'sess-stopped',
+        taskId: 'task-stopped',
+        toolUseId: 'agent-stopped',
+        status: 'stopped',
+        summary: 'Stopped by the user',
+      })
+    );
+    tracer.finalize(resultSuccess({sessionId: 'sess-stopped', result: 'done'}));
+
+    expect(
+      getExporter()
+        .getFinishedSpans()
+        .filter(
+          span =>
+            span.name === INVOKE &&
+            span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'stoppable'
+        )
+        .map(span => ({
+          errorType: span.attributes[ATTR_ERROR_TYPE],
+          statusCode: span.status.code,
+          statusMessage: span.status.message,
+        }))
+    ).toEqual([
+      {
+        errorType: 'aborted',
+        statusCode: SpanStatusCode.ERROR,
+        statusMessage: 'Stopped by the user',
+      },
+    ]);
+  });
+
+  test('a subagent tool_result flagged is_error fails the invoke_agent span', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-subagent-error',
+        model: 'claude-main',
+        content: [
+          toolUseBlock('agent-err', 'Agent', {
+            prompt: 'Fail please',
+            subagent_type: 'failer',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-subagent-error',
+        toolUseId: 'agent-err',
+        content: 'subagent blew up',
+        isError: true,
+      })
+    );
+    tracer.finalize(
+      resultSuccess({sessionId: 'sess-subagent-error', result: 'done'})
+    );
+
+    expect(
+      getExporter()
+        .getFinishedSpans()
+        .filter(
+          span =>
+            span.name === INVOKE &&
+            span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'failer'
+        )
+        .map(span => ({
+          errorType: span.attributes[ATTR_ERROR_TYPE],
+          outputMessages: span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES],
+          statusCode: span.status.code,
+          statusMessage: span.status.message,
+        }))
+    ).toEqual([
+      {
+        errorType: 'subagent_error',
+        outputMessages: outputMessagesJson('subagent blew up'),
+        statusCode: SpanStatusCode.ERROR,
+        statusMessage: 'subagent blew up',
+      },
+    ]);
+  });
+
+  test('creates a SubAgent span for a forwarded message with no observed tool block', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'resume mid-delegation'});
+    // No `Agent` tool_use block is ever seen — only the forwarded child.
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-orphan',
+        parentToolUseId: 'agent-unseen',
+        subagentType: 'orphan',
+        taskDescription: 'Work started before the tracer attached',
+        model: 'claude-orphan',
+        content: [textBlock('still working')],
+      })
+    );
+    tracer.finalize(resultSuccess({sessionId: 'sess-orphan', result: 'done'}));
+
+    const spans = getExporter().getFinishedSpans();
+    const orphan = spans.find(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'orphan'
+    )!;
+    const root = spans.find(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'claude_agent_sdk'
+    )!;
+    expect({
+      agentDescription: orphan.attributes[ATTR_GEN_AI_AGENT_DESCRIPTION],
+      // With no launch options observed the span is turn-scoped, so an absent
+      // result closes it as aborted rather than leaking it.
+      errorType: orphan.attributes[ATTR_ERROR_TYPE],
+      model: orphan.attributes[ATTR_GEN_AI_REQUEST_MODEL],
+      parentSpanId: orphan.parentSpanId,
+      statusCode: orphan.status.code,
+    }).toEqual({
+      agentDescription: 'Work started before the tracer attached',
+      errorType: 'aborted',
+      model: 'claude-orphan',
+      parentSpanId: root.spanContext().spanId,
+      statusCode: SpanStatusCode.ERROR,
+    });
   });
 
   test('nests a legacy Task subagent under a forwarded Agent span', () => {

--- a/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
+++ b/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
@@ -5,12 +5,14 @@ import type {
   ModelUsage,
   SDKAssistantMessage,
   SDKResultMessage,
+  SDKTaskNotificationMessage,
   SDKUserMessage,
 } from '@anthropic-ai/claude-agent-sdk';
 
 import {
   ATTR_ERROR_TYPE,
   ATTR_GEN_AI_AGENT_DESCRIPTION,
+  ATTR_GEN_AI_AGENT_ID,
   ATTR_GEN_AI_AGENT_NAME,
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_INPUT_MESSAGES,
@@ -144,6 +146,7 @@ function userToolResult(opts: {
   parentToolUseId?: string | null;
   subagentType?: string;
   taskDescription?: string;
+  toolUseResult?: unknown;
 }): SDKUserMessage {
   const block: ToolResultBlock = {
     type: 'tool_result',
@@ -157,7 +160,28 @@ function userToolResult(opts: {
     parent_tool_use_id: opts.parentToolUseId ?? null,
     subagent_type: opts.subagentType,
     task_description: opts.taskDescription,
+    tool_use_result: opts.toolUseResult,
     message: {role: 'user', content: [block]},
+  };
+}
+
+function taskNotification(opts: {
+  sessionId: string;
+  status: SDKTaskNotificationMessage['status'];
+  summary: string;
+  taskId: string;
+  toolUseId?: string;
+}): SDKTaskNotificationMessage {
+  return {
+    type: 'system',
+    subtype: 'task_notification',
+    session_id: opts.sessionId,
+    uuid: randomUUID(),
+    task_id: opts.taskId,
+    tool_use_id: opts.toolUseId,
+    status: opts.status,
+    summary: opts.summary,
+    output_file: '',
   };
 }
 
@@ -727,6 +751,411 @@ describe('Claude Agent SDK — OTel tracer', () => {
         name: 'type-reader',
         output: [{role: 'assistant', content: 'types complete'}],
         parentSpanId: root.spanContext().spanId,
+      },
+    ]);
+  });
+
+  test('keeps parallel background subagents across launch results and turns', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate both checks'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-background',
+        model: 'claude-main',
+        stopReason: 'tool_use',
+        content: [
+          toolUseBlock('agent-a', 'Agent', {
+            description: 'Verify alpha',
+            prompt: 'Return ALPHA_OK',
+            run_in_background: true,
+            subagent_type: 'alpha-verifier',
+          }),
+          toolUseBlock('agent-b', 'Agent', {
+            description: 'Verify beta',
+            prompt: 'Return BETA_OK',
+            run_in_background: true,
+            subagent_type: 'beta-verifier',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-background',
+        toolUseId: 'agent-a',
+        content: 'Async agent launched successfully',
+        toolUseResult: {
+          status: 'async_launched',
+          agentId: 'task-a',
+          resolvedModel: 'claude-haiku',
+        },
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-background',
+        toolUseId: 'agent-b',
+        content: 'Async agent launched successfully',
+        toolUseResult: {
+          status: 'async_launched',
+          agentId: 'task-b',
+          resolvedModel: 'claude-haiku',
+        },
+      })
+    );
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-background',
+        parentToolUseId: 'agent-a',
+        subagentType: 'alpha-verifier',
+        model: 'claude-haiku',
+        content: [textBlock('ALPHA_OK')],
+      })
+    );
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-background',
+        parentToolUseId: 'agent-b',
+        subagentType: 'beta-verifier',
+        model: 'claude-haiku',
+        content: [textBlock('BETA_OK')],
+      })
+    );
+    tracer.processMessage(
+      resultSuccess({sessionId: 'sess-background', result: 'launched'})
+    );
+
+    expect(
+      getExporter()
+        .getFinishedSpans()
+        .filter(
+          span =>
+            span.name === INVOKE &&
+            span.attributes[ATTR_GEN_AI_AGENT_NAME] !== 'claude_agent_sdk'
+        )
+    ).toEqual([]);
+
+    tracer.processMessage(
+      taskNotification({
+        sessionId: 'sess-background',
+        taskId: 'task-b',
+        toolUseId: 'agent-b',
+        status: 'completed',
+        summary: 'Beta verification finished',
+      })
+    );
+    tracer.processMessage(
+      taskNotification({
+        sessionId: 'sess-background',
+        taskId: 'task-a',
+        status: 'completed',
+        summary: 'Alpha verification finished',
+      })
+    );
+    tracer.finalize(
+      resultSuccess({sessionId: 'sess-background', result: 'done'})
+    );
+
+    const spans = getExporter().getFinishedSpans();
+    const subagents = spans
+      .filter(
+        span =>
+          span.name === INVOKE &&
+          span.attributes[ATTR_GEN_AI_AGENT_NAME] !== 'claude_agent_sdk'
+      )
+      .sort((a, b) =>
+        String(a.attributes[ATTR_GEN_AI_AGENT_NAME]).localeCompare(
+          String(b.attributes[ATTR_GEN_AI_AGENT_NAME])
+        )
+      );
+    expect(
+      subagents.map(span => ({
+        agentId: span.attributes[ATTR_GEN_AI_AGENT_ID],
+        childMessages: spans
+          .filter(
+            child =>
+              child.name === 'chat' &&
+              child.parentSpanId === span.spanContext().spanId
+          )
+          .map(child =>
+            JSON.parse(child.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string)
+          ),
+        errorType: span.attributes[ATTR_ERROR_TYPE],
+        inputMessages: JSON.parse(
+          span.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string
+        ),
+        model: span.attributes[ATTR_GEN_AI_REQUEST_MODEL],
+        name: span.attributes[ATTR_GEN_AI_AGENT_NAME],
+        outputMessages: span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES],
+        statusCode: span.status.code,
+        toolCallId: span.attributes[ATTR_GEN_AI_TOOL_CALL_ID],
+        toolCallResult: span.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT],
+      }))
+    ).toEqual([
+      {
+        agentId: 'task-a',
+        childMessages: [
+          [
+            {
+              role: 'assistant',
+              parts: [{type: 'text', content: 'ALPHA_OK'}],
+            },
+          ],
+        ],
+        errorType: undefined,
+        inputMessages: [{role: 'user', content: 'Return ALPHA_OK'}],
+        model: 'claude-haiku',
+        name: 'alpha-verifier',
+        outputMessages: undefined,
+        statusCode: SpanStatusCode.UNSET,
+        toolCallId: 'agent-a',
+        toolCallResult: undefined,
+      },
+      {
+        agentId: 'task-b',
+        childMessages: [
+          [
+            {
+              role: 'assistant',
+              parts: [{type: 'text', content: 'BETA_OK'}],
+            },
+          ],
+        ],
+        errorType: undefined,
+        inputMessages: [{role: 'user', content: 'Return BETA_OK'}],
+        model: 'claude-haiku',
+        name: 'beta-verifier',
+        outputMessages: undefined,
+        statusCode: SpanStatusCode.UNSET,
+        toolCallId: 'agent-b',
+        toolCallResult: undefined,
+      },
+    ]);
+  });
+
+  test('marks a failed background subagent from its task notification', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-failed-background',
+        model: 'claude-main',
+        content: [
+          toolUseBlock('agent-failed', 'Agent', {
+            prompt: 'Fail',
+            subagent_type: 'failure-checker',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-failed-background',
+        toolUseId: 'agent-failed',
+        content: 'Async agent launched successfully',
+        toolUseResult: {
+          status: 'async_launched',
+          agentId: 'task-failed',
+        },
+      })
+    );
+    tracer.processMessage(
+      resultSuccess({sessionId: 'sess-failed-background', result: 'launched'})
+    );
+    tracer.processMessage(
+      taskNotification({
+        sessionId: 'sess-failed-background',
+        taskId: 'task-failed',
+        status: 'failed',
+        summary: 'Subagent crashed',
+      })
+    );
+    tracer.finalize(
+      resultSuccess({sessionId: 'sess-failed-background', result: 'done'})
+    );
+
+    const subagent = getExporter()
+      .getFinishedSpans()
+      .filter(
+        span =>
+          span.name === INVOKE &&
+          span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'failure-checker'
+      );
+    expect(
+      subagent.map(span => ({
+        agentId: span.attributes[ATTR_GEN_AI_AGENT_ID],
+        errorType: span.attributes[ATTR_ERROR_TYPE],
+        statusCode: span.status.code,
+        statusMessage: span.status.message,
+        toolCallId: span.attributes[ATTR_GEN_AI_TOOL_CALL_ID],
+      }))
+    ).toEqual([
+      {
+        agentId: 'task-failed',
+        errorType: 'subagent_error',
+        statusCode: SpanStatusCode.ERROR,
+        statusMessage: 'Subagent crashed',
+        toolCallId: 'agent-failed',
+      },
+    ]);
+  });
+
+  test('aborts a background subagent that never reports completion', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-unfinished-background',
+        model: 'claude-main',
+        content: [
+          toolUseBlock('agent-unfinished', 'Agent', {
+            prompt: 'Keep running',
+            run_in_background: true,
+            subagent_type: 'unfinished-checker',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-unfinished-background',
+        toolUseId: 'agent-unfinished',
+        content: 'Async agent launched successfully',
+        toolUseResult: {
+          status: 'async_launched',
+          agentId: 'task-unfinished',
+        },
+      })
+    );
+    tracer.processMessage(
+      resultSuccess({
+        sessionId: 'sess-unfinished-background',
+        result: 'launched',
+      })
+    );
+    tracer.finalize();
+
+    const subagents = getExporter()
+      .getFinishedSpans()
+      .filter(
+        span =>
+          span.name === INVOKE &&
+          span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'unfinished-checker'
+      );
+    expect(
+      subagents.map(span => ({
+        agentId: span.attributes[ATTR_GEN_AI_AGENT_ID],
+        errorType: span.attributes[ATTR_ERROR_TYPE],
+        statusCode: span.status.code,
+        statusMessage: span.status.message,
+        toolCallId: span.attributes[ATTR_GEN_AI_TOOL_CALL_ID],
+      }))
+    ).toEqual([
+      {
+        agentId: 'task-unfinished',
+        errorType: 'aborted',
+        statusCode: SpanStatusCode.ERROR,
+        statusMessage: 'Agent ended with open subagent span',
+        toolCallId: 'agent-unfinished',
+      },
+    ]);
+  });
+
+  test('nests a legacy Task subagent under a forwarded Agent span', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate recursively'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-nested',
+        model: 'claude-main',
+        content: [
+          toolUseBlock('agent-parent', 'Agent', {
+            prompt: 'Coordinate the check',
+            subagent_type: 'coordinator',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-nested',
+        parentToolUseId: 'agent-parent',
+        subagentType: 'coordinator',
+        model: 'claude-coordinator',
+        content: [
+          toolUseBlock('task-child', 'Task', {
+            prompt: 'Perform the check',
+            subagent_type: 'worker',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-nested',
+        parentToolUseId: 'task-child',
+        subagentType: 'worker',
+        model: 'claude-worker',
+        content: [textBlock('checked')],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-nested',
+        toolUseId: 'task-child',
+        content: 'worker complete',
+      })
+    );
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-nested',
+        parentToolUseId: 'agent-parent',
+        subagentType: 'coordinator',
+        model: 'claude-coordinator',
+        content: [textBlock('coordinated')],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-nested',
+        toolUseId: 'agent-parent',
+        content: 'coordinator complete',
+      })
+    );
+    tracer.finalize(resultSuccess({sessionId: 'sess-nested', result: 'done'}));
+
+    const spans = getExporter().getFinishedSpans();
+    const subagents = spans.filter(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] !== 'claude_agent_sdk'
+    );
+    const coordinator = subagents.find(
+      span => span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'coordinator'
+    )!;
+    expect(
+      subagents
+        .map(span => ({
+          name: span.attributes[ATTR_GEN_AI_AGENT_NAME],
+          parentSpanId: span.parentSpanId,
+          statusCode: span.status.code,
+          toolName: span.attributes[ATTR_GEN_AI_TOOL_NAME],
+        }))
+        .sort((a, b) => String(a.name).localeCompare(String(b.name)))
+    ).toEqual([
+      {
+        name: 'coordinator',
+        parentSpanId: spans
+          .find(
+            span =>
+              span.name === INVOKE &&
+              span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'claude_agent_sdk'
+          )!
+          .spanContext().spanId,
+        statusCode: SpanStatusCode.UNSET,
+        toolName: 'Agent',
+      },
+      {
+        name: 'worker',
+        parentSpanId: coordinator.spanContext().spanId,
+        statusCode: SpanStatusCode.UNSET,
+        toolName: 'Task',
       },
     ]);
   });

--- a/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
+++ b/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
@@ -346,7 +346,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
     }
 
     const invoke = findSpan(spans, INVOKE);
-    expect(invoke.kind).toBe(SpanKind.CLIENT);
+    expect(invoke.kind).toBe(SpanKind.INTERNAL);
     expect(invoke.attributes[ATTR_GEN_AI_OPERATION_NAME]).toBe('invoke_agent');
     expect(invoke.attributes[ATTR_GEN_AI_AGENT_NAME]).toBe('claude_agent_sdk');
     expect(invoke.attributes[ATTR_GEN_AI_PROVIDER_NAME]).toBeUndefined();
@@ -375,6 +375,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
     )!;
     expect(chat.kind).toBe(SpanKind.CLIENT);
     expect(chat.attributes[ATTR_GEN_AI_OPERATION_NAME]).toBe('chat');
+    expect(chat.attributes[ATTR_GEN_AI_PROVIDER_NAME]).toBe('anthropic');
     expect(chat.attributes[ATTR_GEN_AI_REQUEST_MODEL]).toBe('claude-x');
     expect(chat.attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('sess-1');
     expect(chat.attributes[ATTR_GEN_AI_RESPONSE_FINISH_REASONS]).toEqual([
@@ -883,9 +884,11 @@ describe('Claude Agent SDK — OTel tracer', () => {
         inputMessages: JSON.parse(
           span.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string
         ),
+        kind: span.kind,
         model: span.attributes[ATTR_GEN_AI_REQUEST_MODEL],
         name: span.attributes[ATTR_GEN_AI_AGENT_NAME],
         outputMessages: span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES],
+        providerName: span.attributes[ATTR_GEN_AI_PROVIDER_NAME],
         statusCode: span.status.code,
         toolCallId: span.attributes[ATTR_GEN_AI_TOOL_CALL_ID],
         toolCallResult: span.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT],
@@ -903,9 +906,11 @@ describe('Claude Agent SDK — OTel tracer', () => {
         ],
         errorType: undefined,
         inputMessages: [{role: 'user', content: 'Return ALPHA_OK'}],
+        kind: SpanKind.INTERNAL,
         model: 'claude-haiku',
         name: 'alpha-verifier',
         outputMessages: undefined,
+        providerName: undefined,
         statusCode: SpanStatusCode.UNSET,
         toolCallId: 'agent-a',
         toolCallResult: undefined,
@@ -922,9 +927,11 @@ describe('Claude Agent SDK — OTel tracer', () => {
         ],
         errorType: undefined,
         inputMessages: [{role: 'user', content: 'Return BETA_OK'}],
+        kind: SpanKind.INTERNAL,
         model: 'claude-haiku',
         name: 'beta-verifier',
         outputMessages: undefined,
+        providerName: undefined,
         statusCode: SpanStatusCode.UNSET,
         toolCallId: 'agent-b',
         toolCallResult: undefined,

--- a/sdks/node/src/__tests__/integrations/claudeAgentSdk.test.ts
+++ b/sdks/node/src/__tests__/integrations/claudeAgentSdk.test.ts
@@ -130,6 +130,7 @@ describe('Claude Agent SDK — query() patch', () => {
   });
 
   test('streaming input emits one root per user turn', async () => {
+    let receivedOptions: Record<string, unknown> | undefined;
     async function* prompts() {
       yield {
         type: 'user',
@@ -144,7 +145,14 @@ describe('Claude Agent SDK — query() patch', () => {
     }
 
     const sdk = {
-      query: ({prompt}: {prompt: AsyncIterable<any>}) => {
+      query: ({
+        prompt,
+        options,
+      }: {
+        prompt: AsyncIterable<any>;
+        options?: Record<string, unknown>;
+      }) => {
+        receivedOptions = options;
         async function* gen() {
           let turn = 0;
           for await (const _input of prompt) {
@@ -180,7 +188,10 @@ describe('Claude Agent SDK — query() patch', () => {
     };
     patchClaudeAgentSdk(sdk);
 
-    const query = sdk.query({prompt: prompts()});
+    const query = sdk.query({
+      prompt: prompts(),
+      options: {forwardSubagentText: true},
+    });
     await expect(query.next()).resolves.toMatchObject({
       value: {type: 'assistant'},
       done: false,
@@ -203,6 +214,7 @@ describe('Claude Agent SDK — query() patch', () => {
       .getFinishedSpans()
       .filter(span => span.name === INVOKE);
     expect(roots).toHaveLength(2);
+    expect(receivedOptions).toEqual({forwardSubagentText: true});
     expect(
       roots.map(root => ({
         conversationId: root.attributes[ATTR_GEN_AI_CONVERSATION_ID],

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -115,7 +115,7 @@ export class SubAgent extends SpanBase {
     const attributes: Attributes = {...(opts.attributes ?? {})};
     const span = tracer.startSpan(
       'invoke_agent',
-      {kind: SpanKind.CLIENT, attributes, startTime: opts.startTime},
+      {kind: SpanKind.INTERNAL, attributes, startTime: opts.startTime},
       opts.parentContext
     );
     return new SubAgent({

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -16,12 +16,15 @@ import {
   ATTR_GEN_AI_AGENT_NAME,
   ATTR_GEN_AI_AGENT_VERSION,
   ATTR_GEN_AI_CONVERSATION_ID,
+  ATTR_GEN_AI_INPUT_MESSAGES,
   ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_OUTPUT_MESSAGES,
   ATTR_GEN_AI_REQUEST_MODEL,
   ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   WEAVE_GENAI_TRACER_NAME,
 } from './semconv';
 import {Tool, type ToolInit} from './tool';
+import type {Message} from './types';
 
 export interface SubAgentInit extends SpanInitBase {
   name: string;
@@ -83,6 +86,8 @@ export class SubAgent extends SpanBase {
   private _conversationId: string;
   private _name: string;
   private _model: string;
+  private _inputMessages: Message[] = [];
+  private _outputMessages: Message[] = [];
   private _systemInstructions: string[];
   private _agentId: string;
   private _agentDescription: string;
@@ -163,9 +168,12 @@ export class SubAgent extends SpanBase {
   }
 
   /**
-   * Bulk-set any fields. Replaces (does not merge).
+   * Bulk-set any subset of the mutable fields. Replaces (does not merge).
+   * Input and output messages are serialized when the span ends.
    */
   record(opts: {
+    messages?: Message[];
+    outputMessages?: Message[];
     name?: string;
     model?: string;
     systemInstructions?: string[];
@@ -175,6 +183,12 @@ export class SubAgent extends SpanBase {
   }): this {
     if (this._warnIfEnded('record')) return this;
 
+    if (opts.messages !== undefined) {
+      this._inputMessages = opts.messages;
+    }
+    if (opts.outputMessages !== undefined) {
+      this._outputMessages = opts.outputMessages;
+    }
     if (opts.name !== undefined) {
       this._name = opts.name;
     }
@@ -226,6 +240,18 @@ export class SubAgent extends SpanBase {
     }
     if (this._agentVersion) {
       this.span.setAttribute(ATTR_GEN_AI_AGENT_VERSION, this._agentVersion);
+    }
+    if (this._inputMessages.length > 0) {
+      this.span.setAttribute(
+        ATTR_GEN_AI_INPUT_MESSAGES,
+        JSON.stringify(this._inputMessages)
+      );
+    }
+    if (this._outputMessages.length > 0) {
+      this.span.setAttribute(
+        ATTR_GEN_AI_OUTPUT_MESSAGES,
+        JSON.stringify(this._outputMessages)
+      );
     }
     if (this._systemInstructions.length > 0) {
       this.span.setAttribute(

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -146,7 +146,7 @@ export class Turn extends SpanBase {
     // library's active span as a parent.
     const span = tracer.startSpan(
       'invoke_agent',
-      {kind: SpanKind.CLIENT, attributes, startTime: opts.startTime},
+      {kind: SpanKind.INTERNAL, attributes, startTime: opts.startTime},
       ROOT_CONTEXT
     );
     const turn = new Turn({

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -3,13 +3,20 @@ import {
   runIsolated,
   type Message,
   type MessagePart,
+  type SubAgent,
   type Tool,
   type Turn,
   type Usage,
 } from '../../genai';
 import {
   ATTR_ERROR_TYPE,
+  ATTR_GEN_AI_INPUT_MESSAGES,
+  ATTR_GEN_AI_OUTPUT_MESSAGES,
   ATTR_GEN_AI_PROVIDER_NAME,
+  ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
+  ATTR_GEN_AI_TOOL_CALL_ID,
+  ATTR_GEN_AI_TOOL_CALL_RESULT,
+  ATTR_GEN_AI_TOOL_NAME,
   ATTR_GEN_AI_USAGE_TOTAL_TOKENS,
 } from '../../genai/semconv';
 import {asOtelAttributes, libraryIntegration} from '../integrationMetadata';
@@ -67,6 +74,11 @@ type ToolResultBlock = Extract<
   {type: 'tool_result'}
 >;
 
+type ToolUseBlock = Extract<
+  SDKAssistantMessage['message']['content'][number],
+  {type: 'tool_use'}
+>;
+
 function toolResultText(content: ToolResultBlock['content']): string {
   if (!content) {
     return '';
@@ -106,6 +118,23 @@ function userInputMessage(msg: SDKUserMessage): Message {
     return {role: 'user', content: parts[0].content};
   }
   return {role: 'user', parts};
+}
+
+function recordOf(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value != null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringField(
+  value: Record<string, unknown>,
+  key: string
+): string | undefined {
+  return typeof value[key] === 'string' ? value[key] : undefined;
+}
+
+function isSubagentTool(name: string): boolean {
+  return name === 'Agent' || name === 'Task';
 }
 
 type NormalizedUsage = {
@@ -164,10 +193,16 @@ type PendingTurn = {
   startedAt: Date;
 };
 
+type SpanParent = Pick<
+  Turn | SubAgent,
+  'startLLM' | 'startSubagent' | 'startTool'
+>;
+
 /** Emits Claude Agent SDK traces through Weave GenAI handles. */
 export class ClaudeAgentOtelTracer {
   private readonly agentName: string;
   private readonly startedAt = new Date();
+  private readonly openSubagents = new Map<string, SubAgent>();
   private readonly openTools = new Map<string, Tool>();
   private readonly pendingTurns: PendingTurn[] = [];
 
@@ -258,6 +293,11 @@ export class ClaudeAgentOtelTracer {
       tool.end({error: new Error('Agent ended with open tool span')});
     }
     this.openTools.clear();
+    for (const subagent of [...this.openSubagents.values()].reverse()) {
+      subagent.setAttributes({[ATTR_ERROR_TYPE]: 'aborted'});
+      subagent.end({error: new Error('Agent ended with open subagent span')});
+    }
+    this.openSubagents.clear();
 
     if (result) {
       this.emitModelUsageSpans(result, turn);
@@ -381,15 +421,16 @@ export class ClaudeAgentOtelTracer {
 
   private processAssistant(msg: SDKAssistantMessage, turn: Turn): void {
     const model = msg.message.model;
-    if (this.rootModel == null && model) {
+    if (msg.parent_tool_use_id == null && this.rootModel == null && model) {
       this.rootModel = model;
     }
 
+    const parent = this.spanParent(msg, turn);
     const content = msg.message.content;
     const parts = assistantParts(content);
 
     runIsolated(() => {
-      const llm = turn.startLLM({
+      const llm = parent.startLLM({
         model: model ?? '',
         providerName: PROVIDER_NAME,
       });
@@ -410,13 +451,75 @@ export class ClaudeAgentOtelTracer {
       if (block.type !== 'tool_use') {
         continue;
       }
-      const tool = turn.startTool({
+      if (isSubagentTool(block.name)) {
+        this.startSubagent(block, parent);
+        continue;
+      }
+      const tool = parent.startTool({
         name: block.name,
         toolCallId: block.id,
         args: JSON.stringify(block.input ?? {}),
       });
       this.openTools.set(block.id, tool);
     }
+  }
+
+  private spanParent(msg: SDKAssistantMessage, turn: Turn): SpanParent {
+    const parentToolUseId = msg.parent_tool_use_id;
+    if (parentToolUseId == null) {
+      return turn;
+    }
+
+    let subagent = this.openSubagents.get(parentToolUseId);
+    if (!subagent) {
+      subagent = turn.startSubagent({
+        name: msg.subagent_type ?? 'subagent',
+        model: msg.message.model,
+        agentDescription: msg.task_description,
+      });
+      subagent.setAttributes({
+        [ATTR_GEN_AI_PROVIDER_NAME]: PROVIDER_NAME,
+        [ATTR_GEN_AI_TOOL_CALL_ID]: parentToolUseId,
+      });
+      this.openSubagents.set(parentToolUseId, subagent);
+    } else {
+      subagent.record({
+        ...(msg.subagent_type ? {name: msg.subagent_type} : {}),
+        ...(msg.message.model ? {model: msg.message.model} : {}),
+        ...(msg.task_description
+          ? {agentDescription: msg.task_description}
+          : {}),
+      });
+    }
+    return subagent;
+  }
+
+  private startSubagent(block: ToolUseBlock, parent: SpanParent): void {
+    const input = recordOf(block.input);
+    const name =
+      stringField(input, 'subagent_type') ??
+      stringField(input, 'name') ??
+      'subagent';
+    const prompt = stringField(input, 'prompt');
+    const subagent = parent.startSubagent({
+      name,
+      model: stringField(input, 'model'),
+      agentDescription: stringField(input, 'description'),
+    });
+    subagent.setAttributes({
+      [ATTR_GEN_AI_PROVIDER_NAME]: PROVIDER_NAME,
+      [ATTR_GEN_AI_TOOL_CALL_ID]: block.id,
+      [ATTR_GEN_AI_TOOL_NAME]: block.name,
+      [ATTR_GEN_AI_TOOL_CALL_ARGUMENTS]: JSON.stringify(block.input ?? {}),
+      ...(prompt
+        ? {
+            [ATTR_GEN_AI_INPUT_MESSAGES]: JSON.stringify([
+              {role: 'user', content: prompt},
+            ]),
+          }
+        : {}),
+    });
+    this.openSubagents.set(block.id, subagent);
   }
 
   private processUser(msg: SDKUserMessage | SDKUserMessageReplay): void {
@@ -427,12 +530,35 @@ export class ClaudeAgentOtelTracer {
       if (block.type !== 'tool_result') {
         continue;
       }
+      const resultText = toolResultText(block.content);
+      const subagent = this.openSubagents.get(block.tool_use_id);
+      if (subagent) {
+        this.openSubagents.delete(block.tool_use_id);
+        subagent.setAttributes({
+          [ATTR_GEN_AI_TOOL_CALL_RESULT]: resultText,
+          ...(resultText
+            ? {
+                [ATTR_GEN_AI_OUTPUT_MESSAGES]: JSON.stringify([
+                  {role: 'assistant', content: resultText},
+                ]),
+              }
+            : {}),
+        });
+        if (block.is_error) {
+          subagent.setAttributes({[ATTR_ERROR_TYPE]: 'subagent_error'});
+          subagent.end({
+            error: new Error(resultText || 'Subagent execution failed'),
+          });
+        } else {
+          subagent.end();
+        }
+        continue;
+      }
       const tool = this.openTools.get(block.tool_use_id);
       if (!tool) {
         continue;
       }
       this.openTools.delete(block.tool_use_id);
-      const resultText = toolResultText(block.content);
       tool.result = resultText;
       if (block.is_error) {
         tool.setAttributes({[ATTR_ERROR_TYPE]: 'tool_error'});

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -10,12 +10,6 @@ import {
 } from '../../genai';
 import {
   ATTR_ERROR_TYPE,
-  ATTR_GEN_AI_INPUT_MESSAGES,
-  ATTR_GEN_AI_OUTPUT_MESSAGES,
-  ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
-  ATTR_GEN_AI_TOOL_CALL_ID,
-  ATTR_GEN_AI_TOOL_CALL_RESULT,
-  ATTR_GEN_AI_TOOL_NAME,
   ATTR_GEN_AI_USAGE_TOTAL_TOKENS,
 } from '../../genai/semconv';
 import {asOtelAttributes, libraryIntegration} from '../integrationMetadata';
@@ -500,9 +494,6 @@ export class ClaudeAgentOtelTracer {
         model: msg.message.model,
         agentDescription: msg.task_description,
       });
-      span.setAttributes({
-        [ATTR_GEN_AI_TOOL_CALL_ID]: parentToolUseId,
-      });
       openSubagent = {background: false, span};
       this.openSubagents.set(parentToolUseId, openSubagent);
     } else {
@@ -529,17 +520,8 @@ export class ClaudeAgentOtelTracer {
       model: stringField(input, 'model'),
       agentDescription: stringField(input, 'description'),
     });
-    subagent.setAttributes({
-      [ATTR_GEN_AI_TOOL_CALL_ID]: block.id,
-      [ATTR_GEN_AI_TOOL_NAME]: block.name,
-      [ATTR_GEN_AI_TOOL_CALL_ARGUMENTS]: JSON.stringify(block.input ?? {}),
-      ...(prompt
-        ? {
-            [ATTR_GEN_AI_INPUT_MESSAGES]: JSON.stringify([
-              {role: 'user', content: prompt},
-            ]),
-          }
-        : {}),
+    subagent.record({
+      messages: prompt ? [{role: 'user', content: prompt}] : [],
     });
     this.openSubagents.set(block.id, {background: false, span: subagent});
   }
@@ -565,15 +547,10 @@ export class ClaudeAgentOtelTracer {
           });
           continue;
         }
-        openSubagent.span.setAttributes({
-          [ATTR_GEN_AI_TOOL_CALL_RESULT]: resultText,
-          ...(resultText
-            ? {
-                [ATTR_GEN_AI_OUTPUT_MESSAGES]: JSON.stringify([
-                  {role: 'assistant', content: resultText},
-                ]),
-              }
-            : {}),
+        openSubagent.span.record({
+          outputMessages: resultText
+            ? [{role: 'assistant', content: resultText}]
+            : [],
         });
         if (block.is_error) {
           openSubagent.completion = {

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -449,7 +449,7 @@ export class ClaudeAgentOtelTracer {
       this.rootModel = model;
     }
 
-    const parent = this.spanParent(msg, turn);
+    const parent = this.getOrCreateMessageParent(msg, turn);
     const content = msg.message.content;
     const parts = assistantParts(content);
 
@@ -488,7 +488,10 @@ export class ClaudeAgentOtelTracer {
     }
   }
 
-  private spanParent(msg: SDKAssistantMessage, turn: Turn): Turn | SubAgent {
+  private getOrCreateMessageParent(
+    msg: SDKAssistantMessage,
+    turn: Turn
+  ): Turn | SubAgent {
     const parentToolUseId = msg.parent_tool_use_id;
     if (parentToolUseId == null) {
       return turn;

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -404,9 +404,6 @@ export class ClaudeAgentOtelTracer {
         startTime: pending.startedAt,
       })
     );
-    this.activeTurn.setAttributes({
-      [ATTR_GEN_AI_PROVIDER_NAME]: PROVIDER_NAME,
-    });
     if (pending.inputMessages.length > 0) {
       this.activeTurn.record({
         messages: pending.inputMessages,

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -127,6 +127,25 @@ function stringField(
   return typeof value[key] === 'string' ? value[key] : undefined;
 }
 
+function completedSubagentOutputText(
+  value: Record<string, unknown>
+): string | undefined {
+  if (value.status !== 'completed' || !Array.isArray(value.content)) {
+    return undefined;
+  }
+
+  const text: string[] = [];
+  for (const item of value.content) {
+    const block = recordOf(item);
+    const blockText = stringField(block, 'text');
+    if (block.type !== 'text' || blockText == null) {
+      return undefined;
+    }
+    text.push(blockText);
+  }
+  return text.join('\n');
+}
+
 // `Task` is the pre-rename name for `Agent`; older SDK versions still emit it.
 const SUBAGENT_TOOL_NAMES = new Set(['Agent', 'Task']);
 
@@ -167,6 +186,7 @@ type SubagentIdentity = {
 function subagentResult(value: unknown): {
   acknowledgesLaunch: boolean;
   identity: SubagentIdentity;
+  outputText: string | undefined;
 } {
   const raw = recordOf(value);
   return {
@@ -178,6 +198,7 @@ function subagentResult(value: unknown): {
       // A remote launch names its handle `taskId`; the others use `agentId`.
       taskId: stringField(raw, 'taskId'),
     },
+    outputText: completedSubagentOutputText(raw),
   };
 }
 
@@ -326,7 +347,7 @@ export class ClaudeAgentOtelTracer {
 
     switch (msg.type) {
       case 'assistant':
-        this.processAssistant(msg, this.getOrCreateTurn());
+        this.processAssistant(msg);
         break;
       case 'user':
         this.processUser(msg);
@@ -490,13 +511,13 @@ export class ClaudeAgentOtelTracer {
     }
   }
 
-  private processAssistant(msg: SDKAssistantMessage, turn: Turn): void {
+  private processAssistant(msg: SDKAssistantMessage): void {
     const model = msg.message.model;
     if (msg.parent_tool_use_id == null && this.rootModel == null && model) {
       this.rootModel = model;
     }
 
-    const parent = this.getOrCreateMessageParent(msg, turn);
+    const parent = this.getOrCreateMessageParent(msg);
     const content = msg.message.content;
     const parts = assistantParts(content);
 
@@ -537,17 +558,15 @@ export class ClaudeAgentOtelTracer {
     }
   }
 
-  private getOrCreateMessageParent(
-    msg: SDKAssistantMessage,
-    turn: Turn
-  ): Turn | SubAgent {
+  private getOrCreateMessageParent(msg: SDKAssistantMessage): Turn | SubAgent {
     const parentToolUseId = msg.parent_tool_use_id;
     if (parentToolUseId == null) {
-      return turn;
+      return this.getOrCreateTurn();
     }
 
     let openSubagent = this.openSubagents.get(parentToolUseId);
     if (!openSubagent) {
+      const turn = this.getOrCreateTurn();
       const span = turn.startSubagent({
         name: msg.subagent_type ?? 'subagent',
         model: msg.message.model,
@@ -631,7 +650,9 @@ export class ClaudeAgentOtelTracer {
     resultText: string,
     msg: SDKUserMessage | SDKUserMessageReplay
   ): void {
-    const {acknowledgesLaunch, identity} = subagentResult(msg.tool_use_result);
+    const {acknowledgesLaunch, identity, outputText} = subagentResult(
+      msg.tool_use_result
+    );
     // The identity fields ride on every `Agent` result shape, launch or not.
     openSubagent.agentId = identity.agentId ?? openSubagent.agentId;
     openSubagent.taskId = identity.taskId ?? openSubagent.taskId;
@@ -646,16 +667,19 @@ export class ClaudeAgentOtelTracer {
       return;
     }
 
+    const terminalOutputText = block.is_error
+      ? resultText
+      : (outputText ?? resultText);
     openSubagent.span.record({
-      outputMessages: resultText
-        ? [{role: 'assistant', content: resultText}]
+      outputMessages: terminalOutputText
+        ? [{role: 'assistant', content: terminalOutputText}]
         : [],
     });
     openSubagent.outcome = block.is_error
       ? {
           status: 'error',
           errorType: 'subagent_error',
-          error: new Error(resultText || 'Subagent execution failed'),
+          error: new Error(terminalOutputText || 'Subagent execution failed'),
           endedAt: new Date(),
         }
       : {status: 'ok', endedAt: new Date()};

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -127,21 +127,57 @@ function stringField(
   return typeof value[key] === 'string' ? value[key] : undefined;
 }
 
+// `Task` is the pre-rename name for `Agent`; older SDK versions still emit it.
+const SUBAGENT_TOOL_NAMES = new Set(['Agent', 'Task']);
+
 function isSubagentTool(name: string): boolean {
-  return name === 'Agent' || name === 'Task';
+  return SUBAGENT_TOOL_NAMES.has(name);
 }
 
-function asyncSubagentLaunch(value: unknown): {
+function booleanField(value: Record<string, unknown>, key: string): boolean {
+  return value[key] === true;
+}
+
+/**
+ * `run_in_background` and `isolation: 'remote'` (which the SDK documents as
+ * always backgrounded) are declared on the `Agent` input, so read the lifetime
+ * from the caller's request rather than inferring it from the result shape —
+ * an unrecognized result status must not silently downgrade it.
+ */
+function subagentLifetime(
+  input: Record<string, unknown>
+): 'turn-scoped' | 'background' {
+  return booleanField(input, 'run_in_background') ||
+    stringField(input, 'isolation') === 'remote'
+    ? 'background'
+    : 'turn-scoped';
+}
+
+type SubagentIdentity = {
+  agentId?: string;
   model?: string;
   taskId?: string;
-} | null {
-  const result = recordOf(value);
-  if (result.status !== 'async_launched') {
-    return null;
-  }
+};
+
+/**
+ * Reads an `Agent`/`Task` tool result. `async_launched` and `remote_launched`
+ * only acknowledge the launch — the real outcome arrives later as a
+ * `task_notification` — so neither is terminal.
+ */
+function subagentResult(value: unknown): {
+  acknowledgesLaunch: boolean;
+  identity: SubagentIdentity;
+} {
+  const raw = recordOf(value);
   return {
-    model: stringField(result, 'resolvedModel'),
-    taskId: stringField(result, 'agentId'),
+    acknowledgesLaunch:
+      raw.status === 'async_launched' || raw.status === 'remote_launched',
+    identity: {
+      agentId: stringField(raw, 'agentId'),
+      model: stringField(raw, 'resolvedModel'),
+      // A remote launch names its handle `taskId`; the others use `agentId`.
+      taskId: stringField(raw, 'taskId'),
+    },
   };
 }
 
@@ -201,16 +237,38 @@ type PendingTurn = {
   startedAt: Date;
 };
 
-type SubagentCompletion = {
-  error?: Error;
-  errorType?: 'aborted' | 'subagent_error';
-};
+/**
+ * A subagent's terminal state. Buffered rather than applied on the spot because
+ * `SpanBase` only exposes error recording through `end()`, so deferring the
+ * close (to keep child spans closing before their parent) also defers the
+ * `Error`. `endedAt` preserves the real duration across that deferral.
+ */
+type SubagentOutcome =
+  | {status: 'ok'; endedAt: Date}
+  | {
+      status: 'error';
+      errorType: 'aborted' | 'subagent_error';
+      error: Error;
+      endedAt: Date;
+    };
 
 type OpenSubagent = {
-  background: boolean;
-  completion?: SubagentCompletion;
+  /** `AgentOutput.agentId` — the subagent's own identity. */
+  agentId?: string;
+  /** `background` subagents outlive the turn that launched them. */
+  lifetime: 'turn-scoped' | 'background';
+  /** Owning subagent's tool-use ID; undefined when the parent is the Turn. */
+  parentToolUseId?: string;
   span: SubAgent;
+  /** `task_notification.task_id` — the task-registry handle, not assumed equal to `agentId`. */
   taskId?: string;
+  outcome?: SubagentOutcome;
+};
+
+type OpenTool = {
+  /** Owning subagent's tool-use ID; undefined when the parent is the Turn. */
+  ownerToolUseId?: string;
+  tool: Tool;
 };
 
 /** Emits Claude Agent SDK traces through Weave GenAI handles. */
@@ -218,7 +276,7 @@ export class ClaudeAgentOtelTracer {
   private readonly agentName: string;
   private readonly startedAt = new Date();
   private readonly openSubagents = new Map<string, OpenSubagent>();
-  private readonly openTools = new Map<string, Tool>();
+  private readonly openTools = new Map<string, OpenTool>();
   private readonly pendingTurns: PendingTurn[] = [];
 
   private conversation: Conversation | null = null;
@@ -304,17 +362,16 @@ export class ClaudeAgentOtelTracer {
     ) {
       this.endTurn(undefined, error);
     }
-    this.finishOpenSubagents(true);
+    this.finishOpenTools('shutdown');
+    this.finishOpenSubagents('shutdown');
   }
 
   private endTurn(result?: SDKResultMessage, error?: unknown): void {
     const turn = this.getOrCreateTurn();
-    for (const tool of this.openTools.values()) {
-      tool.setAttributes({[ATTR_ERROR_TYPE]: 'aborted'});
-      tool.end({error: new Error('Agent ended with open tool span')});
-    }
-    this.openTools.clear();
-    this.finishOpenSubagents(false);
+    // Sweep children before their parents, and spare anything owned by a
+    // background subagent that is still running past this turn boundary.
+    this.finishOpenTools('turn-boundary');
+    this.finishOpenSubagents('turn-boundary');
 
     if (result) {
       this.emitModelUsageSpans(result, turn);
@@ -460,13 +517,15 @@ export class ClaudeAgentOtelTracer {
       llm.end();
     });
 
-    // Tool spans stay open until the matching tool_result arrives.
+    // Tool spans stay open until the matching tool_result arrives. Record the
+    // owning subagent so a turn boundary can tell whose children these are.
+    const ownerToolUseId = msg.parent_tool_use_id ?? undefined;
     for (const block of content) {
       if (block.type !== 'tool_use') {
         continue;
       }
       if (isSubagentTool(block.name)) {
-        this.startSubagent(block, parent);
+        this.startSubagent(block, parent, ownerToolUseId);
         continue;
       }
       const tool = parent.startTool({
@@ -474,7 +533,7 @@ export class ClaudeAgentOtelTracer {
         toolCallId: block.id,
         args: JSON.stringify(block.input ?? {}),
       });
-      this.openTools.set(block.id, tool);
+      this.openTools.set(block.id, {ownerToolUseId, tool});
     }
   }
 
@@ -494,7 +553,9 @@ export class ClaudeAgentOtelTracer {
         model: msg.message.model,
         agentDescription: msg.task_description,
       });
-      openSubagent = {background: false, span};
+      // Reached only when the `Agent` tool_use block was never observed, so
+      // the launch options are unknown and the parent is this Turn.
+      openSubagent = {lifetime: 'turn-scoped', span};
       this.openSubagents.set(parentToolUseId, openSubagent);
     } else {
       openSubagent.span.record({
@@ -508,7 +569,11 @@ export class ClaudeAgentOtelTracer {
     return openSubagent.span;
   }
 
-  private startSubagent(block: ToolUseBlock, parent: Turn | SubAgent): void {
+  private startSubagent(
+    block: ToolUseBlock,
+    parent: Turn | SubAgent,
+    parentToolUseId: string | undefined
+  ): void {
     const input = recordOf(block.input);
     const name =
       stringField(input, 'subagent_type') ??
@@ -523,7 +588,11 @@ export class ClaudeAgentOtelTracer {
     subagent.record({
       messages: prompt ? [{role: 'user', content: prompt}] : [],
     });
-    this.openSubagents.set(block.id, {background: false, span: subagent});
+    this.openSubagents.set(block.id, {
+      lifetime: subagentLifetime(input),
+      parentToolUseId,
+      span: subagent,
+    });
   }
 
   private processUser(msg: SDKUserMessage | SDKUserMessageReplay): void {
@@ -537,36 +606,15 @@ export class ClaudeAgentOtelTracer {
       const resultText = toolResultText(block.content);
       const openSubagent = this.openSubagents.get(block.tool_use_id);
       if (openSubagent) {
-        const launch = asyncSubagentLaunch(msg.tool_use_result);
-        if (launch && !block.is_error) {
-          openSubagent.background = true;
-          openSubagent.taskId = launch.taskId;
-          openSubagent.span.record({
-            ...(launch.model ? {model: launch.model} : {}),
-            ...(launch.taskId ? {agentId: launch.taskId} : {}),
-          });
-          continue;
-        }
-        openSubagent.span.record({
-          outputMessages: resultText
-            ? [{role: 'assistant', content: resultText}]
-            : [],
-        });
-        if (block.is_error) {
-          openSubagent.completion = {
-            errorType: 'subagent_error',
-            error: new Error(resultText || 'Subagent execution failed'),
-          };
-        } else {
-          openSubagent.completion = {};
-        }
+        this.processSubagentResult(openSubagent, block, resultText, msg);
         continue;
       }
-      const tool = this.openTools.get(block.tool_use_id);
-      if (!tool) {
+      const openTool = this.openTools.get(block.tool_use_id);
+      if (!openTool) {
         continue;
       }
       this.openTools.delete(block.tool_use_id);
+      const tool = openTool.tool;
       tool.result = resultText;
       if (block.is_error) {
         tool.setAttributes({[ATTR_ERROR_TYPE]: 'tool_error'});
@@ -577,13 +625,52 @@ export class ClaudeAgentOtelTracer {
     }
   }
 
-  private processTaskNotification(msg: SDKTaskNotificationMessage): void {
-    let toolUseId = msg.tool_use_id;
-    if (!toolUseId) {
-      toolUseId = [...this.openSubagents.entries()].find(
-        ([, openSubagent]) => openSubagent.taskId === msg.task_id
-      )?.[0];
+  private processSubagentResult(
+    openSubagent: OpenSubagent,
+    block: ToolResultBlock,
+    resultText: string,
+    msg: SDKUserMessage | SDKUserMessageReplay
+  ): void {
+    const {acknowledgesLaunch, identity} = subagentResult(msg.tool_use_result);
+    // The identity fields ride on every `Agent` result shape, launch or not.
+    openSubagent.agentId = identity.agentId ?? openSubagent.agentId;
+    openSubagent.taskId = identity.taskId ?? openSubagent.taskId;
+    openSubagent.span.record({
+      ...(identity.model ? {model: identity.model} : {}),
+      ...(identity.agentId ? {agentId: identity.agentId} : {}),
+    });
+
+    if (acknowledgesLaunch && !block.is_error) {
+      // Only an acknowledgement — the outcome arrives as a task_notification.
+      openSubagent.lifetime = 'background';
+      return;
     }
+
+    openSubagent.span.record({
+      outputMessages: resultText
+        ? [{role: 'assistant', content: resultText}]
+        : [],
+    });
+    openSubagent.outcome = block.is_error
+      ? {
+          status: 'error',
+          errorType: 'subagent_error',
+          error: new Error(resultText || 'Subagent execution failed'),
+          endedAt: new Date(),
+        }
+      : {status: 'ok', endedAt: new Date()};
+  }
+
+  private processTaskNotification(msg: SDKTaskNotificationMessage): void {
+    // `task_id` and the launch result's `agentId` are not documented as the
+    // same value, so match either before giving up.
+    const toolUseId =
+      msg.tool_use_id ??
+      [...this.openSubagents.entries()].find(
+        ([, openSubagent]) =>
+          openSubagent.taskId === msg.task_id ||
+          openSubagent.agentId === msg.task_id
+      )?.[0];
     if (!toolUseId) {
       return;
     }
@@ -592,37 +679,91 @@ export class ClaudeAgentOtelTracer {
     if (!openSubagent) {
       return;
     }
-    openSubagent.background = true;
     openSubagent.taskId = msg.task_id;
-    openSubagent.span.record({agentId: msg.task_id});
+    if (openSubagent.agentId == null) {
+      openSubagent.agentId = msg.task_id;
+      openSubagent.span.record({agentId: msg.task_id});
+    }
+    if (msg.usage) {
+      openSubagent.span.setAttributes({
+        [ATTR_GEN_AI_USAGE_TOTAL_TOKENS]: msg.usage.total_tokens,
+      });
+    }
+    const endedAt = new Date();
     if (msg.status === 'completed') {
-      openSubagent.completion = {};
+      // The summary is the only result text a background subagent ever reports.
+      if (msg.summary) {
+        openSubagent.span.record({
+          outputMessages: [{role: 'assistant', content: msg.summary}],
+        });
+      }
+      openSubagent.outcome = {status: 'ok', endedAt};
       return;
     }
 
-    openSubagent.completion = {
+    openSubagent.outcome = {
+      status: 'error',
       errorType: msg.status === 'stopped' ? 'aborted' : 'subagent_error',
       error: new Error(msg.summary || `Background subagent ${msg.status}`),
+      endedAt,
     };
   }
 
-  private finishOpenSubagents(finalizing: boolean): void {
+  /**
+   * True when `toolUseId` is a background subagent, or a descendant of one, so
+   * it must outlive the turn that launched it. Terminates because a parent is
+   * always registered before its children.
+   */
+  private outlivesTurn(toolUseId: string | undefined): boolean {
+    let cursor = toolUseId;
+    while (cursor) {
+      const openSubagent = this.openSubagents.get(cursor);
+      if (!openSubagent) {
+        return false;
+      }
+      if (openSubagent.lifetime === 'background') {
+        return true;
+      }
+      cursor = openSubagent.parentToolUseId;
+    }
+    return false;
+  }
+
+  private finishOpenTools(reason: 'turn-boundary' | 'shutdown'): void {
+    for (const [toolUseId, openTool] of [...this.openTools.entries()]) {
+      if (
+        reason === 'turn-boundary' &&
+        this.outlivesTurn(openTool.ownerToolUseId)
+      ) {
+        continue;
+      }
+      openTool.tool.setAttributes({[ATTR_ERROR_TYPE]: 'aborted'});
+      openTool.tool.end({error: new Error('Agent ended with open tool span')});
+      this.openTools.delete(toolUseId);
+    }
+  }
+
+  private finishOpenSubagents(reason: 'turn-boundary' | 'shutdown'): void {
+    // Newest-first so a nested subagent closes before the parent it hangs off.
     const openSubagents = [...this.openSubagents.entries()].reverse();
     for (const [toolUseId, openSubagent] of openSubagents) {
-      const completion = openSubagent.completion;
-      if (completion) {
-        if (completion.errorType) {
+      const outcome = openSubagent.outcome;
+      if (outcome) {
+        if (outcome.status === 'error') {
           openSubagent.span.setAttributes({
-            [ATTR_ERROR_TYPE]: completion.errorType,
+            [ATTR_ERROR_TYPE]: outcome.errorType,
           });
+          openSubagent.span.end({
+            error: outcome.error,
+            endTime: outcome.endedAt,
+          });
+        } else {
+          openSubagent.span.end({endTime: outcome.endedAt});
         }
-        openSubagent.span.end(
-          completion.error ? {error: completion.error} : undefined
-        );
         this.openSubagents.delete(toolUseId);
         continue;
       }
-      if (openSubagent.background && !finalizing) {
+      if (reason === 'turn-boundary' && this.outlivesTurn(toolUseId)) {
         continue;
       }
       openSubagent.span.setAttributes({[ATTR_ERROR_TYPE]: 'aborted'});

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -208,11 +208,6 @@ type PendingTurn = {
   startedAt: Date;
 };
 
-type SpanParent = Pick<
-  Turn | SubAgent,
-  'startLLM' | 'startSubagent' | 'startTool'
->;
-
 type SubagentCompletion = {
   error?: Error;
   errorType?: 'aborted' | 'subagent_error';
@@ -493,7 +488,7 @@ export class ClaudeAgentOtelTracer {
     }
   }
 
-  private spanParent(msg: SDKAssistantMessage, turn: Turn): SpanParent {
+  private spanParent(msg: SDKAssistantMessage, turn: Turn): Turn | SubAgent {
     const parentToolUseId = msg.parent_tool_use_id;
     if (parentToolUseId == null) {
       return turn;
@@ -524,7 +519,7 @@ export class ClaudeAgentOtelTracer {
     return openSubagent.span;
   }
 
-  private startSubagent(block: ToolUseBlock, parent: SpanParent): void {
+  private startSubagent(block: ToolUseBlock, parent: Turn | SubAgent): void {
     const input = recordOf(block.input);
     const name =
       stringField(input, 'subagent_type') ??

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -622,16 +622,16 @@ export class ClaudeAgentOtelTracer {
       if (block.type !== 'tool_result') {
         continue;
       }
-      const resultText = toolResultText(block.content);
       const openSubagent = this.openSubagents.get(block.tool_use_id);
       if (openSubagent) {
-        this.processSubagentResult(openSubagent, block, resultText, msg);
+        this.processSubagentResult(openSubagent, block, msg);
         continue;
       }
       const openTool = this.openTools.get(block.tool_use_id);
       if (!openTool) {
         continue;
       }
+      const resultText = toolResultText(block.content);
       this.openTools.delete(block.tool_use_id);
       const tool = openTool.tool;
       tool.result = resultText;
@@ -647,7 +647,6 @@ export class ClaudeAgentOtelTracer {
   private processSubagentResult(
     openSubagent: OpenSubagent,
     block: ToolResultBlock,
-    resultText: string,
     msg: SDKUserMessage | SDKUserMessageReplay
   ): void {
     const {acknowledgesLaunch, identity, outputText} = subagentResult(
@@ -667,9 +666,11 @@ export class ClaudeAgentOtelTracer {
       return;
     }
 
-    const terminalOutputText = block.is_error
-      ? resultText
-      : (outputText ?? resultText);
+    let terminalOutputText = outputText;
+    if (block.is_error || terminalOutputText === undefined) {
+      const fallbackText = toolResultText(block.content);
+      terminalOutputText = fallbackText;
+    }
     openSubagent.span.record({
       outputMessages: terminalOutputText
         ? [{role: 'assistant', content: terminalOutputText}]

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -26,6 +26,7 @@ import type {
   SDKAssistantMessage,
   SDKMessage,
   SDKResultMessage,
+  SDKTaskNotificationMessage,
   SDKUserMessage,
   SDKUserMessageReplay,
 } from '@anthropic-ai/claude-agent-sdk';
@@ -137,6 +138,20 @@ function isSubagentTool(name: string): boolean {
   return name === 'Agent' || name === 'Task';
 }
 
+function asyncSubagentLaunch(value: unknown): {
+  model?: string;
+  taskId?: string;
+} | null {
+  const result = recordOf(value);
+  if (result.status !== 'async_launched') {
+    return null;
+  }
+  return {
+    model: stringField(result, 'resolvedModel'),
+    taskId: stringField(result, 'agentId'),
+  };
+}
+
 type NormalizedUsage = {
   usage: Usage;
   totalTokens: number;
@@ -198,11 +213,23 @@ type SpanParent = Pick<
   'startLLM' | 'startSubagent' | 'startTool'
 >;
 
+type SubagentCompletion = {
+  error?: Error;
+  errorType?: 'aborted' | 'subagent_error';
+};
+
+type OpenSubagent = {
+  background: boolean;
+  completion?: SubagentCompletion;
+  span: SubAgent;
+  taskId?: string;
+};
+
 /** Emits Claude Agent SDK traces through Weave GenAI handles. */
 export class ClaudeAgentOtelTracer {
   private readonly agentName: string;
   private readonly startedAt = new Date();
-  private readonly openSubagents = new Map<string, SubAgent>();
+  private readonly openSubagents = new Map<string, OpenSubagent>();
   private readonly openTools = new Map<string, Tool>();
   private readonly pendingTurns: PendingTurn[] = [];
 
@@ -261,6 +288,11 @@ export class ClaudeAgentOtelTracer {
       case 'result':
         this.endTurn(msg);
         break;
+      case 'system':
+        if (msg.subtype === 'task_notification') {
+          this.processTaskNotification(msg);
+        }
+        break;
       default:
         break;
     }
@@ -284,6 +316,7 @@ export class ClaudeAgentOtelTracer {
     ) {
       this.endTurn(undefined, error);
     }
+    this.finishOpenSubagents(true);
   }
 
   private endTurn(result?: SDKResultMessage, error?: unknown): void {
@@ -293,11 +326,7 @@ export class ClaudeAgentOtelTracer {
       tool.end({error: new Error('Agent ended with open tool span')});
     }
     this.openTools.clear();
-    for (const subagent of [...this.openSubagents.values()].reverse()) {
-      subagent.setAttributes({[ATTR_ERROR_TYPE]: 'aborted'});
-      subagent.end({error: new Error('Agent ended with open subagent span')});
-    }
-    this.openSubagents.clear();
+    this.finishOpenSubagents(false);
 
     if (result) {
       this.emitModelUsageSpans(result, turn);
@@ -470,20 +499,21 @@ export class ClaudeAgentOtelTracer {
       return turn;
     }
 
-    let subagent = this.openSubagents.get(parentToolUseId);
-    if (!subagent) {
-      subagent = turn.startSubagent({
+    let openSubagent = this.openSubagents.get(parentToolUseId);
+    if (!openSubagent) {
+      const span = turn.startSubagent({
         name: msg.subagent_type ?? 'subagent',
         model: msg.message.model,
         agentDescription: msg.task_description,
       });
-      subagent.setAttributes({
+      span.setAttributes({
         [ATTR_GEN_AI_PROVIDER_NAME]: PROVIDER_NAME,
         [ATTR_GEN_AI_TOOL_CALL_ID]: parentToolUseId,
       });
-      this.openSubagents.set(parentToolUseId, subagent);
+      openSubagent = {background: false, span};
+      this.openSubagents.set(parentToolUseId, openSubagent);
     } else {
-      subagent.record({
+      openSubagent.span.record({
         ...(msg.subagent_type ? {name: msg.subagent_type} : {}),
         ...(msg.message.model ? {model: msg.message.model} : {}),
         ...(msg.task_description
@@ -491,7 +521,7 @@ export class ClaudeAgentOtelTracer {
           : {}),
       });
     }
-    return subagent;
+    return openSubagent.span;
   }
 
   private startSubagent(block: ToolUseBlock, parent: SpanParent): void {
@@ -519,7 +549,7 @@ export class ClaudeAgentOtelTracer {
           }
         : {}),
     });
-    this.openSubagents.set(block.id, subagent);
+    this.openSubagents.set(block.id, {background: false, span: subagent});
   }
 
   private processUser(msg: SDKUserMessage | SDKUserMessageReplay): void {
@@ -531,10 +561,19 @@ export class ClaudeAgentOtelTracer {
         continue;
       }
       const resultText = toolResultText(block.content);
-      const subagent = this.openSubagents.get(block.tool_use_id);
-      if (subagent) {
-        this.openSubagents.delete(block.tool_use_id);
-        subagent.setAttributes({
+      const openSubagent = this.openSubagents.get(block.tool_use_id);
+      if (openSubagent) {
+        const launch = asyncSubagentLaunch(msg.tool_use_result);
+        if (launch && !block.is_error) {
+          openSubagent.background = true;
+          openSubagent.taskId = launch.taskId;
+          openSubagent.span.record({
+            ...(launch.model ? {model: launch.model} : {}),
+            ...(launch.taskId ? {agentId: launch.taskId} : {}),
+          });
+          continue;
+        }
+        openSubagent.span.setAttributes({
           [ATTR_GEN_AI_TOOL_CALL_RESULT]: resultText,
           ...(resultText
             ? {
@@ -545,12 +584,12 @@ export class ClaudeAgentOtelTracer {
             : {}),
         });
         if (block.is_error) {
-          subagent.setAttributes({[ATTR_ERROR_TYPE]: 'subagent_error'});
-          subagent.end({
+          openSubagent.completion = {
+            errorType: 'subagent_error',
             error: new Error(resultText || 'Subagent execution failed'),
-          });
+          };
         } else {
-          subagent.end();
+          openSubagent.completion = {};
         }
         continue;
       }
@@ -566,6 +605,62 @@ export class ClaudeAgentOtelTracer {
       } else {
         tool.end();
       }
+    }
+  }
+
+  private processTaskNotification(msg: SDKTaskNotificationMessage): void {
+    let toolUseId = msg.tool_use_id;
+    if (!toolUseId) {
+      toolUseId = [...this.openSubagents.entries()].find(
+        ([, openSubagent]) => openSubagent.taskId === msg.task_id
+      )?.[0];
+    }
+    if (!toolUseId) {
+      return;
+    }
+
+    const openSubagent = this.openSubagents.get(toolUseId);
+    if (!openSubagent) {
+      return;
+    }
+    openSubagent.background = true;
+    openSubagent.taskId = msg.task_id;
+    openSubagent.span.record({agentId: msg.task_id});
+    if (msg.status === 'completed') {
+      openSubagent.completion = {};
+      return;
+    }
+
+    openSubagent.completion = {
+      errorType: msg.status === 'stopped' ? 'aborted' : 'subagent_error',
+      error: new Error(msg.summary || `Background subagent ${msg.status}`),
+    };
+  }
+
+  private finishOpenSubagents(finalizing: boolean): void {
+    const openSubagents = [...this.openSubagents.entries()].reverse();
+    for (const [toolUseId, openSubagent] of openSubagents) {
+      const completion = openSubagent.completion;
+      if (completion) {
+        if (completion.errorType) {
+          openSubagent.span.setAttributes({
+            [ATTR_ERROR_TYPE]: completion.errorType,
+          });
+        }
+        openSubagent.span.end(
+          completion.error ? {error: completion.error} : undefined
+        );
+        this.openSubagents.delete(toolUseId);
+        continue;
+      }
+      if (openSubagent.background && !finalizing) {
+        continue;
+      }
+      openSubagent.span.setAttributes({[ATTR_ERROR_TYPE]: 'aborted'});
+      openSubagent.span.end({
+        error: new Error('Agent ended with open subagent span'),
+      });
+      this.openSubagents.delete(toolUseId);
     }
   }
 }

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -12,7 +12,6 @@ import {
   ATTR_ERROR_TYPE,
   ATTR_GEN_AI_INPUT_MESSAGES,
   ATTR_GEN_AI_OUTPUT_MESSAGES,
-  ATTR_GEN_AI_PROVIDER_NAME,
   ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
   ATTR_GEN_AI_TOOL_CALL_ID,
   ATTR_GEN_AI_TOOL_CALL_RESULT,
@@ -502,7 +501,6 @@ export class ClaudeAgentOtelTracer {
         agentDescription: msg.task_description,
       });
       span.setAttributes({
-        [ATTR_GEN_AI_PROVIDER_NAME]: PROVIDER_NAME,
         [ATTR_GEN_AI_TOOL_CALL_ID]: parentToolUseId,
       });
       openSubagent = {background: false, span};
@@ -532,7 +530,6 @@ export class ClaudeAgentOtelTracer {
       agentDescription: stringField(input, 'description'),
     });
     subagent.setAttributes({
-      [ATTR_GEN_AI_PROVIDER_NAME]: PROVIDER_NAME,
       [ATTR_GEN_AI_TOOL_CALL_ID]: block.id,
       [ATTR_GEN_AI_TOOL_NAME]: block.name,
       [ATTR_GEN_AI_TOOL_CALL_ARGUMENTS]: JSON.stringify(block.input ?? {}),

--- a/sdks/node/src/integrations/claudeAgentSdk.ts
+++ b/sdks/node/src/integrations/claudeAgentSdk.ts
@@ -11,6 +11,10 @@
  * through the high-level Weave GenAI SDK — `invoke_agent`/`chat`/`execute_tool`
  * spans to the `/agents/otel` endpoints (the Agents tab). See {@link ClaudeAgentOtelTracer}.
  *
+ * Agent/Task tool calls become nested `invoke_agent` spans. The SDK forwards
+ * nested tool blocks by default; callers that set `forwardSubagentText: true`
+ * also get the subagent's text and thinking recorded on nested `chat` spans.
+ *
  * Instrumentation is automatic via the CJS/ESM module hooks (registered from
  * `integrations/hooks.ts`), the same mechanism used by the other integrations.
  */


### PR DESCRIPTION
## Summary

- Trace Claude Agent SDK `Agent` and legacy `Task` calls as nested `invoke_agent` spans.
- Keep one background subagent span across the async launch acknowledgement, forwarded child messages, turn boundaries, and terminal task notification.
- Record the resolved model, agent ID, child chats, and terminal status on that span.

## Live validation

| State | Result |
| --- | --- |
| [Master baseline](https://wandb.ai/wandb/pr-7630-subagent-trace-validation/weave/agents/spans/27cd99007041c95b21eed2ecba9f49d6) | Two generic `Agent` tool spans; no nested subagent spans. |
| [Current PR](https://wandb.ai/wandb/pr-7630-subagent-trace-validation/weave/agents/spans/884d47f438be0ee6bf426c1fa72e9a41) | Two nested INTERNAL subagents with correct prompts, IDs, models, and child chats; no agent-level provider or tool fields. |

<img width="1914" height="810" alt="image" src="https://github.com/user-attachments/assets/9f30a575-d601-41cd-afdd-bcb69b0fc393" />

## Testing

- `pnpm test` — 59 suites, 467 tests, and 58 snapshots passed.
- Focused Claude Agent SDK tests — 27 passed.
- Build, lint, Prettier, CJS/ESM typechecks, and packaged host-app tests passed.
- Live Claude run completed with `FIXED_OK`; stored span topology and attributes were queried back and asserted exactly.

## Breaking changes

None.
