### PR TITLE
feat(weave_ts): add provider name to turns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,9 @@ pnpm exec tsx examples/claudeAgents.ts
 - Record a terminal agent result with
   `Turn.record({outputMessages: [...]})`; `Turn.end()` serializes it onto the
   `invoke_agent` span as `gen_ai.output.messages`.
+- `Turn.providerName` is the typed source for `gen_ai.provider.name` on the
+  root `invoke_agent` span. Pass it through `startTurn` or `Turn.record`
+  instead of setting that semantic attribute with `setAttributes`.
 
 ### TypeScript GenAI span handles
 

--- a/sdks/node/src/__tests__/genai/turn.test.ts
+++ b/sdks/node/src/__tests__/genai/turn.test.ts
@@ -16,6 +16,7 @@ describe('Turn', () => {
   it('emits an invoke_agent span with GenAI agent / model attributes', () => {
     const turn = Turn.create({
       model: 'gpt-4o',
+      providerName: 'openai',
       agentId: '12345',
       agentName: 'weather-bot',
       agentDescription: 'Finds the most accurate weather',
@@ -37,6 +38,7 @@ describe('Turn', () => {
           "gen_ai.conversation.id": "<uuid>",
           "gen_ai.input.messages": "[{"role":"user","parts":[{"type":"text","content":"What's the weather?"}]}]",
           "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.provider.name": "openai",
           "gen_ai.request.model": "gpt-4o",
           "gen_ai.system_instructions": "[{"type":"text","content":"Be helpful"},{"type":"text","content":"Be concise"}]",
         },
@@ -69,6 +71,7 @@ describe('Turn', () => {
       agentId: 'weather-bot-prod',
       agentDescription: 'Looks up the weather',
       agentVersion: '1.4.2',
+      providerName: 'anthropic',
       systemInstructions: ['Be helpful'],
     });
     turn.end();
@@ -83,6 +86,7 @@ describe('Turn', () => {
           "gen_ai.agent.version": "1.4.2",
           "gen_ai.operation.name": "invoke_agent",
           "gen_ai.output.messages": "[{"role":"assistant","content":"It is sunny."}]",
+          "gen_ai.provider.name": "anthropic",
           "gen_ai.system_instructions": "[{"type":"text","content":"Be helpful"}]",
         },
         "endTime": "<timestamp>",
@@ -96,6 +100,7 @@ describe('Turn', () => {
       agentName: 'weather-bot',
       agentId: 'preset',
       agentVersion: 'v1',
+      providerName: 'openai',
       systemInstructions: ['initial'],
     });
     turn.record({agentVersion: 'v2'});
@@ -109,6 +114,7 @@ describe('Turn', () => {
           "gen_ai.agent.name": "weather-bot",
           "gen_ai.agent.version": "v2",
           "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.provider.name": "openai",
           "gen_ai.system_instructions": "[{"type":"text","content":"initial"}]",
         },
         "endTime": "<timestamp>",

--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -43,6 +43,7 @@ export const startSession = startConversation;
  * weave.startTurn({
  *   agentId: 'research-bot-prod',
  *   agentName: 'research-bot',
+ *   providerName: 'openai',
  *   agentDescription: 'Looks up facts on Wikipedia.',
  *   agentVersion: '1.4.2',
  *   model: 'gpt-4o',

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -21,6 +21,7 @@ import {
   ATTR_GEN_AI_INPUT_MESSAGES,
   ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_OUTPUT_MESSAGES,
+  ATTR_GEN_AI_PROVIDER_NAME,
   ATTR_GEN_AI_REQUEST_MODEL,
   ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   WEAVE_GENAI_TRACER_NAME,
@@ -31,6 +32,8 @@ import type {Message} from './types';
 
 export interface TurnInit extends SpanInitBase {
   model?: string;
+  /** GenAI provider emitted as `gen_ai.provider.name` on the invoke_agent span. */
+  providerName?: string;
   systemInstructions?: string[];
   userMessage?: string;
   agentId?: string;
@@ -78,6 +81,7 @@ type Opts = {
  * @example
  * const turn = weave.startTurn({
  *   model: 'gpt-4o',
+ *   providerName: 'openai',
  *   agentName: 'research-bot',
  *   agentId: 'research-bot-prod',
  *   agentDescription: 'Looks up facts on Wikipedia.',
@@ -103,6 +107,7 @@ export class Turn extends SpanBase {
   private _agentDescription: string;
   private _agentVersion: string;
   private _model: string;
+  private _providerName: string;
   private _inputMessages: Message[];
   private _outputMessages: Message[] = [];
   private _systemInstructions: string[];
@@ -116,6 +121,10 @@ export class Turn extends SpanBase {
     return this._model;
   }
 
+  public get providerName() {
+    return this._providerName;
+  }
+
   private constructor(opts: Opts) {
     super(opts.span);
     this._context = opts.context;
@@ -126,6 +135,7 @@ export class Turn extends SpanBase {
     this._agentVersion = opts.agentVersion;
     this._inputMessages = opts.messages;
     this._model = opts.model;
+    this._providerName = opts.providerName;
     this._systemInstructions = opts.systemInstructions;
     this._attributes = opts.attributes;
   }
@@ -154,6 +164,7 @@ export class Turn extends SpanBase {
       context: trace.setSpan(ROOT_CONTEXT, span),
       conversationId: opts.conversationId ?? '',
       model: opts.model ?? '',
+      providerName: opts.providerName ?? '',
       agentName: opts.agentName ?? '',
       messages,
       systemInstructions: opts.systemInstructions ?? [],
@@ -214,6 +225,7 @@ export class Turn extends SpanBase {
     messages?: Message[];
     outputMessages?: Message[];
     model?: string;
+    providerName?: string;
     systemInstructions?: string[];
     agentId?: string;
     agentName?: string;
@@ -230,6 +242,9 @@ export class Turn extends SpanBase {
     }
     if (opts.model !== undefined) {
       this._model = opts.model;
+    }
+    if (opts.providerName !== undefined) {
+      this._providerName = opts.providerName;
     }
     if (opts.systemInstructions !== undefined) {
       this._systemInstructions = opts.systemInstructions;
@@ -265,6 +280,9 @@ export class Turn extends SpanBase {
     }
     if (this._model) {
       this.span.setAttribute(ATTR_GEN_AI_REQUEST_MODEL, this._model);
+    }
+    if (this._providerName) {
+      this.span.setAttribute(ATTR_GEN_AI_PROVIDER_NAME, this._providerName);
     }
     if (this._conversationId) {
       this.span.setAttribute(ATTR_GEN_AI_CONVERSATION_ID, this._conversationId);

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -8,7 +8,6 @@ import {
 } from '../../genai';
 import {
   ATTR_ERROR_TYPE,
-  ATTR_GEN_AI_PROVIDER_NAME,
   ATTR_GEN_AI_USAGE_TOTAL_TOKENS,
 } from '../../genai/semconv';
 import {asOtelAttributes, libraryIntegration} from '../integrationMetadata';
@@ -213,11 +212,9 @@ export class ClaudeAgentOtelTracer {
         attributes: CLAUDE_AGENT_SDK_ATTRIBUTES,
       });
       return conversation.startTurn({
+        providerName: PROVIDER_NAME,
         startTime: this.startedAt,
       });
-    });
-    this.turn.setAttributes({
-      [ATTR_GEN_AI_PROVIDER_NAME]: PROVIDER_NAME,
     });
     if (this.prompt != null) {
       this.turn.record({


### PR DESCRIPTION
## Summary

- add optional typed `providerName` state to the TypeScript `Turn` API
- accept it through `startTurn()` / `Conversation.startTurn()` and `Turn.record()`
- emit it as `gen_ai.provider.name` on the root `invoke_agent` span at `Turn.end()`
- update the Claude Agent SDK integration to pass `providerName` when creating its turn instead of calling `setAttributes()`
- cover initial, recorded, and preserved provider values in Turn tests

## Testing

- `pnpm exec jest --runInBand src/__tests__/genai/turn.test.ts src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts` — 25 passed
- `pnpm test` — 455 passed
- `pnpm run typecheck:cjs` — passed
- `pnpm run typecheck:esm` — passed
- `pnpm run prettier-check` — passed
- targeted ESLint — passed

## Breaking changes

None. `providerName` is optional and defaults to an empty string.

## Related

TypeScript parity for the Python Turn provider support in #7654. This PR is independent and based directly on `master`.
