### PR TITLE
security(weave): 0.83.x server release patch 1

### DIFF
--- a/tests/trace_server/test_orm.py
+++ b/tests/trace_server/test_orm.py
@@ -118,6 +118,26 @@ def test_transform_external_field_to_internal_field():
     assert result[0] == "toString(JSON_VALUE(payload_dump, {pb_0:String}))"
     assert result[2] == {"payload_dump"}
 
+    # Qualified fields must preserve simple table aliases.
+    result = _transform_external_field_to_internal_field(
+        "feedback.id", all_columns=all_columns, json_columns=json_columns
+    )
+    assert result[0] == "feedback.id"
+    assert result[2] == {"feedback.id"}
+
+    # Reject SQL expressions disguised as table prefixes or nested fields.
+    invalid_fields = [
+        ("(SELECT 'BENIGN_SQLI_PROBE') AS probe --.id", "Invalid table prefix"),
+        ("id.value) FROM system.one --", "Unknown field"),
+    ]
+    for invalid_field, error_match in invalid_fields:
+        with pytest.raises(ValueError, match=error_match):
+            _transform_external_field_to_internal_field(
+                invalid_field,
+                all_columns=all_columns,
+                json_columns=json_columns,
+            )
+
 
 def test_array_string_column_round_trip():
     table = Table("t", [Column("id", "string"), Column("tags", "array_string")])

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -15,6 +15,7 @@ from weave.trace_server.errors import InvalidFieldError
 from weave.trace_server.interface import query as tsi_query
 
 param_builder_count = 0
+_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class ParamBuilder:
@@ -757,18 +758,11 @@ def _transform_external_field_to_internal_field(
     unprefixed_field = field
     if "." in field:
         table_prefix, field = field.split(".", 1)
+        if _SQL_IDENTIFIER_RE.fullmatch(table_prefix) is None:
+            raise ValueError(f"Invalid table prefix: {table_prefix}")
 
     # validate field
-    if (
-        field not in all_columns
-        and field != "*"
-        and field.lower() != "count(*)"
-        and not any(
-            # Check if field starts with a valid column name as prefix
-            unprefixed_field.lower().startswith(col_name.lower() + ".")
-            for col_name in all_columns
-        )
-    ):
+    if field not in all_columns and field != "*" and field.lower() != "count(*)":
         # add back table prefix when erroring
         if table_prefix:
             field = f"{table_prefix}.{field}"


### PR DESCRIPTION
## Summary
Cherry-pick branch for the 0.83.x server release patch. Branched off the weave commit pinned by `wandb/core@server-release-0.83.x` (`eacf46d`).

Cherry-picked from:
- #7656 security(weave): validate ORM field qualifiers

## Testing
`uv run --group test python -m pytest tests/trace_server/test_orm.py -q` on this branch.