### PR TITLE
fix(weave_ts): return the real image from client.get()

### DIFF
--- a/sdks/node/src/__tests__/weaveClient.get.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.get.test.ts
@@ -1,0 +1,110 @@
+import {Api as TraceServerApi} from '../generated/traceServerApi';
+import {WeaveClient} from '../weaveClient';
+import {ObjectRef} from '../weaveObject';
+
+// Not valid UTF-8, so a fix that routes the body through a string fails here.
+const IMAGE_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0xfe]);
+const IMAGE_DIGEST = 'test-digest';
+const REF = new ObjectRef('other-entity/other-project', 'my-image', 'v1');
+const REF_URI = 'weave:///other-entity/other-project/object/my-image:v1';
+
+function objReadBody(files: Record<string, string> | null) {
+  return JSON.stringify({
+    obj: {
+      val: {
+        _type: 'CustomWeaveType',
+        weave_type: {type: 'PIL.Image.Image'},
+        files,
+        load_op: 'NO_LOAD_OP',
+      },
+    },
+  });
+}
+
+// The endpoint sends the file with no content type, so neither does this.
+const respondWithImageBytes = async () => new Response(IMAGE_BYTES);
+
+function clientServingFileContent(
+  fileContent: () => Promise<Response>,
+  files: Record<string, string> | null = {'image.png': IMAGE_DIGEST}
+) {
+  const fileRequests: unknown[] = [];
+  const traceServerApi = new TraceServerApi({
+    baseUrl: 'https://trace.example',
+    customFetch: async (input, init) => {
+      const url = input.toString();
+      if (url.endsWith('/obj/read')) {
+        return new Response(objReadBody(files), {
+          headers: {'content-type': 'application/json'},
+        });
+      }
+      if (url.endsWith('/file/content')) {
+        fileRequests.push(JSON.parse(init!.body as string));
+        return fileContent();
+      }
+      throw new Error(`Unexpected request to ${url}`);
+    },
+  });
+  const client = new WeaveClient({
+    traceServerApi,
+    projectId: 'this-entity/this-project',
+  });
+  return {client, fileRequests};
+}
+
+describe('WeaveClient.get on a published image', () => {
+  it('returns a WeaveImage carrying the stored bytes', async () => {
+    const {client, fileRequests} = clientServingFileContent(
+      respondWithImageBytes
+    );
+
+    expect(await client.get(REF)).toEqual({
+      _weaveType: 'Image',
+      data: IMAGE_BYTES,
+      imageType: 'png',
+    });
+    expect(fileRequests).toEqual([
+      {project_id: 'other-entity/other-project', digest: IMAGE_DIGEST},
+    ]);
+  });
+
+  it('takes the stored file whatever it is named', async () => {
+    const {client} = clientServingFileContent(respondWithImageBytes, {
+      'image.jpg': IMAGE_DIGEST,
+    });
+
+    expect((await client.get(REF)).data).toEqual(IMAGE_BYTES);
+  });
+
+  it('rejects when the file request fails', async () => {
+    const {client} = clientServingFileContent(
+      async () => new Response('not found', {status: 404})
+    );
+
+    await expect(client.get(REF)).rejects.toMatchObject({
+      status: 404,
+      data: null,
+    });
+  });
+
+  it('rejects when the file body cannot be read', async () => {
+    const {client} = clientServingFileContent(async () => {
+      const truncated = new ReadableStream({
+        start: controller => controller.error(new Error('terminated')),
+      });
+      return new Response(truncated);
+    });
+
+    await expect(client.get(REF)).rejects.toThrow(
+      `Unable to download file for ref uri: ${REF_URI}`
+    );
+  });
+
+  it('rejects when the object stores no image file', async () => {
+    const {client} = clientServingFileContent(respondWithImageBytes, null);
+
+    await expect(client.get(REF)).rejects.toThrow(
+      `No image file stored for ref uri: ${REF_URI}`
+    );
+  });
+});

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -39,6 +39,7 @@ import {
   type ImageType,
   isWeaveAudio,
   isWeaveImage,
+  weaveImage,
 } from './media';
 import {
   type Op,
@@ -1407,40 +1408,31 @@ export class WeaveClient {
     } else if (t == 'CustomWeaveType') {
       const typeName = val.weave_type.type;
       if (typeName == 'PIL.Image.Image') {
-        const loadedFiles: {[key: string]: Buffer} = {};
-        for (const [name, digest] of Object.entries(val.files)) {
-          try {
-            const fileContent =
-              await this.traceServerApi.file.fileContentFileContentPost({
-                project_id: this.projectId,
-                digest: digest as string,
-              });
-            loadedFiles[name] = fileContent.data?.content;
-          } catch (error) {
-            console.error('Error loading file:', error);
-          }
+        const [digest] = Object.values<string | undefined>(val.files ?? {});
+        if (digest == null) {
+          throw new Error(`No image file stored for ref uri: ${ref.uri()}`);
         }
-        // TODO: Implement getting img back as buffer
-        return 'Coming soon!';
+        return weaveImage({data: await this.downloadFile(ref, digest)});
       } else if (typeName == 'wave.Wave_read') {
-        const loadedFiles: {[key: string]: Buffer} = {};
-        for (const [name, digest] of Object.entries(val.files)) {
-          try {
-            const fileContent =
-              await this.traceServerApi.file.fileContentFileContentPost({
-                project_id: this.projectId,
-                digest: digest as string,
-              });
-            loadedFiles[name] = fileContent.data?.content;
-          } catch (error) {
-            console.error('Error loading file:', error);
-          }
-        }
         // TODO: Implement getting audio back as buffer
         return 'Coming soon!';
       }
     }
     return val;
+  }
+
+  // Reads from the project the ref points at, not the one this client is on.
+  private async downloadFile(ref: ObjectRef, digest: string): Promise<Buffer> {
+    const fileContent =
+      await this.traceServerApi.file.fileContentFileContentPost(
+        {project_id: ref.projectId, digest},
+        // The endpoint streams the file, so the body is not JSON.
+        {format: 'arrayBuffer'}
+      );
+    if (fileContent.data == null) {
+      throw new Error(`Unable to download file for ref uri: ${ref.uri()}`);
+    }
+    return Buffer.from(fileContent.data);
   }
 
   private async resolveRegistryPromptRef(


### PR DESCRIPTION
## Jira

Fixes [WB-38320](https://coreweave.atlassian.net/browse/WB-38320)

## Description

Master branch behavior: if you log an image with the TS SDK, then read it back with `client.get(ref)`, you don't get the image. You get the string `Coming soon!`.

Python gets this right: `get()` there hands you back a real image. So it's a TS-only hole in a fairly basic function, and it's been there since the first commit of the TS SDK. Nobody noticed because nothing tested this path.

I thought it was a two-line fix. `media.ts` already has a `weaveImage()` wrapper that builds the object from bytes, so I just had to call it instead of returning the string. Then I ran it and got nothing back.

The download had never worked. `/file/content` streams the file as raw bytes, but the generated client was asking for JSON, so parsing failed every time. Nobody ever saw that error, because the generated client catches it (!) and leaves the result empty, and `get()` then fell through to the placeholder. The same code was also reading the file from the client's own project rather than the project the ref points at, which breaks reading an object that lives somewhere else.

The fix is small: ask for the response as an `arrayBuffer`, read from `ref.projectId`, and wrap the bytes with `weaveImage()`. `format` is just a call argument, so I didn't have to touch the generated file.

On master you get `Coming soon!`. With this PR you get your image back, byte for byte, and if the download fails you get a real error instead of a string.

## Plan of work

- This PR: `get()` on an image gives you the real image, right bytes, right project.
- Next PR: the format label. An image always comes back as `png` today, even when Python wrote a JPEG or WEBP. The bytes are already correct and only the label is wrong, so the fix is widening the `ImageType` type in `media.ts`.
- Next PR: audio, which still returns the placeholder. Same round trip as here, plus Python can write an extra `_metadata.json` next to the audio file, so that path has to pick the right file.

It's split this way because the risky part is only in this PR: proving the download works at all. The other two are small once that's settled, and each brings its own tests. Bundling them would give you one big diff with the interesting change buried in it.

## Testing

Five new tests. They fake the server's replies so the real client code still runs, and all five fail on `master`. I also tried it for real against a live server: logged an image, read it back, same bytes, then read the same image from a client on a different project and got the same bytes again. Tests, lint and typecheck are green locally.


[WB-38320]: https://coreweave.atlassian.net/browse/WB-38320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