### PR TITLE
fix(weave): exclude media payloads from agent chat text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -562,7 +562,4 @@ Think of this as the reverse-task assignment - a place where you can communicate
 - [ ] Repair the existing `pnpm run typecheck:examples` failures caused by
       OpenAI type drift in `examples/agent.ts`, `classesWithOps.ts`,
       `imageGeneration.ts`, `quickstart*.ts`, and `streamFunctionCalls.ts`.
-- [ ] Exclude `.git` from the Ruff pre-push scan. A remote branch whose name
-      ends in `.py` currently makes `nox --no-install -e lint` parse its ref and
-      reflog files as Python source.
 - [ ] ...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -562,4 +562,7 @@ Think of this as the reverse-task assignment - a place where you can communicate
 - [ ] Repair the existing `pnpm run typecheck:examples` failures caused by
       OpenAI type drift in `examples/agent.ts`, `classesWithOps.ts`,
       `imageGeneration.ts`, `quickstart*.ts`, and `streamFunctionCalls.ts`.
+- [ ] Exclude `.git` from the Ruff pre-push scan. A remote branch whose name
+      ends in `.py` currently makes `nox --no-install -e lint` parse its ref and
+      reflog files as Python source.
 - [ ] ...

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -1386,6 +1386,40 @@ def test_inline_internal_ref_surfaces_without_span_content_refs() -> None:
     assert _assistant_payload(assistant).content_refs == []
 
 
+def test_blob_content_is_media_not_user_message_text() -> None:
+    """A Weave blob's `content` is base64/ref data, not displayable prose."""
+    audio_internal = "weave-trace-internal:///PID/object/Content:AUDIODIGEST"
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="audio-inspector",
+            input_messages=[
+                {
+                    "role": "user",
+                    "content": _parts(
+                        {
+                            "type": "blob",
+                            "content": audio_internal,
+                            "mimeType": "audio/mpeg",
+                            "modality": "audio",
+                        },
+                        _text_part("Inspect this audio."),
+                    ),
+                }
+            ],
+        )
+    ]
+
+    messages = build_chat_messages(spans)
+    user = next(m for m in messages if m.type == "user_message")
+
+    assert _user_payload(user) == AgentChatUserMessage(
+        text="Inspect this audio.",
+        content_refs=[audio_internal],
+    )
+
+
 @pytest.mark.xfail(
     reason=(
         "Known limitation (PR #7489 discussion): the inline-ref sweep "

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -1388,23 +1388,23 @@ def test_inline_internal_ref_surfaces_without_span_content_refs() -> None:
 
 def test_blob_content_is_media_not_user_message_text() -> None:
     """A Weave blob's `content` is base64/ref data, not displayable prose."""
-    audio_internal = "weave-trace-internal:///PID/object/Content:AUDIODIGEST"
+    image_internal = "weave-trace-internal:///PID/object/Content:IMAGEDIGEST"
     spans = [
         _span(
             span_id="agent",
             operation_name="invoke_agent",
-            agent_name="audio-inspector",
+            agent_name="image-analyzer",
             input_messages=[
                 {
                     "role": "user",
                     "content": _parts(
                         {
                             "type": "blob",
-                            "content": audio_internal,
-                            "mimeType": "audio/mpeg",
-                            "modality": "audio",
+                            "content": image_internal,
+                            "mimeType": "image/png",
+                            "modality": "image",
                         },
-                        _text_part("Inspect this audio."),
+                        _text_part("Describe this image."),
                     ),
                 }
             ],
@@ -1415,8 +1415,8 @@ def test_blob_content_is_media_not_user_message_text() -> None:
     user = next(m for m in messages if m.type == "user_message")
 
     assert _user_payload(user) == AgentChatUserMessage(
-        text="Inspect this audio.",
-        content_refs=[audio_internal],
+        text="Describe this image.",
+        content_refs=[image_internal],
     )
 
 

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -690,9 +690,9 @@ def _display_text(content: str) -> str:
     """Extract human-readable text from a message content field.
 
     Content is either plain text (legacy) or a JSON-serialized parts array
-    (multimodal messages).  For parts arrays, concatenate the text parts;
-    reasoning parts are excluded (they surface separately via
-    `reasoning_content`).  For plain text, return as-is.
+    (multimodal messages). For parts arrays, concatenate text parts. Reasoning
+    surfaces through ``reasoning_content``; media surfaces through
+    ``content_refs``. For plain text, return as-is.
     """
     if not content or not content.startswith("["):
         return content
@@ -709,9 +709,7 @@ def _display_text(content: str) -> str:
             # concatenating it here would duplicate it in the message body.
             if p.get("type") == "reasoning":
                 continue
-            # Weave blob parts carry their base64 payload (or the Content ref
-            # that replaces it at ingest) in `content`. That field is media,
-            # not prose, and must not leak into the chat bubble's text.
+            # Media belongs in content_refs, never chat text.
             if p.get("type") in _MEDIA_PART_TYPES:
                 continue
             # Support both the weave parts model (``content``) and the

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -709,9 +709,14 @@ def _display_text(content: str) -> str:
             # concatenating it here would duplicate it in the message body.
             if p.get("type") == "reasoning":
                 continue
+            # Weave blob parts carry their base64 payload (or the Content ref
+            # that replaces it at ingest) in `content`. That field is media,
+            # not prose, and must not leak into the chat bubble's text.
+            if p.get("type") in _MEDIA_PART_TYPES:
+                continue
             # Support both the weave parts model (``content``) and the
             # OpenAI-style multimodal shape (``text``). Non-text parts (e.g.
-            # images) carry neither and are skipped for display.
+            # images) are skipped for display.
             if isinstance(p.get("content"), str):
                 texts.append(p["content"])
             elif isinstance(p.get("text"), str):


### PR DESCRIPTION
## Summary

- Keep blob, URI, and file media parts out of visible Agents chat text.
- Continue surfacing stored Weave Content references through `content_refs`.
- Add regression coverage for an image blob whose base64 payload is replaced by a Content ref at ingest.

<img width="1542" height="1138" alt="image" src="https://github.com/user-attachments/assets/716417e1-8689-4b08-8fbe-1d780d1ffd43" />

## Testing

- `uv run --group test python -m pytest tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py tests/trace_server/test_genai_chat_view.py -q` (73 passed, 1 existing xfailed)
- Targeted Ruff check and format verification passed.
- `nox --no-install -e lint`: ty, import-linter, pyright, and mypy passed; Ruff hooks were blocked by an unrelated local `.git` remote-ref filename issue.

## Breaking changes

None. Stored trace data and API schemas are unchanged.