### PR TITLE
fix(weave): align integration otel keys and retain instrumentation scope

### DIFF
--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
@@ -63,15 +63,15 @@ def get_attrs(span: Any) -> dict[str, Any]:
 
 
 def check_integration_and_strip(attrs: dict[str, Any]) -> dict[str, Any]:
-    """Assert + remove the flattened integration.* provenance keys.
+    """Assert + remove the flattened weave.integration.* provenance keys.
 
     The agent OTel processor stamps integration provenance on every span; pop it
     here so the exact-shape assertions below stay focused on the GenAI semconv keys.
     """
-    assert attrs["integration.name"] == "claude_agent_sdk"
-    assert attrs["integration.version"]  # weave SDK version
-    assert attrs["integration.meta.package_name"] == "claude_agent_sdk"
-    return {k: v for k, v in attrs.items() if not k.startswith("integration.")}
+    assert attrs["weave.integration.name"] == "claude_agent_sdk"
+    assert attrs["weave.integration.version"]  # weave SDK version
+    assert attrs["weave.integration.meta.package_name"] == "claude_agent_sdk"
+    return {k: v for k, v in attrs.items() if not k.startswith("weave.integration.")}
 
 
 def get_spans_by_op(spans: list[Any], op: str) -> list[Any]:

--- a/tests/integrations/google_adk/test_google_adk.py
+++ b/tests/integrations/google_adk/test_google_adk.py
@@ -642,11 +642,13 @@ class TestAdkRunnerE2E:
         stamped = [
             span.attributes
             for span in adk_test_harness.exporter.get_finished_spans()
-            if "integration.name" in (span.attributes or {})
+            if "weave.integration.name" in (span.attributes or {})
         ]
         assert stamped, "expected >=1 ADK span to carry integration metadata"
-        assert all(a["integration.name"] == "google_adk" for a in stamped)
-        assert all(a["integration.meta.package_name"] == "google-adk" for a in stamped)
+        assert all(a["weave.integration.name"] == "google_adk" for a in stamped)
+        assert all(
+            a["weave.integration.meta.package_name"] == "google-adk" for a in stamped
+        )
 
         # ADK opens exactly one invoke_agent span per turn.
         invoke_spans = by_op.get("invoke_agent", [])

--- a/tests/integrations/openai_agents/openai_agents_otel_test.py
+++ b/tests/integrations/openai_agents/openai_agents_otel_test.py
@@ -141,10 +141,12 @@ def test_openai_agents_quickstart_otel(
 
     spans = otel_spans.get_finished_spans()
     # Integration-tracking metadata is stamped (flattened) on every emitted span.
-    stamped = [_attrs(s) for s in spans if "integration.name" in _attrs(s)]
+    stamped = [_attrs(s) for s in spans if "weave.integration.name" in _attrs(s)]
     assert stamped, "expected >=1 span to carry integration metadata"
-    assert all(a["integration.name"] == "openai_agents" for a in stamped)
-    assert all(a["integration.meta.package_name"] == "openai-agents" for a in stamped)
+    assert all(a["weave.integration.name"] == "openai_agents" for a in stamped)
+    assert all(
+        a["weave.integration.meta.package_name"] == "openai-agents" for a in stamped
+    )
     by_name = {s.name: s for s in spans}
 
     # No synthetic trace root: TaskSpan is the OTel root, named "workflow ..."

--- a/tests/trace/test_integration_metadata.py
+++ b/tests/trace/test_integration_metadata.py
@@ -84,9 +84,6 @@ def test_otel_attribute_constants_match_node(
     node_semconv = (
         Path(__file__).resolve().parents[2] / "sdks/node/src/genai/semconv.ts"
     )
-    if not node_semconv.exists():
-        pytest.skip("Node SDK source is not included in this checkout")
-
     match = re.search(
         rf"export const {constant_name} = ['\"]([^'\"]+)['\"];",
         node_semconv.read_text(encoding="utf-8"),

--- a/tests/trace/test_integration_metadata.py
+++ b/tests/trace/test_integration_metadata.py
@@ -8,11 +8,17 @@ block and `with_integration_metadata` to thread it through `OpSettings`.
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 import pytest
 
 import weave
 from weave.integrations.integration_metadata import (
     INTEGRATION_ATTRIBUTE_KEY,
+    WEAVE_INTEGRATION_META_PREFIX,
+    WEAVE_INTEGRATION_NAME,
+    WEAVE_INTEGRATION_VERSION,
     IntegrationMetadata,
     apply_integration_metadata,
     library_integration,
@@ -50,10 +56,10 @@ def test_as_otel_attributes_flattens_to_dotted_keys():
         meta={"package_name": "openai-agents", "package_version": "0.1.0"},
     )
     assert meta.as_otel_attributes() == {
-        "integration.name": "openai_agents",
-        "integration.version": "1.2.3",
-        "integration.meta.package_name": "openai-agents",
-        "integration.meta.package_version": "0.1.0",
+        "weave.integration.name": "openai_agents",
+        "weave.integration.version": "1.2.3",
+        "weave.integration.meta.package_name": "openai-agents",
+        "weave.integration.meta.package_version": "0.1.0",
     }
 
 
@@ -61,7 +67,32 @@ def test_as_otel_attributes_stringifies_non_scalar_meta():
     meta = IntegrationMetadata(name="demo", version="1", meta={"opts": {"a": 1}})
     otel = meta.as_otel_attributes()
     # Nested values are not OTel-legal scalars, so they are stringified.
-    assert otel["integration.meta.opts"] == "{'a': 1}"
+    assert otel["weave.integration.meta.opts"] == "{'a': 1}"
+
+
+@pytest.mark.parametrize(
+    ("constant_name", "python_value"),
+    [
+        ("WEAVE_INTEGRATION_NAME", WEAVE_INTEGRATION_NAME),
+        ("WEAVE_INTEGRATION_VERSION", WEAVE_INTEGRATION_VERSION),
+        ("WEAVE_INTEGRATION_META_PREFIX", WEAVE_INTEGRATION_META_PREFIX),
+    ],
+)
+def test_otel_attribute_constants_match_node(
+    constant_name: str, python_value: str
+) -> None:
+    node_semconv = (
+        Path(__file__).resolve().parents[2] / "sdks/node/src/genai/semconv.ts"
+    )
+    if not node_semconv.exists():
+        pytest.skip("Node SDK source is not included in this checkout")
+
+    match = re.search(
+        rf"export const {constant_name} = ['\"]([^'\"]+)['\"];",
+        node_semconv.read_text(encoding="utf-8"),
+    )
+    assert match is not None
+    assert match.group(1) == python_value
 
 
 def test_as_attributes_returns_fresh_copies():

--- a/tests/trace_server/test_genai_extraction.py
+++ b/tests/trace_server/test_genai_extraction.py
@@ -423,7 +423,7 @@ def test_multi_alias_extraction_canonical_weave_key_wins() -> None:
         _make_span(
             attrs={
                 semconv.USAGE_REASONING_TOKENS.key: 99,
-                **dict.fromkeys(semconv.USAGE_REASONING_TOKENS.gen_ai_aliases, 10),
+                **dict.fromkeys(semconv.USAGE_REASONING_TOKENS.wire_aliases, 10),
             }
         ),
         project_id="p1",

--- a/tests/trace_server/test_genai_semconv.py
+++ b/tests/trace_server/test_genai_semconv.py
@@ -29,7 +29,7 @@ def test_multi_alias_lookup_keys_priority_order() -> None:
         key="weave.example",
         type="string",
         description="synthetic example with multiple aliases",
-        gen_ai_aliases=[
+        wire_aliases=[
             "gen_ai.example.primary",
             "gen_ai.example.legacy",
             "gen_ai.example.experimental",

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -44,11 +44,12 @@ from weave.trace_server.opentelemetry.helpers import (
     unflatten_key_values,
 )
 from weave.trace_server.opentelemetry.python_spans import (
-    Span as PySpan,
-)
-from weave.trace_server.opentelemetry.python_spans import (
+    Scope,
     SpanKind,
     StatusCode,
+)
+from weave.trace_server.opentelemetry.python_spans import (
+    Span as PySpan,
 )
 from weave.trace_server.opentelemetry.python_spans import TracesData as PyTracesData
 
@@ -168,6 +169,13 @@ def test_otel_export_clickhouse(client: weave_client.WeaveClient):
 
     assert call.id == decoded_span
     assert call.trace_id == decoded_trace
+
+    # The instrumentation scope survives the real ingest path, not just
+    # ScopeSpans.from_proto.
+    assert call.attributes["otel_span"]["scope"] == {
+        "name": "test_instrumentation",
+        "version": "1.0.0",
+    }
 
     for kv in export_span.attributes:
         key = kv.key
@@ -643,22 +651,24 @@ class TestPythonSpans:
 
         assert span.name == "test_span"
         assert span.kind == SpanKind.INTERNAL
-        assert span.scope_name == "test_instrumentation"
-        assert span.scope_version == "1.0.0"
+        assert span.scope == Scope(name="test_instrumentation", version="1.0.0")
         assert span.as_dict()["scope"] == {
             "name": "test_instrumentation",
             "version": "1.0.0",
         }
 
-        # An omitted instrumentation scope is represented by an empty proto.
-        empty_scope_spans = ScopeSpans(spans=[create_test_span()])
-        empty_resource_spans = ResourceSpans(scope_spans=[empty_scope_spans])
-        empty_traces_data = PyTracesData.from_proto(
-            TracesData(resource_spans=[empty_resource_spans])
+        # A sender that omits the scope is distinguishable from one that sends
+        # an empty scope, rather than both collapsing to "".
+        omitted = PyTracesData.from_proto(
+            TracesData(
+                resource_spans=[
+                    ResourceSpans(scope_spans=[ScopeSpans(spans=[create_test_span()])])
+                ]
+            )
         )
-        empty_span = empty_traces_data.resource_spans[0].scope_spans[0].spans[0]
-        assert empty_span.scope_name == ""
-        assert empty_span.scope_version == ""
+        omitted_span = omitted.resource_spans[0].scope_spans[0].spans[0]
+        assert omitted_span.scope is None
+        assert omitted_span.as_dict()["scope"] is None
 
 
 class TestAttributes:

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -643,6 +643,22 @@ class TestPythonSpans:
 
         assert span.name == "test_span"
         assert span.kind == SpanKind.INTERNAL
+        assert span.scope_name == "test_instrumentation"
+        assert span.scope_version == "1.0.0"
+        assert span.as_dict()["scope"] == {
+            "name": "test_instrumentation",
+            "version": "1.0.0",
+        }
+
+        # An omitted instrumentation scope is represented by an empty proto.
+        empty_scope_spans = ScopeSpans(spans=[create_test_span()])
+        empty_resource_spans = ResourceSpans(scope_spans=[empty_scope_spans])
+        empty_traces_data = PyTracesData.from_proto(
+            TracesData(resource_spans=[empty_resource_spans])
+        )
+        empty_span = empty_traces_data.resource_spans[0].scope_spans[0].spans[0]
+        assert empty_span.scope_name == ""
+        assert empty_span.scope_version == ""
 
 
 class TestAttributes:

--- a/weave/integrations/integration_metadata.py
+++ b/weave/integrations/integration_metadata.py
@@ -25,6 +25,12 @@ logger = logging.getLogger(__name__)
 # Top-level attribute key under which integration provenance is stored.
 INTEGRATION_ATTRIBUTE_KEY = "integration"
 
+# Restated locally because import-linter forbids integrations from importing
+# trace-server semconv constants; a cross-SDK parity test guards drift.
+WEAVE_INTEGRATION_NAME = "weave.integration.name"
+WEAVE_INTEGRATION_VERSION = "weave.integration.version"
+WEAVE_INTEGRATION_META_PREFIX = "weave.integration.meta"
+
 # OpenTelemetry span attributes must be scalars (or scalar sequences); values
 # outside this set are stringified when flattened onto a span.
 # See opentelemetry.util.types.AttributeValue.
@@ -93,17 +99,16 @@ class IntegrationMetadata:
         """Render the metadata as flattened OpenTelemetry span attributes.
 
         OTel span attributes must be scalars, so the nested shape from
