### PR TITLE
feat(weave): add Cerebras Gemma 4 pricing metadata

### DIFF
--- a/tests/integrations/cerebras/cerebras_test.py
+++ b/tests/integrations/cerebras/cerebras_test.py
@@ -7,7 +7,7 @@ from cerebras.cloud.sdk import AsyncCerebras, Cerebras
 import weave
 from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
 
-model = "llama3.1-8b"  # Cerebras model
+model = "gpt-oss-120b"  # Cerebras model
 
 
 @pytest.fixture(autouse=True)

--- a/weave/trace_server/costs/cost_checkpoint.json
+++ b/weave/trace_server/costs/cost_checkpoint.json
@@ -33882,5 +33882,15 @@
       "cache_creation_input": 0.0,
       "created_at": "2026-08-31 16:21:06"
     }
+  ],
+  "cerebras/gemma-4-31b": [
+    {
+      "provider": "cerebras",
+      "input": 9.9e-07,
+      "output": 1.49e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-28 00:00:00"
+    }
   ]
 }

--- a/weave/trace_server/costs/cost_checkpoint.json
+++ b/weave/trace_server/costs/cost_checkpoint.json
@@ -28648,5 +28648,15 @@
       "cache_creation_input": 0,
       "created_at": "2026-07-01 09:59:23"
     }
+  ],
+  "cerebras/gemma-4-31b": [
+    {
+      "provider": "cerebras",
+      "input": 9.9e-07,
+      "output": 1.49e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-28 00:00:00"
+    }
   ]
 }

--- a/weave/trace_server/costs/manual_costs.json
+++ b/weave/trace_server/costs/manual_costs.json
@@ -38,5 +38,15 @@
       "cache_creation_input": 0.0,
       "created_at": "2026-05-19 10:13:20"
     }
+  ],
+  "cerebras/gemma-4-31b": [
+    {
+      "provider": "cerebras",
+      "input": 9.9e-07,
+      "output": 1.49e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-07-28 00:00:00"
+    }
   ]
 }


### PR DESCRIPTION
## Summary\n\n- Adds historical gemma-4-31b pricing metadata to the manual and checkpoint cost catalogs.\n- Moves the Cerebras integration test from retired llama3.1-8b to current gpt-oss-120b.\n\n## Why\n\nGemma 4 31B was available on Cerebras public endpoints through September 3, 2026. Retaining its published token pricing allows Weave to price historical traces from that period. Gemma remains available through Dedicated Endpoints, where customer-specific pricing may differ.\n\nThe integration test used a retired model ID, so it now uses gpt-oss-120b, which remains on the current public catalog.\n\n## Validation\n\n- Rebased onto current master.\n- 17 focused cost-update tests pass.\n- JSON parsing and git diff checks pass.\n- The Gemma pricing values match the LiteLLM registry now published on main.\n- Current public model source of truth: https://inference-docs.cerebras.ai/models/overview