### PR TITLE
fix(weave_ts): harden Claude subagent result routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,6 +377,13 @@ deterministic.
   `async_launched` or `remote_launched` tool result before forwarded child
   messages, then finish via a `task_notification`. Keep one `SubAgent` keyed by
   tool-use ID across turn boundaries until that notification arrives.
+- Route a forwarded assistant message to an already-open `SubAgent` before
+  creating a `Turn`; background messages can arrive after the root result and
+  must not create an empty root turn or consume the next pending input.
+- For synchronous `Agent`/`Task` completion, read terminal output from the
+  structured `SDKUserMessage.tool_use_result.content`; use the model-facing
+  `tool_result` block content only as a compatibility fallback. Background
+  completion output continues to come from `task_notification.summary`.
 - Read a subagent's lifetime from the launch request (`run_in_background`, or
   `isolation: 'remote'`, which is always backgrounded) rather than inferring it
   from the result status — an unrecognized status must not downgrade it.

--- a/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
+++ b/sdks/node/src/__tests__/integrations/claude-agent-sdk/otelTracer.test.ts
@@ -8,6 +8,7 @@ import type {
   SDKTaskNotificationMessage,
   SDKUserMessage,
 } from '@anthropic-ai/claude-agent-sdk';
+import type {AgentOutput} from '@anthropic-ai/claude-agent-sdk/sdk-tools';
 
 import {
   ATTR_ERROR_TYPE,
@@ -162,6 +163,35 @@ function userToolResult(opts: {
     task_description: opts.taskDescription,
     tool_use_result: opts.toolUseResult,
     message: {role: 'user', content: [block]},
+  };
+}
+
+type CompletedAgentOutput = Extract<AgentOutput, {status: 'completed'}>;
+
+function completedAgentOutput(opts: {
+  agentId: string;
+  content: string[];
+  prompt: string;
+  resolvedModel?: string;
+}): CompletedAgentOutput {
+  return {
+    status: 'completed',
+    agentId: opts.agentId,
+    content: opts.content.map(text => ({type: 'text', text})),
+    ...(opts.resolvedModel ? {resolvedModel: opts.resolvedModel} : {}),
+    totalToolUseCount: 0,
+    totalDurationMs: 0,
+    totalTokens: 0,
+    usage: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      server_tool_use: null,
+      service_tier: null,
+      cache_creation: null,
+    },
+    prompt: opts.prompt,
   };
 }
 
@@ -957,6 +987,122 @@ describe('Claude Agent SDK — OTel tracer', () => {
     ]);
   });
 
