### PR TITLE
fix(weave): normalize Claude Agent SDK cached input tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,6 +376,21 @@ pnpm exec tsx examples/claudeAgents.ts
   ```
 - Some integrations (like instructor) may need to patch multiple libraries
 
+### Claude Agent SDK token accounting
+
+- Anthropic reports Claude Agent SDK `input_tokens` as fresh, uncached input
+  only. Weave usage requires an inclusive prompt total, with
+  `cache_read_input_tokens` and `cache_creation_input_tokens` represented as
+  subsets of `input_tokens`, because cost and cache-hit-rate rollups use that
+  convention.
+- Both Python tracing paths must normalize aggregate result usage through
+  `weave/integrations/claude_agent_sdk/usage.py`. Keep the SDK's yielded
+  `ResultMessage` and the calls-based root output unchanged; normalize the
+  calls-based usage summary and the OTel span attributes consumed by Weave
+  rollups.
+- Regression coverage must exercise both the calls-based and OTel integrations
+  with nonzero cache-read and cache-creation counts.
+
 ### Documentation
 
 - Update relevant docstrings for Python code

--- a/tests/integrations/claude_agent_sdk/cassettes/cache_usage_response.json
+++ b/tests/integrations/claude_agent_sdk/cassettes/cache_usage_response.json
@@ -1,0 +1,36 @@
+[
+  {
+    "type": "system",
+    "subtype": "init",
+    "session_id": "s-cache789"
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "content": [
+        {
+          "type": "text",
+          "text": "The cached response."
+        }
+      ],
+      "model": "claude-sonnet-4-6"
+    }
+  },
+  {
+    "type": "result",
+    "subtype": "result",
+    "duration_ms": 1200,
+    "duration_api_ms": 900,
+    "is_error": false,
+    "num_turns": 1,
+    "session_id": "s-cache789",
+    "total_cost_usd": 0.003,
+    "usage": {
+      "input_tokens": 10,
+      "output_tokens": 75,
+      "cache_read_input_tokens": 19447,
+      "cache_creation_input_tokens": 1024
+    },
+    "result": "The cached response."
+  }
+]

--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
@@ -201,6 +201,30 @@ async def test_tool_use_query_otel(otel_spans: InMemorySpanExporter) -> None:
     assert len(tool_call_chats) == 1
 
 
+# --- query(): prompt caching ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cached_usage_is_normalized_in_otel_span(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    await run_query("cache_usage_response", "Use the cache")
+
+    chat_spans = get_spans_by_op(otel_spans.get_finished_spans(), "chat")
+    assert len(chat_spans) == 1
+    usage_attrs = {
+        key: value
+        for key, value in get_attrs(chat_spans[0]).items()
+        if key.startswith("gen_ai.usage.")
+    }
+    assert usage_attrs == {
+        "gen_ai.usage.input_tokens": 20481,
+        "gen_ai.usage.output_tokens": 75,
+        "gen_ai.usage.cache_creation.input_tokens": 1024,
+        "gen_ai.usage.cache_read.input_tokens": 19447,
+    }
+
+
 # --- query(): multiple tools in one response --------------------------------
 
 

--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_test.py
@@ -371,3 +371,39 @@ async def test_usage_summary(
     assert model_usage["requests"] == 1
     assert model_usage["input_tokens"] == 150
     assert model_usage["output_tokens"] == 75
+
+
+@pytest.mark.asyncio
+async def test_cached_usage_is_normalized_in_call_summary(
+    client: weave.trace.weave_client.WeaveClient,
+) -> None:
+    async for _ in query(
+        prompt="Use the cache",
+        options=ClaudeAgentOptions(),
+        transport=ReplayTransport(load_cassette("cache_usage_response")),
+    ):
+        pass
+
+    calls_by_op = {op_name_from_call(call): call for call in client.get_calls()}
+    assert set(calls_by_op) == {
+        "claude_agent_sdk.query",
+        "claude_agent_sdk.text",
+    }
+    root_call = calls_by_op["claude_agent_sdk.query"]
+    raw_usage = {
+        "input_tokens": 10,
+        "output_tokens": 75,
+        "cache_read_input_tokens": 19447,
+        "cache_creation_input_tokens": 1024,
+    }
+    expected_summary_usage = {
+        **raw_usage,
+        "input_tokens": 20481,
+    }
+    assert root_call.output["usage"] == raw_usage
+    assert root_call.summary["usage"] == {
+        "claude-sonnet-4-6": {
+            "requests": 1,
+            **expected_summary_usage,
+        }
+    }

--- a/weave/integrations/claude_agent_sdk/claude_agent_sdk_integration.py
+++ b/weave/integrations/claude_agent_sdk/claude_agent_sdk_integration.py
@@ -14,6 +14,7 @@ from weave.integrations.claude_agent_sdk.display_utils import (
     tool_use_display_name,
     turn_display_name,
 )
+from weave.integrations.claude_agent_sdk.usage import total_input_tokens
 from weave.integrations.integration_metadata import library_integration
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings
@@ -210,11 +211,13 @@ def _finalize_stream(
             # Set summary directly so usage propagates even when tool
             # call children exist (children path skips output-based summary).
             if state["root_model"]:
+                summary_usage = dict(result_msg.usage)
+                summary_usage["input_tokens"] = total_input_tokens(summary_usage)
                 root_call.summary = {
                     "usage": {
                         state["root_model"]: {
                             "requests": 1,
-                            **result_msg.usage,
+                            **summary_usage,
                         }
                     }
                 }

--- a/weave/integrations/claude_agent_sdk/otel_integration.py
+++ b/weave/integrations/claude_agent_sdk/otel_integration.py
@@ -47,6 +47,7 @@ from weave.conversation.conversation_otel import (
     llm_attributes,
 )
 from weave.conversation.types import Message, Reasoning, ToolCallPart, Usage
+from weave.integrations.claude_agent_sdk.usage import total_input_tokens
 from weave.integrations.integration_metadata import library_integration
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings
@@ -109,7 +110,7 @@ def _usage_from_result(usage: dict[str, Any] | None) -> Usage:
     """Build a Usage from a ResultMessage's aggregate usage dict."""
     raw = usage or {}
     return Usage(
-        input_tokens=int(raw.get("input_tokens", 0) or 0),
+        input_tokens=total_input_tokens(raw),
         output_tokens=int(raw.get("output_tokens", 0) or 0),
         cache_creation_input_tokens=int(raw.get("cache_creation_input_tokens", 0) or 0),
         cache_read_input_tokens=int(raw.get("cache_read_input_tokens", 0) or 0),

--- a/weave/integrations/claude_agent_sdk/usage.py
+++ b/weave/integrations/claude_agent_sdk/usage.py
@@ -1,0 +1,21 @@
+"""Usage normalization shared by Claude Agent SDK tracing variants."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def total_input_tokens(usage: Mapping[str, Any] | None) -> int:
+    """Return Weave's gross prompt count for an Anthropic usage payload.
+
+    Anthropic reports fresh input tokens separately from cache-read and
+    cache-creation tokens. Weave records those cache counts as subsets of the
+    full prompt, so its input token count must include all three values.
+    """
+    raw = usage or {}
+    return (
+        int(raw.get("input_tokens", 0) or 0)
+        + int(raw.get("cache_read_input_tokens", 0) or 0)
+        + int(raw.get("cache_creation_input_tokens", 0) or 0)
+    )


### PR DESCRIPTION
## Summary

- Normalize Claude Agent SDK prompt usage to the Weave convention: `input_tokens = fresh + cache_read + cache_creation`.
- Apply the same shared normalization to the calls-based summary and OTel usage attributes.
- Preserve cache-specific token fields and the provider-native raw usage returned in the calls-based output.
- Add a deterministic cache-heavy replay cassette and regression coverage for both Python tracing paths.

## Why

Anthropic reports `input_tokens` as only fresh, uncached input for Claude Agent SDK results. Weave cost and cache-hit calculations treat cache-read and cache-creation values as subsets of the full prompt total. Forwarding the Anthropic-native count therefore subtracts cached tokens from an already-exclusive denominator, undercounting input cost and allowing cache-hit rates above 100%.

This brings the Python integration in line with the existing Node Claude Agent SDK tracer.

## Testing

- `uvx --from ruff==0.15.5 ruff check` and `ruff format --check` on all changed Python files
- Calls-based cache-accounting regression: passed
- OTel cache-accounting regression: passed

## Breaking changes

None. Raw SDK result usage remains unchanged; only Weave accounting surfaces are normalized.

## Related

- [WB-37897](https://coreweave.atlassian.net/browse/WB-37897)
- #7634 adds the Claude Agent SDK shard to PR CI and should merge first so this regression coverage is uploaded to Codecov.
- Overlaps #7621, which addresses the same ticket; this is the newly requested branch.

[WB-37897]: https://coreweave.atlassian.net/browse/WB-37897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