-        :meth:`as_attributes` is flattened to dotted keys (``integration.name``,
-        ``integration.version``, ``integration.meta.<key>``). The trace server
-        reconstructs the nested dict from these keys on ingest. Used by the
-        agent OTel processors that emit spans instead of calling ``create_call``.
+        :meth:`as_attributes` is emitted as dotted ``weave.integration.*`` keys
+        for OTel consumers. The trace server does not rebuild these into a nested
+        ``attributes["integration"]`` dict on ingest.
         """
         attributes: dict[str, Any] = {
-            f"{INTEGRATION_ATTRIBUTE_KEY}.name": self.name,
-            f"{INTEGRATION_ATTRIBUTE_KEY}.version": self.version,
+            WEAVE_INTEGRATION_NAME: self.name,
+            WEAVE_INTEGRATION_VERSION: self.version,
         }
         for key, value in self.meta.items():
-            attributes[f"{INTEGRATION_ATTRIBUTE_KEY}.meta.{key}"] = (
+            attributes[f"{WEAVE_INTEGRATION_META_PREFIX}.{key}"] = (
                 value if isinstance(value, _OTEL_SCALAR_TYPES) else str(value)
             )
         return attributes

--- a/weave/integrations/integration_metadata.py
+++ b/weave/integrations/integration_metadata.py
@@ -25,8 +25,8 @@ logger = logging.getLogger(__name__)
 # Top-level attribute key under which integration provenance is stored.
 INTEGRATION_ATTRIBUTE_KEY = "integration"
 
-# Restated locally because import-linter forbids integrations from importing
-# trace-server semconv constants; a cross-SDK parity test guards drift.
+# Must match sdks/node/src/genai/semconv.ts; import-linter bars importing the
+# trace-server copy of these keys.
 WEAVE_INTEGRATION_NAME = "weave.integration.name"
 WEAVE_INTEGRATION_VERSION = "weave.integration.version"
 WEAVE_INTEGRATION_META_PREFIX = "weave.integration.meta"
@@ -99,9 +99,7 @@ class IntegrationMetadata:
         """Render the metadata as flattened OpenTelemetry span attributes.
 
         OTel span attributes must be scalars, so the nested shape from
