### PR TITLE
feat(weave): propagate Custom Runtime conversation context

### DIFF
--- a/tests/trace/test_chat_completions.py
+++ b/tests/trace/test_chat_completions.py
@@ -37,6 +37,22 @@ def _chunk_payload(content: str = "Hello") -> dict:
     }
 
 
+def _completion_payload(content: str = "Hello") -> dict:
+    return {
+        "id": "completion-1",
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+            }
+        ],
+        "created": 1,
+        "model": "runtime-model",
+        "object": "chat.completion",
+    }
+
+
 class _TrackingByteStream(httpx.SyncByteStream):
     def __init__(self, content: bytes, close_error: Exception | None = None) -> None:
         self.content = content
@@ -208,3 +224,102 @@ def test_stream_parse_error_closes_resources(monkeypatch) -> None:
     assert stream.response.is_closed
     assert body.closed
     assert clients[0].is_closed
+
+
+def test_playground_completion_reuses_conversation_across_provider_switches(
+    monkeypatch,
+) -> None:
+    request_bodies = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        request_bodies.append(body)
+        conversation_id = body.get("conversation_id", "server-conversation")
+        return httpx.Response(
+            200,
+            json={
+                "response": _completion_payload(),
+                "conversation_id": conversation_id,
+            },
+        )
+
+    _install_mock_transport(monkeypatch, handler)
+    completions = Completions(_client())
+
+    first = completions.create(
+        endpoint="playground",
+        model="custom::runtime-a::model-a",
+        messages=[{"role": "user", "content": "Hello"}],
+        track_llm_call=False,
+    )
+    second = completions.create(
+        endpoint="playground",
+        model="openai/gpt-4o",
+        messages=[{"role": "user", "content": "Continue"}],
+        conversation_id=first.conversation_id,
+        track_llm_call=False,
+    )
+    third = completions.create(
+        endpoint="playground",
+        model="custom::runtime-b::model-b",
+        messages=[{"role": "user", "content": "Finish"}],
+        conversation_id=second.conversation_id,
+        track_llm_call=False,
+    )
+
+    assert second.conversation_id == first.conversation_id
+    assert third.conversation_id == first.conversation_id
+    assert [body["inputs"]["model"] for body in request_bodies] == [
+        "custom::runtime-a::model-a",
+        "openai/gpt-4o",
+        "custom::runtime-b::model-b",
+    ]
+    assert "conversation_id" not in request_bodies[0]
+    assert request_bodies[1]["conversation_id"] == first.conversation_id
+    assert request_bodies[2]["conversation_id"] == first.conversation_id
+
+
+def test_custom_runtime_stream_consumes_server_conversation_context(
+    monkeypatch,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        content = (
+            json.dumps({"_meta": {"conversation_id": "server-conversation"}}).encode()
+            + b"\n"
+            + json.dumps(_chunk_payload()).encode()
+            + b"\n"
+        )
+        return httpx.Response(200, content=content)
+
+    _install_mock_transport(monkeypatch, handler)
+    completions = Completions(_client())
+
+    stream = completions.create(
+        endpoint="playground",
+        model="custom::runtime::model",
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=True,
+        track_llm_call=False,
+    )
+
+    assert [chunk.choices[0].delta.content for chunk in stream] == ["Hello"]
+    assert stream.conversation_id == "server-conversation"
+
+
+def test_inference_completion_has_no_playground_conversation_context(
+    monkeypatch,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_completion_payload())
+
+    _install_mock_transport(monkeypatch, handler)
+    completions = Completions(_client())
+
+    result = completions.create(
+        endpoint="inference",
+        model="coreweave/runtime-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        track_llm_call=False,
+    )
+
+    assert "conversation_id" not in result.model_dump()

--- a/tests/trace_server/test_async_clickhouse_trace_server.py
+++ b/tests/trace_server/test_async_clickhouse_trace_server.py
@@ -24,6 +24,7 @@ from weave.trace_server.datadog import _db_insert_path
 from weave.trace_server.external_to_internal_trace_server_adapter import (
     ExternalTraceServer,
 )
+from weave.trace_server.llm_completion import CustomProviderInfo
 
 LITELLM_ACOMPLETION_PATCH = (
     "weave.trace_server.async_clickhouse_trace_server.lite_llm_acompletion"
@@ -112,6 +113,42 @@ async def test_tracking_routes_through_log_completion_call(
     assert log_mock.call_count == 1
     forwarded_res = log_mock.call_args.args[2]
     assert forwarded_res is llm_res
+
+
+@pytest.mark.asyncio
+async def test_async_custom_runtime_preserves_tracking_and_forwards_context(
+    server: AsyncClickHouseTraceServer,
+) -> None:
+    llm_res = tsi.CompletionsCreateRes(response={"choices": [{"x": 1}]})
+    completion = AsyncMock(return_value=llm_res)
+    req = _make_req(track_llm_call=True, model="custom::runtime::model")
+    with (
+        patch(
+            "weave.trace_server.clickhouse_trace_server_batched.get_custom_provider_info",
+            return_value=CustomProviderInfo(
+                base_url="https://runtime.example.com/v1",
+                api_key="runtime-key",
+                extra_headers={"X-Tenant": "customer"},
+                return_type="openai",
+                actual_model_name="model",
+            ),
+        ),
+        patch(LITELLM_ACOMPLETION_PATCH, new=completion),
+        patch.object(
+            server,
+            "_log_completion_call",
+            return_value=tsi.CompletionsCreateRes(response=llm_res.response),
+        ) as log_completion,
+    ):
+        await server.acompletions_create(req)
+
+    assert req.conversation_id
+    assert req.track_llm_call is True
+    log_completion.assert_called_once()
+    assert completion.await_args.kwargs["extra_headers"] == {
+        "X-Tenant": "customer",
+        "X-Weave-Conversation-Id": req.conversation_id,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -566,10 +566,11 @@ def test_completions_create_stream_custom_provider():
         stream = server.completions_create_stream(req)
         chunks = list(stream)
 
-        assert len(chunks) == 2
-        assert chunks[0]["choices"][0]["delta"]["content"] == "Streamed"
-        assert chunks[1]["choices"][0]["finish_reason"] == "stop"
-        assert "usage" in chunks[1]
+        assert req.conversation_id
+        assert chunks[0] == {"_meta": {"conversation_id": req.conversation_id}}
+        assert chunks[1]["choices"][0]["delta"]["content"] == "Streamed"
+        assert chunks[2]["choices"][0]["finish_reason"] == "stop"
+        assert "usage" in chunks[2]
 
         # Verify litellm was called with correct parameters
         mock_litellm.assert_called_once()
@@ -578,7 +579,10 @@ def test_completions_create_stream_custom_provider():
             call_args.get("api_base")
             or call_args.get("base_url") == "https://api.custom.com"
         )
-        assert call_args["extra_headers"] == {"X-Custom": "value"}
+        assert call_args["extra_headers"] == {
+            "X-Custom": "value",
+            "X-Weave-Conversation-Id": req.conversation_id,
+        }
 
 
 def test_completions_create_stream_custom_provider_with_tracking():
@@ -709,6 +713,8 @@ def test_completions_create_stream_custom_provider_with_tracking():
         assert len(chunks) == 3  # Meta chunk + 2 content chunks
         assert "_meta" in chunks[0]
         assert "weave_call_id" in chunks[0]["_meta"]
+        assert req.track_llm_call is True
+        assert chunks[0]["_meta"]["conversation_id"] == req.conversation_id
         assert chunks[1]["choices"][0]["delta"]["content"] == "Streamed"
         assert chunks[2]["choices"][0]["finish_reason"] == "stop"
         assert "usage" in chunks[2]
@@ -724,7 +730,10 @@ def test_completions_create_stream_custom_provider_with_tracking():
             call_args.get("api_base")
             or call_args.get("base_url") == "https://api.custom.com"
         )
-        assert call_args["extra_headers"] == {"X-Custom": "value"}
+        assert call_args["extra_headers"] == {
+            "X-Custom": "value",
+            "X-Weave-Conversation-Id": req.conversation_id,
+        }
 
 
 def test_completions_create_stream_multiple_choices():

--- a/tests/trace_server/test_custom_provider.py
+++ b/tests/trace_server/test_custom_provider.py
@@ -363,10 +363,11 @@ def test_custom_provider_completions_create(client):
                 f"API base URL mismatch. Expected 'https://api.example.com', "
                 f"got '{call_args['api_base']}'"
             )
-            assert call_args["extra_headers"] == {"X-Custom-Header": "value"}, (
-                f"Extra headers mismatch. Expected {{'X-Custom-Header': 'value'}}, "
-                f"got {call_args['extra_headers']}"
-            )
+            assert res.conversation_id
+            assert call_args["extra_headers"] == {
+                "X-Custom-Header": "value",
+                "X-Weave-Conversation-Id": res.conversation_id,
+            }
 
             # Completions now write to the spans table, not calls.
             # Verify the span was created with correct identifiers.

--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -672,9 +672,10 @@ class TestLLMCompletionStreaming(unittest.TestCase):
             chunks = list(stream)
 
             # Verify the chunks
-            assert len(chunks) == 2
-            assert chunks[0]["choices"][0]["delta"]["content"] == "Custom"
-            assert chunks[1]["choices"][0]["finish_reason"] == "stop"
+            assert req.conversation_id
+            assert chunks[0] == {"_meta": {"conversation_id": req.conversation_id}}
+            assert chunks[1]["choices"][0]["delta"]["content"] == "Custom"
+            assert chunks[2]["choices"][0]["finish_reason"] == "stop"
 
             # Verify litellm was called with correct parameters
             mock_litellm.assert_called_once()
@@ -682,7 +683,10 @@ class TestLLMCompletionStreaming(unittest.TestCase):
             assert (
                 call_args.get("api_base") or call_args.get("base_url")
             ) == "https://api.custom.com"
-            assert call_args["extra_headers"] == {"X-Custom": "value"}
+            assert call_args["extra_headers"] == {
+                "X-Custom": "value",
+                "X-Weave-Conversation-Id": req.conversation_id,
+            }
 
     def test_missing_api_key(self):
         """Test handling of missing API key in streaming completion."""
@@ -2279,6 +2283,64 @@ def test_custom_provider_name_matching_selector_prefix_is_preserved(monkeypatch)
         obj_read_func=obj_read,
     )
     assert model_info.model_name == "custom/gpt-4"
