### PR TITLE
feat(weave): add custom runtime TypeScript SDK wrapper

### DIFF
--- a/sdks/node/src/__tests__/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.test.ts
@@ -74,6 +74,70 @@ describe('WeaveClient', () => {
     });
   });
 
+  describe('registerCustomRuntime', () => {
+    let register: jest.Mock;
+    let runtimeClient: WeaveClient;
+
+    beforeEach(() => {
+      register = jest.fn().mockResolvedValue({data: {name: 'support'}});
+      runtimeClient = new WeaveClient({
+        traceServerApi: {
+          v2: {
+            customRuntimeApplyV2EntityProjectRuntimesRuntimeNamePut: register,
+          },
+        } as any,
+        projectId: 'test-entity/test-project',
+      });
+    });
+
+    it('normalizes runtime IDs and registers the complete configuration', async () => {
+      const result = await runtimeClient.registerCustomRuntime({
+        name: 'support/agent',
+        baseUrl: 'https://agent.example/v1',
+        apiKeySecret: 'AGENT_API_KEY',
+        headers: {'X-Tenant-ID': 'customer-1'},
+        runtimeIds: ['support-v12', {id: 'support-canary', maxTokens: 8192}],
+      });
+
+      expect(register).toHaveBeenCalledWith(
+        'test-entity',
+        'test-project',
+        'support/agent',
+        {
+          base_url: 'https://agent.example/v1',
+          api_key_secret: 'AGENT_API_KEY',
+          headers: {'X-Tenant-ID': 'customer-1'},
+          runtime_ids: [
+            {id: 'support-v12'},
+            {id: 'support-canary', max_tokens: 8192},
+          ],
+        }
+      );
+      expect(result).toEqual({data: {name: 'support'}});
+    });
+
+    it('supports header authentication without an API key secret', async () => {
+      await runtimeClient.registerCustomRuntime({
+        name: 'support',
+        baseUrl: 'https://agent.example/v1',
+        headers: {Authorization: 'Custom token'},
+        runtimeIds: ['support-v12'],
+      });
+
+      expect(register).toHaveBeenCalledWith(
+        'test-entity',
+        'test-project',
+        'support',
+        {
+          base_url: 'https://agent.example/v1',
+          api_key_secret: undefined,
+          headers: {Authorization: 'Custom token'},
+          runtime_ids: [{id: 'support-v12'}],
+        }
+      );
+    });
+  });
+
   describe('getCalls', () => {
     it('should fetch and return calls with the legacy signature', async () => {
       const mockCalls = [

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -24,6 +24,7 @@ export type {
   AgentSpan,
   AgentTurn,
   AgentVersion,
+  CustomRuntimeId,
   GetAgentsOptions,
   GetAgentsResult,
   GetAgentSpansOptions,
@@ -35,6 +36,8 @@ export type {
   GetAgentVersionsOptions,
   GetAgentVersionsResult,
   GetCallsOptions,
+  RegisterCustomRuntimeOptions,
+  RegisterCustomRuntimeResult,
   Response,
   WeaveClient,
 } from './weaveClient';

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -19,6 +19,7 @@ import type {
   CallSchema,
   CallsQueryReq,
   CallsFilter,
+  CustomRuntimeApplyRes,
   EndedCallSchemaForInsert,
   Query,
   SortBy,
@@ -64,6 +65,22 @@ const WEAVE_ERRORS_LOG_FNAME = 'weaveErrors.log';
 const DEFAULT_GET_CALLS_LIMIT = 1000;
 
 export type Response<T> = HttpResponse<T, HTTPValidationError>;
+
+export interface CustomRuntimeId {
+  id: string;
+  maxTokens?: number;
+}
+
+export interface RegisterCustomRuntimeOptions {
+  name: string;
+  baseUrl: string;
+  /** Complete desired list; omitted IDs are removed from an existing runtime. */
+  runtimeIds: ReadonlyArray<string | CustomRuntimeId>;
+  apiKeySecret?: string;
+  headers?: Readonly<Record<string, string>>;
+}
+
+export type RegisterCustomRuntimeResult = CustomRuntimeApplyRes;
 
 /**
  * Serialized representation of a file blob stored in the Weave content store.
@@ -490,6 +507,28 @@ export class WeaveClient {
     this.projectId = projectId;
     this.settings = makeSettings(settings);
     this.useCallsComplete = this.settings.useCallsComplete;
+  }
+
+  /** Register a custom runtime, replacing its complete configuration if it exists. */
+  public registerCustomRuntime(
+    options: RegisterCustomRuntimeOptions
+  ): Promise<Response<RegisterCustomRuntimeResult>> {
+    const [entity, project] = this.projectId.split('/');
+    return this.traceServerApi.v2.customRuntimeApplyV2EntityProjectRuntimesRuntimeNamePut(
+      entity,
+      project,
+      options.name,
+      {
+        base_url: options.baseUrl,
+        api_key_secret: options.apiKeySecret,
+        headers: {...(options.headers ?? {})},
+        runtime_ids: options.runtimeIds.map(runtimeId =>
+          typeof runtimeId === 'string'
+            ? {id: runtimeId}
+            : {id: runtimeId.id, max_tokens: runtimeId.maxTokens}
+        ),
+      }
+    );
   }
 
   /**


### PR DESCRIPTION
## Description

Adds a public `registerCustomRuntime` method to the TypeScript SDK, matching the custom runtime registration experience already available in the Python SDK. Customers can pass camelCase runtime configuration while the wrapper delegates to the generated `PUT /v2/{entity}/{project}/runtimes/{runtime_name}` client.

The method accepts string or structured runtime IDs, preserves optional token limits, headers, and API-key secret configuration, and returns the generated API response type. No generated transport or OpenAPI files are changed.

A separate npm release will be required after merge for customers to consume this method; this feature PR does not change the package version.

## Testing

- `npm test -- --runInBand src/__tests__/weaveClient.test.ts` (45 passed)
- `npm test -- --runInBand src/__tests__/generatedTraceServerApi.test.ts` (1 passed)
- CommonJS and ESM type checks passed
- Node SDK build passed