-        :meth:`as_attributes` is emitted as dotted ``weave.integration.*`` keys
-        for OTel consumers. The trace server does not rebuild these into a nested
-        ``attributes["integration"]`` dict on ingest.
+        :meth:`as_attributes` is emitted as dotted ``weave.integration.*`` keys.
         """
         attributes: dict[str, Any] = {
             WEAVE_INTEGRATION_NAME: self.name,

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -13,6 +13,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, TypeVar, cast
 
+from opentelemetry.proto.common.v1.common_pb2 import InstrumentationScope
+
 from weave.shared import refs_internal as ri
 from weave.trace_server.agents import ingest_sampling
 from weave.trace_server.agents.chat_view import (
@@ -90,7 +92,11 @@ from weave.trace_server.opentelemetry.genai_extraction import (
     strip_inline_blobs_from_span,
 )
 from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
-from weave.trace_server.opentelemetry.python_spans import Resource, Span
+from weave.trace_server.opentelemetry.python_spans import (
+    Resource,
+    Span,
+    iter_proto_spans,
+)
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.agent_query_builder import (
     make_agent_versions_count_query,
@@ -848,10 +854,14 @@ class AgentWriteHandler:
 
         # Both branches below account every parse/extraction failure through
         # these two helpers, so the bookkeeping cannot drift between them.
-        def parse_span(protobuf_span: Any, resource: Resource) -> Span | None:
+        def parse_span(
+            protobuf_span: Any,
+            resource: Resource,
+            scope: InstrumentationScope | None,
+        ) -> Span | None:
             nonlocal rejected
             try:
-                return Span.from_proto(protobuf_span, resource)
+                return Span.from_proto(protobuf_span, resource, scope=scope)
             except AttributePathConflictError as e:
                 _record_ingest_failure(
                     failure_counts,
@@ -904,14 +914,15 @@ class AgentWriteHandler:
             # Sampler off (the default): the unmodified single-pass path.
             for processed_span in req.processed_spans:
                 resource = Resource.from_proto(processed_span.resource_spans.resource)
-                for protobuf_scope_spans in processed_span.resource_spans.scope_spans:
-                    for protobuf_span in protobuf_scope_spans.spans:
-                        span = parse_span(protobuf_span, resource)
-                        if span is None:
-                            continue
-                        row = extract_row(span, processed_span.run_id)
-                        if row is not None:
-                            span_rows.append(row)
+                for protobuf_span, scope in iter_proto_spans(
+                    processed_span.resource_spans
+                ):
+                    span = parse_span(protobuf_span, resource, scope)
+                    if span is None:
+                        continue
+                    row = extract_row(span, processed_span.run_id)
+                    if row is not None:
+                        span_rows.append(row)
         else:
             # Pass 1 (cheap): parse everything, then decide keep/drop per
             # trace before any blob-strip/extraction work happens.
@@ -919,13 +930,14 @@ class AgentWriteHandler:
             byte_sizes: list[int] = []
             for processed_span in req.processed_spans:
                 resource = Resource.from_proto(processed_span.resource_spans.resource)
-                for protobuf_scope_spans in processed_span.resource_spans.scope_spans:
-                    for protobuf_span in protobuf_scope_spans.spans:
-                        span = parse_span(protobuf_span, resource)
-                        if span is None:
-                            continue
-                        parsed.append((span, processed_span.run_id))
-                        byte_sizes.append(protobuf_span.ByteSize())
+                for protobuf_span, scope in iter_proto_spans(
+                    processed_span.resource_spans
+                ):
+                    span = parse_span(protobuf_span, resource, scope)
+                    if span is None:
+                        continue
+                    parsed.append((span, processed_span.run_id))
+                    byte_sizes.append(protobuf_span.ByteSize())
 
             decisions = ingest_sampling.decide_spans(
                 sampling, [span for span, _ in parsed], byte_sizes

--- a/weave/trace_server/agents/semconv.py
+++ b/weave/trace_server/agents/semconv.py
@@ -30,17 +30,14 @@ AttributeType = Literal["string", "int", "float", "string[]", "json"]
 class Attribute:
     """A single semantic convention attribute.
 
