### PR TITLE
fix(weave): use standard custom runtime validation

### DIFF
--- a/tests/trace_server/test_custom_runtime_api.py
+++ b/tests/trace_server/test_custom_runtime_api.py
@@ -290,16 +290,14 @@ def test_custom_runtime_apply_objects_work_with_existing_completion_lookup(
     "request_data",
     [
         {"runtime_name": "", "runtime_ids": [{"id": "runtime"}]},
+        {"runtime_name": "runtime name", "runtime_ids": [{"id": "runtime"}]},
         {"runtime_name": "name::part", "runtime_ids": [{"id": "runtime"}]},
         {"runtime_name": "a" * 129, "runtime_ids": [{"id": "runtime"}]},
         {"runtime_name": "runtime", "runtime_ids": [{"id": ""}]},
+        {"runtime_name": "runtime", "runtime_ids": [{"id": "runtime\tid"}]},
         {
             "runtime_name": "runtime",
             "runtime_ids": [{"id": "duplicate"}, {"id": "duplicate"}],
-        },
-        {
-            "runtime_name": "r" * 64,
-            "runtime_ids": [{"id": "i" * 64}],
         },
     ],
 )
@@ -311,6 +309,59 @@ def test_custom_runtime_apply_validates_names_before_writes(
             project_id=PROJECT_ID,
             base_url="https://agent.example.com/v1",
             **request_data,
+        )
+
+
+def test_custom_runtime_apply_trims_identifiers_before_validation() -> None:
+    request = tsi.CustomRuntimeApplyReq(
+        project_id=PROJECT_ID,
+        runtime_name=f" {'r' * 64} ",
+        base_url="https://agent.example.com/v1",
+        runtime_ids=[
+            {"id": " runtime "},
+        ],
+    )
+
+    assert request.runtime_name == "r" * 64
+    assert request.runtime_ids[0].id == "runtime"
+
+    with pytest.raises(ValidationError, match="duplicate runtime ID"):
+        tsi.CustomRuntimeApplyReq(
+            project_id=PROJECT_ID,
+            runtime_name="runtime",
+            base_url="https://agent.example.com/v1",
+            runtime_ids=[
+                {"id": "duplicate"},
+                {"id": " duplicate "},
+            ],
+        )
+
+
+def test_custom_runtime_id_constraints_are_reflected_in_schema() -> None:
+    id_schema = tsi.CustomRuntimeID.model_json_schema()["properties"]["id"]
+
+    assert id_schema["minLength"] == 1
+    assert id_schema["pattern"] == r"^\S+$"
+
+
+def test_custom_runtime_name_constraints_are_reflected_in_schema() -> None:
+    request_schema = tsi.CustomRuntimeApplyReq.model_json_schema()
+    name_schema = request_schema["properties"]["runtime_name"]
+
+    assert name_schema["minLength"] == 1
+    assert name_schema["pattern"] == r"^[^\s:]*(?::[^\s:]+)*:?$"
+
+
+def test_custom_runtime_request_validates_storage_name_length() -> None:
+    with pytest.raises(
+        InvalidRequest,
+        match="Runtime name and ID together cannot exceed 128 characters",
+    ):
+        tsi.CustomRuntimeApplyReq(
+            project_id=PROJECT_ID,
+            runtime_name="r" * 64,
+            base_url="https://agent.example.com/v1",
+            runtime_ids=[{"id": "i" * 64}],
         )
 
 

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -7,11 +7,13 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    StringConstraints,
     field_serializer,
+    field_validator,
     model_validator,
     with_config,
 )
-from typing_extensions import TypedDict
+from typing_extensions import Self, TypedDict
 
 if TYPE_CHECKING:
     from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans
@@ -33,6 +35,7 @@ from weave.trace_server.constants import (
     DEFAULT_CUSTOM_RUNTIME_MAX_TOKENS,
     MAX_OBJECT_NAME_LENGTH,
 )
+from weave.trace_server.errors import InvalidRequest
 from weave.trace_server.interface.query import Query
 
 # Re-exported from service_interface for backwards compatibility.
@@ -2703,10 +2706,28 @@ class DatasetDeleteRes(BaseModel):
     num_deleted: int = Field(..., description="Number of dataset versions deleted")
 
 
