### PR TITLE
test(weave): run Claude Agent SDK coverage in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -150,6 +150,13 @@ jobs:
             # "stainless",
             "autogen_tests",
           ]
+        # The Claude Agent SDK has both ClickHouse-backed calls tests and
+        # no-server OTel tests. Run it once to collect coverage for both paths
+        # without multiplying the integration shard across every Python version.
+        include:
+          - python-version-major: "3"
+            python-version-minor: "10"
+            nox-shard: "claude_agent_sdk"
         # Shards that don't support certain Python versions. Excluding here
         # (vs. skipping inside noxfile) avoids spinning up a runner just to
         # emit an empty coverage.xml that Codecov then rejects.
@@ -217,8 +224,12 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'sk-1234567890abcdef1234567890abcdef' }}
           DD_TRACE_ENABLED: false
         run: |
-          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.nox-shard }}')" -- \
-            -m "trace_server"
+          if [[ "${{ matrix.nox-shard }}" == "claude_agent_sdk" ]]; then
+            nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.nox-shard }}')"
+          else
+            nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.nox-shard }}')" -- \
+              -m "trace_server"
+          fi
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,12 @@ Focus on these primary test shards:
 - `tests-3.12(shard='trace_server')` - Server implementation
 - `tests-3.12(shard='trace_server_bindings')` - Server bindings
 
+The Claude Agent SDK shard combines ClickHouse-backed calls tests with
+no-server OTel tests. PR CI runs `tests-3.10(shard='claude_agent_sdk')` once
+without a marker filter so both tracing paths contribute coverage.
+Calls-based tests must include the integration's intentional text and thinking
+child calls in exact operation-set assertions.
+
 ### Running Tests
 
 **IMPORTANT**: Any test depending on the `client` fixture runs against ClickHouse, the only trace-server backend. Locally, the test fixtures auto-start a ClickHouse Docker container if one isn't already running, so Docker must be available. Pass `--clickhouse-process=true` to use a local `clickhouse-server` binary instead of Docker.

