### PR TITLE
feat(weave): trace Claude Agent SDK image prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,6 +469,9 @@ pnpm exec tsx examples/claudeAgents.ts
   OTel spans or call the low-level GenAI attribute builders itself. Use
   `set_attributes()` only for semantic fields the typed handles do not expose.
   The legacy calls-based path remains separate.
+- Tap Python `AsyncIterable[dict]` prompts without consuming or cloning them.
+  Map Claude text and base64/URL image blocks to GenAI text, blob, and URI
+  parts; media payloads remain data for `content_refs`, not chat prose.
 - Stream adapters can create child handles when work starts, then enter them
   with a normal `with` when the completion message arrives. Preserve logical
   timing with `LLM.started_at` and an explicit `Tool.started_at` instead of

--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Generator
+from collections.abc import AsyncIterator, Generator
 from typing import Any
 
 import pytest
@@ -355,6 +355,73 @@ async def test_multi_turn_client_otel(otel_spans: InMemorySpanExporter) -> None:
         for agent_span in agent_spans
     }
     assert prompts == {"Hello", "What is the capital of France?"}
+
+
+# --- query(): streamed image prompt -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streamed_image_prompt_otel(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    image_base64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+        "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )
+    image_message = {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": image_base64,
+                    },
+                },
+                {"type": "text", "text": "Describe this image."},
+            ],
+        },
+        "parent_tool_use_id": None,
+    }
+
+    async def image_prompt() -> AsyncIterator[dict[str, Any]]:
+        yield image_message
+
+    transport = ReplayTransport(load_cassette("simple_text_response"))
+    messages = [
+        message
+        async for message in query(
+            prompt=image_prompt(),
+            options=ClaudeAgentOptions(),
+            transport=transport,
+        )
+    ]
+
+    assert [type(message).__name__ for message in messages] == [
+        "SystemMessage",
+        "AssistantMessage",
+        "ResultMessage",
+    ]
+    assert transport.user_messages == [image_message]
+    agent_spans = get_spans_by_op(otel_spans.get_finished_spans(), "invoke_agent")
+    assert len(agent_spans) == 1
+    assert get_messages(agent_spans[0], "gen_ai.input.messages") == [
+        {
+            "role": "user",
+            "parts": [
+                {
+                    "type": "blob",
+                    "mime_type": "image/png",
+                    "modality": "image",
+                    "content": image_base64,
+                },
+                {"type": "text", "content": "Describe this image."},
+            ],
+        }
+    ]
 
 
 # --- agent name override ----------------------------------------------------

--- a/tests/integrations/claude_agent_sdk/conftest.py
+++ b/tests/integrations/claude_agent_sdk/conftest.py
@@ -31,12 +31,15 @@ class ReplayTransport(Transport):
         self._connected = False
         self._pending_control_ids: list[str] = []
         self._control_event = anyio.Event()
+        self.user_messages: list[dict[str, Any]] = []
 
     async def connect(self) -> None:
         self._connected = True
 
     async def write(self, data: str) -> None:
         parsed = json.loads(data.strip())
+        if parsed.get("type") == "user":
+            self.user_messages.append(parsed)
         if parsed.get("type") == "control_request":
             self._pending_control_ids.append(parsed["request_id"])
             self._control_event.set()