+CustomRuntimeName: TypeAlias = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+        max_length=MAX_OBJECT_NAME_LENGTH,
+        # Forbid whitespace and "::".
+        pattern=r"^[^\s:]*(?::[^\s:]+)*:?$",
+    ),
+]
+
+
 class CustomRuntimeID(BaseModelStrict):
-    id: str = Field(
-        description="Value sent in the OpenAI-compatible request model field"
-    )
+    id: Annotated[
+        str,
+        StringConstraints(
+            strip_whitespace=True,
+            min_length=1,
+            # Forbid whitespace.
+            pattern=r"^\S+$",
+        ),
+    ] = Field(description="Value sent in the OpenAI-compatible request model field")
     max_tokens: int = Field(
         default=DEFAULT_CUSTOM_RUNTIME_MAX_TOKENS,
         gt=0,
@@ -2728,33 +2749,31 @@ class CustomRuntimeApplyBody(BaseModelStrict):
         description="Complete desired list of IDs exposed by the endpoint"
     )
 
-
-class CustomRuntimeApplyReq(CustomRuntimeApplyBody):
-    project_id: str
-    runtime_name: str
-    wb_user_id: str | None = Field(None, description=WB_USER_ID_DESCRIPTION)
-
-    @model_validator(mode="after")
-    def validate_runtime_identity(self) -> "CustomRuntimeApplyReq":
-        if not self.runtime_name.strip():
-            raise ValueError("runtime_name must not be empty")
-        if len(self.runtime_name) > MAX_OBJECT_NAME_LENGTH:
-            raise ValueError(
-                f"runtime_name cannot exceed {MAX_OBJECT_NAME_LENGTH} characters"
-            )
-        if "::" in self.runtime_name:
-            raise ValueError("runtime_name cannot contain '::'")
-
+    @field_validator("runtime_ids")
+    @classmethod
+    def validate_unique_runtime_ids(
+        cls, runtime_ids: list[CustomRuntimeID]
+    ) -> list[CustomRuntimeID]:
         seen_ids: set[str] = set()
-        for runtime_id in self.runtime_ids:
-            if not runtime_id.id.strip():
-                raise ValueError("runtime ID must not be empty")
+        for runtime_id in runtime_ids:
             if runtime_id.id in seen_ids:
                 raise ValueError(f"duplicate runtime ID: {runtime_id.id}")
             seen_ids.add(runtime_id.id)
+        return runtime_ids
+
+
+class CustomRuntimeApplyReq(CustomRuntimeApplyBody):
+    project_id: str
+    runtime_name: CustomRuntimeName
+    wb_user_id: str | None = Field(None, description=WB_USER_ID_DESCRIPTION)
+
+    @model_validator(mode="after")
+    def validate_storage_name_length(self) -> Self:
+        for runtime_id in self.runtime_ids:
             if len(f"{self.runtime_name}/{runtime_id.id}") > MAX_OBJECT_NAME_LENGTH:
-                raise ValueError(
-                    f"runtime name and ID cannot exceed {MAX_OBJECT_NAME_LENGTH} characters"
+                raise InvalidRequest(
+                    f"Runtime name and ID together cannot exceed "
+                    f"{MAX_OBJECT_NAME_LENGTH} characters"
                 )
         return self
 


### PR DESCRIPTION
## Summary

- Move runtime-name and runtime-ID checks to reusable Pydantic field validation.
- Trim leading/trailing whitespace, then reject empty values or identifiers containing internal whitespace.
- Keep duplicate-ID validation after normalization.
- Keep the combined storage-name limit in the Custom Runtime service as an `InvalidRequest` raised before writes.

## Why

Core route validation currently has to catch and reformat an internal `ValidationError` after combining its path and body. This keeps structural validation at the request boundary and the cross-field storage constraint at the domain boundary.

## Related change

- Core route cleanup: [wandb/core#49011](https://github.com/wandb/core/pull/49011)

## Verification

- `20 passed` in `tests/trace_server/test_custom_runtime_api.py`
- Weave pre-push type, import-boundary, lint, and format checks passed
- Regression coverage verifies normalization occurs before length and duplicate checks
