### PR TITLE
fix(weave_ts): label a fetched image with its real format

### DIFF
--- a/sdks/node/src/__tests__/weaveClient.get.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.get.test.ts
@@ -1,4 +1,5 @@
 import {Api as TraceServerApi} from '../generated/traceServerApi';
+import {type ImageType} from '../media';
 import {WeaveClient} from '../weaveClient';
 import {ObjectRef} from '../weaveObject';
 
@@ -68,12 +69,23 @@ describe('WeaveClient.get on a published image', () => {
     ]);
   });
 
-  it('takes the stored file whatever it is named', async () => {
+  // The Python SDK stores the image under its own format's extension; an
+  // extension we do not know keeps the png default.
+  const formatCases: Array<[string, ImageType]> = [
+    ['image.jpg', 'jpeg'],
+    ['image.webp', 'webp'],
+    ['image.gif', 'png'],
+  ];
+  it.each(formatCases)('reads %s back as %s', async (fileName, imageType) => {
     const {client} = clientServingFileContent(respondWithImageBytes, {
-      'image.jpg': IMAGE_DIGEST,
+      [fileName]: IMAGE_DIGEST,
     });
 
-    expect((await client.get(REF)).data).toEqual(IMAGE_BYTES);
+    expect(await client.get(REF)).toEqual({
+      _weaveType: 'Image',
+      data: IMAGE_BYTES,
+      imageType,
+    });
   });
 
   it('rejects when the file request fails', async () => {

--- a/sdks/node/src/media.ts
+++ b/sdks/node/src/media.ts
@@ -1,7 +1,7 @@
 export const DEFAULT_IMAGE_TYPE = 'png';
 export const DEFAULT_AUDIO_TYPE = 'wav';
 
-export type ImageType = 'png';
+export type ImageType = 'png' | 'jpeg' | 'webp';
 export type AudioType = 'wav';
 
 // Define WeaveImage type
@@ -19,7 +19,8 @@ export interface WeaveImage extends WeaveImageInput {
  *
  * @param options The options for this media type
  *    - data: The raw image data as a Buffer
- *    - imageType: (Optional) The type of image file, currently only 'png' is supported
+ *    - imageType: (Optional) The image format: 'png' (default), 'jpeg' or 'webp'.
+ *      Publishing always names the stored file image.png
  *
  * @example
  * const imageBuffer = fs.readFileSync('path/to/image.png');
@@ -32,6 +33,25 @@ export function weaveImage({data, imageType}: WeaveImageInput): WeaveImage {
     data,
     imageType: resolvedImageType,
   };
+}
+
+// Mirrors ext_to_pil_format in weave/type_handlers/Image/image.py; the label is
+// MIME spelling, so a stored `jpg` reads back as `jpeg`.
+const IMAGE_TYPE_BY_EXTENSION = new Map<string, ImageType>([
+  ['png', 'png'],
+  ['jpg', 'jpeg'],
+  ['webp', 'webp'],
+]);
+
+/**
+ * Read the image format off a stored file name, e.g. `image.jpg` -> `jpeg`.
+ * Returns undefined for an extension we do not know, so the caller keeps the
+ * default format.
+ */
+export function imageTypeFromFileName(fileName: string): ImageType | undefined {
+  return IMAGE_TYPE_BY_EXTENSION.get(
+    fileName.slice(fileName.lastIndexOf('.') + 1)
+  );
 }
 
 // Function to check if a value is a WeaveImage

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -37,6 +37,7 @@ import {
   DEFAULT_AUDIO_TYPE,
   DEFAULT_IMAGE_TYPE,
   type ImageType,
+  imageTypeFromFileName,
   isWeaveAudio,
   isWeaveImage,
   weaveImage,
@@ -1408,11 +1409,16 @@ export class WeaveClient {
     } else if (t == 'CustomWeaveType') {
       const typeName = val.weave_type.type;
       if (typeName == 'PIL.Image.Image') {
-        const [digest] = Object.values<string | undefined>(val.files ?? {});
+        const files: Record<string, string | undefined> = val.files ?? {};
+        const [fileName] = Object.keys(files);
+        const digest = files[fileName];
         if (digest == null) {
           throw new Error(`No image file stored for ref uri: ${ref.uri()}`);
         }
-        return weaveImage({data: await this.downloadFile(ref, digest)});
+        return weaveImage({
+          data: await this.downloadFile(ref, digest),
+          imageType: imageTypeFromFileName(fileName),
+        });
       } else if (typeName == 'wave.Wave_read') {
         // TODO: Implement getting audio back as buffer
         return 'Coming soon!';


### PR DESCRIPTION
## JIRA Issue(s)

[WB-38335](https://coreweave.atlassian.net/browse/WB-38335)

## Description

Right now, if you publish an image from Python and then read it back with the TypeScript client, the format is wrong. A JPEG comes back as PNG, and so does a WEBP. The bytes are right, only the label is wrong. That is a problem for any code that trusts the label. You end up naming the file `photo.png` when a JPEG is inside it, or serving the bytes as `image/png` when they are not a PNG.

This sits on top of #7685, which is what makes `get()` return a real image at all. That PR always labels the image `png`.

The obvious fix is to look at the bytes, because a JPEG and a PNG start with different magic numbers. We do not need that. Python saves the image under its own name: `image.png`, `image.jpg` or `image.webp`. That name comes down together with the file, we were just throwing it away.

So now we read the name and believe it. `ImageType` accepts `png`, `jpeg` and `webp`. The file on disk says `jpg` while the label says `jpeg`, because we build the content type out of the label (`image/jpeg`). An extension we do not know keeps `png`, same as today, so nothing new can break.

Publishing did not change. It still stores the file as `image.png`, so an image published from TypeScript reads back exactly as before.

Before this, the TypeScript client called every image a PNG. Now it reports the format the image was actually saved in.

## Testing

Tests cover `image.jpg`, `image.webp` and an extension we do not know. Two of them fail on the parent branch. I also published a JPEG, a WEBP and a PNG from Python to a live server and read them back here: right labels, same bytes.


[WB-38335]: https://coreweave.atlassian.net/browse/WB-38335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