### PR TITLE
fix(weave): preserve user IDs in object creation

### DIFF
--- a/tests/trace/test_trace_server_v2_api.py
+++ b/tests/trace/test_trace_server_v2_api.py
@@ -13,6 +13,7 @@ This module tests the V2 API endpoints for:
 The tests run against the ClickHouse backend.
 """
 
+import base64
 import datetime
 
 import pytest
@@ -23,6 +24,72 @@ from weave.trace_server import constants
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ids import generate_id
 from weave.utils.project_id import from_project_id
+
+
+def test_object_creation_preserves_wb_user_id(client):
+    project_id = client.project_id
+    wb_user_id = client.entity
+
+    client.server.op_create(
+        tsi.OpCreateReq(
+            project_id=project_id,
+            name="user_id_op",
+            source_code="def user_id_op():\n    return 42",
+            wb_user_id=wb_user_id,
+        )
+    )
+    dataset_res = client.server.dataset_create(
+        tsi.DatasetCreateReq(
+            project_id=project_id,
+            name="user_id_dataset",
+            rows=[{"input": "hello", "output": "world"}],
+            wb_user_id=wb_user_id,
+        )
+    )
+    client.server.scorer_create(
+        tsi.ScorerCreateReq(
+            project_id=project_id,
+            name="user_id_scorer",
+            op_source_code="def score(output):\n    return output",
+            wb_user_id=wb_user_id,
+        )
+    )
+
+    entity, project = from_project_id(project_id)
+    dataset_ref = f"weave:///{entity}/{project}/object/{dataset_res.object_id}:{dataset_res.digest}"
+    client.server.evaluation_create(
+        tsi.EvaluationCreateReq(
+            project_id=project_id,
+            name="user_id_evaluation",
+            dataset=dataset_ref,
+            wb_user_id=wb_user_id,
+        )
+    )
+
+    object_ids = {
+        "user_id_op",
+        "user_id_dataset",
+        "user_id_scorer",
+        "user_id_scorer_score",
+        "user_id_scorer_summarize",
+        "user_id_evaluation",
+        "user_id_evaluation.evaluate",
+        "user_id_evaluation.predict_and_score",
+        "user_id_evaluation.summarize",
+    }
+    res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=project_id,
+            filter=tsi.ObjectVersionFilter(
+                object_ids=list(object_ids),
+                latest_only=True,
+            ),
+        )
+    )
+    internal_user_id = base64.b64encode(wb_user_id.encode()).decode()
+    assert {obj.object_id: obj.wb_user_id for obj in res.objs} == dict.fromkeys(
+        object_ids, internal_user_id
+    )
 
 
 class TestOpsV2API:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -4043,7 +4043,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 project_id=req.project_id,
                 object_id=object_id,
                 val=op_val,
-                wb_user_id=None,
+                wb_user_id=req.wb_user_id,
             )
         )
         obj_result = self.obj_create(obj_req)
@@ -4272,7 +4272,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 project_id=req.project_id,
                 object_id=dataset_id,
                 val=dataset_val,
-                wb_user_id=None,
+                wb_user_id=req.wb_user_id,
             )
         )
         obj_result = self.obj_create(obj_req)
@@ -4406,6 +4406,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             project_id=req.project_id,
             name=f"{scorer_id}_score",
             source_code=req.op_source_code,
+            wb_user_id=req.wb_user_id,
         )
         score_op_res = self.op_create(score_op_req)
         score_op_ref = score_op_res.digest
@@ -4415,6 +4416,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             project_id=req.project_id,
             name=f"{scorer_id}_summarize",
             source_code=object_creation_utils.PLACEHOLDER_SCORER_SUMMARIZE_OP_SOURCE,
+            wb_user_id=req.wb_user_id,
         )
         summarize_op_res = self.op_create(summarize_op_req)
         summarize_op_ref = summarize_op_res.digest
@@ -4431,7 +4433,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 project_id=req.project_id,
                 object_id=scorer_id,
                 val=scorer_val,
-                wb_user_id=None,
+                wb_user_id=req.wb_user_id,
             )
         )
         obj_result = self.obj_create(obj_req)
@@ -4511,6 +4513,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             project_id=req.project_id,
             name=f"{evaluation_id}.evaluate",
             source_code=object_creation_utils.PLACEHOLDER_EVALUATE_OP_SOURCE,
+            wb_user_id=req.wb_user_id,
         )
         evaluate_op_res = self.op_create(evaluate_op_req)
         evaluate_ref = evaluate_op_res.digest
@@ -4520,6 +4523,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             project_id=req.project_id,
             name=f"{evaluation_id}.predict_and_score",
             source_code=object_creation_utils.PLACEHOLDER_PREDICT_AND_SCORE_OP_SOURCE,
+            wb_user_id=req.wb_user_id,
         )
         predict_and_score_op_res = self.op_create(predict_and_score_op_req)
         predict_and_score_ref = predict_and_score_op_res.digest
@@ -4529,6 +4533,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             project_id=req.project_id,
             name=f"{evaluation_id}.summarize",
             source_code=object_creation_utils.PLACEHOLDER_EVALUATION_SUMMARIZE_OP_SOURCE,
+            wb_user_id=req.wb_user_id,
         )
         summarize_op_res = self.op_create(summarize_op_req)
         summarize_ref = summarize_op_res.digest
@@ -4553,7 +4558,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 project_id=req.project_id,
                 object_id=evaluation_id,
                 val=evaluation_val,
-                wb_user_id=None,
+                wb_user_id=req.wb_user_id,
             )
         )
         obj_result = self.obj_create(obj_req)

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1115,6 +1115,8 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     def op_create(self, req: tsi.OpCreateReq) -> tsi.OpCreateRes:
         req = req.model_copy(deep=True)
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        if req.wb_user_id is not None:
+            req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
         return self._ref_apply(
             self._internal_trace_server.op_create, req, req.project_id
         )
@@ -1142,6 +1144,8 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     def dataset_create(self, req: tsi.DatasetCreateReq) -> tsi.DatasetCreateRes:
         req = req.model_copy(deep=True)
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        if req.wb_user_id is not None:
+            req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
         return self._ref_apply(
             self._internal_trace_server.dataset_create, req, req.project_id
         )
@@ -1181,6 +1185,8 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     def scorer_create(self, req: tsi.ScorerCreateReq) -> tsi.ScorerCreateRes:
         req = req.model_copy(deep=True)
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        if req.wb_user_id is not None:
+            req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
         return self._ref_apply(
             self._internal_trace_server.scorer_create, req, req.project_id
         )
@@ -1211,6 +1217,8 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     ) -> tsi.EvaluationCreateRes:
         req = req.model_copy(deep=True)
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        if req.wb_user_id is not None:
+            req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
         return self._ref_apply(
             self._internal_trace_server.evaluation_create, req, req.project_id
         )

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -5388,6 +5388,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                 project_id=req.project_id,
                 object_id=object_id,
                 val=op_val,
+                wb_user_id=req.wb_user_id,
             )
         )
         obj_result = self.obj_create(obj_req)
@@ -5514,7 +5515,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                 project_id=req.project_id,
                 object_id=dataset_id,
                 val=dataset_val,
-                wb_user_id=None,
+                wb_user_id=req.wb_user_id,
             )
         )
         obj_result = self.obj_create(obj_req)
@@ -5612,6 +5613,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             project_id=req.project_id,
             name=f"{scorer_id}_score",
             source_code=req.op_source_code,
+            wb_user_id=req.wb_user_id,
         )
         score_op_res = self.op_create(score_op_req)
         score_op_ref = score_op_res.digest
@@ -5620,6 +5622,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             project_id=req.project_id,
             name=f"{scorer_id}_summarize",
             source_code=object_creation_utils.PLACEHOLDER_SCORER_SUMMARIZE_OP_SOURCE,
+            wb_user_id=req.wb_user_id,
         )
         summarize_op_res = self.op_create(summarize_op_req)
         summarize_op_ref = summarize_op_res.digest
@@ -5636,7 +5639,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                 project_id=req.project_id,
                 object_id=scorer_id,
                 val=scorer_val,
-                wb_user_id=None,
+                wb_user_id=req.wb_user_id,
             )
         )
         obj_result = self.obj_create(obj_req)
@@ -5700,6 +5703,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             project_id=req.project_id,
             name=f"{evaluation_id}.evaluate",
             source_code=object_creation_utils.PLACEHOLDER_EVALUATE_OP_SOURCE,
+            wb_user_id=req.wb_user_id,
         )
         evaluate_op_res = self.op_create(evaluate_op_req)
         evaluate_ref = evaluate_op_res.digest
@@ -5708,6 +5712,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             project_id=req.project_id,
             name=f"{evaluation_id}.predict_and_score",
             source_code=object_creation_utils.PLACEHOLDER_PREDICT_AND_SCORE_OP_SOURCE,
+            wb_user_id=req.wb_user_id,
         )
         predict_and_score_op_res = self.op_create(predict_and_score_op_req)
         predict_and_score_ref = predict_and_score_op_res.digest
@@ -5716,6 +5721,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             project_id=req.project_id,
             name=f"{evaluation_id}.summarize",
             source_code=object_creation_utils.PLACEHOLDER_EVALUATION_SUMMARIZE_OP_SOURCE,
+            wb_user_id=req.wb_user_id,
         )
         summarize_op_res = self.op_create(summarize_op_req)
         summarize_ref = summarize_op_res.digest
@@ -5740,7 +5746,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                 project_id=req.project_id,
                 object_id=evaluation_id,
                 val=evaluation_val,
-                wb_user_id=None,
+                wb_user_id=req.wb_user_id,
             )
         )
         obj_result = self.obj_create(obj_req)


### PR DESCRIPTION
## Summary

- preserve the authenticated wb_user_id across op, dataset, scorer, and evaluation creation
- propagate the ID to scorer and evaluation child ops
- convert the external user ID at the adapter boundary before ClickHouse persistence
- keep the in-memory trace server aligned with the production backend

## Before / after

Before, a DatasetCreateReq carrying wb_user_id reached the backend helper, but the generated ObjSchemaForInsert hardcoded the field to None. The same happened for ops, scorers, and evaluations, while generated scorer/evaluation ops omitted the field entirely.

After, the adapter converts the external ID to its internal representation once and every object version emitted by these four creation paths stores that ID in both ClickHouse and the in-memory test backend.

## Testing

- focused object-creation test against ClickHouse (passed)
- focused object-creation test plus the four existing no-ID create tests with --trace-server=fake (5 passed)
- uvx ruff check on all changed files
- uvx ruff format --check on all changed files
- pre-push hooks: ty, import-linter, pyright, mypy, Fixit, Ruff

## Scope

This intentionally does not add global non-null assertions, change worker payload contracts, or backfill historical rows.