--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_test.py
@@ -76,10 +76,14 @@ async def test_simple_text_query(
     assert all(
         i["meta"]["package_name"] == "claude_agent_sdk" for i in claude_agent_sdk_meta
     )
-    assert len(calls) == 1
+    assert sorted(op_name_from_call(call) for call in calls) == [
+        "claude_agent_sdk.query",
+        "claude_agent_sdk.text",
+    ]
 
-    root_call = calls[0]
-    assert op_name_from_call(root_call) == "claude_agent_sdk.query"
+    root_call = next(
+        call for call in calls if op_name_from_call(call) == "claude_agent_sdk.query"
+    )
     assert root_call.inputs["prompt"] == "What is 2+2?"
     assert root_call.exception is None
     assert root_call.ended_at is not None
@@ -122,9 +126,14 @@ async def test_tool_use_query(
 
     assert any(isinstance(m, ResultMessage) for m in messages)
 
-    # Verify weave calls: root + 1 tool use child
+    # Verify weave calls: root + 2 text children + 1 tool-use child
     calls = list(client.get_calls())
-    assert len(calls) == 2
+    assert sorted(op_name_from_call(call) for call in calls) == [
+        "claude_agent_sdk.query",
+        "claude_agent_sdk.text",
+        "claude_agent_sdk.text",
+        "claude_agent_sdk.tool_use.Bash",
+    ]
 
     root_call = next(
         c for c in calls if op_name_from_call(c) == "claude_agent_sdk.query"
@@ -143,7 +152,7 @@ async def test_tool_use_query(
     assert tool_call.ended_at is not None
     assert tool_call.output is not None
     assert tool_call.output["tool_use_id"] == "toolu_01ABC"
-    assert "file1.py" in tool_call.output["content"]
+    assert tool_call.output["content"] == "file1.py\nfile2.py\nREADME.md"
 
 
 # =====================================================================
@@ -166,9 +175,14 @@ async def test_multi_tool_query(
     ):
         messages.append(msg)
 
-    # Verify weave calls: root + 2 tool use children
+    # Verify weave calls: root + 1 text child + 2 tool-use children
     calls = list(client.get_calls())
-    assert len(calls) == 3
+    assert sorted(op_name_from_call(call) for call in calls) == [
+        "claude_agent_sdk.query",
+        "claude_agent_sdk.text",
+        "claude_agent_sdk.tool_use.Bash",
+        "claude_agent_sdk.tool_use.Read",
+    ]
 
     root_call = next(
         c for c in calls if op_name_from_call(c) == "claude_agent_sdk.query"
@@ -179,8 +193,10 @@ async def test_multi_tool_query(
     assert len(tool_calls) == 2
 
     tool_names = {op_name_from_call(c) for c in tool_calls}
-    assert "claude_agent_sdk.tool_use.Read" in tool_names
-    assert "claude_agent_sdk.tool_use.Bash" in tool_names
+    assert tool_names == {
+        "claude_agent_sdk.tool_use.Bash",
+        "claude_agent_sdk.tool_use.Read",
+    }
 
     # Both are children of root
     for tc in tool_calls:
@@ -211,11 +227,17 @@ async def test_thinking_query(
     # Thinking messages should still be yielded to the caller
     assert any(isinstance(m, AssistantMessage) for m in messages)
 
-    # Verify weave calls — no tool calls, just the root
+    # Verify weave calls — root plus thinking and text children
     calls = list(client.get_calls())
-    assert len(calls) == 1
+    assert sorted(op_name_from_call(call) for call in calls) == [
+        "claude_agent_sdk.query",
+        "claude_agent_sdk.text",
+        "claude_agent_sdk.thinking",
+    ]
 
-    root_call = calls[0]
+    root_call = next(
+        call for call in calls if op_name_from_call(call) == "claude_agent_sdk.query"
+    )
     assert root_call.output["status"] == "completed"
     assert (
         root_call.output["result"] == "After careful consideration, the answer is 42."
@@ -251,12 +273,18 @@ async def test_error_query(
     assert result_msg.is_error is True
 
     calls = list(client.get_calls())
-    assert len(calls) == 1
+    assert sorted(op_name_from_call(call) for call in calls) == [
+        "claude_agent_sdk.query",
+        "claude_agent_sdk.text",
+    ]
 
-    root_call = calls[0]
+    root_call = next(
+        call for call in calls if op_name_from_call(call) == "claude_agent_sdk.query"
+    )
     assert root_call.output["status"] == "error"
-    assert root_call.exception is not None
-    assert "something went wrong" in root_call.exception
+    assert root_call.exception == (
+        '{"type": "Exception", "message": "Error: something went wrong"}'
+    )
 
 
 # =====================================================================


### PR DESCRIPTION
## Summary

- Add the Python Claude Agent SDK shard to the PR test matrix once on Python 3.10.
- Run that shard without the `trace_server` marker filter so both the ClickHouse-backed calls tests and no-server OTel tests contribute coverage.
- Refresh stale calls-based expectations to include intentional text and thinking child calls and assert complete values.
- Keep TypeScript coverage unchanged: the existing Node.js Tests workflow already runs both the Claude Agent SDK OTel tracer and host-app tests through `pnpm test`.

## Why

Before this PR, the TypeScript Claude Agent SDK integration was already exercised by CI, but the Python Claude Agent SDK shard existed in nox without being included in the PR test matrix. Python integration changes could therefore reach Codecov without either Python tracing path being exercised.

Running one targeted Python matrix entry provides coverage without multiplying the shard across every Python version. This PR does not add or change TypeScript test selection.

This is split from #7632 so the CI coverage change can land independently. Merging this PR first lets #7632 use the new shard for its cache-accounting regression coverage.

<img width="836" height="445" alt="image" src="https://github.com/user-attachments/assets/87362653-be75-49a9-8cc8-39b13daff9e0" />

## Testing

- `uvx --from ruff==0.15.5 ruff check tests/integrations/claude_agent_sdk/claude_agent_sdk_test.py`
- `uvx --from ruff==0.15.5 ruff format --check tests/integrations/claude_agent_sdk/claude_agent_sdk_test.py`
- `uv run --frozen --group test --extra claude-agent-sdk python -m pytest tests/integrations/claude_agent_sdk/ -q` (22 passed)
- PR CI: `Trace nox tests (3, 10, claude_agent_sdk)` passed all 22 Python tests.
- PR CI: `Node.js Tests / test (20)` passed the existing TypeScript Claude Agent SDK OTel tracer and host-app tests.
- `actionlint .github/workflows/test.yaml` reports only existing ShellCheck findings outside the changed block.

## Breaking changes

None.

## Related

- #7632