+
+
+def test_custom_runtime_context_overrides_configured_header(monkeypatch):
+    req = tsi.CompletionsCreateReq(
+        project_id="entity/project",
+        inputs=_completion_inputs(model="custom::runtime::model"),
+        track_llm_call=False,
+        conversation_id="conv-1",
+    )
+    monkeypatch.setattr(
+        chts,
+        "get_custom_provider_info",
+        MagicMock(
+            return_value=llm_mod.CustomProviderInfo(
+                base_url="https://runtime.example.com/v1",
+                api_key=None,
+                extra_headers={
+                    "X-Tenant": "customer",
+                    "x-weave-conversation-id": "configured-value",
+                },
+                return_type="openai",
+                actual_model_name="model",
+            )
+        ),
+    )
+
+    info = chts._setup_completion_model_info(None, req, MagicMock())
+
+    assert req.track_llm_call is False
+    assert info.extra_headers == {
+        "X-Tenant": "customer",
+        "X-Weave-Conversation-Id": "conv-1",
+    }
+
+
+def test_custom_runtime_context_is_header_safe(monkeypatch):
+    req = tsi.CompletionsCreateReq(
+        project_id="entity/project",
+        inputs=_completion_inputs(model="custom::runtime::model"),
+        conversation_id="support/café\n",
+    )
+    monkeypatch.setattr(
+        chts,
+        "get_custom_provider_info",
+        MagicMock(
+            return_value=llm_mod.CustomProviderInfo(
+                base_url="https://runtime.example.com/v1",
+                api_key=None,
+                extra_headers={},
+                return_type="openai",
+                actual_model_name="model",
+            )
+        ),
+    )
+
+    info = chts._setup_completion_model_info(None, req, MagicMock())
+
+    assert info.extra_headers == {"X-Weave-Conversation-Id": "support%2Fcaf%C3%A9%0A"}
 
 
 def test_coreweave_with_api_key_keeps_litellm_configuration():

