### PR TITLE
fix(weave): keep chat completion streams open for iteration

### DIFF
--- a/tests/trace/test_chat_completions.py
+++ b/tests/trace/test_chat_completions.py
@@ -1,0 +1,210 @@
+"""Regression coverage for the public chat completions client."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from weave.chat import completions as completions_module
+from weave.chat.completions import Completions
+from weave.trace.weave_client import WeaveClient
+
+
+def _client() -> WeaveClient:
+    client = MagicMock(spec=WeaveClient)
+    client.entity = "entity"
+    client.project = "project"
+    return client
+
+
+def _chunk_payload(content: str = "Hello") -> dict:
+    return {
+        "id": "completion-1",
+        "choices": [
+            {
+                "delta": {"role": "assistant", "content": content},
+                "finish_reason": None,
+                "index": 0,
+            }
+        ],
+        "created": 1,
+        "model": "runtime-model",
+        "object": "chat.completion.chunk",
+    }
+
+
+class _TrackingByteStream(httpx.SyncByteStream):
+    def __init__(self, content: bytes, close_error: Exception | None = None) -> None:
+        self.content = content
+        self.close_error = close_error
+        self.closed = False
+
+    def __iter__(self):
+        yield self.content
+
+    def close(self) -> None:
+        self.closed = True
+        if self.close_error is not None:
+            raise self.close_error
+
+
+def _install_mock_transport(monkeypatch, handler) -> list[httpx.Client]:
+    real_client = httpx.Client
+    transport = httpx.MockTransport(handler)
+
+    clients = []
+
+    def client_factory(**kwargs):
+        client = real_client(transport=transport, **kwargs)
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(
+        completions_module.httpx,
+        "Client",
+        client_factory,
+    )
+    monkeypatch.setattr(completions_module, "get_wandb_api_context", lambda: "key")
+    return clients
+
+
+def _create_stream(
+    completions: Completions,
+    endpoint: completions_module.Endpoint = "inference",
+    model: str = "coreweave/runtime-model",
+):
+    return completions.create(
+        endpoint=endpoint,
+        model=model,
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=True,
+        track_llm_call=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "model"),
+    [
+        ("inference", "coreweave/runtime-model"),
+        ("playground", "runtime-model"),
+    ],
+)
+def test_stream_remains_open_until_consumed(monkeypatch, endpoint, model) -> None:
+    chunk = json.dumps(_chunk_payload()).encode()
+    content = (
+        b"data: " + chunk + b"\n\ndata: [DONE]\n\n"
+        if endpoint == "inference"
+        else chunk + b"\n"
+    )
+    body = _TrackingByteStream(content)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=body)
+
+    clients = _install_mock_transport(monkeypatch, handler)
+    completions = Completions(_client())
+
+    stream = _create_stream(completions, endpoint, model)
+
+    assert not stream.response.is_closed
+    assert not clients[0].is_closed
+    assert [chunk.choices[0].delta.content for chunk in stream] == ["Hello"]
+    assert stream.response.is_closed
+    assert body.closed
+    assert clients[0].is_closed
+
+
+def test_stream_context_manager_closes_unconsumed_resources(monkeypatch) -> None:
+    body = _TrackingByteStream(b"")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=body)
+
+    clients = _install_mock_transport(monkeypatch, handler)
+    completions = Completions(_client())
+    stream = _create_stream(completions)
+
+    with stream:
+        assert not stream.response.is_closed
+
+    assert stream.response.is_closed
+    assert body.closed
+    assert clients[0].is_closed
+
+
+def test_stream_close_always_closes_client(monkeypatch) -> None:
+    body = _TrackingByteStream(b"", RuntimeError("response close failed"))
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=body)
+
+    clients = _install_mock_transport(monkeypatch, handler)
+    completions = Completions(_client())
+    stream = _create_stream(completions)
+
+    with pytest.raises(RuntimeError, match="response close failed"):
+        stream.close()
+
+    assert stream.response.is_closed
+    assert body.closed
+    assert clients[0].is_closed
+
+
+def test_stream_setup_error_closes_resources(monkeypatch) -> None:
+    body = _TrackingByteStream(b'{"error":"failed"}')
+    responses = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        response = httpx.Response(500, stream=body)
+        responses.append(response)
+        return response
+
+    clients = _install_mock_transport(monkeypatch, handler)
+    completions = Completions(_client())
+
+    with pytest.raises(httpx.HTTPStatusError):
+        _create_stream(completions)
+
+    assert responses[0].is_closed
+    assert body.closed
+    assert clients[0].is_closed
+
+
+def test_stream_setup_error_always_closes_client(monkeypatch) -> None:
+    body = _TrackingByteStream(
+        b'{"error":"failed"}', RuntimeError("response close failed")
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, stream=body)
+
+    clients = _install_mock_transport(monkeypatch, handler)
+    completions = Completions(_client())
+
+    with pytest.raises(RuntimeError, match="response close failed"):
+        _create_stream(completions)
+
+    assert body.closed
+    assert clients[0].is_closed
+
+
+def test_stream_parse_error_closes_resources(monkeypatch) -> None:
+    body = _TrackingByteStream(b"not-json\n")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=body)
+
+    clients = _install_mock_transport(monkeypatch, handler)
+    completions = Completions(_client())
+    stream = _create_stream(completions)
+
+    with pytest.raises(ValidationError):
+        list(stream)
+
+    assert stream.response.is_closed
+    assert body.closed
+    assert clients[0].is_closed

--- a/weave/chat/completions.py
+++ b/weave/chat/completions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from contextlib import ExitStack
 from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
@@ -249,17 +250,21 @@ class Completions:
             response.raise_for_status()
 
         if request_stream:
-            # For streaming, we need to keep the client and response context
-            client = httpx.Client(timeout=timeout)
-            with client.stream(
-                "POST",
-                url,
-                auth=auth,
-                headers=headers,
-                json=data,
-            ) as response:
+            with ExitStack() as stack:
+                client = stack.enter_context(httpx.Client(timeout=timeout))
+                response = stack.enter_context(
+                    client.stream(
+                        "POST",
+                        url,
+                        auth=auth,
+                        headers=headers,
+                        json=data,
+                    )
+                )
                 check_response(response)
-                return ChatCompletionChunkStream(response)
+
+                # Transfer ownership so the returned stream controls cleanup.
+                return ChatCompletionChunkStream(response, stack.pop_all())
         else:
             with httpx.Client(timeout=timeout) as client:
                 response = client.post(

--- a/weave/chat/stream.py
+++ b/weave/chat/stream.py
@@ -1,7 +1,9 @@
 import json
 from collections.abc import Iterator
+from contextlib import ExitStack
 
 import httpx
+from typing_extensions import Self
 
 from weave.chat.types.chat_completion_chunk import ChatCompletionChunk
 
@@ -14,6 +16,7 @@ class ChatCompletionChunkStream:
 
     Args:
         response: The httpx.Response object from a streaming API call.
+        exit_stack: Optional owned contexts for the response and its client.
 
     Yields:
         ChatCompletionChunk: Parsed chat completion chunks from the stream.
@@ -29,20 +32,36 @@ class ChatCompletionChunkStream:
         ...             print(chunk.choices[0].delta.content)
     """
 
