### PR TITLE
feat(weave_ts): add shared GenAI media attachment type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,6 +354,14 @@ pnpm exec tsx examples/claudeAgents.ts
 - The Claude Agent SDK integration keeps each `Tool` open until its matching
   `tool_result`.
 
+### TypeScript GenAI media attachments
+
+- `MediaAttachment` is the shared discriminated union for inline base64 blobs,
+  URIs, and file IDs. Export it from both `genai/index.ts` and the public SDK
+  entry point when integrations need to accept tracing-only media.
+- Keep `AttachMediaOpts` as a compatibility alias for `MediaAttachment`; new
+  APIs should use the shared name directly.
+
 ## Code Review & PR Guidelines
 
 ### PR Requirements

--- a/sdks/node/src/genai/index.ts
+++ b/sdks/node/src/genai/index.ts
@@ -42,6 +42,7 @@ export {Turn, type TurnInit} from './turn';
 export type {
   Message,
   MessagePart,
+  MediaAttachment,
   Modality,
   Reasoning,
   Role,

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -31,7 +31,14 @@ import {
 } from './semconv';
 import {SubAgent, type SubAgentInit} from './subagent';
 import {Tool, type ToolInit} from './tool';
-import type {Message, MessagePart, Modality, Reasoning, Usage} from './types';
+import type {
+  MediaAttachment,
+  Message,
+  MessagePart,
+  Modality,
+  Reasoning,
+  Usage,
+} from './types';
 
 export interface LLMInit extends SpanInitBase {
   model: string;
@@ -39,11 +46,8 @@ export interface LLMInit extends SpanInitBase {
   systemInstructions?: string[];
 }
 
-/** Discriminated union for `LLM.attachMedia`: pick one of content / uri / fileId. */
-export type AttachMediaOpts =
-  | {content: string; mimeType: string; modality: Modality}
-  | {uri: string; modality: Modality}
-  | {fileId: string; modality: Modality; mimeType?: string};
+/** @deprecated Use {@link MediaAttachment}. */
+export type AttachMediaOpts = MediaAttachment;
 
 /**
  * An LLM call. Emits a `chat` span with `gen_ai.*` attributes.

--- a/sdks/node/src/genai/types.ts
+++ b/sdks/node/src/genai/types.ts
@@ -12,6 +12,12 @@ export type Role =
 
 export type Modality = 'image' | 'audio' | 'video' | 'document';
 
+/** A media attachment to append to a GenAI input message. */
+export type MediaAttachment =
+  | {content: string; mimeType: string; modality: Modality}
+  | {uri: string; modality: Modality}
+  | {fileId: string; modality: Modality; mimeType?: string};
+
 export interface Message {
   role: Role;
   content?: string;

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -76,6 +76,7 @@ export type {
   ConversationInit,
   LLM,
   LLMInit,
+  MediaAttachment,
   Message,
   MessagePart,
   Modality,


### PR DESCRIPTION
## Summary

- Add a shared `MediaAttachment` discriminated union for inline base64 blobs, URIs, and file IDs.
- Export the type from the GenAI module and the public Node SDK entry point.
- Keep `AttachMediaOpts` as a compatibility alias so the existing `LLM.attachMedia()` API is unchanged.

## Testing

- `corepack pnpm run build`
- `corepack pnpm test -- --runInBand src/__tests__/genai/llm.test.ts` (17 passed, 2 snapshots)
- `corepack pnpm run typecheck:cjs`
- `corepack pnpm run typecheck:esm`
- Focused ESLint and Prettier checks

## Breaking changes

None. `AttachMediaOpts` remains available with the same shape; `MediaAttachment` is an additive public type.

## Related PR

- #7661 is stacked on this PR and uses `MediaAttachment` in the Claude Agent SDK integration.