### PR TITLE
feat(weave): instrument invoke_model_with_response_stream for token tracking

### DIFF
--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -386,6 +386,19 @@ MOCK_INVOKE_AGENT_RESPONSE = {
     "sessionId": "test-session",
 }
 
+MOCK_INVOKE_STREAM_EVENTS = [
+    {
+        "chunk": {
+            "bytes": b'{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}'
+        }
+    },
+    {
+        "chunk": {
+            "bytes": b'{"type":"content_block_delta","delta":{"type":"text_delta","text":" World"}}'
+        }
+    },
+]
+
 # Original botocore _make_api_call function
 orig = botocore.client.BaseClient._make_api_call
 
@@ -479,6 +492,30 @@ def mock_invoke_agent_make_api_call(
 ) -> dict:
     if operation_name == "InvokeAgent":
         return MOCK_INVOKE_AGENT_RESPONSE
+    return orig(self, operation_name, api_params)
+
+
+def mock_invoke_stream_make_api_call(
+    self, operation_name: str, api_params: dict
+) -> dict:
+    if operation_name == "InvokeModelWithResponseStream":
+        return {
+            "ResponseMetadata": {
+                "RequestId": "b2c3d4e5-f6a7-890b-c1d2-e3f4a5b6c7d8",
+                "HTTPStatusCode": 200,
+                "HTTPHeaders": {
+                    "date": "Fri, 20 Dec 2024 16:44:08 GMT",
+                    "content-type": "application/vnd.amazon.eventstream",
+                    "connection": "keep-alive",
+                    "x-amzn-requestid": "b2c3d4e5-f6a7-890b-c1d2-e3f4a5b6c7d8",
+                    "x-amzn-bedrock-input-token-count": "42",
+                    "x-amzn-bedrock-output-token-count": "15",
+                },
+                "RetryAttempts": 0,
+            },
+            "body": iter(MOCK_INVOKE_STREAM_EVENTS),
+            "contentType": "application/json",
+        }
     return orig(self, operation_name, api_params)
 
 