+  test('routes a late background message without creating another root turn', () => {
+    const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate'});
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-late-background',
+        model: 'claude-main',
+        content: [
+          toolUseBlock('agent-late', 'Agent', {
+            prompt: 'Finish in the background',
+            run_in_background: true,
+            subagent_type: 'late-worker',
+          }),
+        ],
+      })
+    );
+    tracer.processMessage(
+      userToolResult({
+        sessionId: 'sess-late-background',
+        toolUseId: 'agent-late',
+        content: 'Async agent launched successfully',
+        toolUseResult: {
+          status: 'async_launched',
+          agentId: 'task-late',
+        },
+      })
+    );
+    tracer.processMessage(
+      resultSuccess({sessionId: 'sess-late-background', result: 'launched'})
+    );
+
+    tracer.processMessage(
+      assistantMessage({
+        sessionId: 'sess-late-background',
+        parentToolUseId: 'agent-late',
+        subagentType: 'late-worker',
+        model: 'claude-worker',
+        content: [textBlock('late child output')],
+      })
+    );
+    tracer.processMessage(
+      taskNotification({
+        sessionId: 'sess-late-background',
+        taskId: 'task-late',
+        toolUseId: 'agent-late',
+        status: 'completed',
+        summary: 'Background work finished',
+      })
+    );
+    tracer.finalize();
+
+    const spans = getExporter().getFinishedSpans();
+    const root = spans.find(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'claude_agent_sdk'
+    )!;
+    const subagent = spans.find(
+      span =>
+        span.name === INVOKE &&
+        span.attributes[ATTR_GEN_AI_AGENT_NAME] === 'late-worker'
+    )!;
+    expect(
+      spans
+        .filter(span => span.name === INVOKE)
+        .map(span => ({
+          agentName: span.attributes[ATTR_GEN_AI_AGENT_NAME],
+          inputMessages: JSON.parse(
+            span.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string
+          ),
+          outputMessages: JSON.parse(
+            span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string
+          ),
+          parentSpanId: span.parentSpanId,
+        }))
+    ).toEqual([
+      {
+        agentName: 'claude_agent_sdk',
+        inputMessages: [{role: 'user', content: 'delegate'}],
+        outputMessages: [{role: 'assistant', content: 'launched'}],
+        parentSpanId: undefined,
+      },
+      {
+        agentName: 'late-worker',
+        inputMessages: [{role: 'user', content: 'Finish in the background'}],
+        outputMessages: [
+          {role: 'assistant', content: 'Background work finished'},
+        ],
+        parentSpanId: root.spanContext().spanId,
+      },
+    ]);
+    expect(
+      spans
+        .filter(
+          span =>
+            span.name === 'chat' &&
+            span.attributes[ATTR_GEN_AI_REQUEST_MODEL] === 'claude-worker'
+        )
+        .map(span => ({
+          outputMessages: JSON.parse(
+            span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string
+          ),
+          parentSpanId: span.parentSpanId,
+        }))
+    ).toEqual([
+      {
+        outputMessages: [
+          {
+            role: 'assistant',
+            parts: [{type: 'text', content: 'late child output'}],
+          },
+        ],
+        parentSpanId: subagent.spanContext().spanId,
+      },
+    ]);
+  });
+
   test('marks a failed background subagent from its task notification', () => {
     const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate'});
     tracer.processMessage(
@@ -1364,7 +1510,7 @@ describe('Claude Agent SDK — OTel tracer', () => {
     ]);
   });
 
-  test('records the resolved model and agent id from a synchronous subagent result', () => {
+  test('records structured output and identity from a synchronous subagent result', () => {
     const tracer = new ClaudeAgentOtelTracer({prompt: 'delegate once'});
     tracer.processMessage(
       assistantMessage({
@@ -1384,12 +1530,13 @@ describe('Claude Agent SDK — OTel tracer', () => {
       userToolResult({
         sessionId: 'sess-sync',
         toolUseId: 'agent-sync',
-        content: 'the answer',
-        toolUseResult: {
-          status: 'completed',
+        content: 'Agent completed successfully',
+        toolUseResult: completedAgentOutput({
           agentId: 'agent-sync-1',
+          content: ['the answer'],
+          prompt: 'Answer briefly',
           resolvedModel: 'claude-haiku-4-5',
-        },
+        }),
       })
     );
     tracer.finalize(resultSuccess({sessionId: 'sess-sync', result: 'done'}));

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -127,6 +127,25 @@ function stringField(
   return typeof value[key] === 'string' ? value[key] : undefined;
 }
 
+function completedSubagentOutputText(
+  value: Record<string, unknown>
+): string | undefined {
+  if (value.status !== 'completed' || !Array.isArray(value.content)) {
+    return undefined;
+  }
+
+  const text: string[] = [];
+  for (const item of value.content) {
+    const block = recordOf(item);
+    const blockText = stringField(block, 'text');
+    if (block.type !== 'text' || blockText == null) {
+      return undefined;
+    }
+    text.push(blockText);
+  }
+  return text.join('\n');
+}
+
 // `Task` is the pre-rename name for `Agent`; older SDK versions still emit it.
 const SUBAGENT_TOOL_NAMES = new Set(['Agent', 'Task']);
 
@@ -167,6 +186,7 @@ type SubagentIdentity = {
 function subagentResult(value: unknown): {
   acknowledgesLaunch: boolean;
   identity: SubagentIdentity;
+  outputText: string | undefined;
 } {
   const raw = recordOf(value);
   return {
@@ -178,6 +198,7 @@ function subagentResult(value: unknown): {
       // A remote launch names its handle `taskId`; the others use `agentId`.
       taskId: stringField(raw, 'taskId'),
     },
+    outputText: completedSubagentOutputText(raw),
   };
 }
 
@@ -326,7 +347,7 @@ export class ClaudeAgentOtelTracer {
 
     switch (msg.type) {
       case 'assistant':
-        this.processAssistant(msg, this.getOrCreateTurn());
+        this.processAssistant(msg);
         break;
       case 'user':
         this.processUser(msg);
@@ -490,13 +511,13 @@ export class ClaudeAgentOtelTracer {
     }
   }
 
-  private processAssistant(msg: SDKAssistantMessage, turn: Turn): void {
+  private processAssistant(msg: SDKAssistantMessage): void {
     const model = msg.message.model;
     if (msg.parent_tool_use_id == null && this.rootModel == null && model) {
       this.rootModel = model;
     }
 
-    const parent = this.getOrCreateMessageParent(msg, turn);
+    const parent = this.getOrCreateMessageParent(msg);
     const content = msg.message.content;
     const parts = assistantParts(content);
 
@@ -537,17 +558,15 @@ export class ClaudeAgentOtelTracer {
     }
   }
 
-  private getOrCreateMessageParent(
-    msg: SDKAssistantMessage,
-    turn: Turn
-  ): Turn | SubAgent {
+  private getOrCreateMessageParent(msg: SDKAssistantMessage): Turn | SubAgent {
     const parentToolUseId = msg.parent_tool_use_id;
     if (parentToolUseId == null) {
-      return turn;
+      return this.getOrCreateTurn();
     }
 
     let openSubagent = this.openSubagents.get(parentToolUseId);
     if (!openSubagent) {
+      const turn = this.getOrCreateTurn();
       const span = turn.startSubagent({
         name: msg.subagent_type ?? 'subagent',
         model: msg.message.model,
@@ -631,7 +650,9 @@ export class ClaudeAgentOtelTracer {
     resultText: string,
     msg: SDKUserMessage | SDKUserMessageReplay
   ): void {
-    const {acknowledgesLaunch, identity} = subagentResult(msg.tool_use_result);
+    const {acknowledgesLaunch, identity, outputText} = subagentResult(
+      msg.tool_use_result
+    );
     // The identity fields ride on every `Agent` result shape, launch or not.
     openSubagent.agentId = identity.agentId ?? openSubagent.agentId;
     openSubagent.taskId = identity.taskId ?? openSubagent.taskId;
@@ -646,16 +667,19 @@ export class ClaudeAgentOtelTracer {
       return;
     }
 
+    const terminalOutputText = block.is_error
+      ? resultText
+      : (outputText ?? resultText);
     openSubagent.span.record({
-      outputMessages: resultText
-        ? [{role: 'assistant', content: resultText}]
+      outputMessages: terminalOutputText
+        ? [{role: 'assistant', content: terminalOutputText}]
         : [],
     });
     openSubagent.outcome = block.is_error
       ? {
           status: 'error',
           errorType: 'subagent_error',
-          error: new Error(resultText || 'Subagent execution failed'),
+          error: new Error(terminalOutputText || 'Subagent execution failed'),
           endedAt: new Date(),
         }
       : {status: 'ok', endedAt: new Date()};


### PR DESCRIPTION
## Summary

- Route forwarded background assistant messages to an existing `SubAgent` before creating or consuming a root `Turn`.
- Record synchronous Agent output from structured `tool_use_result.content`, with the model-facing `tool_result` text retained as a compatibility and error fallback.
- Add exact regression coverage for a child message arriving after the root result and for structured output that differs from the wrapper text.

This is a stacked follow-up to #7630 and addresses both unresolved review threads:

- https://github.com/wandb/weave/pull/7630#discussion_r3716220502
- https://github.com/wandb/weave/pull/7630#discussion_r3716227789

## Live validation

| Scenario | Master | This stack |
| --- | --- | --- |
| Synchronous Agent output | [Generic Agent tool span; no nested agent](https://wandb.ai/wandb/pr-7630-followup-live-validation/weave/agents/spans/906f5652d60e6fe65f37e83271c00df1). The SDK emitted wrapper text containing the result plus agent ID and usage. | [Nested `sync-trace-worker`](https://wandb.ai/wandb/pr-7630-followup-live-validation/weave/agents/spans/b3c5963789d7678a13994a53e591beff) records exactly `SYNC_CHILD_DONE` from structured content, with the correct agent ID and resolved model. |
| Background child after root result | [Launch root](https://wandb.ai/wandb/pr-7630-followup-live-validation/weave/agents/spans/4fbe7ddeac551077911c0ee5f6531996) plus a [separate continuation root](https://wandb.ai/wandb/pr-7630-followup-live-validation/weave/agents/spans/58d8b6c4a6d177c9f15c741eaa8cd1fa); no nested subagent. | [Nested `background-trace-worker`](https://wandb.ai/wandb/pr-7630-followup-live-validation/weave/agents/spans/d2ad8549c66e798070c6f4c87e96f390); the forwarded child message arrived after the root result and its `chat` remained parented to the original subagent. |

The live runs used the same explicit foreground and background prompts on current `master` and this follow-up. Stored spans were queried back with details and compared by trace ID, span ID, parent span ID, operation, agent identity, model, and complete input/output messages.

## Testing

- `pnpm exec jest --silent --runInBand` — 59 suites, 475 tests, and 58 snapshots passed, including packaged host apps.
- Focused Claude Agent SDK OTel tracer suite — 23 tests passed.
- `pnpm run build`
- `pnpm run lint`
- `pnpm run prettier-check`
- `pnpm run typecheck:cjs`
- `pnpm run typecheck:esm`

## Breaking changes

None.