--- a/weave/integrations/claude_agent_sdk/otel_integration.py
+++ b/weave/integrations/claude_agent_sdk/otel_integration.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import importlib
 import json
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterable, AsyncIterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import wraps
@@ -40,7 +40,13 @@ from claude_agent_sdk import (
 
 from weave.conversation import LLM, Conversation, Message, Reasoning, Tool, Turn, Usage
 from weave.conversation.agent_context import resolve_agent_name
-from weave.conversation.types import ToolCallPart
+from weave.conversation.types import (
+    BlobPart,
+    MessagePart,
+    TextPart,
+    ToolCallPart,
+    UriPart,
+)
 from weave.integrations.claude_agent_sdk.usage import total_input_tokens
 from weave.integrations.integration_metadata import library_integration
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
@@ -69,6 +75,68 @@ class _AssistantOutput:
     message: Message
     text: str
     reasoning: Reasoning
+
+
+def _message_from_prompt(prompt: dict[str, Any]) -> Message | None:
+    if prompt.get("type") != "user":
+        return None
+    raw_message = prompt.get("message")
+    if not isinstance(raw_message, dict):
+        return None
+    content = raw_message.get("content")
+    if isinstance(content, str):
+        return Message.user(content)
+    if not isinstance(content, list):
+        return None
+
+    parts: list[MessagePart] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text" and isinstance(block.get("text"), str):
+            parts.append(TextPart(content=block["text"]))
+            continue
+        if block.get("type") != "image":
+            continue
+        source = block.get("source")
+        if not isinstance(source, dict):
+            continue
+        if source.get("type") == "base64" and isinstance(source.get("data"), str):
+            media_type = source.get("media_type")
+            parts.append(
+                BlobPart(
+                    mime_type=media_type if isinstance(media_type, str) else "",
+                    modality="image",
+                    content=source["data"],
+                )
+            )
+        elif source.get("type") == "url" and isinstance(source.get("url"), str):
+            media_type = source.get("media_type")
+            parts.append(
+                UriPart(
+                    mime_type=media_type if isinstance(media_type, str) else "",
+                    modality="image",
+                    uri=source["url"],
+                )
+            )
+
+    if len(parts) == 1 and isinstance(parts[0], TextPart):
+        return Message.user(parts[0].content)
+    return Message(role="user", parts=parts) if parts else None
+
+
+async def _track_prompt(
+    prompt: AsyncIterable[dict[str, Any]],
+    input_messages: list[Message],
+) -> AsyncIterator[dict[str, Any]]:
+    async for message in prompt:
+        try:
+            traced_message = _message_from_prompt(message)
+            if traced_message is not None:
+                input_messages.append(traced_message)
+        except Exception:
+            logger.exception("claude_agent_sdk input tracing failed")
+        yield message
 
 
 def _usage_from_result(usage: dict[str, Any] | None) -> Usage:
@@ -247,7 +315,7 @@ def _finalize_turn(state: _TurnState) -> None:
 async def _trace_turn(
     messages: AsyncIterator[Any],
     *,
-    user_prompt: str | None,
+    input_messages: list[Message],
     conversation_id_holder: list[str] | None = None,
 ) -> AsyncIterator[Any]:
     """Wrap a message stream, emitting the span tree for one turn.
@@ -266,7 +334,7 @@ async def _trace_turn(
         continue_parent_trace=True,
         attributes=_INTEGRATION_OTEL_ATTRS,
     ) as conversation:
-        with conversation.start_turn(user_message=user_prompt or "") as turn:
+        with conversation.start_turn() as turn:
             state = _TurnState(
                 conversation=conversation,
                 turn=turn,
@@ -284,6 +352,7 @@ async def _trace_turn(
                         )
                     yield msg
             finally:
+                state.turn.record(messages=list(input_messages))
                 _finalize_turn(state)
 
 
@@ -298,15 +367,27 @@ def _patched_process_query_wrapper(settings: IntegrationSettings) -> Any:
             options: Any,
             transport: Any = None,
         ) -> AsyncIterator[Any]:
-            inner = original_process_query(
-                self_client, prompt=prompt, options=options, transport=transport
-            )
             if should_disable_weave():
+                inner = original_process_query(
+                    self_client, prompt=prompt, options=options, transport=transport
+                )
                 async for msg in inner:
                     yield msg
                 return
-            user_prompt = prompt if isinstance(prompt, str) else None
-            async for msg in _trace_turn(inner, user_prompt=user_prompt):
+
+            input_messages = [Message.user(prompt)] if isinstance(prompt, str) else []
+            traced_prompt = (
+                prompt
+                if isinstance(prompt, str)
+                else _track_prompt(prompt, input_messages)
+            )
+            inner = original_process_query(
+                self_client,
+                prompt=traced_prompt,
+                options=options,
+                transport=transport,
+            )
+            async for msg in _trace_turn(inner, input_messages=input_messages):
                 yield msg
 
         return wrapped_process_query
@@ -331,15 +412,23 @@ def _patched_init_wrapper(settings: IntegrationSettings) -> Any:
             original_receive_response = self.receive_response
             # One-element holder so wrapped_query can hand the prompt to the
             # next receive_response() turn.
-            user_prompt_holder: list[str | None] = [None]
+            input_messages_holder: list[list[Message]] = [[]]
             # Persists the SDK session_id across turns: system/init is only sent
             # on the first turn, so later turns inherit the conversation id here.
             conversation_id_holder: list[str] = [""]
 
             @wraps(original_query)
             async def wrapped_query(prompt: Any, session_id: str = "default") -> None:
-                user_prompt_holder[0] = prompt if isinstance(prompt, str) else None
-                return await original_query(prompt, session_id=session_id)
+                input_messages = (
+                    [Message.user(prompt)] if isinstance(prompt, str) else []
+                )
+                input_messages_holder[0] = input_messages
+                traced_prompt = (
+                    prompt
+                    if isinstance(prompt, str)
+                    else _track_prompt(prompt, input_messages)
+                )
+                return await original_query(traced_prompt, session_id=session_id)
 
             @wraps(original_receive_response)
             async def wrapped_receive_response() -> AsyncIterator[Any]:
@@ -350,7 +439,7 @@ def _patched_init_wrapper(settings: IntegrationSettings) -> Any:
                     return
                 async for msg in _trace_turn(
                     inner,
-                    user_prompt=user_prompt_holder[0],
+                    input_messages=input_messages_holder[0],
                     conversation_id_holder=conversation_id_holder,
                 ):
                     yield msg


### PR DESCRIPTION
## Summary

- Record streamed Python Claude Agent SDK text and base64 or URL image prompts as GenAI input messages.
- Preserve the original prompt iterator and the messages sent to Claude.

## Example

[Streamed image prompt in Weave](https://wandb.ai/wandb/materials-weave-demo/weave/agents/conversations/4b9b11a0-b60a-40d4-957e-b091cc5826e3?convTurn=1&chatTrace=6da1375e77cfac2597f38e156664ae3e) captures the generated blue square with `42`; Claude answers with the same color and number.

## Testing

- Python 3.10 Claude Agent SDK shard: 16 passed.
- Ruff check and format verification passed.

## Breaking changes

None.