-    ``gen_ai_aliases`` lists wire keys recognized as equivalent to this column.
-    The first is the canonical upstream name; later entries are parallel forms
-    also accepted on ingest. Most are ``gen_ai.*``, but not all: ``ERROR_TYPE``
-    recognizes the OTel core key ``error.type``.
+    ``wire_aliases`` lists the wire keys recognized as equivalent to this
+    column, canonical upstream name first.
     """
 
     key: str  # canonical weave.* key
     type: AttributeType
     description: str
-    # Equivalent wire key(s) recognized on ingest, if any
-    gen_ai_aliases: list[str] = field(default_factory=list)
+    wire_aliases: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         """Validate that canonical attributes stay in the Weave namespace."""
@@ -57,7 +54,7 @@ class Attribute:
         so callers can rely on the weave.* key winning over OTel aliases
         when both are present on a span.
         """
-        return (self.key, *self.gen_ai_aliases)
+        return (self.key, *self.wire_aliases)
 
 
 # ---------------------------------------------------------------------------
@@ -428,13 +425,13 @@ ATTRIBUTES: dict[str, Attribute] = {a.key: a for a in _DEFS}
 # attribute is known statically.
 SEMCONV_LOOKUP_KEYS: dict[str, tuple[str, ...]] = {a.key: a.lookup_keys for a in _DEFS}
 
