### PR TITLE
fix(weave): enforce cost query project scope

### DIFF
--- a/tests/trace/test_client_cost.py
+++ b/tests/trace/test_client_cost.py
@@ -44,6 +44,39 @@ def test_cost_apis(client):
     cost_ids = res.ids
     assert len(cost_ids) == 4
 
+    # A matching cost in another project must never be returned.
+    other_project_id = f"{project_id}_{uuid.uuid4().hex}"
+    res = client.server.cost_create(
+        tsi.CostCreateReq(
+            project_id=other_project_id,
+            costs={
+                "foreign_project_model": {
+                    "prompt_token_cost": 50,
+                    "completion_token_cost": 100,
+                }
+            },
+            wb_user_id="VXNlcjo0NTI1NDQ=",
+        )
+    )
+    assert len(res.ids) == 1
+
+    res = client.server.cost_query(
+        tsi.CostQueryReq(
+            project_id=project_id,
+            query=Query(
+                **{
+                    "$expr": {
+                        "$eq": [
+                            {"$getField": "pricing_level_id"},
+                            {"$literal": other_project_id},
+                        ],
+                    }
+                }
+            ),
+        )
+    )
+    assert res.results == []
+
     # query costs by project
     req = tsi.CostQueryReq(
         project_id=project_id,

--- a/tests/trace_server/test_orm.py
+++ b/tests/trace_server/test_orm.py
@@ -150,14 +150,16 @@ def test_transform_external_field_to_internal_field():
 
     # Qualified fields must preserve simple table aliases.
     result = _transform_external_field_to_internal_field(
-        "feedback.id", all_columns=all_columns, json_columns=json_columns
+        "f.id", all_columns=all_columns, json_columns=json_columns
     )
-    assert result[0] == "feedback.id"
-    assert result[2] == {"feedback.id"}
+    assert result[0] == "f.id"
+    assert result[2] == {"f.id"}
 
-    # Reject SQL expressions disguised as table prefixes or nested fields.
+    # Reject malformed qualifiers and SQL expressions disguised as fields.
     invalid_fields = [
         ("(SELECT 'BENIGN_SQLI_PROBE') AS probe --.id", "Invalid table prefix"),
+        (".id", "Invalid table prefix"),
+        ("feedback.", "Unknown field"),
         ("id.value) FROM system.one --", "Unknown field"),
     ]
     for invalid_field, error_match in invalid_fields:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6676,16 +6676,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def cost_query(self, req: tsi.CostQueryReq) -> tsi.CostQueryRes:
         expr = {
             "$and": [
-                (
-                    req.query.expr_
-                    if req.query
-                    else {
-                        "$eq": [
-                            {"$getField": "pricing_level_id"},
-                            {"$literal": req.project_id},
-                        ],
-                    }
-                ),
+                *([req.query.expr_] if req.query else []),
+                {
+                    "$eq": [
+                        {"$getField": "pricing_level_id"},
+                        {"$literal": req.project_id},
+                    ],
+                },
                 {
                     "$eq": [
                         {"$getField": "pricing_level"},

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -4175,16 +4175,13 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
     def cost_query(self, req: tsi.CostQueryReq) -> tsi.CostQueryRes:
         expr = {
             "$and": [
-                (
-                    req.query.expr_
-                    if req.query
-                    else {
-                        "$eq": [
-                            {"$getField": "pricing_level_id"},
-                            {"$literal": req.project_id},
-                        ],
-                    }
-                ),
+                *([req.query.expr_] if req.query else []),
+                {
+                    "$eq": [
+                        {"$getField": "pricing_level_id"},
+                        {"$literal": req.project_id},
+                    ],
+                },
                 {
                     "$eq": [
                         {"$getField": "pricing_level"},

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -15,7 +15,7 @@ from weave.trace_server.errors import InvalidFieldError
 from weave.trace_server.interface import query as tsi_query
 
 param_builder_count = 0
-_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SQL_IDENTIFIER_RE = re.compile(r"^(?!$)[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class ParamBuilder:


### PR DESCRIPTION
## Summary

- always combine caller-supplied cost filters with the requested project scope
- enforce the same isolation in the ClickHouse and in-memory trace servers
- make the ORM identifier regex explicitly reject empty qualifiers while preserving one-character aliases
- cover a direct cross-project cost lookup and malformed qualified fields
