### PR TITLE
fix(weave): prevent Claude async turn misattribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -484,6 +484,12 @@ pnpm exec tsx examples/claudeAgents.ts
 - Keep its output adapters split by SDK contract: string `query()` and each
   `ClaudeSDKClient.receive_response()` use the linear single-turn tracer, while
   only standalone `query(AsyncIterable)` uses multi-result queue/lookahead logic.
+- Standalone async-iterable queries can emit bootstrap `system/init` before the
+  first prompt is consumed. Defer only that init for trace attribution; forward
+  other output received without a pending query-triggering input without
+  attaching it to the next turn, especially late background-task notifications.
+  Correctly completing background subagents across results requires separate
+  conversation-scoped task ownership.
 - Name the corresponding test cases "string prompt" and "async-iterable
   prompt" rather than sync/async: both SDK entry points are asynchronous. Keep
   one-input success and pre/post-result failure assertions paired across them.

--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
@@ -1085,6 +1085,46 @@ async def test_async_iterable_query_multi_turn_otel(
 
 
 @pytest.mark.asyncio
+async def test_delayed_async_iterable_prompt_after_system_message_otel(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    release_prompt = asyncio.Event()
+
+    async def delayed_prompt() -> AsyncIterator[dict[str, Any]]:
+        await release_prompt.wait()
+        yield user_prompt("Hello")
+
+    transport = ReplayTransport(
+        load_cassette("simple_text_response"),
+        wait_for_user_after_first_message=True,
+    )
+    message_iterator = aiter(
+        query(
+            prompt=delayed_prompt(),
+            options=ClaudeAgentOptions(),
+            transport=transport,
+        )
+    )
+
+    first_message = await anext(message_iterator)
+    assert type(first_message).__name__ == "SystemMessage"
+    release_prompt.set()
+    messages = [first_message, *[message async for message in message_iterator]]
+
+    assert [type(message).__name__ for message in messages] == [
+        "SystemMessage",
+        "AssistantMessage",
+        "ResultMessage",
+    ]
+    agent_spans = get_spans_by_op(otel_spans.get_finished_spans(), "invoke_agent")
+    assert len(agent_spans) == 1
+    assert get_messages(agent_spans[0], "gen_ai.input.messages") == [
+        {"role": "user", "parts": [{"type": "text", "content": "Hello"}]}
+    ]
+    assert get_attrs(agent_spans[0])["gen_ai.conversation.id"] == "s-abc123"
+
+
+@pytest.mark.asyncio
 async def test_async_iterable_query_buffers_non_query_inputs_otel(
     otel_spans: InMemorySpanExporter,
 ) -> None:

--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
@@ -1096,7 +1096,7 @@ async def test_delayed_async_iterable_prompt_after_system_message_otel(
 
     transport = ReplayTransport(
         load_cassette("simple_text_response"),
-        wait_for_user_after_first_message=True,
+        wait_for_user_messages_after={0: 1},
     )
     message_iterator = aiter(
         query(
@@ -1122,6 +1122,111 @@ async def test_delayed_async_iterable_prompt_after_system_message_otel(
         {"role": "user", "parts": [{"type": "text", "content": "Hello"}]}
     ]
     assert get_attrs(agent_spans[0])["gen_ai.conversation.id"] == "s-abc123"
+
+
+@pytest.mark.asyncio
+async def test_delayed_async_iterable_prompt_failure_after_system_message_otel(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    release_prompt = asyncio.Event()
+
+    async def delayed_prompt() -> AsyncIterator[dict[str, Any]]:
+        await release_prompt.wait()
+        yield user_prompt("Hello")
+
+    transport = ReplayTransport(
+        load_cassette("simple_text_response"),
+        fail_after_messages=1,
+        wait_for_user_messages_after={0: 1},
+    )
+    message_iterator = aiter(
+        query(
+            prompt=delayed_prompt(),
+            options=ClaudeAgentOptions(),
+            transport=transport,
+        )
+    )
+
+    first_message = await anext(message_iterator)
+    assert type(first_message).__name__ == "SystemMessage"
+    release_prompt.set()
+    with pytest.raises(Exception, match="replay transport failed"):
+        await anext(message_iterator)
+
+    agent_spans = get_spans_by_op(otel_spans.get_finished_spans(), "invoke_agent")
+    assert len(agent_spans) == 1
+    assert agent_spans[0].status.status_code == StatusCode.ERROR
+    assert get_messages(agent_spans[0], "gen_ai.input.messages") == [
+        {"role": "user", "parts": [{"type": "text", "content": "Hello"}]}
+    ]
+    assert get_attrs(agent_spans[0])["gen_ai.conversation.id"] == "s-abc123"
+
+
+@pytest.mark.asyncio
+async def test_async_iterable_query_does_not_trace_stale_task_output_in_next_turn(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    release_second_prompt = asyncio.Event()
+
+    async def delayed_second_prompt() -> AsyncIterator[dict[str, Any]]:
+        yield user_prompt("Hello")
+        await release_second_prompt.wait()
+        yield user_prompt("What is the capital of France?")
+
+    messages = load_cassette("multi_turn_response")
+    stale_task_messages = load_cassette("background_subagent_response")[8:10]
+    stale_task_messages[0]["session_id"] = "s-mt001"
+    messages[3:3] = stale_task_messages
+    transport = ReplayTransport(
+        messages,
+        wait_for_user_messages_after={4: 2},
+    )
+    message_iterator = aiter(
+        query(
+            prompt=delayed_second_prompt(),
+            options=ClaudeAgentOptions(),
+            transport=transport,
+        )
+    )
+
+    messages_before_second_prompt = [await anext(message_iterator) for _ in range(5)]
+    assert [type(message).__name__ for message in messages_before_second_prompt] == [
+        "SystemMessage",
+        "AssistantMessage",
+        "ResultMessage",
+        "TaskNotificationMessage",
+        "AssistantMessage",
+    ]
+    release_second_prompt.set()
+    remaining_messages = [message async for message in message_iterator]
+    assert [type(message).__name__ for message in remaining_messages] == [
+        "AssistantMessage",
+        "ResultMessage",
+    ]
+
+    spans = otel_spans.get_finished_spans()
+    agent_spans = sorted(
+        get_spans_by_op(spans, "invoke_agent"),
+        key=lambda span: span.start_time,
+    )
+    assert [
+        get_all_text(get_messages(agent_span, "gen_ai.input.messages"))
+        for agent_span in agent_spans
+    ] == [
+        "Hello",
+        "What is the capital of France?",
+    ]
+    chat_spans = sorted(
+        get_spans_by_op(spans, "chat"),
+        key=lambda span: span.start_time,
+    )
+    assert [
+        get_all_text(get_messages(chat_span, "gen_ai.output.messages"))
+        for chat_span in chat_spans
+    ] == [
+        "Hello! How can I help you?",
+        "The capital of France is Paris.",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/claude_agent_sdk/conftest.py
+++ b/tests/integrations/claude_agent_sdk/conftest.py
@@ -31,11 +31,11 @@ class ReplayTransport(Transport):
         messages: list[dict[str, Any]],
         *,
         fail_after_messages: int | None = None,
-        wait_for_user_after_first_message: bool = False,
+        wait_for_user_messages_after: dict[int, int] | None = None,
     ) -> None:
         self._messages = messages
         self._fail_after_messages = fail_after_messages
-        self._wait_for_user_after_first_message = wait_for_user_after_first_message
+        self._wait_for_user_messages_after = wait_for_user_messages_after or {}
         self._connected = False
         self._pending_control_ids: list[str] = []
         self._control_event = anyio.Event()
@@ -80,8 +80,13 @@ class ReplayTransport(Transport):
             if self._fail_after_messages == index:
                 raise RuntimeError("replay transport failed")
             yield msg
-            if index == 0 and self._wait_for_user_after_first_message:
+            required_user_messages = self._wait_for_user_messages_after.get(index)
+            while (
+                required_user_messages is not None
+                and len(self.user_messages) < required_user_messages
+            ):
                 await self._user_message_event.wait()
+                self._user_message_event = anyio.Event()
         if self._fail_after_messages == len(self._messages):
             raise RuntimeError("replay transport failed")
 

--- a/tests/integrations/claude_agent_sdk/conftest.py
+++ b/tests/integrations/claude_agent_sdk/conftest.py
@@ -31,12 +31,15 @@ class ReplayTransport(Transport):
         messages: list[dict[str, Any]],
         *,
         fail_after_messages: int | None = None,
+        wait_for_user_after_first_message: bool = False,
     ) -> None:
         self._messages = messages
         self._fail_after_messages = fail_after_messages
+        self._wait_for_user_after_first_message = wait_for_user_after_first_message
         self._connected = False
         self._pending_control_ids: list[str] = []
         self._control_event = anyio.Event()
+        self._user_message_event = anyio.Event()
         self.user_messages: list[dict[str, Any]] = []
 
     async def connect(self) -> None:
@@ -46,6 +49,7 @@ class ReplayTransport(Transport):
         parsed = json.loads(data.strip())
         if parsed.get("type") == "user":
             self.user_messages.append(parsed)
+            self._user_message_event.set()
         if parsed.get("type") == "control_request":
             self._pending_control_ids.append(parsed["request_id"])
             self._control_event.set()
@@ -76,6 +80,8 @@ class ReplayTransport(Transport):
             if self._fail_after_messages == index:
                 raise RuntimeError("replay transport failed")
             yield msg
+            if index == 0 and self._wait_for_user_after_first_message:
+                await self._user_message_event.wait()
         if self._fail_after_messages == len(self._messages):
             raise RuntimeError("replay transport failed")
 

--- a/weave/integrations/claude_agent_sdk/otel_integration.py
+++ b/weave/integrations/claude_agent_sdk/otel_integration.py
@@ -737,6 +737,7 @@ async def _trace_async_iterable_query(
         attributes=_INTEGRATION_OTEL_ATTRS,
     ) as conversation:
         message_iterator = aiter(messages)
+        deferred_messages: list[Any] = []
         while True:
             try:
                 next_message = await anext(message_iterator)
@@ -747,12 +748,28 @@ async def _trace_async_iterable_query(
                     raise
                 turn = _start_tracked_turn(conversation, inputs.take())
                 with turn:
-                    raise
+                    state = _TurnState(conversation=conversation, turn=turn)
+                    try:
+                        for msg in deferred_messages:
+                            _process_message_for_turn(msg, state)
+                        raise
+                    finally:
+                        _finalize_turn(state)
+
+            # Input tracking happens before the SDK writes each prompt, but
+            # bootstrap output can arrive before the first prompt is consumed.
+            if not inputs.has_pending_turn():
+                deferred_messages.append(next_message)
+                yield next_message
+                continue
 
             turn = _start_tracked_turn(conversation, inputs.take())
             with turn:
                 state = _TurnState(conversation=conversation, turn=turn)
                 try:
+                    for msg in deferred_messages:
+                        _process_message_for_turn(msg, state)
+                    deferred_messages.clear()
                     while True:
                         msg = next_message
                         _process_message_for_turn(msg, state)

--- a/weave/integrations/claude_agent_sdk/otel_integration.py
+++ b/weave/integrations/claude_agent_sdk/otel_integration.py
@@ -737,7 +737,7 @@ async def _trace_async_iterable_query(
         attributes=_INTEGRATION_OTEL_ATTRS,
     ) as conversation:
         message_iterator = aiter(messages)
-        deferred_messages: list[Any] = []
+        deferred_init_messages: list[Any] = []
         while True:
             try:
                 next_message = await anext(message_iterator)
@@ -750,16 +750,20 @@ async def _trace_async_iterable_query(
                 with turn:
                     state = _TurnState(conversation=conversation, turn=turn)
                     try:
-                        for msg in deferred_messages:
+                        for msg in deferred_init_messages:
                             _process_message_for_turn(msg, state)
                         raise
                     finally:
                         _finalize_turn(state)
 
-            # Input tracking happens before the SDK writes each prompt, but
-            # bootstrap output can arrive before the first prompt is consumed.
+            # Input tracking happens before the SDK writes each prompt, but the
+            # bootstrap init can arrive before the first prompt is consumed.
             if not inputs.has_pending_turn():
-                deferred_messages.append(next_message)
+                if (
+                    isinstance(next_message, SystemMessage)
+                    and next_message.subtype == "init"
+                ):
+                    deferred_init_messages.append(next_message)
                 yield next_message
                 continue
 
@@ -767,9 +771,9 @@ async def _trace_async_iterable_query(
             with turn:
                 state = _TurnState(conversation=conversation, turn=turn)
                 try:
-                    for msg in deferred_messages:
+                    for msg in deferred_init_messages:
                         _process_message_for_turn(msg, state)
-                    deferred_messages.clear()
+                    deferred_init_messages.clear()
                     while True:
                         msg = next_message
                         _process_message_for_turn(msg, state)


### PR DESCRIPTION
## Summary

- Prevent promptless turns when `system/init` precedes a delayed async prompt.
- Defer only bootstrap init messages, keeping late background-task output out of the next turn.
- Add regressions for delayed init, transport failure, and stale task output.

Follow-up to #7665 and its [review thread](https://github.com/wandb/weave/pull/7665#discussion_r3716355213).

## Validation

- Claude Agent SDK shard: 44 passed
- Ruff check and format: passed

| Scenario | `master` | This PR |
| --- | --- | --- |
| Delayed prompt | [Mispaired turns](https://wandb.ai/wandb/materials-weave-demo/weave/agents/conversations/pr7697-delayed-master-1786045230124629001?convTurn=1&chatTrace=ee23b0f2c4df932a58cede8056eca256) | [Correctly paired turns](https://wandb.ai/wandb/materials-weave-demo/weave/agents/conversations/pr7697-delayed-dev-1786045230124629001?convTurn=1&chatTrace=dbf0c0d0350d15108322420f113a309f) |
| Late task output | [Attributed to next turn](https://wandb.ai/wandb/materials-weave-demo/weave/agents/conversations/pr7697-stale-task-master-1786045230124629001?convTurn=2&chatTrace=42dd68d44240f621a8bc740400c5fb18) | [Excluded from next turn](https://wandb.ai/wandb/materials-weave-demo/weave/agents/conversations/pr7697-stale-task-dev-1786045230124629001?convTurn=2&chatTrace=4e4838296869e5306c7d7d127418bbf1) |

## Breaking changes

None.
