### PR TITLE
feat(weave): record turn output messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,6 +385,15 @@ pnpm exec tsx examples/claudeAgents.ts
   ```
 - Some integrations (like instructor) may need to patch multiple libraries
 
+### Python Conversation Turn messages
+
+- `Turn.messages` stores input messages, while `Turn.output_messages` stores
+  the terminal agent response. `Turn.record(messages=..., output_messages=...)`
+  replaces the two lists independently.
+- Keep streaming and batch paths aligned: `Turn._build_attrs()` must apply
+  content gating and PII redaction to both lists before passing them to
+  `invoke_agent_attributes()`, and `log_turn()` must accept both fields.
+
 ### Claude Agent SDK token accounting
 
 - Anthropic reports Claude Agent SDK `input_tokens` as fresh, uncached input

--- a/tests/conversation/test_conversation_otel.py
+++ b/tests/conversation/test_conversation_otel.py
@@ -1417,6 +1417,7 @@ class TestLogTurn:
             agent_name="weather-bot",
             conversation_name="Weather Chat",
             messages=[Message(role="user", content="What's the weather?")],
+            output_messages=[Message(role="assistant", content="It is sunny.")],
             started_at=_ts(0),
             ended_at=_ts(3),
         )
@@ -1430,6 +1431,18 @@ class TestLogTurn:
         assert attrs["gen_ai.agent.name"] == "weather-bot"
         assert attrs["gen_ai.conversation.id"] == "convo-1"
         assert attrs["gen_ai.conversation.name"] == "Weather Chat"
+        assert json.loads(attrs["gen_ai.input.messages"]) == [
+            {
+                "role": "user",
+                "parts": [{"type": "text", "content": "What's the weather?"}],
+            },
+        ]
+        assert json.loads(attrs["gen_ai.output.messages"]) == [
+            {
+                "role": "assistant",
+                "parts": [{"type": "text", "content": "It is sunny."}],
+            },
+        ]
         assert sp.start_time == int(_ts(0).timestamp() * 1_000_000_000)
         assert sp.end_time == int(_ts(3).timestamp() * 1_000_000_000)
 
@@ -1853,6 +1866,8 @@ class TestLogConversation:
                     agent_description="A helpful bot",
                     agent_version="v2",
                     system_instructions=["You are a weather bot"],
+                    messages=[Message.user("What is the weather?")],
+                    output_messages=[Message.assistant("It is sunny.")],
                     started_at=_ts(0),
                     ended_at=_ts(1),
                 ),
@@ -1864,6 +1879,18 @@ class TestLogConversation:
         attrs = dict(turn_spans[0].attributes or {})
         assert json.loads(attrs["gen_ai.system_instructions"]) == [
             {"type": "text", "content": "You are a weather bot"},
+        ]
+        assert json.loads(attrs["gen_ai.input.messages"]) == [
+            {
+                "role": "user",
+                "parts": [{"type": "text", "content": "What is the weather?"}],
+            },
+        ]
+        assert json.loads(attrs["gen_ai.output.messages"]) == [
+            {
+                "role": "assistant",
+                "parts": [{"type": "text", "content": "It is sunny."}],
+            },
         ]
         assert attrs["gen_ai.agent.id"] == "agent-123"
         assert attrs["gen_ai.agent.description"] == "A helpful bot"
@@ -2198,17 +2225,22 @@ class TestTurnRecord:
 
     def test_partial_record_preserves_existing(self) -> None:
         """Fields not passed (None) keep their existing values."""
-        turn = Turn(agent_name="bot")
+        turn = Turn(
+            agent_name="bot",
+            output_messages=[Message.assistant("existing response")],
+        )
         turn.agent_id = "preset"
         turn.record(system_instructions=["You are a bot"])
         assert turn.agent_id == "preset"
         assert turn.agent_name == "bot"
+        assert turn.output_messages == [Message.assistant("existing response")]
         assert turn.system_instructions == ["You are a bot"]
 
     def test_sets_all_fields(self) -> None:
         turn = Turn()
         turn.record(
             messages=[Message.user("hi")],
+            output_messages=[Message.assistant("hello")],
             system_instructions=["sys"],
             agent_name="bot",
             model="gpt-4o",
@@ -2217,6 +2249,7 @@ class TestTurnRecord:
             agent_version="v1",
         )
         assert turn.messages == [Message.user("hi")]
+        assert turn.output_messages == [Message.assistant("hello")]
         assert turn.system_instructions == ["sys"]
         assert turn.agent_name == "bot"
         assert turn.model == "gpt-4o"
@@ -2235,6 +2268,8 @@ class TestTurnRecord:
         with Conversation(conversation_id="convo-turn-record") as s:
             with s.start_turn(agent_name="weather-bot") as turn:
                 turn.record(
+                    messages=[Message.user("What is the weather?")],
+                    output_messages=[Message.assistant("It is sunny.")],
                     system_instructions=["You are a weather bot"],
                     agent_id="agent-9",
                     agent_description="A helpful bot",
@@ -2247,6 +2282,18 @@ class TestTurnRecord:
         attrs = dict(turn_spans[0].attributes or {})
         assert json.loads(attrs["gen_ai.system_instructions"]) == [
             {"type": "text", "content": "You are a weather bot"},
+        ]
+        assert json.loads(attrs["gen_ai.input.messages"]) == [
+            {
+                "role": "user",
+                "parts": [{"type": "text", "content": "What is the weather?"}],
+            },
+        ]
+        assert json.loads(attrs["gen_ai.output.messages"]) == [
+            {
+                "role": "assistant",
+                "parts": [{"type": "text", "content": "It is sunny."}],
+            },
         ]
         assert attrs["gen_ai.agent.id"] == "agent-9"
         assert attrs["gen_ai.agent.description"] == "A helpful bot"

--- a/tests/conversation/test_conversation_settings.py
+++ b/tests/conversation/test_conversation_settings.py
@@ -183,8 +183,10 @@ def _streaming_llm_reasoning_with_pii() -> None:
 
 def _streaming_turn_with_pii() -> None:
     with start_conversation(conversation_id="convo-pii-streaming-turn") as sess:
-        with sess.start_turn(user_message=_PII_EMAIL):
-            pass
+        with sess.start_turn(user_message=_PII_EMAIL) as turn:
+            turn.record(
+                output_messages=[Message(role="assistant", content=f"hi {_PII_EMAIL}")]
+            )
 
 
 def _batch_turn_messages_with_pii() -> None:
@@ -192,6 +194,7 @@ def _batch_turn_messages_with_pii() -> None:
         conversation_id="convo-pii-batch-turn-messages",
         agent_name="a",
         messages=[Message(role="user", content=_PII_EMAIL)],
+        output_messages=[Message(role="assistant", content=f"hi {_PII_EMAIL}")],
     )
 
 
@@ -244,13 +247,13 @@ def _batch_child_tool_with_pii() -> None:
         pytest.param(
             _streaming_turn_with_pii,
             "invoke_agent",
-            ("gen_ai.input.messages",),
+            ("gen_ai.input.messages", "gen_ai.output.messages"),
             id="streaming_turn",
         ),
         pytest.param(
             _batch_turn_messages_with_pii,
             "invoke_agent",
-            ("gen_ai.input.messages",),
+            ("gen_ai.input.messages", "gen_ai.output.messages"),
             id="batch_turn_messages",
         ),
         pytest.param(
@@ -314,8 +317,10 @@ def _content_off_turn() -> None:
     with start_conversation(
         conversation_id="convo-content-off-turn", include_content=False
     ) as sess:
-        with sess.start_turn(user_message=_PII_EMAIL):
-            pass
+        with sess.start_turn(user_message=_PII_EMAIL) as turn:
+            turn.record(
+                output_messages=[Message(role="assistant", content=f"hi {_PII_EMAIL}")]
+            )
 
 
 def _content_off_log_turn() -> None:
@@ -324,6 +329,7 @@ def _content_off_log_turn() -> None:
         agent_name="a",
         include_content=False,
         messages=[Message(role="user", content=_PII_EMAIL)],
+        output_messages=[Message(role="assistant", content=f"hi {_PII_EMAIL}")],
         spans=[Tool(name="lookup", arguments=f'{{"email":"{_PII_EMAIL}"}}')],
     )
 

--- a/weave/conversation/conversation.py
+++ b/weave/conversation/conversation.py
@@ -967,6 +967,7 @@ class Turn(_SpanBase):
     agent_version: str = ""
     system_instructions: list[str] = Field(default_factory=list)
     messages: list[Message] = Field(default_factory=list)
+    output_messages: list[Message] = Field(default_factory=list)
     spans: list[LLM | Tool | SubAgent] = Field(default_factory=list)
     continue_parent_trace: bool = False
     started_at: datetime | None = None
@@ -1074,6 +1075,7 @@ class Turn(_SpanBase):
         self,
         *,
         messages: list[Message] | None = None,
+        output_messages: list[Message] | None = None,
         system_instructions: list[str] | None = None,
         agent_name: str | None = None,
         model: str | None = None,
@@ -1087,8 +1089,9 @@ class Turn(_SpanBase):
         otherwise makes on a turn (``system_instructions``, ``agent_id``,
         ...) into a single keyword call. Only fields explicitly passed
         (non-``None``) are applied — existing values are preserved.
-        ``messages`` **replaces** the turn's existing messages (unlike
-        ``Turn.user(...)``, which appends a single message). Returns
+        ``messages`` and ``output_messages`` independently replace the turn's
+        existing input and output messages. This differs from
+        ``Turn.user(...)``, which appends a single input message. Returns
         ``self`` for chaining. Mirrors ``LLM.record``.
 
         Note: on the streaming (``with``) path the turn span is named from
@@ -1099,6 +1102,8 @@ class Turn(_SpanBase):
         """
         if messages is not None:
             self.messages = messages
+        if output_messages is not None:
+            self.output_messages = output_messages
         if system_instructions is not None:
             self.system_instructions = system_instructions
         if agent_name is not None:
@@ -1119,21 +1124,25 @@ class Turn(_SpanBase):
         """Build the full OTel attribute dict for this turn span.
 
         Shared by streaming (``end``) and batch (``log_turn``). The Turn
-        carries user messages; ``include_content=False`` strips them at
-        source so Presidio is never called for already-dropped content.
+        carries input and output messages; ``include_content=False`` strips
+        both at source so Presidio is never called for already-dropped content.
         """
         messages: list[Message] | None
+        output_messages: list[Message] | None
         system_instructions: list[str] | None
         if include_content:
             messages = self.messages
+            output_messages = self.output_messages
             system_instructions = self.system_instructions
             if should_redact_pii():
                 messages = pii_redaction.redact_messages(messages)
+                output_messages = pii_redaction.redact_messages(output_messages)
                 system_instructions = pii_redaction.redact_system_instructions(
                     system_instructions
                 )
         else:
             messages = None
+            output_messages = None
             system_instructions = None
         attrs = invoke_agent_attributes(
             agent_name=self.agent_name,
@@ -1141,6 +1150,7 @@ class Turn(_SpanBase):
             conversation_name=conversation_name,
             model=self.model,
             input_messages=messages,
+            output_messages=output_messages,
             system_instructions=system_instructions,
             agent_id=self.agent_id,
             agent_description=self.agent_description,
@@ -1650,6 +1660,7 @@ def log_turn(
     agent_description: str = "",
     agent_version: str = "",
     messages: list[Message] | None = None,
+    output_messages: list[Message] | None = None,
     system_instructions: list[str] | None = None,
     spans: list[LLM | Tool | SubAgent] | None = None,
     started_at: datetime | None = None,
@@ -1671,6 +1682,9 @@ def log_turn(
     these from the active conversation instead. Use custom, non-semconv keys: a
     key that collides with a span's own ``gen_ai.*`` / ``weave.*`` attribute
     is unsupported (which value wins is path-dependent).
+
+    ``messages`` records the turn input and ``output_messages`` records the
+    terminal agent response on the same ``invoke_agent`` span.
     """
     if not _OTEL_AVAILABLE or should_disable_weave():
         return LogResult(conversation_id=conversation_id)
@@ -1692,6 +1706,7 @@ def log_turn(
         agent_version=agent_version,
         system_instructions=system_instructions or [],
         messages=messages or [],
+        output_messages=output_messages or [],
         spans=resolved_spans,
         started_at=turn_started_at,
         ended_at=turn_ended_at,


### PR DESCRIPTION
## Summary

- Add `Turn.output_messages` and `Turn.record(output_messages=...)` to the Python Conversation SDK while preserving `messages` as the input-side API.
- Emit both input and terminal output messages on the `invoke_agent` span through the existing semantic-convention serializer.
- Apply content gating and PII redaction to both message lists.
- Add `output_messages` to the imperative `log_turn()` path so streaming and batch Turn emission stay aligned.

## Why

The TypeScript Turn API can record a terminal agent response separately from its input messages. Python already supports `output_messages` in the lower-level `invoke_agent_attributes()` builder, but `Turn.record()` could not supply it. This closes that gap without overloading the existing input `messages` field.

## Testing

- `uvx ruff check weave/conversation/conversation.py tests/conversation/test_conversation_otel.py tests/conversation/test_conversation_settings.py`
- `uvx ruff format --check weave/conversation/conversation.py tests/conversation/test_conversation_otel.py tests/conversation/test_conversation_settings.py`
- `uv run --frozen --group test python -m pytest tests/conversation/test_conversation_otel.py tests/conversation/test_conversation_settings.py -q` (198 passed)

## Breaking changes

None. Existing `messages` behavior is unchanged; `output_messages` is additive.

## Related

- #7624