### PR TITLE
fix(weave_ts): return a real Date from client.get()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,11 +339,18 @@ pnpm exec tsx examples/claudeAgents.ts
   flattened `weave.integration.meta.*` provenance. OTel scalar metadata stays
   typed; non-scalar values are stringified.
 
-### TypeScript media round trip
+### TypeScript custom type round trip
 
 - `client.get()` rebuilds a `WeaveImage` from a `PIL.Image.Image` payload and a
   `WeaveAudio` from a `wave.Wave_read` one, downloading the stored file from
   `ref.projectId`, not the client's project.
+- It also rebuilds a `Date` from a `datetime.datetime` payload, which stores no
+  file: Python writes the ISO string inline into the record's `val`. A `Date`
+  is a UTC instant with millisecond resolution, so the round trip keeps the
+  moment but loses the original offset and truncates Python's microseconds. It
+  reads whole-minute offsets only, so a timestamp from before its zone adopted
+  one comes back as an `Invalid Date` (`Africa/Monrovia` ran on `-00:44:30`
+  until 1972).
 - `wave.Wave_read` is what this SDK writes, and what Python wrote until May
   2025. Both store one `audio.wav` and no metadata file.
 - Python now records every `Audio` and `wave.Wave_read` object as

--- a/sdks/node/src/__tests__/weaveClient.get.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.get.test.ts
@@ -14,7 +14,14 @@ const AUDIO_DIGEST = 'test-audio-digest';
 const AUDIO_REF = new ObjectRef('other-entity/other-project', 'my-audio', 'v1');
 const AUDIO_REF_URI = 'weave:///other-entity/other-project/object/my-audio:v1';
 
-function objReadBody(weaveType: string, files: Record<string, string> | null) {
+const DATE_REF = new ObjectRef('other-entity/other-project', 'my-date', 'v1');
+
+// An image or audio stores a file; a datetime stores its value inline in `val`.
+function objReadBody(
+  weaveType: string,
+  files?: Record<string, string> | null,
+  val?: string
+) {
   return JSON.stringify({
     obj: {
       val: {
@@ -22,6 +29,7 @@ function objReadBody(weaveType: string, files: Record<string, string> | null) {
         weave_type: {type: weaveType},
         files,
         load_op: 'NO_LOAD_OP',
+        val,
       },
     },
   });
@@ -31,10 +39,9 @@ function objReadBody(weaveType: string, files: Record<string, string> | null) {
 const respondWithImageBytes = async () => new Response(IMAGE_BYTES);
 const respondWithAudioBytes = async () => new Response(AUDIO_BYTES);
 
-function clientServingFileContent(
-  fileContent: () => Promise<Response>,
-  files: Record<string, string> | null = {'image.png': IMAGE_DIGEST},
-  weaveType = 'PIL.Image.Image'
+function clientServingObjBody(
+  objBody: string,
+  fileContent: () => Promise<Response>
 ) {
   const fileRequests: unknown[] = [];
   const traceServerApi = new TraceServerApi({
@@ -42,7 +49,7 @@ function clientServingFileContent(
     customFetch: async (input, init) => {
       const url = input.toString();
       if (url.endsWith('/obj/read')) {
-        return new Response(objReadBody(weaveType, files), {
+        return new Response(objBody, {
           headers: {'content-type': 'application/json'},
         });
       }
@@ -58,6 +65,23 @@ function clientServingFileContent(
     projectId: 'this-entity/this-project',
   });
   return {client, fileRequests};
+}
+
+function clientServingFileContent(
+  fileContent: () => Promise<Response>,
+  files: Record<string, string> | null = {'image.png': IMAGE_DIGEST},
+  weaveType = 'PIL.Image.Image'
+) {
+  return clientServingObjBody(objReadBody(weaveType, files), fileContent);
+}
+
+function clientServingDatetime(val: string) {
+  return clientServingObjBody(
+    objReadBody('datetime.datetime', undefined, val),
+    () => {
+      throw new Error('Unexpected file request for a datetime');
+    }
+  );
 }
 
 describe('WeaveClient.get on a published image', () => {
@@ -155,6 +179,34 @@ describe('WeaveClient.get on published audio', () => {
 
     await expect(client.get(AUDIO_REF)).rejects.toThrow(
       `No audio file stored for ref uri: ${AUDIO_REF_URI}`
+    );
+  });
+});
+
+describe('WeaveClient.get on a published datetime', () => {
+  it('returns a Date without downloading a file', async () => {
+    const {client, fileRequests} = clientServingDatetime(
+      '2025-01-01T00:00:00+00:00'
+    );
+
+    expect(await client.get(DATE_REF)).toEqual(new Date(Date.UTC(2025, 0, 1)));
+    expect(fileRequests).toEqual([]);
+  });
+
+  it('keeps the instant a non-UTC offset points at', async () => {
+    const {client} = clientServingDatetime('2026-03-01T10:15:30+05:30');
+
+    expect(await client.get(DATE_REF)).toEqual(
+      new Date(Date.UTC(2026, 2, 1, 4, 45, 30))
+    );
+  });
+
+  // Python keeps microseconds, a Date only holds milliseconds.
+  it('truncates microseconds to milliseconds', async () => {
+    const {client} = clientServingDatetime('2026-08-05T12:34:56.999999+00:00');
+
+    expect(await client.get(DATE_REF)).toEqual(
+      new Date(Date.UTC(2026, 7, 5, 12, 34, 56, 999))
     );
   });
 });

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -1428,6 +1428,8 @@ export class WeaveClient {
           throw new Error(`No audio file stored for ref uri: ${ref.uri()}`);
         }
         return weaveAudio({data: await this.downloadFile(ref, digest)});
+      } else if (typeName == 'datetime.datetime') {
+        return new Date(val.val);
       }
     }
     return val;


### PR DESCRIPTION
## JIRA Issue(s)

- Fixes [WB-38379](https://coreweave.atlassian.net/browse/WB-38379)

## Description

This tiny PR is another step toward TypeScript/Python parity in the SDK — the fourth in a row in `client.get()`, taking the most visible gaps first.

`client.get()` in the TypeScript SDK returns a `datetime` published from Python as a raw internal record instead of a `Date`:

```ts
// today
{_type: 'CustomWeaveType', weave_type: {type: 'datetime.datetime'},
 val: '2025-01-01T00:00:00+00:00', load_op: ...}

// with this change
2025-01-01T00:00:00.000Z
```

The call succeeds, so the failure lands later — the first time someone compares or formats the value.

Weave stores rich types in a record tagged with a type name, and `client.get()` reads that tag to rebuild the object. Images and audio had branches, both downloading a stored file; a date fell through to the default, which returns the record as is. A date is the cheap case — Python writes the ISO string straight into the record's `val` — so the new branch is one line: read `val`, return a `Date`.

A `Date` holds milliseconds and an instant, so `.999999` becomes `.999` and `10:15:30+05:30` becomes `04:45:30Z`. Tests pin both; `AGENTS.md` has the rest.

Separate work, still open: publishing a `Date` from TypeScript, and datetimes inside table rows.

## Testing

Three new tests — a plain UTC date, a `+05:30` offset, and one with microseconds — fail on `master` and pass here. I also ran the round trip against a live server. The helper split lets a datetime record omit the `files` key the way the server does; image and audio tests still get the same bytes.


[WB-38379]: https://coreweave.atlassian.net/browse/WB-38379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
