### PR TITLE
fix(weave): honor explicit wandb.is_turn over OTel conversation id

### DIFF
--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -617,7 +617,6 @@ class TestPythonSpans:
 
         kv_is_turn_false = KeyValue()
         kv_is_turn_false.key = "wandb.is_turn"
-        # Assign explicitly so the proto3 oneof records field presence.
         kv_is_turn_false.value.bool_value = False
         pb_span_false.attributes.append(kv_is_turn_false)
 
@@ -1510,25 +1509,29 @@ class TestSemanticConventionParsing:
         )
         extracted = get_wandb_attributes(attributes)
         assert extracted["thread_id"] == test_conversation_id
-        # is_turn should be truthy (the conversation id itself)
-        assert extracted["is_turn"]
+        # Absent an explicit marker, is_turn falls back to the conversation id.
+        assert extracted["is_turn"] == test_conversation_id
 
         # An explicit Boolean wandb.is_turn overrides the conversation-id turn
         # fallback while the conversation id still populates thread_id.
         extracted_false = get_wandb_attributes(
-            {
-                "gen_ai.conversation.id": test_conversation_id,
-                "wandb.is_turn": False,
-            }
+            create_attributes(
+                {
+                    "gen_ai.conversation.id": test_conversation_id,
+                    "wandb.is_turn": False,
+                }
+            )
         )
         assert extracted_false["thread_id"] == test_conversation_id
         assert extracted_false["is_turn"] is False
 
         extracted_true = get_wandb_attributes(
-            {
-                "gen_ai.conversation.id": test_conversation_id,
-                "wandb.is_turn": True,
-            }
+            create_attributes(
+                {
+                    "gen_ai.conversation.id": test_conversation_id,
+                    "wandb.is_turn": True,
+                }
+            )
         )
         assert extracted_true["thread_id"] == test_conversation_id
         assert extracted_true["is_turn"] is True

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -607,6 +607,26 @@ class TestPythonSpans:
         # is_turn is truthy via conversation.id, so turn_id should be set
         assert start_call.turn_id == py_span.span_id
 
+        # An explicit wandb.is_turn=false overrides the conversation-id turn
+        # inference: thread_id is retained but no turn_id is materialized.
+        pb_span_false = create_test_span()
+        kv_conv_false = KeyValue()
+        kv_conv_false.key = "gen_ai.conversation.id"
+        kv_conv_false.value.string_value = "conv-xyz"
+        pb_span_false.attributes.append(kv_conv_false)
+
+        kv_is_turn_false = KeyValue()
+        kv_is_turn_false.key = "wandb.is_turn"
+        # Assign explicitly so the proto3 oneof records field presence.
+        kv_is_turn_false.value.bool_value = False
+        pb_span_false.attributes.append(kv_is_turn_false)
+
+        py_span_false = PySpan.from_proto(pb_span_false)
+        start_call_false, _ = py_span_false.to_call("test_project")
+
+        assert start_call_false.thread_id == "conv-xyz"
+        assert start_call_false.turn_id is None
+
     def test_traces_data_from_proto(self):
         """Test converting protobuf TracesData to Python TracesData."""
         export_req = create_test_export_request()
@@ -1061,7 +1081,7 @@ class TestSemanticConventionParsing:
             }
         )
         extracted_false = get_wandb_attributes(attributes_false)
-        assert "is_turn" not in extracted_false.keys()
+        assert extracted_false["is_turn"] is False
         assert extracted_false["thread_id"] == test_thread_id
 
         # Test with only thread_id
@@ -1492,6 +1512,26 @@ class TestSemanticConventionParsing:
         assert extracted["thread_id"] == test_conversation_id
         # is_turn should be truthy (the conversation id itself)
         assert extracted["is_turn"]
+
+        # An explicit Boolean wandb.is_turn overrides the conversation-id turn
+        # fallback while the conversation id still populates thread_id.
+        extracted_false = get_wandb_attributes(
+            {
+                "gen_ai.conversation.id": test_conversation_id,
+                "wandb.is_turn": False,
+            }
+        )
+        assert extracted_false["thread_id"] == test_conversation_id
+        assert extracted_false["is_turn"] is False
+
+        extracted_true = get_wandb_attributes(
+            {
+                "gen_ai.conversation.id": test_conversation_id,
+                "wandb.is_turn": True,
+            }
+        )
+        assert extracted_true["thread_id"] == test_conversation_id
+        assert extracted_true["is_turn"] is True
 
     def test_genai_semconv_conversation_id_priority_over_wandb(self):
         """Test that gen_ai.conversation.id takes priority over wandb.thread_id."""