-    def __init__(self, response: httpx.Response) -> None:
+    def __init__(
+        self, response: httpx.Response, exit_stack: ExitStack | None = None
+    ) -> None:
         self.response = response
+        self._exit_stack = exit_stack
+
+    def close(self) -> None:
+        if self._exit_stack is None:
+            self.response.close()
+        else:
+            self._exit_stack.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
 
     def __iter__(self) -> Iterator[ChatCompletionChunk]:
-        for raw_line in self.response.iter_lines():
-            if raw_line:  # skip keep-alive lines
-                line = raw_line
-                if raw_line.startswith("data: "):
-                    # This is how OpenAI streams things back
-                    line = raw_line[6:]
-                if line == "[DONE]":
-                    continue
-                try:
-                    yield ChatCompletionChunk.model_validate_json(line)
-                except json.JSONDecodeError:
-                    print(f"Error parsing line as JSON: {line}")
-                    raise
+        with self:
+            for raw_line in self.response.iter_lines():
+                if raw_line:  # skip keep-alive lines
+                    line = raw_line
+                    if raw_line.startswith("data: "):
+                        # This is how OpenAI streams things back
+                        line = raw_line[6:]
+                    if line == "[DONE]":
+                        continue
+                    try:
+                        yield ChatCompletionChunk.model_validate_json(line)
+                    except json.JSONDecodeError:
+                        print(f"Error parsing line as JSON: {line}")
+                        raise