-# Map from any recognized key (weave.* or any registered gen_ai.* alias) to
-# canonical weave.* key. Every entry in ``gen_ai_aliases`` participates so
+# Map from any recognized key (weave.* or any registered wire alias) to
+# canonical weave.* key. Every entry in ``wire_aliases`` participates so
 # parallel client emissions all resolve to the same column.
 _ALIAS_TO_CANONICAL: dict[str, str] = {}
 for _a in _DEFS:
     _ALIAS_TO_CANONICAL[_a.key] = _a.key
-    for _alias in _a.gen_ai_aliases:
+    for _alias in _a.wire_aliases:
         _ALIAS_TO_CANONICAL[_alias] = _a.key
 
 
@@ -523,9 +520,9 @@ def _build_filterable_lookup() -> dict[str, str]:
     for canonical, col in CANONICAL_KEY_TO_COLUMN.items():
         out[canonical] = col
         attr = ATTRIBUTES[canonical]
-        for alias in attr.gen_ai_aliases:
+        for alias in attr.wire_aliases:
             out[alias] = col
-        for k in (canonical, *attr.gen_ai_aliases):
+        for k in (canonical, *attr.wire_aliases):
             for prefix in ("weave.", "gen_ai."):
                 if k.startswith(prefix):
                     out[k[len(prefix) :]] = col

--- a/weave/trace_server/agents/semconv.py
+++ b/weave/trace_server/agents/semconv.py
@@ -30,16 +30,16 @@ AttributeType = Literal["string", "int", "float", "string[]", "json"]
 class Attribute:
     """A single semantic convention attribute.
 
-    ``gen_ai_aliases`` lists the OTel ``gen_ai.*`` wire key(s) for this
-    column. The first entry is the canonical upstream name; later entries
-    are parallel forms recognised on ingest. See ``USAGE_REASONING_TOKENS``
-    for an example with multiple aliases.
+    ``gen_ai_aliases`` lists wire keys recognized as equivalent to this column.
+    The first is the canonical upstream name; later entries are parallel forms
+    also accepted on ingest. Most are ``gen_ai.*``, but not all: ``ERROR_TYPE``
+    recognizes the OTel core key ``error.type``.
     """
 
     key: str  # canonical weave.* key
     type: AttributeType
     description: str
-    # OTel gen_ai.* equivalent(s), if any
+    # Equivalent wire key(s) recognized on ingest, if any
     gen_ai_aliases: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -249,7 +249,11 @@ from weave.trace_server.model_providers.model_providers import (
     read_model_to_provider_info_map,
 )
 from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
