### PR TITLE
fix(weave): stop UnboundLocalError in the MCP read_resource wrapper

### DIFF
--- a/tests/integrations/fastmcp/fastmcp_test.py
+++ b/tests/integrations/fastmcp/fastmcp_test.py
@@ -17,6 +17,7 @@ from weave.integrations.integration_utilities import (
     flatten_calls,
     flattened_calls_to_names,
 )
+from weave.trace.op import OpCallError
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server.trace_server_interface import CallsFilter
 
@@ -169,6 +170,13 @@ def test_fastmcp_client(client: WeaveClient) -> None:
     assert "Please review this code" in prompt_text, (
         "Expected prompt to contain 'Please review this code'"
     )
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_client_read_resource_without_uri(weave_active) -> None:
+    # `None` is a safe stand-in for `self`: argument binding fails before it is used.
+    with pytest.raises(OpCallError, match="missing a required argument: 'uri'"):
+        await ClientSession.read_resource(None)
 
 
 @pytest.mark.vcr(

--- a/weave/integrations/fastmcp/fastmcp_client.py
+++ b/weave/integrations/fastmcp/fastmcp_client.py
@@ -65,6 +65,7 @@ def fastmcp_client_wrapper(settings: OpSettings) -> Callable:
 
             def wrapped_read_resource(*args: Any, **kwargs: Any) -> Any:
                 display_uri = None
+                uri = None
 
                 # uri is an object of pydantic `AnyUrl`
                 if len(args) >= 2:


### PR DESCRIPTION
## JIRA Issue(s)

[WB-38372](https://coreweave.atlassian.net/browse/WB-38372)

## Description

Weave wraps three MCP client methods so their calls show up in traces: `call_tool`, `read_resource` and `get_prompt`. Each one picks a name out of the call arguments, like the tool name or the resource address. I found this reading the three side by side: two of them guard against a missing argument, one does not.

It matters because the crash comes from us. Call `read_resource()` with no `uri` and Weave raises `UnboundLocalError` before your real call runs. You get a traceback from our tracing code instead of a plain argument error, so you go looking in the wrong place.

The wrapper has been like this since the first MCP commit, so this is not a regression. `call_tool` and `get_prompt` set their name variable to `None` first. `read_resource` sets `uri` only inside two `if` branches, then reads it on the next line. If the call has no `uri`, neither branch runs and the variable does not exist yet.

With `uri = None` added, the call fails the normal way and says `missing a required argument: 'uri'`.

## Testing

Added a test that calls `read_resource` with no `uri` and fails without the fix, and the fastmcp tests and `nox -e lint` pass locally.


[WB-38372]: https://coreweave.atlassian.net/browse/WB-38372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