--- a/weave/trace_server/opentelemetry/attributes.py
+++ b/weave/trace_server/opentelemetry/attributes.py
@@ -121,13 +121,18 @@ def get_weave_outputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[st
     return parse_weave_values(attributes, OUTPUT_KEYS)
 
 
+# Read wandb.is_turn directly: parse_weave_values checks the conversation/session-id aliases first and drops a literal False
+def _explicit_is_turn(attributes: dict[str, Any]) -> bool | None:
+    value = get_attribute(attributes, "wandb.is_turn")
+    return value if isinstance(value, bool) else None
+
+
 # Custom attributes for weave to enable setting fields like wb_user_id otherwise unavailable in OTEL Traces
 def get_wandb_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
     result = parse_weave_values(attributes, WB_KEYS)
-    # An explicit Boolean wandb.is_turn overrides the conversation/session-id turn
-    # fallback; read it directly since parse_weave_values drops a literal False.
-    explicit_is_turn = get_attribute(attributes, "wandb.is_turn")
-    if isinstance(explicit_is_turn, bool):
+    # An explicit Boolean wandb.is_turn overrides the conversation/session-id turn fallback
+    explicit_is_turn = _explicit_is_turn(attributes)
+    if explicit_is_turn is not None:
         result["is_turn"] = explicit_is_turn
     return result
 

--- a/weave/trace_server/opentelemetry/attributes.py
+++ b/weave/trace_server/opentelemetry/attributes.py
@@ -123,7 +123,13 @@ def get_weave_outputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[st
 
 # Custom attributes for weave to enable setting fields like wb_user_id otherwise unavailable in OTEL Traces
 def get_wandb_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
-    return parse_weave_values(attributes, WB_KEYS)
+    result = parse_weave_values(attributes, WB_KEYS)
+    # An explicit Boolean wandb.is_turn overrides the conversation/session-id turn
+    # fallback; read it directly since parse_weave_values drops a literal False.
+    explicit_is_turn = get_attribute(attributes, "wandb.is_turn")
+    if isinstance(explicit_is_turn, bool):
+        result["is_turn"] = explicit_is_turn
+    return result
 
 
 # Pass events here even though they are unused because some libraries put input in event attributes

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -176,10 +176,10 @@ WB_KEYS = {
     "wb_run_step": ["wandb.wb_run_step"],
     "wb_run_step_end": ["wandb.wb_run_step_end"],
     "is_turn": [
-        "gen_ai.conversation.id",  # OpenTelemetry GenAI semconv - presence implies a turn
+        "gen_ai.conversation.id",  # OpenTelemetry GenAI semconv - legacy fallback: a non-empty id infers a turn unless wandb.is_turn overrides it
         "gcp.vertex.agent.session_id",
         "wandb.is_turn",
-    ],  # We just check if this is truthy so we can reuse the id
+    ],  # An explicit Boolean wandb.is_turn is authoritative; otherwise a non-empty conversation/session id infers a turn (see get_wandb_attributes)
 }
 
 # These represent fields that are set by a provider which override top level span information

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -176,7 +176,7 @@ WB_KEYS = {
     "wb_run_step": ["wandb.wb_run_step"],
     "wb_run_step_end": ["wandb.wb_run_step_end"],
     "is_turn": [
-        "gen_ai.conversation.id",  # OpenTelemetry GenAI semconv - legacy fallback: a non-empty id infers a turn unless wandb.is_turn overrides it
+        "gen_ai.conversation.id",  # OpenTelemetry GenAI semconv
         "gcp.vertex.agent.session_id",
         "wandb.is_turn",
     ],  # An explicit Boolean wandb.is_turn is authoritative; otherwise a non-empty conversation/session id infers a turn (see get_wandb_attributes)


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-37944

## Description

Weave was splitting one conversation into several separate turns. In the Threads view, one agent run showed up as duplicated, broken-up turns instead of one clean thread. That is the bug in #7066.

The worse part - some senders already say "this span is not a turn" by setting `wandb.is_turn=false`. We ignored it and made a turn anyway.

I thought that flag should just win. If a sender takes the trouble to say `false`, we should listen, not override it with a guess.

The fix is small. After the normal parsing, we read `wandb.is_turn` directly. If it is a real true/false, we use that.

So why was it broken? I dug in, and it was subtle. To decide if a span is a turn, Weave checks a few fields in order, and `gen_ai.conversation.id` is first. Just having a conversation id was enough to mark the span as a turn.

But that id is really just a session/thread id for [grouping messages](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-conversation-id). It does not mean the span is a turn. So using it that way is only a guess.

The explicit `false` was checked later. But a bare `false` looks "empty" to the shared parser, so it got dropped. The guess always won.

The clean fix was not to reorder or rewrite that parser (lots of other fields use it). I just read the one flag at the end and let it win.

Bottom line: before, `wandb.is_turn=false` was ignored and threads fell apart. Now it is respected and the turns stay whole. Spans that do not set the flag work exactly like before. Only a real true/false counts, not the text "false" and not 0/1. Nothing else changes - no producer, storage, schema, or UI.

## Testing

Extended three tests in `tests/trace_server/test_opentelemetry.py` for the explicit true/false cases, plus a full span that keeps its thread but gets no turn. All pass (71 passed, 1 pre-existing skip), and lint and type checks are clean.