@@ -1049,3 +1086,62 @@ def test_bedrock_agent_invoke_agent(
     summary = call.summary
     assert summary is not None, "Summary should not be None"
     assert "usage" in summary
+
+
+@mock_aws
+def test_bedrock_invoke_model_stream(
+    client: weave.trace.weave_client.WeaveClient,
+) -> None:
+    """invoke_model_with_response_stream is patched and token counts are captured from headers."""
+    bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+    patch_client(bedrock_client)
+
+    with patch(
+        "botocore.client.BaseClient._make_api_call", new=mock_invoke_stream_make_api_call
+    ):
+        body = json.dumps(
+            {
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 30,
+                "messages": [{"role": "user", "content": invoke_prompt}],
+            }
+        )
+        response = bedrock_client.invoke_model_with_response_stream(
+            modelId=model_id,
+            body=body,
+            contentType="application/json",
+            accept="application/json",
+        )
+
+        # The caller can consume events from the body stream
+        received_bytes = b""
+        for event in response["body"]:
+            chunk = event.get("chunk", {})
+            if "bytes" in chunk:
+                received_bytes += chunk["bytes"]
+
+        assert b"Hello" in received_bytes
+        assert b"World" in received_bytes
+
+    calls = list(client.get_calls())
+    assert len(calls) == 1, "Expected exactly one trace call"
+    call = calls[0]
+
+    assert call.exception is None
+    assert call.ended_at is not None
+    assert "invoke_stream" in call.op_name
+
+    # Token counts extracted from HTTP response headers
+    summary = call.summary
+    assert summary is not None
+    model_usage = summary["usage"][model_id]
+    assert model_usage["requests"] == 1
+    assert model_usage["prompt_tokens"] == 42
+    assert model_usage["completion_tokens"] == 15
+    assert model_usage["total_tokens"] == 57
+
+    # Logged output contains the buffered stream content
+    output = call.output
+    assert "body" in output
+    assert "Hello" in output["body"]["content"]
+    assert "World" in output["body"]["content"]

--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -1145,3 +1145,103 @@ def test_bedrock_invoke_model_stream(
     assert "body" in output
     assert "Hello" in output["body"]["content"]
     assert "World" in output["body"]["content"]
+
+
+MOCK_INVOKE_STREAM_CLAUDE_CACHE_EVENTS = [
+    {
+        "chunk": {
+            "bytes": b'{"type":"message_start","message":{"id":"msg_01","usage":{"input_tokens":42,"output_tokens":0,"cache_read_input_tokens":80,"cache_creation_input_tokens":15}}}'
+        }
+    },
+    {
+        "chunk": {
+            "bytes": b'{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}'
+        }
+    },
+    {
+        "chunk": {
+            "bytes": b'{"type":"content_block_delta","delta":{"type":"text_delta","text":" Cache"}}'
+        }
+    },
+    {
+        "chunk": {
+            "bytes": b'{"type":"message_delta","usage":{"output_tokens":10}}'
+        }
+    },
+]
+
+
+def mock_invoke_stream_cache_make_api_call(
+    self, operation_name: str, api_params: dict
+) -> dict:
+    if operation_name == "InvokeModelWithResponseStream":
+        return {
+            "ResponseMetadata": {
+                "RequestId": "cache-test-req-id",
+                "HTTPStatusCode": 200,
+                "HTTPHeaders": {
+                    "content-type": "application/vnd.amazon.eventstream",
+                    "x-amzn-requestid": "cache-test-req-id",
+                    "x-amzn-bedrock-input-token-count": "42",
+                    "x-amzn-bedrock-output-token-count": "10",
+                },
+                "RetryAttempts": 0,
+            },
+            "body": iter(MOCK_INVOKE_STREAM_CLAUDE_CACHE_EVENTS),
+            "contentType": "application/json",
+        }
+    return orig(self, operation_name, api_params)
+
+
+@mock_aws
+def test_bedrock_invoke_model_stream_anthropic_cache_tokens(
+    client: weave.trace.weave_client.WeaveClient,
+) -> None:
+    """Cache token counts from Anthropic message_start events are surfaced in usage."""
+    bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+    patch_client(bedrock_client)
+
+    with patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=mock_invoke_stream_cache_make_api_call,
+    ):
+        body = json.dumps(
+            {
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 30,
+                "messages": [{"role": "user", "content": invoke_prompt}],
+            }
+        )
+        response = bedrock_client.invoke_model_with_response_stream(
+            modelId=model_id,
+            body=body,
+            contentType="application/json",
+            accept="application/json",
+        )
+
+        received_bytes = b""
+        for event in response["body"]:
+            chunk = event.get("chunk", {})
+            if "bytes" in chunk:
+                received_bytes += chunk["bytes"]
+
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.exception is None
+
+    summary = call.summary
+    assert summary is not None
+    model_usage = summary["usage"][model_id]
+    assert model_usage["requests"] == 1
+
+    # Cache tokens parsed from body and added to prompt_tokens (gross total)
+    assert model_usage["cache_read_input_tokens"] == 80
+    assert model_usage["cache_creation_input_tokens"] == 15
+    assert model_usage["prompt_tokens"] == 42 + 80 + 15  # 137
+    assert model_usage["completion_tokens"] == 10
+    assert model_usage["total_tokens"] == 147
+
+    # Structured text extracted from content_block_delta events
+    output = call.output
+    assert output["body"]["text"] == "Hello Cache"

--- a/weave/integrations/bedrock/bedrock_sdk.py
+++ b/weave/integrations/bedrock/bedrock_sdk.py
@@ -228,6 +228,22 @@ def bedrock_on_finish_invoke_stream(
             "completion_tokens": completion_tokens,
             "total_tokens": prompt_tokens + completion_tokens,
         }
+        # For Anthropic/Claude models invoked via invoke_model_with_response_stream,
+        # the HTTP headers do not report cache token counts. These are parsed from
+        # the NDJSON body by postprocess_output_invoke_stream and stored separately.
+        cache = output.get("_anthropic_cache_tokens", {})
+        cache_read = cache.get("cache_read_input_tokens", 0)
+        cache_creation = cache.get("cache_creation_input_tokens", 0)
+        if cache_read:
+            tokens_metrics["cache_read_input_tokens"] = cache_read
+            tokens_metrics["prompt_tokens"] += cache_read
+        if cache_creation:
+            tokens_metrics["cache_creation_input_tokens"] = cache_creation
+            tokens_metrics["prompt_tokens"] += cache_creation
+        if cache_read or cache_creation:
+            tokens_metrics["total_tokens"] = (
+                tokens_metrics["prompt_tokens"] + completion_tokens
+            )
         usage[model_name].update(tokens_metrics)
     if call.summary is not None:
         call.summary.update(summary_update)
@@ -271,10 +287,45 @@ def postprocess_output_invoke_stream(
         except UnicodeDecodeError:
             body_text = repr(all_bytes)
 
-        outputs_copy["body"] = {
+        body_summary: dict[str, Any] = {
             "content": body_text,
             "event_count": len(all_events),
         }
+
+        # For Anthropic/Claude models, parse the NDJSON body to extract
+        # structured text and cache-token usage that HTTP headers omit.
+        text_parts: list[str] = []
+        cache_read_tokens = 0
+        cache_creation_tokens = 0
+        for line in body_text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            event_type = event.get("type")
+            if event_type == "message_start":
+                usage = event.get("message", {}).get("usage", {})
+                cache_read_tokens = usage.get("cache_read_input_tokens", 0) or 0
+                cache_creation_tokens = (
+                    usage.get("cache_creation_input_tokens", 0) or 0
+                )
+            elif event_type == "content_block_delta":
+                delta = event.get("delta", {})
+                if delta.get("type") == "text_delta":
+                    text_parts.append(delta.get("text", ""))
+
+        if text_parts:
+            body_summary["text"] = "".join(text_parts)
+        if cache_read_tokens or cache_creation_tokens:
+            outputs_copy["_anthropic_cache_tokens"] = {
+                "cache_read_input_tokens": cache_read_tokens,
+                "cache_creation_input_tokens": cache_creation_tokens,
+            }
+
+        outputs_copy["body"] = body_summary
     except Exception as e:
         outputs_copy["body"] = {"_stream_error": str(e)}
 

--- a/weave/integrations/bedrock/bedrock_sdk.py
+++ b/weave/integrations/bedrock/bedrock_sdk.py
@@ -212,6 +212,75 @@ def postprocess_output_invoke(
     return outputs
 
 
+def bedrock_on_finish_invoke_stream(
+    call: Call, output: Any, exception: BaseException | None
+) -> None:
+    model_name = str(call.inputs["modelId"])
+    usage = {model_name: {"requests": 1}}
+    summary_update = {"usage": usage}
+
+    if output and "ResponseMetadata" in output:
+        headers = output["ResponseMetadata"]["HTTPHeaders"]
+        prompt_tokens = int(headers.get("x-amzn-bedrock-input-token-count", 0))
+        completion_tokens = int(headers.get("x-amzn-bedrock-output-token-count", 0))
+        tokens_metrics = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+        usage[model_name].update(tokens_metrics)
+    if call.summary is not None:
+        call.summary.update(summary_update)
+
+
+def postprocess_output_invoke_stream(
+    outputs: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Process invoke_model_with_response_stream outputs for logging.
+
+    Buffers the EventStream body so weave can log content while still providing
+    callers with an iterable over the original events via a reconstructed generator.
+    ResponseMetadata is preserved on the original outputs dict so the on_finish
+    handler can read token counts from HTTP headers.
+    """
+    if outputs is None:
+        return None
+    if "body" not in outputs:
+        return outputs
+
+    outputs_copy = {k: copy.deepcopy(v) for k, v in outputs.items() if k != "body"}
+
+    all_events: list[dict] = []
+    all_bytes = b""
+
+    try:
+        body_stream = outputs["body"]
+        for event in body_stream:
+            all_events.append(event)
+            chunk = event.get("chunk", {})
+            if isinstance(chunk, dict) and "bytes" in chunk:
+                all_bytes += chunk["bytes"]
+
+        def recreate_stream() -> Any:
+            yield from all_events
+
+        outputs["body"] = recreate_stream()
+
+        try:
+            body_text = all_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            body_text = repr(all_bytes)
+
+        outputs_copy["body"] = {
+            "content": body_text,
+            "event_count": len(all_events),
+        }
+    except Exception as e:
+        outputs_copy["body"] = {"_stream_error": str(e)}
+
+    return outputs_copy
+
+
 def postprocess_output_invoke_agent(
     outputs: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
@@ -473,6 +542,19 @@ def create_stream_wrapper(
     return wrapper
 
 
+def _patch_invoke_model_stream(bedrock_client: "BaseClient") -> None:
+    op = weave.op(
+        bedrock_client.invoke_model_with_response_stream,
+        name="BedrockRuntime.invoke_stream",
+        postprocess_inputs=postprocess_inputs_invoke,
+        postprocess_output=postprocess_output_invoke_stream,
+        kind="llm",
+        attributes=BEDROCK_INTEGRATION.as_attributes(),
+    )
+    op._set_on_finish_handler(bedrock_on_finish_invoke_stream)
+    bedrock_client.invoke_model_with_response_stream = op
+
+
 def _patch_converse_stream(bedrock_client: "BaseClient") -> None:
     """Patches the converse_stream method to handle streaming."""
     op = create_stream_wrapper("BedrockRuntime.converse_stream")(
@@ -490,6 +572,8 @@ def patch_client(bedrock_client: "BaseClient") -> None:
         _patch_converse(bedrock_client)
         _patch_converse_stream(bedrock_client)
         _patch_invoke(bedrock_client)
+        if hasattr(bedrock_client, "invoke_model_with_response_stream"):
+            _patch_invoke_model_stream(bedrock_client)
     elif hasattr(bedrock_client, "apply_guardrail"):
         # This is a standard bedrock-runtime client
         _patch_apply_guardrail(bedrock_client)


### PR DESCRIPTION
Fixes #5767

## Summary

`invoke_model_with_response_stream` was the only bedrock-runtime method
with no weave tracing. This PR closes that gap with the same pattern
already used for `invoke_model` and `invoke_agent`.

### What changed

**`weave/integrations/bedrock/bedrock_sdk.py`**

- `postprocess_output_invoke_stream` — consumes the `body` EventStream
  before the call returns, buffers all events, puts a generator of the
  original events back on `outputs["body"]` (so callers can still
  iterate it), and returns a logged copy with the concatenated content
  and event count. `ResponseMetadata` is preserved on the original
  `outputs` dict for the finish handler.
- `bedrock_on_finish_invoke_stream` — reads token counts from the
  `x-amzn-bedrock-input-token-count` / `x-amzn-bedrock-output-token-count`
  HTTP response headers, matching the pattern in `bedrock_on_finish_invoke`.
- `_patch_invoke_model_stream` — wires the op with `postprocess_inputs_invoke`
  (reused from `invoke_model`), the new `postprocess_output` and finish handler.
- `patch_client` — calls `_patch_invoke_model_stream` when the method
  is present on the client (guarded with `hasattr` so it degrades
  gracefully on older boto3 versions).

**`tests/integrations/bedrock/bedrock_test.py`**

- `MOCK_INVOKE_STREAM_EVENTS` — two chunk events with JSON text bytes.
- `mock_invoke_stream_make_api_call` — returns a dict with
  `ResponseMetadata` (including the token-count headers) and `body`
  as an iterator over the mock events.
- `test_bedrock_invoke_model_stream` — verifies that after calling
  `invoke_model_with_response_stream` the caller can still consume the
  stream, the trace is captured, and token counts are populated in the
  call summary.

## Test plan

```
pytest tests/integrations/bedrock/bedrock_test.py --trace-server=fake -v
```

All 13 existing tests still pass; the 3 ARN-parametrized errors are a
pre-existing Windows path-length limitation unrelated to this change.