--- a/weave/chat/completions.py
+++ b/weave/chat/completions.py
@@ -29,8 +29,14 @@ if TYPE_CHECKING:
 Endpoint = Literal["playground", "inference"]
 
 
+class _PlaygroundChatCompletion(ChatCompletion):
+    """OpenAI-compatible completion with W&B Playground conversation context."""
+
+    conversation_id: str
+
+
 # TODO: We remove these to align with OpenAI's API, but maybe they would be useful to keep?
-IGNORE_ARGS = ("self", "endpoint", "track_llm_call")
+IGNORE_ARGS = ("self", "endpoint", "track_llm_call", "conversation_id")
 
 
 def postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
@@ -50,6 +56,7 @@ class Completions:
         *,
         endpoint: Endpoint = "playground",
         track_llm_call: bool = True,
+        conversation_id: str | NotGiven | None = NOT_GIVEN,
         messages: Iterable,
         model: str,
         frequency_penalty: float | NotGiven | None = NOT_GIVEN,
@@ -99,6 +106,8 @@ class Completions:
 
           track_llm_call: Whether to track the LLM call.
 
+          conversation_id: Conversation context to reuse for a Playground request.
+
           messages: A list of messages comprising the conversation so far.
 
           model: ID of the model to use.
@@ -147,6 +156,7 @@ class Completions:
         """
         kwargs = {
             "endpoint": endpoint,
+            "conversation_id": conversation_id,
             "messages": messages,
             "model": model,
             "frequency_penalty": frequency_penalty,
@@ -178,6 +188,10 @@ class Completions:
 
         messages = kwargs["messages"]
         model = kwargs["model"]
+        conversation_id = kwargs.get("conversation_id", NOT_GIVEN)
+        initial_conversation_id = (
+            conversation_id if isinstance(conversation_id, str) else None
+        )
         frequency_penalty = kwargs.get("frequency_penalty", NOT_GIVEN)
         max_tokens = kwargs.get("max_tokens", NOT_GIVEN)
         n = kwargs.get("n", NOT_GIVEN)
@@ -225,6 +239,8 @@ class Completions:
                 "project_id": project_id,
                 "track_llm_call": False,
             }
+            if initial_conversation_id is not None:
+                data["conversation_id"] = initial_conversation_id
         elif endpoint == "inference":
             url = f"https://{INFERENCE_HOST}/v1/chat/completions"
             headers["Authorization"] = f"Bearer {api_key}"
@@ -264,7 +280,11 @@ class Completions:
                 check_response(response)
 
                 # Transfer ownership so the returned stream controls cleanup.
-                return ChatCompletionChunkStream(response, stack.pop_all())
+                return ChatCompletionChunkStream(
+                    response,
+                    exit_stack=stack.pop_all(),
+                    initial_conversation_id=initial_conversation_id,
+                )
         else:
             with httpx.Client(timeout=timeout) as client:
                 response = client.post(
@@ -278,8 +298,13 @@ class Completions:
         # Non-streaming case
         d = response.json()
         if endpoint == "playground":
+            conversation_id = d.get("conversation_id") or initial_conversation_id
             d = d["response"]
         try:
+            if endpoint == "playground" and conversation_id:
+                return _PlaygroundChatCompletion.model_validate(
+                    {**d, "conversation_id": conversation_id}
+                )
             return ChatCompletion.model_validate(d)
         except ValidationError:
             print(d)

--- a/weave/chat/stream.py
+++ b/weave/chat/stream.py
@@ -12,11 +12,13 @@ class ChatCompletionChunkStream:
     """A stream wrapper for ChatCompletionChunk objects from an httpx response.
 
     This class takes an httpx response object and yields ChatCompletionChunk
