### PR TITLE
fix(weave_ts): return the real audio from client.get()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,6 +339,19 @@ pnpm exec tsx examples/claudeAgents.ts
   flattened `weave.integration.meta.*` provenance. OTel scalar metadata stays
   typed; non-scalar values are stringified.
 
+### TypeScript media round trip
+
+- `client.get()` rebuilds a `WeaveImage` from a `PIL.Image.Image` payload and a
+  `WeaveAudio` from a `wave.Wave_read` one, downloading the stored file from
+  `ref.projectId`, not the client's project.
+- `wave.Wave_read` is what this SDK writes, and what Python wrote until May
+  2025. Both store one `audio.wav` and no metadata file.
+- Python now records every `Audio` and `wave.Wave_read` object as
+  `weave.type_handlers.Audio.audio.Audio` with an extra `_metadata.json`,
+  because `register()` in `weave/type_handlers/Audio/audio.py` puts the `Audio`
+  serializer first and its `is_audio_instance` predicate also accepts
+  `wave.Wave_read`.
+
 ### TypeScript GenAI Turn output
 
 - The existing `Turn.record({messages: [...]})` path records input messages;

--- a/sdks/node/src/__tests__/weaveClient.get.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.get.test.ts
@@ -9,12 +9,17 @@ const IMAGE_DIGEST = 'test-digest';
 const REF = new ObjectRef('other-entity/other-project', 'my-image', 'v1');
 const REF_URI = 'weave:///other-entity/other-project/object/my-image:v1';
 
-function objReadBody(files: Record<string, string> | null) {
+const AUDIO_BYTES = Buffer.from([0x52, 0x49, 0x46, 0x46, 0x00, 0xff, 0xfe]);
+const AUDIO_DIGEST = 'test-audio-digest';
+const AUDIO_REF = new ObjectRef('other-entity/other-project', 'my-audio', 'v1');
+const AUDIO_REF_URI = 'weave:///other-entity/other-project/object/my-audio:v1';
+
+function objReadBody(weaveType: string, files: Record<string, string> | null) {
   return JSON.stringify({
     obj: {
       val: {
         _type: 'CustomWeaveType',
-        weave_type: {type: 'PIL.Image.Image'},
+        weave_type: {type: weaveType},
         files,
         load_op: 'NO_LOAD_OP',
       },
@@ -24,10 +29,12 @@ function objReadBody(files: Record<string, string> | null) {
 
 // The endpoint sends the file with no content type, so neither does this.
 const respondWithImageBytes = async () => new Response(IMAGE_BYTES);
+const respondWithAudioBytes = async () => new Response(AUDIO_BYTES);
 
 function clientServingFileContent(
   fileContent: () => Promise<Response>,
-  files: Record<string, string> | null = {'image.png': IMAGE_DIGEST}
+  files: Record<string, string> | null = {'image.png': IMAGE_DIGEST},
+  weaveType = 'PIL.Image.Image'
 ) {
   const fileRequests: unknown[] = [];
   const traceServerApi = new TraceServerApi({
@@ -35,7 +42,7 @@ function clientServingFileContent(
     customFetch: async (input, init) => {
       const url = input.toString();
       if (url.endsWith('/obj/read')) {
-        return new Response(objReadBody(files), {
+        return new Response(objReadBody(weaveType, files), {
           headers: {'content-type': 'application/json'},
         });
       }
@@ -117,6 +124,37 @@ describe('WeaveClient.get on a published image', () => {
 
     await expect(client.get(REF)).rejects.toThrow(
       `No image file stored for ref uri: ${REF_URI}`
+    );
+  });
+});
+
+describe('WeaveClient.get on published audio', () => {
+  it('returns a WeaveAudio carrying the stored bytes', async () => {
+    const {client, fileRequests} = clientServingFileContent(
+      respondWithAudioBytes,
+      {'audio.wav': AUDIO_DIGEST},
+      'wave.Wave_read'
+    );
+
+    expect(await client.get(AUDIO_REF)).toEqual({
+      _weaveType: 'Audio',
+      data: AUDIO_BYTES,
+      audioType: 'wav',
+    });
+    expect(fileRequests).toEqual([
+      {project_id: 'other-entity/other-project', digest: AUDIO_DIGEST},
+    ]);
+  });
+
+  it('rejects when the object stores no audio file', async () => {
+    const {client} = clientServingFileContent(
+      respondWithAudioBytes,
+      null,
+      'wave.Wave_read'
+    );
+
+    await expect(client.get(AUDIO_REF)).rejects.toThrow(
+      `No audio file stored for ref uri: ${AUDIO_REF_URI}`
     );
   });
 });

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -40,6 +40,7 @@ import {
   imageTypeFromFileName,
   isWeaveAudio,
   isWeaveImage,
+  weaveAudio,
   weaveImage,
 } from './media';
 import {
@@ -1420,8 +1421,13 @@ export class WeaveClient {
           imageType: imageTypeFromFileName(fileName),
         });
       } else if (typeName == 'wave.Wave_read') {
-        // TODO: Implement getting audio back as buffer
-        return 'Coming soon!';
+        const files: Record<string, string | undefined> = val.files ?? {};
+        // Every writer of this type stores one file, never a _metadata.json.
+        const [digest] = Object.values(files);
+        if (digest == null) {
+          throw new Error(`No audio file stored for ref uri: ${ref.uri()}`);
+        }
+        return weaveAudio({data: await this.downloadFile(ref, digest)});
       }
     }
     return val;


### PR DESCRIPTION
## JIRA Issue(s)

- Fixes [WB-38338](https://coreweave.atlassian.net/browse/WB-38338)

## Description

This is the third part of a stack.

First part, #7685: `client.get()` returns real images.

Second part, #7686: with the right format label.

This part: audio still comes back as the string `Coming soon!`. This fixes that. The audio branch sits
right below the image one in the same function.

#7685 already added the file download and `media.ts` has a `weaveAudio()` wrapper, so this downloads
the stored file, wraps the bytes and returns them.

Python writes a `_metadata.json` next to the audio, so I expected to pick the audio file by name. Turns
out Python stopped using this type name in May 2025, so there's only ever one file here. Details in
`AGENTS.md`.

Before: `get()` on audio gave you a string. Now it gives you your bytes.

Audio from today's Python still comes back unread. That's a separate PR — it needs its own branch and
an mp3 type.

## Testing

Two unit tests next to the image ones check that `get()` hands back the audio instead of the
`Coming soon!` string, plus a round trip against a live server that came back byte-identical.


[WB-38338]: https://coreweave.atlassian.net/browse/WB-38338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