-from weave.trace_server.opentelemetry.python_spans import Resource, Span
+from weave.trace_server.opentelemetry.python_spans import (
+    Resource,
+    Span,
+    iter_proto_spans,
+)
 from weave.trace_server.orm import ParamBuilder, Row
 from weave.trace_server.parallel_bucket_uploads import (
     BucketUploadBatch,
@@ -814,53 +818,52 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
             proto_resource_spans = processed_span.resource_spans
             resource = Resource.from_proto(proto_resource_spans.resource)
-            for proto_scope_spans in proto_resource_spans.scope_spans:
-                for proto_span in proto_scope_spans.spans:
+            for proto_span, scope in iter_proto_spans(proto_resource_spans):
+                try:
+                    span = Span.from_proto(proto_span, resource, scope=scope)
+                except AttributePathConflictError as e:
+                    # Record and skip malformed spans so we can partially accept the batch
+                    rejected_spans += 1
+                    # Use data available on the proto span for context
                     try:
-                        span = Span.from_proto(proto_span, resource)
-                    except AttributePathConflictError as e:
-                        # Record and skip malformed spans so we can partially accept the batch
-                        rejected_spans += 1
-                        # Use data available on the proto span for context
-                        try:
-                            trace_id = proto_span.trace_id.hex()
-                            span_id = proto_span.span_id.hex()
-                            name = getattr(proto_span, "name", "")
-                        except Exception:
-                            trace_id = ""
-                            span_id = ""
-                            name = ""
-                        span_ident = (
-                            f"name='{name}' trace_id='{trace_id}' span_id='{span_id}'"
-                        )
-                        error_messages.append(f"Rejected span ({span_ident}): {e!s}")
-                        continue
+                        trace_id = proto_span.trace_id.hex()
+                        span_id = proto_span.span_id.hex()
+                        name = getattr(proto_span, "name", "")
+                    except Exception:
+                        trace_id = ""
+                        span_id = ""
+                        name = ""
+                    span_ident = (
+                        f"name='{name}' trace_id='{trace_id}' span_id='{span_id}'"
+                    )
+                    error_messages.append(f"Rejected span ({span_ident}): {e!s}")
+                    continue
 
-                    # Mirror the non-OTel calls path: strip inline base64 /
-                    # base64 data-URIs into Content refs. Converting the span
-                    # attributes in place (before deriving the call) also
-                    # strips the lossless otel_dump the call carries.
-                    span.attributes = replace_base64_with_content_objects(
-                        span.attributes, req.project_id, self, wb_user_id=req.wb_user_id
-                    )
-                    start_call, end_call = span.to_call(
-                        req.project_id,
-                        wb_user_id=req.wb_user_id,
-                        wb_run_id=wb_run_id,
-                    )
-                    # Also convert the derived inputs/output: base64 nested in a
-                    # JSON-encoded message attribute only surfaces as a leaf
-                    # after to_call parses it.
-                    start_call.inputs = replace_base64_with_content_objects(
-                        start_call.inputs,
-                        req.project_id,
-                        self,
-                        wb_user_id=req.wb_user_id,
-                    )
-                    end_call.output = replace_base64_with_content_objects(
-                        end_call.output, req.project_id, self, wb_user_id=req.wb_user_id
-                    )
-                    calls.append((start_call, end_call))
+                # Mirror the non-OTel calls path: strip inline base64 /
+                # base64 data-URIs into Content refs. Converting the span
+                # attributes in place (before deriving the call) also
+                # strips the lossless otel_dump the call carries.
+                span.attributes = replace_base64_with_content_objects(
+                    span.attributes, req.project_id, self, wb_user_id=req.wb_user_id
+                )
+                start_call, end_call = span.to_call(
+                    req.project_id,
+                    wb_user_id=req.wb_user_id,
+                    wb_run_id=wb_run_id,
+                )
+                # Also convert the derived inputs/output: base64 nested in a
+                # JSON-encoded message attribute only surfaces as a leaf
+                # after to_call parses it.
+                start_call.inputs = replace_base64_with_content_objects(
+                    start_call.inputs,
+                    req.project_id,
+                    self,
+                    wb_user_id=req.wb_user_id,
+                )
+                end_call.output = replace_base64_with_content_objects(
+                    end_call.output, req.project_id, self, wb_user_id=req.wb_user_id
+                )
+                calls.append((start_call, end_call))
 
         set_current_span_dd_tags({"call_count": len(calls)})
         return calls, rejected_spans, error_messages

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -116,7 +116,11 @@ from weave.trace_server.model_providers.model_providers import (
     read_model_to_provider_info_map,
 )
 from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
-from weave.trace_server.opentelemetry.python_spans import Resource, Span
+from weave.trace_server.opentelemetry.python_spans import (
+    Resource,
+    Span,
+    iter_proto_spans,
+)
 from weave.trace_server.orm import Table, split_escaped_field_path
 from weave.trace_server.secret_fetcher_context import _secret_fetcher_context
 from weave.trace_server.token_costs import (
@@ -4591,53 +4595,50 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
 
             proto_resource_spans = processed_span.resource_spans
             resource = Resource.from_proto(proto_resource_spans.resource)
-            for proto_scope_spans in proto_resource_spans.scope_spans:
-                for proto_span in proto_scope_spans.spans:
+            for proto_span, scope in iter_proto_spans(proto_resource_spans):
+                try:
+                    span = Span.from_proto(proto_span, resource, scope=scope)
+                except AttributePathConflictError as e:
+                    rejected_spans += 1
                     try:
-                        span = Span.from_proto(proto_span, resource)
-                    except AttributePathConflictError as e:
-                        rejected_spans += 1
-                        try:
-                            trace_id = proto_span.trace_id.hex()
-                            span_id = proto_span.span_id.hex()
-                            name = getattr(proto_span, "name", "")
-                        except Exception:
-                            trace_id = ""
-                            span_id = ""
-                            name = ""
-                        span_ident = (
-                            f"name='{name}' trace_id='{trace_id}' span_id='{span_id}'"
-                        )
-                        error_messages.append(f"Rejected span ({span_ident}): {e!s}")
-                        continue
+                        trace_id = proto_span.trace_id.hex()
+                        span_id = proto_span.span_id.hex()
+                        name = getattr(proto_span, "name", "")
+                    except Exception:
+                        trace_id = ""
+                        span_id = ""
+                        name = ""
+                    span_ident = (
+                        f"name='{name}' trace_id='{trace_id}' span_id='{span_id}'"
+                    )
+                    error_messages.append(f"Rejected span ({span_ident}): {e!s}")
+                    continue
 
-                    start_call, end_call = span.to_call(
-                        req.project_id,
-                        wb_user_id=req.wb_user_id,
-                        wb_run_id=wb_run_id,
-                    )
-                    # ClickHouse resolves span names to op objects and stores
-                    # op refs as op_name; placeholder ops are content-
-                    # addressed so repeats dedupe.
-                    op_res = self.op_create(
-                        tsi.OpCreateReq(
-                            project_id=req.project_id,
-                            name=start_call.op_name,
-                        )
-                    )
-                    start_call.op_name = ri.InternalOpRef(
+                start_call, end_call = span.to_call(
+                    req.project_id,
+                    wb_user_id=req.wb_user_id,
+                    wb_run_id=wb_run_id,
+                )
+                # ClickHouse resolves span names to op objects and stores
+                # op refs as op_name; placeholder ops are content-
+                # addressed so repeats dedupe.
+                op_res = self.op_create(
+                    tsi.OpCreateReq(
                         project_id=req.project_id,
-                        name=op_res.object_id,
-                        version=op_res.digest,
-                    ).uri
-                    calls.extend(
-                        [
-                            tsi.CallBatchStartMode(
-                                req=tsi.CallStartReq(start=start_call)
-                            ),
-                            tsi.CallBatchEndMode(req=tsi.CallEndReq(end=end_call)),
-                        ]
+                        name=start_call.op_name,
                     )
+                )
+                start_call.op_name = ri.InternalOpRef(
+                    project_id=req.project_id,
+                    name=op_res.object_id,
+                    version=op_res.digest,
+                ).uri
+                calls.extend(
+                    [
+                        tsi.CallBatchStartMode(req=tsi.CallStartReq(start=start_call)),
+                        tsi.CallBatchEndMode(req=tsi.CallEndReq(end=end_call)),
+                    ]
+                )
         self.call_start_batch(tsi.CallCreateBatchReq(batch=calls))
         if rejected_spans > 0:
             return tsi.OTelExportRes(

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -202,6 +202,10 @@ class Span:
     start_time_unix_nano: int
     end_time_unix_nano: int
     attributes: dict[str, Any] = field(default_factory=dict)
+    # Carried down from the enclosing ScopeSpans so each persisted span retains
+    # its instrumentation-library identity.
+    scope_name: str = ""
+    scope_version: str = ""
     kind: SpanKind = SpanKind.UNSPECIFIED
     parent_id: str | None = None
     trace_state: str = ""
@@ -236,7 +240,12 @@ class Span:
         return self.duration_ns / 1_000_000
 
     @classmethod
-    def from_proto(cls, proto_span: PbSpan, resource: Resource | None = None) -> Self:
+    def from_proto(
+        cls,
+        proto_span: PbSpan,
+        resource: Resource | None = None,
+        scope: InstrumentationScope | None = None,
+    ) -> Self:
         """Create a Span from a protobuf Span."""
         parent_id = None
         if (
@@ -263,6 +272,8 @@ class Span:
             dropped_links_count=proto_span.dropped_links_count,
             status=Status.from_proto(proto_span.status),
             resource=resource,
+            scope_name=scope.name if scope is not None else "",
+            scope_version=scope.version if scope is not None else "",
         )
 
     # The full OTEL Span as it is received
@@ -284,6 +295,10 @@ class Span:
                 "events": self.events,
                 "links": self.links,
                 "resource": self.resource.as_dict() if self.resource else None,
+                "scope": {
+                    "name": self.scope_name,
+                    "version": self.scope_version,
+                },
             }
         )
 
@@ -456,7 +471,10 @@ class ScopeSpans:
         """Create a ScopeSpans from a protobuf ScopeSpans."""
         return cls(
             scope=proto_scope_spans.scope,
-            spans=[Span.from_proto(s, resource) for s in proto_scope_spans.spans],
+            spans=[
+                Span.from_proto(s, resource, scope=proto_scope_spans.scope)
+                for s in proto_scope_spans.spans
+            ],
             schema_url=proto_scope_spans.schema_url,
         )
 

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -192,6 +192,21 @@ class Resource:
 
 
 @dataclass
+class Scope:
+    """Identifies the instrumentation library that emitted a span."""
+
+    name: str = ""
+    version: str = ""
+
+    @classmethod
+    def from_proto(cls, proto_scope: InstrumentationScope) -> Self:
+        return cls(name=proto_scope.name, version=proto_scope.version)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "version": self.version}
+
+
+@dataclass
 class Span:
     """Represents a span in a trace."""
 
@@ -202,10 +217,7 @@ class Span:
     start_time_unix_nano: int
     end_time_unix_nano: int
     attributes: dict[str, Any] = field(default_factory=dict)
-    # Carried down from the enclosing ScopeSpans so each persisted span retains
-    # its instrumentation-library identity.
-    scope_name: str = ""
-    scope_version: str = ""
+    scope: Scope | None = None
     kind: SpanKind = SpanKind.UNSPECIFIED
     parent_id: str | None = None
     trace_state: str = ""
@@ -272,8 +284,7 @@ class Span:
             dropped_links_count=proto_span.dropped_links_count,
             status=Status.from_proto(proto_span.status),
             resource=resource,
-            scope_name=scope.name if scope is not None else "",
-            scope_version=scope.version if scope is not None else "",
+            scope=Scope.from_proto(scope) if scope is not None else None,
         )
 
     # The full OTEL Span as it is received
