### PR TITLE
feat(weave): add Custom Runtime conversation context

### DIFF
--- a/tests/trace/test_chat_completions.py
+++ b/tests/trace/test_chat_completions.py
@@ -21,6 +21,22 @@ def _client() -> WeaveClient:
     return client
 
 
+def _completion_payload(content: str = "Hello") -> dict:
+    return {
+        "id": "completion-1",
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+            }
+        ],
+        "created": 1,
+        "model": "runtime-model",
+        "object": "chat.completion",
+    }
+
+
 def _chunk_payload(content: str = "Hello") -> dict:
     return {
         "id": "completion-1",
@@ -55,7 +71,6 @@ class _TrackingByteStream(httpx.SyncByteStream):
 def _install_mock_transport(monkeypatch, handler) -> list[httpx.Client]:
     real_client = httpx.Client
     transport = httpx.MockTransport(handler)
-
     clients = []
 
     def client_factory(**kwargs):
@@ -69,6 +84,9 @@ def _install_mock_transport(monkeypatch, handler) -> list[httpx.Client]:
         client_factory,
     )
     monkeypatch.setattr(completions_module, "get_wandb_api_context", lambda: "key")
+    monkeypatch.setattr(
+        completions_module, "weave_trace_server_url", lambda: "https://trace.test"
+    )
     return clients
 
 
@@ -112,6 +130,7 @@ def test_stream_remains_open_until_consumed(monkeypatch, endpoint, model) -> Non
 
     assert not stream.response.is_closed
     assert not clients[0].is_closed
+    assert stream.conversation_id is None
     assert [chunk.choices[0].delta.content for chunk in stream] == ["Hello"]
     assert stream.response.is_closed
     assert body.closed
