### PR TITLE
fix(weave): preserve Bedrock cache tokens from LangChain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,6 +376,20 @@ pnpm exec tsx examples/claudeAgents.ts
   ```
 - Some integrations (like instructor) may need to patch multiple libraries
 
+### LangChain / Bedrock prompt-cache token accounting
+
+- LangChain's `ChatBedrockConverse` converts Bedrock usage to an inclusive
+  `usage_metadata.input_tokens` count and reports the cache subsets as
+  `input_token_details.cache_read` and
+  `input_token_details.cache_creation`. The LangChain integration must map
+  those subset fields to Weave's canonical `cache_read_input_tokens` and
+  `cache_creation_input_tokens` fields without adding them to `prompt_tokens`
+  again.
+- This differs from the direct boto3 Bedrock response: its `inputTokens` count
+  excludes `cacheReadInputTokens` and `cacheWriteInputTokens`, so the direct
+  Bedrock integration adds those two fields when constructing the inclusive
+  `prompt_tokens` total.
+
 ### Documentation
 
 - Update relevant docstrings for Python code

--- a/tests/integrations/langchain/helpers_test.py
+++ b/tests/integrations/langchain/helpers_test.py
@@ -1,7 +1,7 @@
 """Unit tests for langchain integration helpers.
 
 Tests the usage metadata extraction and processing functions that handle
-different provider formats (OpenAI, Google GenAI, Google Vertex AI).
+different provider formats (OpenAI, Google GenAI, Google Vertex AI, AWS Bedrock).
 """
 
 from unittest.mock import Mock
@@ -49,6 +49,44 @@ from weave.trace.call import Call
             {"input_tokens": 497, "output_tokens": 6, "total_tokens": 503},
             TokenUsage(prompt_tokens=497, completion_tokens=6, total_tokens=503),
         ),
+        # AWS Bedrock format exposed by LangChain's ChatBedrockConverse
+        (
+            {
+                "input_tokens": 195,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "input_token_details": {
+                    "cache_read": 80,
+                    "cache_creation": 15,
+                },
+            },
+            TokenUsage(
+                prompt_tokens=195,
+                completion_tokens=20,
+                total_tokens=120,
+                cache_read_input_tokens=80,
+                cache_creation_input_tokens=15,
+            ),
+        ),
+        # Explicit zero cache counts are meaningful and should be preserved
+        (
+            {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "input_token_details": {
+                    "cache_read": 0,
+                    "cache_creation": 0,
+                },
+            },
+            TokenUsage(
+                prompt_tokens=100,
+                completion_tokens=20,
+                total_tokens=120,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=0,
+            ),
+        ),
         # Empty metadata
         (
             {},
@@ -74,9 +112,7 @@ from weave.trace.call import Call
 def test_normalize_usage_metadata(usage_metadata, expected):
     """Test normalization of usage metadata from different provider formats."""
     result = _normalize_usage_metadata(usage_metadata)
-    assert result.prompt_tokens == expected.prompt_tokens
-    assert result.completion_tokens == expected.completion_tokens
-    assert result.total_tokens == expected.total_tokens
+    assert result == expected
 
 
 @pytest.mark.parametrize(
@@ -232,6 +268,48 @@ def test_find_full_model_name(output, partial_model, expected):
                     "prompt_tokens": 9,
                     "completion_tokens": 7,
                     "total_tokens": 16,
+                }
+            },
+        ),
+        # AWS Bedrock chat model format exposed by LangChain's ChatBedrockConverse
+        (
+            {
+                "extra": {
+                    "metadata": {
+                        "ls_provider": "bedrock_converse",
+                        "ls_model_name": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                        "ls_model_type": "chat",
+                    }
+                },
+                "outputs": {
+                    "generations": [
+                        [
+                            {
+                                "message": {
+                                    "kwargs": {
+                                        "usage_metadata": {
+                                            "input_tokens": 195,
+                                            "output_tokens": 20,
+                                            "total_tokens": 120,
+                                            "input_token_details": {
+                                                "cache_read": 80,
+                                                "cache_creation": 15,
+                                            },
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    ]
+                },
+            },
+            {
+                "anthropic.claude-3-5-sonnet-20240620-v1:0": {
+                    "prompt_tokens": 195,
+                    "completion_tokens": 20,
+                    "total_tokens": 120,
+                    "cache_read_input_tokens": 80,
+                    "cache_creation_input_tokens": 15,
                 }
             },
         ),
@@ -395,9 +473,7 @@ def test_extract_usage_data_success(output, expected_usage):
     call = Mock(spec=Call)
     call.summary = None
     _extract_usage_data(call, output)
-    assert call.summary is not None
-    assert "usage" in call.summary
-    assert call.summary["usage"] == expected_usage
+    assert call.summary == {"usage": expected_usage}
 
 
 @pytest.mark.parametrize(

--- a/weave/integrations/langchain/helpers.py
+++ b/weave/integrations/langchain/helpers.py
@@ -7,6 +7,7 @@ Supported providers:
 - OpenAI: "token_usage" with "prompt_tokens", "completion_tokens", "total_tokens"
 - Google GenAI: "usage_metadata" with "input_tokens", "output_tokens", "total_tokens"
 - Google Vertex AI: "usage_metadata" with "prompt_token_count", "candidates_token_count", "total_token_count"
+- AWS Bedrock: LangChain "usage_metadata" with cache tokens in "input_token_details"
 """
 
 from collections import defaultdict
@@ -22,16 +23,18 @@ class TokenUsage:
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int
+    cache_read_input_tokens: int | None = None
+    cache_creation_input_tokens: int | None = None
 
 
-def _normalize_usage_metadata(usage_metadata: dict) -> TokenUsage:
+def _normalize_usage_metadata(usage_metadata: dict[str, Any] | None) -> TokenUsage:
     """Normalize usage metadata from different provider formats to standard format.
 
     Args:
         usage_metadata: Raw usage metadata dictionary from provider
 
     Returns:
-        Tuple of (prompt_tokens, completion_tokens, total_tokens)
+        Normalized token usage.
 
     """
     if not usage_metadata:
@@ -41,6 +44,8 @@ def _normalize_usage_metadata(usage_metadata: dict) -> TokenUsage:
     # - OpenAI: prompt_tokens, completion_tokens, total_tokens
     # - Google GenAI: input_tokens, output_tokens, total_tokens
     # - Google Vertex AI: prompt_token_count, candidates_token_count, total_token_count
+    # - AWS Bedrock: input_tokens includes cached tokens, with cache token subsets
+    #   reported in input_token_details
 
     # Try different provider formats
     variations = {
@@ -59,11 +64,27 @@ def _normalize_usage_metadata(usage_metadata: dict) -> TokenUsage:
                 normalized_usage[key] = usage_metadata.get(value)
                 break
 
+    input_token_details = usage_metadata.get("input_token_details")
+    if not isinstance(input_token_details, dict):
+        input_token_details = {}
+    cache_read_input_tokens = (
+        input_token_details.get("cache_read") or 0
+        if "cache_read" in input_token_details
+        else None
+    )
+    cache_creation_input_tokens = (
+        input_token_details.get("cache_creation") or 0
+        if "cache_creation" in input_token_details
+        else None
+    )
+
     # Ensure all required fields have default values and handle None values
     return TokenUsage(
         prompt_tokens=normalized_usage.get("prompt_tokens") or 0,
         completion_tokens=normalized_usage.get("completion_tokens") or 0,
         total_tokens=normalized_usage.get("total_tokens") or 0,
+        cache_read_input_tokens=cache_read_input_tokens,
+        cache_creation_input_tokens=cache_creation_input_tokens,
     )
 
 
@@ -144,6 +165,14 @@ def _extract_usage_data(call: Call, output: Any) -> None:
                     token_usage.completion_tokens
                 )
                 usage_dict[model_name]["total_tokens"] += token_usage.total_tokens
+                if token_usage.cache_read_input_tokens is not None:
+                    usage_dict[model_name]["cache_read_input_tokens"] += (
+                        token_usage.cache_read_input_tokens
+                    )
+                if token_usage.cache_creation_input_tokens is not None:
+                    usage_dict[model_name]["cache_creation_input_tokens"] += (
+                        token_usage.cache_creation_input_tokens
+                    )
 
     if usage_dict:
         if call.summary is None:


### PR DESCRIPTION
## Description

- Preserve standardized LangChain `input_token_details.cache_read` and `input_token_details.cache_creation` values in Weave usage summaries.
- Map those values to `cache_read_input_tokens` and `cache_creation_input_tokens`, allowing the existing trace-server cost calculation to apply Bedrock cache-read and cache-write rates.
- Keep LangChain `input_tokens` unchanged because `ChatBedrockConverse` already reports an inclusive input total; adding the cache subsets again would double count them.
- Preserve explicit zero cache counts and leave providers without cache details unchanged.

The direct boto3 Bedrock path was addressed in #7540. This follow-up covers the LangChain/LangGraph tracing path used by the customer report.

References:
- [AWS Bedrock prompt caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html)
- [LangChain AWS Bedrock Converse usage mapping](https://github.com/langchain-ai/langchain-aws/blob/8f13fb45ee93736fc3f062ad799aa72ea0798b0f/libs/aws/langchain_aws/chat_models/bedrock_converse.py#L2186-L2226)

## Testing

- `uvx ruff format --check weave/integrations/langchain/helpers.py tests/integrations/langchain/helpers_test.py`
- `uvx ruff check weave/integrations/langchain/helpers.py tests/integrations/langchain/helpers_test.py`
- `uv run --frozen --group test --extra langchain python -m pytest tests/integrations/langchain/helpers_test.py -q` (30 passed)
- `git diff --check`

## Breaking changes

None.