-    objects by parsing the server-sent events stream.
+    objects by parsing the server-sent events stream. W&B ``_meta`` records are
+    consumed internally and are not yielded as completion chunks.
 
     Args:
         response: The httpx.Response object from a streaming API call.
         exit_stack: Optional owned contexts for the response and its client.
+        initial_conversation_id: Optional caller-supplied conversation context.
 
     Yields:
         ChatCompletionChunk: Parsed chat completion chunks from the stream.
@@ -33,10 +35,14 @@ class ChatCompletionChunkStream:
     """
 
     def __init__(
-        self, response: httpx.Response, exit_stack: ExitStack | None = None
+        self,
+        response: httpx.Response,
+        exit_stack: ExitStack | None = None,
+        initial_conversation_id: str | None = None,
     ) -> None:
         self.response = response
         self._exit_stack = exit_stack
+        self.conversation_id = initial_conversation_id
 
     def close(self) -> None:
         if self._exit_stack is None:
@@ -61,7 +67,16 @@ class ChatCompletionChunkStream:
                     if line == "[DONE]":
                         continue
                     try:
-                        yield ChatCompletionChunk.model_validate_json(line)
+                        data = json.loads(line)
                     except json.JSONDecodeError:
-                        print(f"Error parsing line as JSON: {line}")
-                        raise
+                        # Preserve the existing Pydantic validation error for
+                        # malformed completion chunks.
+                        yield ChatCompletionChunk.model_validate_json(line)
+                        continue
+                    metadata = data.get("_meta") if isinstance(data, dict) else None
+                    if isinstance(metadata, dict):
+                        conversation_id = metadata.get("conversation_id")
+                        if isinstance(conversation_id, str):
+                            self.conversation_id = conversation_id
+                        continue
+                    yield ChatCompletionChunk.model_validate(data)

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -110,7 +110,12 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         end_time = datetime.datetime.now()
 
         if not req.track_llm_call:
-            return tsi.CompletionsCreateRes(response=res.response)
+            return tsi.CompletionsCreateRes(
+                response=res.response,
+                conversation_id=(
+                    req.conversation_id if info.is_custom_runtime else None
+                ),
+            )
         return _CompletionCall(prep, res, start_time, end_time)
 
     async def _run_on_ch_executor(self, fn: Callable[..., _T], *args: object) -> _T:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -12,6 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from functools import partial
 from typing import Any, NamedTuple, TypeVar, cast
+from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
 import clickhouse_connect
@@ -175,7 +176,10 @@ from weave.trace_server.common_interface import AnnotationQueueItemsFilter
 from weave.trace_server.constants import (
     IMAGE_GENERATION_CREATE_OP_NAME,
 )
-from weave.trace_server.custom_runtime import apply_custom_runtime
+from weave.trace_server.custom_runtime import (
+    apply_custom_runtime,
+    is_custom_runtime_model,
+)
 from weave.trace_server.datadog import (
     record_db_insert,
     set_current_span_dd_tags,
@@ -373,6 +377,8 @@ CALLS_STREAM_GROWTH_FACTOR = 10
 
 # Retry attempts when reading back a newly-created object (eventual consistency)
 OBJ_READ_RETRY_ATTEMPTS = 3
+
+CUSTOM_RUNTIME_CONVERSATION_ID_HEADER = "X-Weave-Conversation-Id"
 
 # Create a shared connection pool manager for all ClickHouse connections
 _CH_POOL_MANAGER = get_pool_manager(
@@ -6917,6 +6923,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     response={"error": f"Failed to resolve prompt: {e!s}"}
                 )
 
+        _ensure_custom_runtime_conversation_id(req)
+
         # Use shared setup logic
         model_info = self._model_to_provider_info_map.get(req.inputs.model)
         try:
@@ -6988,7 +6996,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     ) -> tsi.CompletionsCreateRes:
         """Post-LLM-call CH insert. Called via `run_in_executor` from the async path."""
         if not req.track_llm_call:
-            return tsi.CompletionsCreateRes(response=res.response)
+            return tsi.CompletionsCreateRes(
+                response=res.response,
+                conversation_id=(
+                    req.conversation_id
+                    if prep.completion_model_info.is_custom_runtime
+                    else None
+                ),
+            )
 
         built = self._build_completion_call_span(req, prep, res, start_time, end_time)
         AgentWriteHandler(self.ch_client, self._async_insert_settings()).insert_span(
@@ -7033,6 +7048,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 yield {"error": f"Failed to resolve and apply prompt: {err!s}"}
 
             return _single_error_iter(e)
+
+        _ensure_custom_runtime_conversation_id(req)
 
         # --- Shared setup logic (copy of completions_create up to litellm call)
         model_info = self._model_to_provider_info_map.get(req.inputs.model)
@@ -7106,6 +7123,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
         if not req.track_llm_call or span_id is None:
+            if completion_model_info.is_custom_runtime and req.conversation_id:
+                return _prepend_completion_conversation_context(
+                    chunk_iter, req.conversation_id
+                )
             return chunk_iter
 
         assert retention_days is not None
@@ -8261,6 +8282,14 @@ def _create_tracked_span_stream_wrapper(
     return _stream_wrapper()
 
 
+def _prepend_completion_conversation_context(
+    chunk_iter: Iterator[dict[str, Any]], conversation_id: str
+) -> Iterator[dict[str, Any]]:
+    """Prepend server-owned conversation context to an untracked stream."""
+    yield {"_meta": {"conversation_id": conversation_id}}
+    yield from chunk_iter
+
+
 @dataclasses.dataclass(frozen=True)
 class CompletionModelInfo:
     model_name: str
@@ -8270,6 +8299,7 @@ class CompletionModelInfo:
     extra_headers: dict[str, str]
     return_type: str | None
     vertex_credentials: str | None = None
+    is_custom_runtime: bool = False
 
 
 class CompletionPrepResult(NamedTuple):
@@ -8290,6 +8320,28 @@ class BuiltCompletionSpan(NamedTuple):
 
     span: AgentSpanCHInsertable
     result: tsi.CompletionsCreateRes
+
+
+def _ensure_custom_runtime_conversation_id(
+    req: tsi.CompletionsCreateReq,
+) -> str | None:
+    if not req.conversation_id and is_custom_runtime_model(req.inputs.model):
+        req.conversation_id = generate_id()
+    return req.conversation_id or None
+
+
+def _custom_runtime_headers(
+    configured_headers: dict[str, str], conversation_id: str | None
+) -> dict[str, str]:
+    context_header = CUSTOM_RUNTIME_CONVERSATION_ID_HEADER.lower()
+    headers = {
+        key: value
+        for key, value in configured_headers.items()
+        if key.lower() != context_header
+    }
+    if conversation_id:
+        headers[CUSTOM_RUNTIME_CONVERSATION_ID_HEADER] = quote(conversation_id, safe="")
+    return headers
 
 
 def _setup_completion_model_info(
@@ -8314,7 +8366,7 @@ def _setup_completion_model_info(
     vertex_credentials: str | None = getattr(req.inputs, "vertex_credentials", None)
 
     # Check for explicit custom provider prefix
-    is_explicit_custom = model_name.startswith("custom::")
+    is_explicit_custom = is_custom_runtime_model(model_name)
 
     is_coreweave = (
         model_info and model_info.get("litellm_provider") == "coreweave"
@@ -8395,9 +8447,12 @@ def _setup_completion_model_info(
             api_key=custom_provider_info.api_key,
             provider="custom",
             base_url=base_url,
-            extra_headers=custom_provider_info.extra_headers,
+            extra_headers=_custom_runtime_headers(
+                custom_provider_info.extra_headers, req.conversation_id
+            ),
             return_type=custom_provider_info.return_type,
             vertex_credentials=None,
+            is_custom_runtime=True,
         )
     elif model_info:
         secret_name = model_info.get("api_key_name")

--- a/weave/trace_server/custom_runtime.py
+++ b/weave/trace_server/custom_runtime.py
@@ -9,6 +9,11 @@ from weave.trace_server.interface.builtin_object_classes.provider import (
 )
 
 
+def is_custom_runtime_model(model: str) -> bool:
+    """Return whether a model selector targets a Custom Runtime."""
+    return model.startswith("custom::")
+
+
 def apply_custom_runtime(
     req: tsi.CustomRuntimeApplyReq,
     obj_create: Callable[[tsi.ObjCreateReq], tsi.ObjCreateRes],

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -71,6 +71,8 @@ from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER, SENTINEL_EPOC
 # module; import it rather than fork it.
 from weave.trace_server.clickhouse_trace_server_batched import (
     CompletionPrepResult,
+    _ensure_custom_runtime_conversation_id,
+    _prepend_completion_conversation_context,
     _setup_completion_model_info,
 )
 from weave.trace_server.clickhouse_trace_server_settings import (
@@ -4294,6 +4296,8 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                     response={"error": f"Failed to resolve prompt: {e!s}"}
                 )
 
+        _ensure_custom_runtime_conversation_id(req)
+
         model_info = _model_to_provider_info_map().get(req.inputs.model)
         try:
             completion_model_info = _setup_completion_model_info(
@@ -4363,7 +4367,12 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
         end_time = datetime.datetime.now()
 
         if not req.track_llm_call:
-            return tsi.CompletionsCreateRes(response=res.response)
+            return tsi.CompletionsCreateRes(
+                response=res.response,
+                conversation_id=(
+                    req.conversation_id if info.is_custom_runtime else None
+                ),
+            )
 
         req.inputs.messages = prep.initial_messages
         span_id = generate_id()
@@ -4438,6 +4447,10 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
         )
 
         if not req.track_llm_call:
+            if info.is_custom_runtime and req.conversation_id:
+                return _prepend_completion_conversation_context(
+                    chunk_iter, req.conversation_id
+                )
             return chunk_iter
 
         req.inputs.messages = prep.initial_messages


### PR DESCRIPTION
## Description

Supersedes #7688 with the first, independently mergeable slice: conversation context propagation only.

Custom Runtimes can emit their own internal spans, but previously they did not receive the conversation ID used by the Playground request. Those spans therefore could not reliably join the same chronological conversation.

This PR:

- generates or reuses a conversation ID before an explicit Custom Runtime request is dispatched
- injects it into the reserved `X-Weave-Conversation-Id` runtime header, overriding any configured header with that name
- returns the ID in non-streaming responses and through the existing streaming `_meta` channel
- exposes the returned ID on the Python Playground completion/stream so it can be reused on later turns, including after switching providers or runtimes
- covers the synchronous, asynchronous, ClickHouse, and in-memory completion paths

This deliberately preserves existing tracing behavior. Both `track_llm_call=true` and `track_llm_call=false` continue to mean what they mean today; this PR does not choose a new Custom Runtime logging default or add UI policy.

## Testing

- `146 passed` across:
  - `tests/trace/test_chat_completions.py`
  - `tests/trace_server/test_llm_completion.py`
  - `tests/trace_server/test_clickhouse_trace_server_batched.py`
  - `tests/trace_server/test_async_clickhouse_trace_server.py`
  - `tests/trace_server/test_custom_provider.py`
- Ruff format/check on all changed files
- `ty check`

The focused coverage includes generated and reused IDs, streaming and non-streaming responses, configured-header override, header-safe encoding, tracked and untracked requests, and provider switching.