@@ -208,3 +227,156 @@ def test_stream_parse_error_closes_resources(monkeypatch) -> None:
     assert stream.response.is_closed
     assert body.closed
     assert clients[0].is_closed
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "model", "uses_local_op"),
+    [
+        ("playground", "custom::runtime::model", False),
+        ("inference", "custom::runtime::model", False),
+        ("playground", "openai/gpt-4o", True),
+    ],
+)
+def test_completion_tracking_dispatch(
+    monkeypatch,
+    endpoint: completions_module.Endpoint,
+    model: str,
+    uses_local_op: bool,
+) -> None:
+    completions = Completions(_client())
+    local_op = MagicMock(return_value="local-op")
+    direct = MagicMock(return_value="direct")
+    monkeypatch.setattr(completions, "_create_op", local_op)
+    monkeypatch.setattr(completions, "_create_non_op", direct)
+
+    result = completions.create(
+        endpoint=endpoint,
+        model=model,
+        messages=[{"role": "user", "content": "Hello"}],
+        track_llm_call=True,
+    )
+
+    if uses_local_op:
+        assert result == "local-op"
+        local_op.assert_called_once()
+        direct.assert_not_called()
+    else:
+        assert result == "direct"
+        direct.assert_called_once()
+        local_op.assert_not_called()
+
+
+def test_playground_completion_reuses_conversation_across_provider_switches(
+    monkeypatch,
+) -> None:
+    request_bodies = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        request_bodies.append(body)
+        conversation_id = body.get("conversation_id", "server-conversation")
+        return httpx.Response(
+            200,
+            json={
+                "response": _completion_payload(),
+                "conversation_id": conversation_id,
+            },
+        )
+
+    _install_mock_transport(monkeypatch, handler)
+    completions = Completions(_client())
+
+    first = completions.create(
+        endpoint="playground",
+        model="custom::runtime-a::model-a",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+    second = completions.create(
+        endpoint="playground",
+        model="openai/gpt-4o",
+        messages=[
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hello"},
+            {"role": "user", "content": "Continue"},
+        ],
+        conversation_id=first.conversation_id,
+        track_llm_call=False,
+    )
+    third = completions.create(
+        endpoint="playground",
+        model="custom::runtime-b::model-b",
+        messages=[
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hello"},
+            {"role": "user", "content": "Continue"},
+            {"role": "assistant", "content": "Hello"},
+            {"role": "user", "content": "Finish"},
+        ],
+        conversation_id=second.conversation_id,
+    )
+
+    assert first.choices[0].message.content == "Hello"
+    assert first.conversation_id
+    assert second.conversation_id == first.conversation_id
+    assert third.conversation_id == first.conversation_id
+    assert [body["inputs"]["model"] for body in request_bodies] == [
+        "custom::runtime-a::model-a",
+        "openai/gpt-4o",
+        "custom::runtime-b::model-b",
+    ]
+    assert "conversation_id" not in request_bodies[0]
+    assert request_bodies[1]["conversation_id"] == first.conversation_id
+    assert request_bodies[2]["conversation_id"] == first.conversation_id
+
+
+def test_custom_runtime_stream_consumes_server_selected_conversation_context(
+    monkeypatch,
+) -> None:
+    request_bodies = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        request_bodies.append(body)
+        content = (
+            json.dumps({"_meta": {"conversation_id": "server-conversation"}}).encode()
+            + b"\n"
+            + json.dumps(_chunk_payload()).encode()
+            + b"\n"
+        )
+        return httpx.Response(200, content=content)
+
+    _install_mock_transport(monkeypatch, handler)
+    completions = Completions(_client())
+
+    stream = completions.create(
+        endpoint="playground",
+        model="custom::runtime::model",
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=True,
+    )
+    chunks = list(stream)
+
+    assert [chunk.choices[0].delta.content for chunk in chunks] == ["Hello"]
+    assert stream.conversation_id == "server-conversation"
+    assert "conversation_id" not in request_bodies[0]
+    assert stream.response.is_closed
+
+
+def test_inference_completion_serialization_has_no_playground_context(
+    monkeypatch,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_completion_payload())
+
+    _install_mock_transport(monkeypatch, handler)
+    completions = Completions(_client())
+
+    result = completions.create(
+        endpoint="inference",
+        model="coreweave/runtime-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        track_llm_call=False,
+    )
+
+    assert "conversation_id" not in result.model_dump()
+    assert "conversation_id" not in result.model_dump_json()

--- a/tests/trace_server/test_async_clickhouse_trace_server.py
+++ b/tests/trace_server/test_async_clickhouse_trace_server.py
@@ -24,6 +24,7 @@ from weave.trace_server.datadog import _db_insert_path
 from weave.trace_server.external_to_internal_trace_server_adapter import (
     ExternalTraceServer,
 )
+from weave.trace_server.llm_completion import CustomProviderInfo
 
 LITELLM_ACOMPLETION_PATCH = (
     "weave.trace_server.async_clickhouse_trace_server.lite_llm_acompletion"
@@ -112,6 +113,44 @@ async def test_tracking_routes_through_log_completion_call(
     assert log_mock.call_count == 1
     forwarded_res = log_mock.call_args.args[2]
     assert forwarded_res is llm_res
+
+
+@pytest.mark.asyncio
+async def test_async_custom_runtime_dispatch_receives_conversation_context(
+    server: AsyncClickHouseTraceServer,
+) -> None:
+    llm_res = tsi.CompletionsCreateRes(response={"choices": [{"x": 1}]})
+    completion = AsyncMock(return_value=llm_res)
+    req = _make_req(track_llm_call=True, model="custom::runtime::model")
+    with (
+        patch(
+            "weave.trace_server.clickhouse_trace_server_batched.get_custom_provider_info",
+            return_value=CustomProviderInfo(
+                base_url="https://runtime.example.com/v1",
+                api_key="runtime-key",
+                extra_headers={"X-Tenant": "customer"},
+                return_type="openai",
+                actual_model_name="model",
+            ),
+        ),
+        patch(LITELLM_ACOMPLETION_PATCH, new=completion),
+        patch.object(
+            server,
+            "_log_completion_call",
+            return_value=tsi.CompletionsCreateRes(response=llm_res.response),
+        ) as log_completion,
+    ):
+        res = await server.acompletions_create(req)
+
+    assert req.conversation_id
+    assert req.track_llm_call is False
+    assert res.conversation_id == req.conversation_id
+    assert res.span_id is None
+    log_completion.assert_not_called()
+    assert completion.await_args.kwargs["extra_headers"] == {
+        "X-Tenant": "customer",
+        "X-Weave-Conversation-Id": req.conversation_id,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -566,10 +566,12 @@ def test_completions_create_stream_custom_provider():
         stream = server.completions_create_stream(req)
         chunks = list(stream)
 
-        assert len(chunks) == 2
-        assert chunks[0]["choices"][0]["delta"]["content"] == "Streamed"
-        assert chunks[1]["choices"][0]["finish_reason"] == "stop"
-        assert "usage" in chunks[1]
+        assert len(chunks) == 3
+        assert req.conversation_id
+        assert chunks[0] == {"_meta": {"conversation_id": req.conversation_id}}
+        assert chunks[1]["choices"][0]["delta"]["content"] == "Streamed"
+        assert chunks[2]["choices"][0]["finish_reason"] == "stop"
+        assert "usage" in chunks[2]
 
         # Verify litellm was called with correct parameters
         mock_litellm.assert_called_once()
@@ -578,11 +580,13 @@ def test_completions_create_stream_custom_provider():
             call_args.get("api_base")
             or call_args.get("base_url") == "https://api.custom.com"
         )
-        assert call_args["extra_headers"] == {"X-Custom": "value"}
+        assert call_args["extra_headers"] == {
+            "X-Custom": "value",
+            "X-Weave-Conversation-Id": req.conversation_id,
+        }
 
 
-def test_completions_create_stream_custom_provider_with_tracking():
-    """Test completions_create_stream for a custom provider with call tracking enabled."""
+def test_custom_runtime_stream_owns_tracing_and_receives_conversation_context():
     # Mock chunks to be returned by the stream
     mock_chunks = [
         {
@@ -706,17 +710,16 @@ def test_completions_create_stream_custom_provider_with_tracking():
         stream = server.completions_create_stream(req)
         chunks = list(stream)
 
-        assert len(chunks) == 3  # Meta chunk + 2 content chunks
-        assert "_meta" in chunks[0]
-        assert "weave_call_id" in chunks[0]["_meta"]
+        assert len(chunks) == 3
+        conversation_id = req.conversation_id
+        assert conversation_id
+        assert req.track_llm_call is False
+        assert chunks[0] == {"_meta": {"conversation_id": conversation_id}}
         assert chunks[1]["choices"][0]["delta"]["content"] == "Streamed"
         assert chunks[2]["choices"][0]["finish_reason"] == "stop"
         assert "usage" in chunks[2]
 
-        # Open span + completed span
-        assert mock_agent_writer.insert_span.call_count == 2
-        completed_span = mock_agent_writer.insert_span.call_args_list[1][0][0]
-        assert completed_span.project_id == "dGVzdF9wcm9qZWN0"
+        mock_agent_writer.insert_span.assert_not_called()
 
         mock_litellm.assert_called_once()
         call_args = mock_litellm.call_args[1]
@@ -724,7 +727,10 @@ def test_completions_create_stream_custom_provider_with_tracking():
             call_args.get("api_base")
             or call_args.get("base_url") == "https://api.custom.com"
         )
-        assert call_args["extra_headers"] == {"X-Custom": "value"}
+        assert call_args["extra_headers"] == {
+            "X-Custom": "value",
+            "X-Weave-Conversation-Id": conversation_id,
+        }
 
 
 def test_completions_create_stream_multiple_choices():

--- a/tests/trace_server/test_custom_provider.py
+++ b/tests/trace_server/test_custom_provider.py
@@ -363,16 +363,16 @@ def test_custom_provider_completions_create(client):
                 f"API base URL mismatch. Expected 'https://api.example.com', "
                 f"got '{call_args['api_base']}'"
             )
-            assert call_args["extra_headers"] == {"X-Custom-Header": "value"}, (
-                f"Extra headers mismatch. Expected {{'X-Custom-Header': 'value'}}, "
-                f"got {call_args['extra_headers']}"
-            )
+            assert res.conversation_id
+            assert call_args["extra_headers"] == {
+                "X-Custom-Header": "value",
+                "X-Weave-Conversation-Id": res.conversation_id,
+            }
 
-            # Completions now write to the spans table, not calls.
-            # Verify the span was created with correct identifiers.
-            assert res.weave_call_id is not None, "Expected a span_id in response"
-            assert res.span_id is not None, "Expected span_id in response"
-            assert res.trace_id is not None, "Expected trace_id in response"
+            # The runtime owns tracing; W&B returns only shared conversation context.
+            assert res.weave_call_id is None
+            assert res.span_id is None
+            assert res.trace_id is None
         finally:
             _secret_fetcher_context.reset(token)
 

--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -672,9 +672,11 @@ class TestLLMCompletionStreaming(unittest.TestCase):
             chunks = list(stream)
 
             # Verify the chunks
-            assert len(chunks) == 2
-            assert chunks[0]["choices"][0]["delta"]["content"] == "Custom"
-            assert chunks[1]["choices"][0]["finish_reason"] == "stop"
+            assert len(chunks) == 3
+            assert req.conversation_id
+            assert chunks[0] == {"_meta": {"conversation_id": req.conversation_id}}
+            assert chunks[1]["choices"][0]["delta"]["content"] == "Custom"
+            assert chunks[2]["choices"][0]["finish_reason"] == "stop"
 
             # Verify litellm was called with correct parameters
             mock_litellm.assert_called_once()
@@ -682,7 +684,10 @@ class TestLLMCompletionStreaming(unittest.TestCase):
             assert (
                 call_args.get("api_base") or call_args.get("base_url")
             ) == "https://api.custom.com"
-            assert call_args["extra_headers"] == {"X-Custom": "value"}
+            assert call_args["extra_headers"] == {
+                "X-Custom": "value",
+                "X-Weave-Conversation-Id": req.conversation_id,
+            }
 
     def test_missing_api_key(self):
         """Test handling of missing API key in streaming completion."""
@@ -2253,6 +2258,36 @@ def test_coreweave_requires_its_inference_api_key():
         chts._setup_completion_model_info(None, req, MagicMock())
 
 
+@pytest.mark.parametrize(
+    ("model", "track_llm_call", "conversation_id", "should_have_id"),
+    [
+        ("gpt-4o", True, None, True),
+        ("gpt-4o", False, None, False),
+        ("custom::runtime::model", False, None, True),
+        ("gpt-4o", False, "conv-1", True),
+    ],
+)
+def test_ensure_completion_conversation_id(
+    model: str,
+    track_llm_call: bool,
+    conversation_id: str | None,
+    should_have_id: bool,
+):
+    req = tsi.CompletionsCreateReq(
+        project_id="entity/project",
+        inputs=_completion_inputs(model=model),
+        track_llm_call=track_llm_call,
+        conversation_id=conversation_id,
+    )
+
+    result = chts._ensure_completion_conversation_id(req)
+
+    assert bool(result) is should_have_id
+    assert req.conversation_id == result
+    if conversation_id is not None:
+        assert result == conversation_id
+
+
 def test_custom_provider_name_matching_selector_prefix_is_preserved(monkeypatch):
     req = tsi.CompletionsCreateReq(
         project_id="entity/project",
@@ -2279,6 +2314,85 @@ def test_custom_provider_name_matching_selector_prefix_is_preserved(monkeypatch)
         obj_read_func=obj_read,
     )
     assert model_info.model_name == "custom/gpt-4"
+
+
+def test_custom_runtime_conversation_context_overrides_configured_header(
+    monkeypatch,
+):
+    req = tsi.CompletionsCreateReq(
+        project_id="entity/project",
+        inputs=_completion_inputs(model="custom::runtime::model"),
+        track_llm_call=False,
+        conversation_id="conv-1",
+    )
+    monkeypatch.setattr(
+        chts,
+        "get_custom_provider_info",
+        MagicMock(
+            return_value=llm_mod.CustomProviderInfo(
+                base_url="https://runtime.example.com/v1",
+                api_key=None,
+                extra_headers={
+                    "X-Tenant": "customer",
+                    "x-weave-conversation-id": "configured-value",
+                },
+                return_type="openai",
+                actual_model_name="model",
+            )
+        ),
+    )
+
+    info = chts._setup_completion_model_info(None, req, MagicMock())
+
+    assert info.is_custom_runtime is True
+    assert info.extra_headers == {
+        "X-Tenant": "customer",
+        "X-Weave-Conversation-Id": "conv-1",
+    }
+
+
+def test_custom_runtime_conversation_context_is_header_safe(monkeypatch):
+    req = tsi.CompletionsCreateReq(
+        project_id="entity/project",
+        inputs=_completion_inputs(model="custom::runtime::model"),
+        track_llm_call=False,
+        conversation_id="support/café\n",
+    )
+    monkeypatch.setattr(
+        chts,
+        "get_custom_provider_info",
+        MagicMock(
+            return_value=llm_mod.CustomProviderInfo(
+                base_url="https://runtime.example.com/v1",
+                api_key=None,
+                extra_headers={},
+                return_type="openai",
+                actual_model_name="model",
+            )
+        ),
+    )
+
+    info = chts._setup_completion_model_info(None, req, MagicMock())
+
+    assert info.extra_headers == {"X-Weave-Conversation-Id": "support%2Fcaf%C3%A9%0A"}
+
+
+def test_coreweave_does_not_receive_custom_runtime_conversation_context():
+    req = tsi.CompletionsCreateReq(
+        project_id="entity/project",
+        inputs=tsi.CompletionsCreateRequestInputs(
+            model="coreweave/test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            extra_headers={"api_key": "wandb-key", "X-Tenant": "customer"},
+        ),
+        conversation_id="conv-1",
+    )
+
+    info = chts._setup_completion_model_info(None, req, MagicMock())
+
+    assert info.is_custom_runtime is False
+    assert info.extra_headers == {"X-Tenant": "customer"}
+    assert req.track_llm_call is True
 
 
 def test_coreweave_with_api_key_keeps_litellm_configuration():

--- a/weave/chat/completions.py
+++ b/weave/chat/completions.py
@@ -20,6 +20,7 @@ from weave.trace.env import weave_trace_server_url
 from weave.trace.op import op
 from weave.trace.settings import http_timeout
 from weave.trace_server.constants import COMPLETIONS_CREATE_OP_NAME, INFERENCE_HOST
+from weave.trace_server.custom_runtime import is_custom_runtime_model
 from weave.utils.project_id import to_project_id
 from weave.wandb_interface.context import get_wandb_api_context
 
@@ -29,8 +30,14 @@ if TYPE_CHECKING:
 Endpoint = Literal["playground", "inference"]
 
 
+class _PlaygroundChatCompletion(ChatCompletion):
+    """OpenAI-compatible completion with W&B Playground conversation context."""
+
+    conversation_id: str
+
+
 # TODO: We remove these to align with OpenAI's API, but maybe they would be useful to keep?
-IGNORE_ARGS = ("self", "endpoint", "track_llm_call")
+IGNORE_ARGS = ("self", "endpoint", "track_llm_call", "conversation_id")
 
 
 def postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
@@ -50,6 +57,7 @@ class Completions:
         *,
         endpoint: Endpoint = "playground",
         track_llm_call: bool = True,
+        conversation_id: str | NotGiven | None = NOT_GIVEN,
         messages: Iterable,
         model: str,
         frequency_penalty: float | NotGiven | None = NOT_GIVEN,
@@ -97,7 +105,10 @@ class Completions:
         Args:
           endpoint: "playground" to use Weave's playground API, "inference" to use the inference service API.
 
-          track_llm_call: Whether to track the LLM call.
+          track_llm_call: Whether to track the LLM call. Custom Runtimes always own
+              their tracing, so this is ignored for `custom::` models.
+
+          conversation_id: Conversation context to reuse for a Playground request.
 
           messages: A list of messages comprising the conversation so far.
 
@@ -147,6 +158,7 @@ class Completions:
         """
         kwargs = {
             "endpoint": endpoint,
+            "conversation_id": conversation_id,
             "messages": messages,
             "model": model,
             "frequency_penalty": frequency_penalty,
@@ -158,11 +170,10 @@ class Completions:
             "temperature": temperature,
             "top_p": top_p,
         }
-        return (
-            self._create_op(**kwargs)
-            if track_llm_call
-            else self._create_non_op(**kwargs)
-        )
+        runtime_owns_tracing = is_custom_runtime_model(model)
+        if track_llm_call and not runtime_owns_tracing:
+            return self._create_op(**kwargs)
+        return self._create_non_op(**kwargs)
 
     @op(name=COMPLETIONS_CREATE_OP_NAME, postprocess_inputs=postprocess_inputs)
     def _create_op(self, **kwargs: Any) -> ChatCompletion | ChatCompletionChunkStream:
@@ -178,6 +189,10 @@ class Completions:
 
         messages = kwargs["messages"]
         model = kwargs["model"]
+        conversation_id = kwargs.get("conversation_id", NOT_GIVEN)
+        initial_conversation_id = (
+            conversation_id if isinstance(conversation_id, str) else None
+        )
         frequency_penalty = kwargs.get("frequency_penalty", NOT_GIVEN)
         max_tokens = kwargs.get("max_tokens", NOT_GIVEN)
         n = kwargs.get("n", NOT_GIVEN)
@@ -225,6 +240,8 @@ class Completions:
                 "project_id": project_id,
                 "track_llm_call": False,
             }
+            if initial_conversation_id is not None:
+                data["conversation_id"] = initial_conversation_id
         elif endpoint == "inference":
             url = f"https://{INFERENCE_HOST}/v1/chat/completions"
             headers["Authorization"] = f"Bearer {api_key}"
@@ -264,7 +281,11 @@ class Completions:
                 check_response(response)
 
                 # Transfer ownership so the returned stream controls cleanup.
-                return ChatCompletionChunkStream(response, stack.pop_all())
+                return ChatCompletionChunkStream(
+                    response,
+                    exit_stack=stack.pop_all(),
+                    initial_conversation_id=initial_conversation_id,
+                )
         else:
             with httpx.Client(timeout=timeout) as client:
                 response = client.post(
@@ -278,8 +299,13 @@ class Completions:
         # Non-streaming case
         d = response.json()
         if endpoint == "playground":
+            conversation_id = d.get("conversation_id") or initial_conversation_id
             d = d["response"]
         try:
+            if endpoint == "playground" and conversation_id:
+                return _PlaygroundChatCompletion.model_validate(
+                    {**d, "conversation_id": conversation_id}
+                )
             return ChatCompletion.model_validate(d)
         except ValidationError:
             print(d)

--- a/weave/chat/stream.py
+++ b/weave/chat/stream.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from collections.abc import Iterator
 from contextlib import ExitStack
@@ -12,11 +14,13 @@ class ChatCompletionChunkStream:
     """A stream wrapper for ChatCompletionChunk objects from an httpx response.
 
     This class takes an httpx response object and yields ChatCompletionChunk
-    objects by parsing the server-sent events stream.
+    objects by parsing the server-sent events stream. W&B ``_meta`` records are
+    consumed internally and are not yielded as completion chunks.
 
     Args:
         response: The httpx.Response object from a streaming API call.
         exit_stack: Optional owned contexts for the response and its client.
+        initial_conversation_id: Optional caller-supplied conversation context.
 
     Yields:
         ChatCompletionChunk: Parsed chat completion chunks from the stream.
@@ -33,10 +37,14 @@ class ChatCompletionChunkStream:
     """
 
     def __init__(
-        self, response: httpx.Response, exit_stack: ExitStack | None = None
+        self,
+        response: httpx.Response,
+        exit_stack: ExitStack | None = None,
+        initial_conversation_id: str | None = None,
     ) -> None:
         self.response = response
         self._exit_stack = exit_stack
+        self.conversation_id = initial_conversation_id
 
     def close(self) -> None:
         if self._exit_stack is None:
@@ -61,7 +69,18 @@ class ChatCompletionChunkStream:
                     if line == "[DONE]":
                         continue
                     try:
-                        yield ChatCompletionChunk.model_validate_json(line)
+                        data = json.loads(line)
                     except json.JSONDecodeError:
-                        print(f"Error parsing line as JSON: {line}")
-                        raise
+                        try:
+                            yield ChatCompletionChunk.model_validate_json(line)
+                        except json.JSONDecodeError:
+                            print(f"Error parsing line as JSON: {line}")
+                            raise
+                        continue
+                    metadata = data.get("_meta") if isinstance(data, dict) else None
+                    if isinstance(metadata, dict):
+                        conversation_id = metadata.get("conversation_id")
+                        if isinstance(conversation_id, str):
+                            self.conversation_id = conversation_id
+                        continue
+                    yield ChatCompletionChunk.model_validate(data)

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -110,7 +110,12 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         end_time = datetime.datetime.now()
 
         if not req.track_llm_call:
-            return tsi.CompletionsCreateRes(response=res.response)
+            return tsi.CompletionsCreateRes(
+                response=res.response,
+                conversation_id=(
+                    req.conversation_id if info.is_custom_runtime else None
+                ),
+            )
         return _CompletionCall(prep, res, start_time, end_time)
 
     async def _run_on_ch_executor(self, fn: Callable[..., _T], *args: object) -> _T:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -12,6 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from functools import partial
 from typing import Any, NamedTuple, TypeVar, cast
+from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
 import clickhouse_connect
@@ -175,7 +176,10 @@ from weave.trace_server.common_interface import AnnotationQueueItemsFilter
 from weave.trace_server.constants import (
     IMAGE_GENERATION_CREATE_OP_NAME,
 )
-from weave.trace_server.custom_runtime import apply_custom_runtime
+from weave.trace_server.custom_runtime import (
+    apply_custom_runtime,
+    is_custom_runtime_model,
+)
 from weave.trace_server.datadog import (
     record_db_insert,
     set_current_span_dd_tags,
@@ -373,6 +377,8 @@ CALLS_STREAM_GROWTH_FACTOR = 10
 
 # Retry attempts when reading back a newly-created object (eventual consistency)
 OBJ_READ_RETRY_ATTEMPTS = 3
+
+CUSTOM_RUNTIME_CONVERSATION_ID_HEADER = "X-Weave-Conversation-Id"
 
 # Create a shared connection pool manager for all ClickHouse connections
 _CH_POOL_MANAGER = get_pool_manager(
@@ -6917,6 +6923,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     response={"error": f"Failed to resolve prompt: {e!s}"}
                 )
 
+        _ensure_completion_conversation_id(req)
+
         # Use shared setup logic
         model_info = self._model_to_provider_info_map.get(req.inputs.model)
         try:
@@ -6988,7 +6996,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     ) -> tsi.CompletionsCreateRes:
         """Post-LLM-call CH insert. Called via `run_in_executor` from the async path."""
         if not req.track_llm_call:
-            return tsi.CompletionsCreateRes(response=res.response)
+            return tsi.CompletionsCreateRes(
+                response=res.response,
+                conversation_id=(
+                    req.conversation_id
+                    if prep.completion_model_info.is_custom_runtime
+                    else None
+                ),
+            )
 
         built = self._build_completion_call_span(req, prep, res, start_time, end_time)
         AgentWriteHandler(self.ch_client, self._async_insert_settings()).insert_span(
@@ -7033,6 +7048,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 yield {"error": f"Failed to resolve and apply prompt: {err!s}"}
 
             return _single_error_iter(e)
+
+        _ensure_completion_conversation_id(req)
 
         # --- Shared setup logic (copy of completions_create up to litellm call)
         model_info = self._model_to_provider_info_map.get(req.inputs.model)
@@ -7106,6 +7123,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
         if not req.track_llm_call or span_id is None:
+            if completion_model_info.is_custom_runtime and req.conversation_id:
+                return _prepend_completion_conversation_context(
+                    chunk_iter, req.conversation_id
+                )
             return chunk_iter
 
         assert retention_days is not None
@@ -8261,6 +8282,14 @@ def _create_tracked_span_stream_wrapper(
     return _stream_wrapper()
 
 
+def _prepend_completion_conversation_context(
+    chunk_iter: Iterator[dict[str, Any]], conversation_id: str
+) -> Iterator[dict[str, Any]]:
+    """Prepend server-owned conversation context to an untracked stream."""
+    yield {"_meta": {"conversation_id": conversation_id}}
+    yield from chunk_iter
+
+
 @dataclasses.dataclass(frozen=True)
 class CompletionModelInfo:
     model_name: str
@@ -8270,6 +8299,7 @@ class CompletionModelInfo:
     extra_headers: dict[str, str]
     return_type: str | None
     vertex_credentials: str | None = None
+    is_custom_runtime: bool = False
 
 
 class CompletionPrepResult(NamedTuple):
@@ -8290,6 +8320,29 @@ class BuiltCompletionSpan(NamedTuple):
 
     span: AgentSpanCHInsertable
     result: tsi.CompletionsCreateRes
+
+
+def _ensure_completion_conversation_id(
+    req: tsi.CompletionsCreateReq,
+) -> str | None:
+    is_custom_runtime = is_custom_runtime_model(req.inputs.model)
+    if not req.conversation_id and (req.track_llm_call or is_custom_runtime):
+        req.conversation_id = generate_id()
+    return req.conversation_id or None
+
+
+def _custom_runtime_headers(
+    configured_headers: dict[str, str], conversation_id: str | None
+) -> dict[str, str]:
+    context_header = CUSTOM_RUNTIME_CONVERSATION_ID_HEADER.lower()
+    headers = {
+        key: value
+        for key, value in configured_headers.items()
+        if key.lower() != context_header
+    }
+    if conversation_id:
+        headers[CUSTOM_RUNTIME_CONVERSATION_ID_HEADER] = quote(conversation_id, safe="")
+    return headers
 
 
 def _setup_completion_model_info(
@@ -8314,7 +8367,7 @@ def _setup_completion_model_info(
     vertex_credentials: str | None = getattr(req.inputs, "vertex_credentials", None)
 
     # Check for explicit custom provider prefix
-    is_explicit_custom = model_name.startswith("custom::")
+    is_explicit_custom = is_custom_runtime_model(model_name)
 
     is_coreweave = (
         model_info and model_info.get("litellm_provider") == "coreweave"
@@ -8389,15 +8442,19 @@ def _setup_completion_model_info(
             if "ollama" in provider_name.lower()
             else "openai/" + final_model_name
         )
+        req.track_llm_call = False
 
         return CompletionModelInfo(
             model_name=provider_model_name,
             api_key=custom_provider_info.api_key,
             provider="custom",
             base_url=base_url,
-            extra_headers=custom_provider_info.extra_headers,
+            extra_headers=_custom_runtime_headers(
+                custom_provider_info.extra_headers, req.conversation_id
+            ),
             return_type=custom_provider_info.return_type,
             vertex_credentials=None,
+            is_custom_runtime=True,
         )
     elif model_info:
         secret_name = model_info.get("api_key_name")

--- a/weave/trace_server/custom_runtime.py
+++ b/weave/trace_server/custom_runtime.py
@@ -9,6 +9,11 @@ from weave.trace_server.interface.builtin_object_classes.provider import (
 )
 
 
+def is_custom_runtime_model(model: str) -> bool:
+    """Return whether a model selector targets a Custom Runtime."""
+    return model.startswith("custom::")
+
+
 def apply_custom_runtime(
     req: tsi.CustomRuntimeApplyReq,
     obj_create: Callable[[tsi.ObjCreateReq], tsi.ObjCreateRes],

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -71,6 +71,8 @@ from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER, SENTINEL_EPOC
 # module; import it rather than fork it.
 from weave.trace_server.clickhouse_trace_server_batched import (
     CompletionPrepResult,
+    _ensure_completion_conversation_id,
+    _prepend_completion_conversation_context,
     _setup_completion_model_info,
 )
 from weave.trace_server.clickhouse_trace_server_settings import (
@@ -4294,6 +4296,8 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                     response={"error": f"Failed to resolve prompt: {e!s}"}
                 )
 
+        _ensure_completion_conversation_id(req)
+
         model_info = _model_to_provider_info_map().get(req.inputs.model)
         try:
             completion_model_info = _setup_completion_model_info(
@@ -4363,7 +4367,12 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
         end_time = datetime.datetime.now()
 
         if not req.track_llm_call:
-            return tsi.CompletionsCreateRes(response=res.response)
+            return tsi.CompletionsCreateRes(
+                response=res.response,
+                conversation_id=(
+                    req.conversation_id if info.is_custom_runtime else None
+                ),
+            )
 
         req.inputs.messages = prep.initial_messages
         span_id = generate_id()
@@ -4438,6 +4447,10 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
         )
 
         if not req.track_llm_call:
+            if info.is_custom_runtime and req.conversation_id:
+                return _prepend_completion_conversation_context(
+                    chunk_iter, req.conversation_id
+                )
             return chunk_iter
 
         req.inputs.messages = prep.initial_messages


### PR DESCRIPTION
## Summary

- make the trace server authoritative for Custom Runtime conversation identity
- generate the ID before runtime dispatch when the caller does not already have one
- send the ID to explicit `custom::` runtimes in the reserved, percent-encoded `X-Weave-Conversation-Id` header
- return the server-selected ID in the non-streaming response or a conversation-only streaming `_meta` record
- let the Custom Runtime own completion tracing, avoiding a duplicate W&B ingress span
- preserve the conversation across later turns and provider switches while recomputing trace ownership for every request

## Existing behavior and decision

Today, when **Trace LLM call** is enabled, the Playground asks the trace server to record the completion boundary. For a Custom Runtime that produces one W&B-owned root `chat` span containing the submitted messages and final response. The public `weave.chat` client has the equivalent behavior through its local completion op. This is useful when the downstream model is opaque, but a Custom Runtime is not opaque: it can independently log its Turn, LLM, subagent, and tool spans to Weave.

If both sides log the same request, the Conversation view receives two representations of the boundary user and assistant messages. A conversation ID can correlate the records, but it cannot determine which duplicate should be hidden: message content and timestamps are not reliable identity, and the W&B span and runtime span do not share a span tree.

This PR therefore makes tracing ownership opinionated for explicit `custom::` requests:

- the trace server establishes conversation identity before dispatch and forwards it to the selected runtime
- the Custom Runtime owns the complete trace, including boundary input/output and internal work
- hosted and CoreWeave requests retain W&B-owned completion tracing
- clients retain the returned identity for later turns but do not need to generate the first ID

This is the smallest implementation with one authoritative trace owner. It is decided per request in the shared completion dispatch path, so it covers Playground, synchronous, streaming, async, and raw API ingress without adding a UI setting or changing the storage model. It also requires no database migration, trace-merging protocol, deduplication heuristic, conversation-specific rendering logic, or coordinated Core deployment. Explicit `custom::` resolution keeps the behavior from leaking to CoreWeave, which also uses LiteLLM's internal `provider="custom"` transport value.

Alternatives considered were materially broader:

- **Log on both sides and deduplicate:** requires a stable cross-system boundary-span identity plus storage or UI reconciliation; content/time heuristics would hide legitimate repeated messages.
- **Pass W&B trace/span IDs and merge the trees:** retains two logging owners and introduces parentage, partial-failure, and cross-ingress lifecycle rules.
- **Return all runtime events for W&B to log:** requires a new runtime event protocol, buffering/streaming semantics, and failure recovery.
- **Add a customer setting:** creates two Custom Runtime behaviors and allows the duplicate state we are trying to avoid.

The tradeoff is deliberate: an uninstrumented Custom Runtime will no longer get a W&B-generated boundary span. The runtime contract and public sample make runtime-owned logging explicit, because only the runtime can provide the complete chronology.

## End-to-end flow

1. A client sends its existing `conversation_id`, or omits it on the first turn.
2. Before runtime dispatch, the trace server preserves the supplied ID or generates one.
3. The trace server resolves whether the request targets an explicit Custom Runtime.
4. For a Custom Runtime, the server overwrites any configured context header with the authoritative, percent-encoded `X-Weave-Conversation-Id` value and disables the W&B completion span for that request.
5. The runtime logs its boundary input/output, LLM, tool, and subagent spans with that conversation ID.
6. A non-streaming response returns `conversation_id` at the top level. A streaming response first emits `{"_meta":{"conversation_id":"..."}}` and then the normal completion chunks.
7. Core already consumes `_meta`; `weave.chat` now consumes it internally, exposes `stream.conversation_id`, and never yields the metadata as an LLM chunk. Later turns and provider switches send the retained ID back to the trace server.

The `_meta` record for an untracked Custom Runtime contains only conversation identity—no synthetic call, span, or trace IDs are created. Existing tracked-stream metadata remains unchanged.

## Provider switching

Trace ownership is decided per request rather than cached for the whole conversation. Automated coverage and the local E2E exercise one conversation moving through:

1. Custom Runtime: receives the context header and owns tracing
2. hosted CoreWeave: reuses the conversation ID and keeps normal W&B tracing
3. Custom Runtime: receives the same context header and again owns tracing

The local trace data preserved the same conversation ID across all three providers. The hosted request retained a W&B-owned `Weave Chat Playground` span; returning to the Custom Runtime rejoined the original runtime-owned conversation.

The hosted CoreWeave turn returned a blank/error response locally because of the existing reasoning-response normalization behavior. That is separate from conversation identity: the persisted span still demonstrated the expected ID and per-request trace ownership, and this PR does not alter response normalization.

## Customer-visible result

The screenshots use the same natural two-turn Seattle-planning conversation. The deterministic OpenAI-compatible downstream keeps the content stable; the conversation storage and runtime-owned Weave spans are real.

### Before: only the boundary input and output

Current production records one root `chat` span per turn. The customer sees the final answers, but none of the runtime's planning, research, or tool work: **2 spans, 0 tools, 2 traces**.

[Open the before conversation](https://wandb.ai/mliu-wandb-weights-biases/quickstart_playground/weave/agents/conversations/019fcf14-05be-7798-a3f1-795817b3e408)

<img width="1728" height="906" alt="Before: two-turn Custom Runtime conversation with only outer input and output spans" src="https://github.com/user-attachments/assets/e3189ea9-6d56-47a2-81cb-d6ad23375fc1" />

### After: runtime work appears chronologically

The runtime receives one conversation ID across both turns and logs the complete workflow: **18 runtime-owned spans, 8 tools, 2 traces**. The app inspection showed 2 user messages and 4 assistant messages, with planning, research, LLM, subagent, and tool activity in chronological order and no synthetic internal user messages.

[Open the production-hosted after example](https://wandb.ai/mliu-wandb-weights-biases/quickstart_playground/weave/agents/conversations/4fcd2acb-b947-41cd-a8ad-98565938896a)

**Turn 1: planning, research, four tools, and the final response**

<img width="1728" height="962" alt="After: first Custom Runtime turn with planning, research, tools, and final response" src="https://github.com/user-attachments/assets/93b4b3a5-4fc8-49f1-83e1-828df7cf3398" />

**Turn 2: the follow-up remains in the same conversation**

<img width="1728" height="962" alt="After: second Custom Runtime turn with a natural follow-up and complete runtime chronology" src="https://github.com/user-attachments/assets/50a7f857-7b3e-449a-8228-91ecfb770842" />

**Trace view: one nine-span runtime-owned hierarchy**

<img width="1728" height="962" alt="Custom Runtime trace tree containing the turn, LLM, subagent, and tool spans" src="https://github.com/user-attachments/assets/ea9c1139-31be-457e-9856-957d313bfd58" />

The [public sample](https://github.com/mattliu-mygit/weave-custom-runtime-sample) implements the runtime side of the contract, including use of the received conversation ID and assistant/tool-oriented trace data. The E2E version is published in [commit `4e6948d`](https://github.com/mattliu-mygit/weave-custom-runtime-sample/commit/4e6948d).

## Verification

- affected-file ClickHouse-backed Weave suite — **154 passed**
- affected-file in-memory Weave suite — **142 passed, 12 skipped**
- focused type checking — **passed**
- Ruff formatting and diff checks — **passed**
- public sample: `npm test` — **104 passed**
- local two-turn Playground E2E — **18 spans, 8 tools, 2 traces**, with complete runtime chronology
- local Custom Runtime → CoreWeave → Custom Runtime E2E — same conversation ID preserved and trace ownership recomputed per request

## Code review

Reviewed the complete diff after moving conversation-ID ownership back into the trace server. The retained tests cover server generation/reuse, streaming `_meta` consumption, non-streaming responses, sync/async/in-memory servers, reserved-header override, CoreWeave isolation, Custom Runtime trace ownership, provider switching, OpenAI SSE compatibility, and stream resource cleanup.
