### PR TITLE
fix(weave): preserve custom provider names in selectors

### DIFF
--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -2190,6 +2190,34 @@ def test_coreweave_requires_its_inference_api_key():
         chts._setup_completion_model_info(None, req, MagicMock())
 
 
+def test_custom_provider_name_matching_selector_prefix_is_preserved(monkeypatch):
+    req = tsi.CompletionsCreateReq(
+        project_id="entity/project",
+        inputs=_completion_inputs(model="custom::custom::gpt-4"),
+    )
+    obj_read = MagicMock()
+    get_provider_info = MagicMock(
+        return_value=llm_mod.CustomProviderInfo(
+            base_url="https://runtime.example.com/v1",
+            api_key=None,
+            extra_headers={},
+            return_type="openai",
+            actual_model_name="gpt-4",
+        )
+    )
+    monkeypatch.setattr(chts, "get_custom_provider_info", get_provider_info)
+
+    model_info = chts._setup_completion_model_info(None, req, obj_read)
+
+    get_provider_info.assert_called_once_with(
+        project_id="entity/project",
+        provider_name="custom",
+        model_name="custom-gpt-4",
+        obj_read_func=obj_read,
+    )
+    assert model_info.model_name == "custom/gpt-4"
+
+
 def test_coreweave_with_api_key_keeps_litellm_configuration():
     req = tsi.CompletionsCreateReq(
         project_id="entity/project",

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -8351,7 +8351,7 @@ def _setup_completion_model_info(
     elif is_explicit_custom:
         # Custom provider path - model_name format: custom::<provider>::<model>
         # Parse provider and model names, create sanitized object_id for lookup
-        name_part = model_name.replace("custom::", "")
+        name_part = model_name.removeprefix("custom::")
 
         if "::" in name_part:
             # Format: custom::<provider>::<model>


### PR DESCRIPTION
## Description

Follow-up to [this review comment](https://github.com/wandb/weave/pull/7614#discussion_r3661131779).

Custom model selectors use `custom::<provider>::<model>`. The existing global replacement removes every `custom::` occurrence, so `custom::custom::gpt-4` is misread as provider `gpt`. This change strips only the leading selector namespace and adds a regression test for a custom runtime/provider named `custom`.

## Testing

- `python -m pytest -q tests/trace_server/test_llm_completion.py -k 'custom_provider_name_matching_selector_prefix or coreweave' tests/trace_server/test_clickhouse_trace_server_batched.py -k custom`
- Result: 23 passed