### PR DESCRIPTION
## Summary

- keep the HTTP response and client open until the returned chat completion stream is consumed
- close both resources after successful iteration, parsing failures, setup failures, or explicit context-manager cleanup
- add focused regression coverage for both Playground and Inference streaming

## Root cause

Simplified, the old implementation did this:

```python
with client.stream(...) as response:
    return ChatCompletionChunkStream(response)
```

A Python `with` block cleans up its resource when the block ends. Returning from inside the block still runs that cleanup before the caller receives the returned value:

1. Open the streaming response.
2. Construct `ChatCompletionChunkStream(response)`.
3. Exit the `with` block.
4. Close the response.
5. Give `ChatCompletionChunkStream` to the caller.

The caller therefore received an object that looked like a stream, but its underlying response had already been closed:

```python
stream = client.chat.completions.create(..., stream=True)

stream.response.is_closed
# True

list(stream)
# httpx.StreamClosed
```

The network connection was disconnected before the caller could consume the first chunk. Pre-buffered response bodies can hide this because their bytes are already in memory, but a genuine network-backed stream needs the response to remain open. The old path also left its separately-created `httpx.Client` open.

## How the fix works

The streaming path now opens the HTTP client and response through one `ExitStack`. If setup or status validation fails, normal context-manager unwinding closes everything that was opened. After successful setup, `pop_all()` transfers those cleanup callbacks to `ChatCompletionChunkStream`, so returning the stream no longer closes its underlying response.

The returned stream then owns both resources. Iterating it uses the stream's context-manager path, while explicit `close()` and `with stream:` usage share the same cleanup implementation. In every case, the response is closed before its client, including when response cleanup raises.

## Reproduction

This reproduces against the pre-fix `origin/master` implementation with a network-like HTTPX byte stream:

```python
stream = client.chat.completions.create(
    endpoint="inference",
    model="coreweave/runtime-model",
    messages=[{"role": "user", "content": "Hello"}],
    stream=True,
    track_llm_call=False,
)

print(stream.response.is_closed)
list(stream)
```

Before this PR:

```text
True
httpx.StreamClosed: Attempted to read or stream content, but the stream has been closed.
```

After this PR:

```text
response closed before iteration: False
received content: Hello
response closed after iteration: True
```

The regression test fails consistently on `origin/master` for both `endpoint="inference"` and `endpoint="playground"`, where the returned response is already closed.

## Impact

Callers can now iterate streamed chat completions normally. The response and client remain open only while needed and are closed after iteration or on an error. This PR contains no Custom Runtime conversation-context changes.

## Validation

- Reproduced the closed-before-iteration failure on untouched `origin/master`
- `python -m pytest tests/trace/test_chat_completions.py tests/trace/test_op_generators.py tests/trace/test_op_decorator_behaviour.py tests/trace/test_llm_structured_completion_model.py -q` — 66 passed
- `pyright weave/chat/completions.py weave/chat/stream.py` — passed
- `ruff check weave/chat/completions.py weave/chat/stream.py tests/trace/test_chat_completions.py` — passed
