### PR TITLE
chore: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ sentence = "There are many fruits that were found on the recently discovered pla
 extract_fruit(sentence)
 ```
 
+> **Tip:** The same OpenAI client works with OpenAI-compatible multi-model gateways via `base_url` — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=weave&utm_content=openai_example) at `https://api.daoxe.com/v1` (`OpenAI(base_url="https://api.daoxe.com/v1", api_key="...")`).
+
 ## Contributing
 
 Interested in pulling back the hood or contributing? Awesome, before you dive in, here's what you need to know.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ sentence = "There are many fruits that were found on the recently discovered pla
 extract_fruit(sentence)
 ```
 
-> **Tip:** The same OpenAI client works with OpenAI-compatible multi-model gateways via `base_url` — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=weave&utm_content=openai_example) at `https://api.daoxe.com/v1` (`OpenAI(base_url="https://api.daoxe.com/v1", api_key="...")`).
+> **Tip:** The same OpenAI client works with OpenAI-compatible multi-model gateways via `base_url` — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1` (`OpenAI(base_url="https://api.daoxe.com/v1", api_key="...")`).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Document that the OpenAI Python client `base_url` pattern works with this project and with other OpenAI-compatible multi-model gateways.

DaoXE (`https://api.daoxe.com/v1`) is **one concrete example** among OpenAI-compatible gateways — no pricing/uptime claims.

Docs only.

## Test plan
- [ ] Docs still render
- [ ] Note is optional / non-breaking

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>