@@ -295,10 +306,7 @@ class Span:
                 "events": self.events,
                 "links": self.links,
                 "resource": self.resource.as_dict() if self.resource else None,
-                "scope": {
-                    "name": self.scope_name,
-                    "version": self.scope_version,
-                },
+                "scope": self.scope.as_dict() if self.scope else None,
             }
         )
 
@@ -469,10 +477,11 @@ class ScopeSpans:
         cls, proto_scope_spans: PbScopeSpans, resource: Resource | None = None
     ) -> Self:
         """Create a ScopeSpans from a protobuf ScopeSpans."""
+        scope = proto_scope_or_none(proto_scope_spans)
         return cls(
             scope=proto_scope_spans.scope,
             spans=[
-                Span.from_proto(s, resource, scope=proto_scope_spans.scope)
+                Span.from_proto(s, resource, scope=scope)
                 for s in proto_scope_spans.spans
             ],
             schema_url=proto_scope_spans.schema_url,
@@ -521,3 +530,22 @@ class TracesData:
                 ResourceSpans.from_proto(rs) for rs in proto_traces_data.resource_spans
             ]
         )
+
+
+def proto_scope_or_none(
+    proto_scope_spans: PbScopeSpans,
+) -> InstrumentationScope | None:
+    """Return the instrumentation scope, or None when the sender omitted it."""
+    if not proto_scope_spans.HasField("scope"):
+        return None
+    return proto_scope_spans.scope
+
+
+def iter_proto_spans(
+    proto_resource_spans: PbResourceSpans,
+) -> Iterator[tuple[PbSpan, InstrumentationScope | None]]:
+    """Yield each proto span in a ResourceSpans paired with its enclosing scope."""
+    for proto_scope_spans in proto_resource_spans.scope_spans:
+        scope = proto_scope_or_none(proto_scope_spans)
+        for proto_span in proto_scope_spans.spans:
+            yield proto_span, scope


