### PR TITLE
fix(weave): preserve typed message fields during PII redaction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -490,6 +490,10 @@ pnpm exec tsx examples/claudeAgents.ts
 - SDK output can fail before the first message or between completed turns. Keep
   the submitted/pending input observable by ending its `Turn` through the
   exception path so the span records the error before the exception propagates.
+- Conversation message PII redaction walks typed parts directly. Preserve
+  roles, discriminators, identifiers, MIME/modality metadata, and media/file
+  references; only flat text, text/reasoning parts, and tool arguments/results
+  are Presidio-scanned.
 
 ### Claude Agent SDK token accounting
 

--- a/tests/conversation/test_conversation_settings.py
+++ b/tests/conversation/test_conversation_settings.py
@@ -36,8 +36,10 @@ from weave.conversation.conversation import (
     Message,
     Reasoning,
     SubAgent,
+    TextPart,
     Tool,
     Turn,
+    UriPart,
     log_conversation,
     log_turn,
     start_conversation,
@@ -46,6 +48,8 @@ from weave.trace.settings import override_settings
 
 _PII_EMAIL = "alice@example.com"
 _REDACTED_EMAIL = "<EMAIL>"
+_PROTOCOL_FALSE_POSITIVE = "uri"
+_REDACTED_PROTOCOL_FALSE_POSITIVE = "<PERSON>"
 
 
 @dataclass
@@ -62,11 +66,17 @@ class _FakeResult:
 class _FakeAnalyzer:
     def analyze(self, *, text: str, **_: Any) -> list[_FakeEntity]:
         i = text.find(_PII_EMAIL)
-        return [_FakeEntity(i, i + len(_PII_EMAIL))] if i >= 0 else []
+        if i >= 0:
+            return [_FakeEntity(i, i + len(_PII_EMAIL))]
+        if text == _PROTOCOL_FALSE_POSITIVE:
+            return [_FakeEntity(0, len(text))]
+        return []
 
 
 class _FakeAnonymizer:
     def anonymize(self, *, text: str, analyzer_results: Any) -> _FakeResult:
+        if text == _PROTOCOL_FALSE_POSITIVE:
+            return _FakeResult(_REDACTED_PROTOCOL_FALSE_POSITIVE)
         return _FakeResult(text.replace(_PII_EMAIL, _REDACTED_EMAIL))
 
 
@@ -375,6 +385,48 @@ def test_subagent_content_is_pii_redacted(
         "gen_ai.tool.call.arguments": json.dumps({"email": _REDACTED_EMAIL}),
         "gen_ai.tool.call.result": f"Found {_REDACTED_EMAIL}",
     }
+
+
+def test_redact_pii_preserves_uri_part_protocol_fields(
+    otel_spans: InMemorySpanExporter, fake_presidio: None
+) -> None:
+    """A Presidio false positive cannot corrupt a typed message discriminator."""
+    source_ref = "weave:///team/project/object/source:abc123"
+    with override_settings(redact_pii=True):
+        log_turn(
+            conversation_id="convo-pii-uri-part",
+            agent_name="a",
+            messages=[
+                Message(
+                    role="user",
+                    parts=[
+                        UriPart(
+                            mime_type="text/plain",
+                            modality="document",
+                            uri=source_ref,
+                        ),
+                        TextPart(content=f"contact {_PII_EMAIL}"),
+                    ],
+                )
+            ],
+        )
+
+    spans = _spans_with_prefix(otel_spans, "invoke_agent")
+    assert len(spans) == 1
+    assert json.loads(spans[0].attributes["gen_ai.input.messages"]) == [
+        {
+            "role": "user",
+            "parts": [
+                {
+                    "type": "uri",
+                    "mime_type": "text/plain",
+                    "modality": "document",
+                    "uri": source_ref,
+                },
+                {"type": "text", "content": f"contact {_REDACTED_EMAIL}"},
+            ],
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/weave/utils/pii_redaction.py
+++ b/weave/utils/pii_redaction.py
@@ -5,8 +5,8 @@ Two layers:
 - ``redact_pii`` / ``redact_pii_string`` are the primitives that walk
   dicts, lists, and dataclasses applying Presidio.
 - ``redact_messages`` / ``redact_system_instructions`` are the Conversation
-  SDK helpers shaped for typed Message payloads (dump → redact →
-  revalidate).
+  SDK helpers shaped for typed Message payloads. Message protocol fields are
+  preserved while textual payload fields are passed to Presidio.
 
 ``presidio`` is an optional dependency gated by ``WEAVE_REDACT_PII``.
 Imports happen inside ``_get_engines`` so the module loads without it —
@@ -18,9 +18,17 @@ NLP stack, and lets users who never enable redaction skip the install.
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, cast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
-from weave.conversation.types import Message
+from weave.conversation.types import (
+    Message,
+    MessagePart,
+    ReasoningPart,
+    TextPart,
+    ToolCallPart,
+    ToolCallResponsePart,
+)
 from weave.telemetry import trace_sentry
 from weave.trace.settings import redact_pii_exclude_fields, redact_pii_fields
 from weave.utils.sanitize import REDACTED_VALUE, redact_dataclass_fields, should_redact
@@ -73,17 +81,33 @@ def _get_redaction_entities() -> list[str]:
     return [e for e in fields if e not in exclude]
 
 
+def _redact_pii_string_with_engines(
+    data: str,
+    analyzer: AnalyzerEngine,
+    anonymizer: AnonymizerEngine,
+    entities: list[str],
+) -> str:
+    if not data:
+        return data
+    results = analyzer.analyze(text=data, language="en", entities=entities)
+    redacted = anonymizer.anonymize(text=data, analyzer_results=results)
+    return redacted.text
+
+
 def redact_pii(
     data: dict[str, Any] | str,
 ) -> dict[str, Any] | str:
+    if isinstance(data, str):
+        return redact_pii_string(data)
+
     analyzer, anonymizer = _get_engines()
     entities = _get_redaction_entities()
 
     def redact_recursive(value: Any) -> Any:
         if isinstance(value, str):
-            results = analyzer.analyze(text=value, language="en", entities=entities)
-            redacted = anonymizer.anonymize(text=value, analyzer_results=results)
-            return redacted.text
+            return _redact_pii_string_with_engines(
+                value, analyzer, anonymizer, entities
+            )
         elif isinstance(value, dict):
             result = {}
             for k, v in value.items():
@@ -100,9 +124,6 @@ def redact_pii(
         else:
             return value
 
-    if isinstance(data, str):
-        return redact_pii_string(data)
-
     return redact_recursive(data)
 
 
@@ -114,27 +135,60 @@ def redact_pii_string(data: str) -> str:
         return data
     analyzer, anonymizer = _get_engines()
     entities = _get_redaction_entities()
-    results = analyzer.analyze(text=data, language="en", entities=entities)
-    redacted = anonymizer.anonymize(text=data, analyzer_results=results)
-    return redacted.text
+    return _redact_pii_string_with_engines(data, analyzer, anonymizer, entities)
+
+
+def _redact_message_part(
+    part: MessagePart, redact_string: Callable[[str, str], str]
+) -> MessagePart:
+    if isinstance(part, (TextPart, ReasoningPart)):
+        return part.model_copy(
+            update={"content": redact_string("content", part.content)}, deep=True
+        )
+    if isinstance(part, ToolCallPart):
+        return part.model_copy(
+            update={"arguments": redact_string("arguments", part.arguments)},
+            deep=True,
+        )
+    if isinstance(part, ToolCallResponsePart):
+        return part.model_copy(
+            update={"response": redact_string("response", part.response)}, deep=True
+        )
+    return part.model_copy(deep=True)
 
 
 def redact_messages(messages: list[Message]) -> list[Message]:
-    """Redact PII in each Message via dump → redact → revalidate.
+    """Redact textual payloads without sending protocol fields to Presidio.
 
-    Routes through the same recursive ``redact_pii`` used by ``@op`` so
-    Conversation SDK content is redacted identically. Discriminator literals
-    (``role``, part ``type``) aren't matched by Presidio's default
-    recognizers, so the round-trip preserves the typed shape.
+    Roles, part discriminators, tool identifiers, MIME metadata, blob data,
+    URIs, and file identifiers are structural values and remain byte-for-byte
+    stable. Flat message content, text/reasoning content, tool arguments, and
+    tool responses use the same Presidio engines and configured redact keys as
+    ``redact_pii``.
     """
     if not messages:
         return messages
-    redacted: list[Message] = []
-    for message in messages:
-        dumped = message.model_dump()
-        redacted_dump = cast(dict[str, Any], redact_pii(dumped))
-        redacted.append(Message.model_validate(redacted_dump))
-    return redacted
+
+    analyzer, anonymizer = _get_engines()
+    entities = _get_redaction_entities()
+
+    def redact_string(field_name: str, value: str) -> str:
+        if should_redact(field_name):
+            return REDACTED_VALUE
+        return _redact_pii_string_with_engines(value, analyzer, anonymizer, entities)
+
+    return [
+        message.model_copy(
+            update={
+                "content": redact_string("content", message.content),
+                "parts": [
+                    _redact_message_part(part, redact_string) for part in message.parts
+                ],
+            },
+            deep=True,
+        )
+        for message in messages
+    ]
 
 
 def redact_system_instructions(instructions: list[str]) -> list[str]:


### PR DESCRIPTION
## Why

I hit this while testing a private HiveMind chat review mirror with `redact_pii=True`.

The Conversation SDK currently serializes each typed `Message`, recursively sends every string through Presidio, and then validates the result back into the typed model. That means a false positive on a protocol value can corrupt the payload before any span is emitted. In the concrete failure, Presidio classified the literal `"uri"` discriminator from `UriPart.type` as a person name, changed it to `"<PERSON>"`, and Pydantic rejected the message union.

This makes URI-backed conversation content impossible to log with PII redaction enabled, even when the URI itself contains no sensitive text.

## What changed

- Walk typed message parts directly instead of redacting a dumped protocol object.
- Preserve roles, union discriminators, IDs, MIME/modality metadata, blobs, file references, and URIs byte-for-byte.
- Continue using the same configured Presidio engines for user-authored text:
  - flat message content;
  - text and reasoning parts;
  - tool-call arguments; and
  - tool-call responses.
- Keep configured field-name redaction behavior for those textual payload fields.
- Add a regression where the fake analyzer deliberately marks the exact string `"uri"` as PII while also redacting an email in adjacent text. The resulting span must retain a valid `UriPart` and contain the redacted email.

## Validation

- `23 passed` in `tests/conversation/test_conversation_settings.py`
- Ruff lint passed
- Ruff formatting check passed
- `git diff --check` passed

This is a small companion fix for the review-mirror work in [wandb/hivemind#8](https://github.com/wandb/hivemind/pull/8). It is independent of the proposed atomic historical-turn API and does not change OTLP delivery or idempotency semantics.