### PR DESCRIPTION
## Summary
- Python `as_otel_attributes()` emitted `integration.*` while the node SDK emits `weave.integration.*`, so a consumer keyed on either spelling missed the other SDK's spans. Python now emits the `weave.integration.*` form `AGENTS.md:322` documents as canonical.
- Instrumentation scope was parsed and then discarded for every ingested span. `ScopeSpans.from_proto` was the only site threading it, and it is reachable only from `TracesData.from_proto`, which has no non-test callers; all three real ingest loops dropped it. `iter_proto_spans` now pairs each span with its enclosing scope in one place, so the three loops cannot disagree.
- Scope absence is a `Scope | None` mirroring `resource` rather than `""`, so "sender omitted the scope" and "sender sent an empty scope" stay distinguishable in the persisted `otel_dump`. This adds `attributes.otel_span.scope` as a permanent user-visible key.
- `gen_ai_aliases` -> `wire_aliases`: it already held non-`gen_ai` keys (`ERROR_TYPE` takes `error.type`), so the name carries the contract instead of a docstring carve-out.

No server-side ladder accepting both spellings: no weave server code consumes either key, so converging the producers now means a consumer needs one key rather than two forever. Note the old spelling is already persisted as custom attrs in real projects, so those will list both until the old spans age out, and a saved filter on `integration.name` stops matching new spans. #7644 should rebase and drop its dual-key rung.

## Testing
The scope assertion runs through the real `otel_export` path, not `TracesData.from_proto`; reverting the threading in `clickhouse_trace_server_batched.py` fails it with `assert None == {...}`. A parity test reads the node literal out of `sdks/node/src/genai/semconv.ts` so the SDKs cannot drift again; the import-linter forbids sharing the constant, so the literals are restated per the `google_adk/_semconv.py` precedent.