### PR TITLE
feat(weave_ts): accept JSON tool values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,6 +379,10 @@ pnpm exec tsx examples/claudeAgents.ts
   without typed `record()` methods.
 - The Claude Agent SDK integration keeps each `Tool` open until its matching
   `tool_result`.
+- `Tool` records string arguments and results as-is and serializes other values
+  for OTel attributes, using JSON when possible. Prefer
+  `Tool.end({result, error, errorType})`; mutable `Tool.result` remains only for
+  backward compatibility.
 - For streamed sessions, queue observed user inputs in FIFO order and close one
   `Turn` for each matching SDK `result`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,8 +379,8 @@ pnpm exec tsx examples/claudeAgents.ts
   without typed `record()` methods.
 - The Claude Agent SDK integration keeps each `Tool` open until its matching
   `tool_result`.
-- `Tool` records string arguments and results as-is and serializes other values
-  for OTel attributes, using JSON when possible. Prefer
+- `Tool` accepts JSON-compatible arguments and results. It records strings
+  as-is and serializes structured values for OTel attributes. Prefer
   `Tool.end({result, error, errorType})`; mutable `Tool.result` remains only for
   backward compatibility.
 - For streamed sessions, queue observed user inputs in FIFO order and close one

--- a/sdks/node/examples/agent.ts
+++ b/sdks/node/examples/agent.ts
@@ -94,10 +94,13 @@ async function executeToolCalls(
       toolCallId: tc.id,
     });
     try {
-      tool.result = await wikipediaSearch(JSON.parse(tc.function.arguments));
-      history.push({role: 'tool', tool_call_id: tc.id, content: tool.result!});
-    } finally {
-      tool.end();
+      const result = await wikipediaSearch(JSON.parse(tc.function.arguments));
+      history.push({role: 'tool', tool_call_id: tc.id, content: result});
+      tool.end({result});
+    } catch (error) {
+      const cause = error instanceof Error ? error : new Error(String(error));
+      tool.end({error: cause, errorType: cause.name});
+      throw error;
     }
   }
 }

--- a/sdks/node/src/__tests__/genai/tool.test.ts
+++ b/sdks/node/src/__tests__/genai/tool.test.ts
@@ -1,6 +1,7 @@
-import {SpanKind} from '@opentelemetry/api';
+import {SpanKind, SpanStatusCode} from '@opentelemetry/api';
 
 import {
+  ATTR_ERROR_TYPE,
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
@@ -62,6 +63,69 @@ describe('Tool', () => {
     const toolSpan = findSpan(spans, 'execute_tool');
     const llmSpan = findSpan(spans, 'chat');
     expect(toolSpan.parentSpanId).toBe(llmSpan.spanContext().spanId);
+  });
+
+  it('serializes structured arguments and a result passed to end()', () => {
+    const turn = Turn.create({});
+    const tool = turn.startTool({
+      name: 'get_weather',
+      args: {city: 'Tokyo', units: ['celsius', 'fahrenheit']},
+    });
+    tool.end({result: {temperature: 24, raining: false}});
+    tool.end({result: {temperature: 99}});
+    turn.end();
+
+    const toolSpan = findSpan(getExporter().getFinishedSpans(), 'execute_tool');
+    expect(toolSpan.attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS]).toBe(
+      '{"city":"Tokyo","units":["celsius","fahrenheit"]}'
+    );
+    expect(toolSpan.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBe(
+      '{"temperature":24,"raining":false}'
+    );
+  });
+
+  it('records result, error type, and failure status together at end()', () => {
+    const turn = Turn.create({});
+    const tool = turn.startTool({name: 'get_weather'});
+    tool.end({
+      result: {message: 'weather service unavailable'},
+      error: new Error('request failed'),
+      errorType: 'weather_service_error',
+    });
+    turn.end();
+
+    const toolSpan = findSpan(getExporter().getFinishedSpans(), 'execute_tool');
+    expect(toolSpan.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBe(
+      '{"message":"weather service unavailable"}'
+    );
+    expect(toolSpan.attributes[ATTR_ERROR_TYPE]).toBe('weather_service_error');
+    expect(toolSpan.status).toEqual({
+      code: SpanStatusCode.ERROR,
+      message: 'request failed',
+    });
+  });
+
+  it('does not throw when a tool value cannot be serialized', () => {
+    const unserializable = {
+      toJSON() {
+        throw new Error('no JSON');
+      },
+      [Symbol.toPrimitive]() {
+        throw new Error('no string');
+      },
+    };
+    const turn = Turn.create({});
+    const tool = turn.startTool({name: 'broken_value', args: unserializable});
+    tool.end({result: unserializable});
+    turn.end();
+
+    const toolSpan = findSpan(getExporter().getFinishedSpans(), 'execute_tool');
+    expect(toolSpan.attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS]).toBe(
+      '[unserializable]'
+    );
+    expect(toolSpan.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBe(
+      '[unserializable]'
+    );
   });
 
   it('setAttributes records attributes on the tool span; warns + no-op after end()', () => {

--- a/sdks/node/src/__tests__/genai/tool.test.ts
+++ b/sdks/node/src/__tests__/genai/tool.test.ts
@@ -10,6 +10,7 @@ import {
   ATTR_GEN_AI_TOOL_NAME,
 } from '../../genai/semconv';
 import {Turn} from '../../genai/turn';
+import type {JsonObject} from '../../genai/types';
 
 import {
   expectSpanTimesToMatch,
@@ -69,7 +70,7 @@ describe('Tool', () => {
     const turn = Turn.create({});
     const tool = turn.startTool({
       name: 'get_weather',
-      args: {city: 'Tokyo', units: ['celsius', 'fahrenheit']},
+      args: {city: 'Tokyo', units: ['celsius', 'fahrenheit'] as const},
     });
     tool.end({result: {temperature: 24, raining: false}});
     tool.end({result: {temperature: 99}});
@@ -105,18 +106,12 @@ describe('Tool', () => {
     });
   });
 
-  it('does not throw when a tool value cannot be serialized', () => {
-    const unserializable = {
-      toJSON() {
-        throw new Error('no JSON');
-      },
-      [Symbol.toPrimitive]() {
-        throw new Error('no string');
-      },
-    };
+  it('does not throw when a typed tool value contains a cycle', () => {
+    const cyclic: JsonObject = {};
+    cyclic.self = cyclic;
     const turn = Turn.create({});
-    const tool = turn.startTool({name: 'broken_value', args: unserializable});
-    tool.end({result: unserializable});
+    const tool = turn.startTool({name: 'cyclic_value', args: cyclic});
+    tool.end({result: cyclic});
     turn.end();
 
     const toolSpan = findSpan(getExporter().getFinishedSpans(), 'execute_tool');

--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -95,14 +95,14 @@ export function startLLM(opts: LLMInit): LLM {
  * @example
  * weave.startTool({
  *   name: 'get_weather',
- *   args: JSON.stringify({city: 'Tokyo'}),
+ *   args: {city: 'Tokyo'},
  *   toolCallId: 'call_t1',
  * });
  *
  * @example
  * weave.startTool({
  *   name: 'get_weather',
- *   args: JSON.stringify({city: 'Tokyo'}),
+ *   args: {city: 'Tokyo'},
  *   toolCallId: 'call_t1',
  *   startTime: new Date('2026-05-29T10:00:00.800Z'),
  * });

--- a/sdks/node/src/genai/index.ts
+++ b/sdks/node/src/genai/index.ts
@@ -36,7 +36,7 @@ export {
   type SessionInit,
 } from './conversation';
 export {SubAgent, type SubAgentInit} from './subagent';
-export {Tool, type ToolInit} from './tool';
+export {Tool, type ToolEndOptions, type ToolInit} from './tool';
 export {Turn, type TurnInit} from './turn';
 
 export type {

--- a/sdks/node/src/genai/index.ts
+++ b/sdks/node/src/genai/index.ts
@@ -40,6 +40,8 @@ export {Tool, type ToolEndOptions, type ToolInit} from './tool';
 export {Turn, type TurnInit} from './turn';
 
 export type {
+  JsonObject,
+  JsonValue,
   Message,
   MessagePart,
   Modality,

--- a/sdks/node/src/genai/tool.ts
+++ b/sdks/node/src/genai/tool.ts
@@ -13,22 +13,23 @@ import {
   ATTR_GEN_AI_TOOL_NAME,
   WEAVE_GENAI_TRACER_NAME,
 } from './semconv';
+import type {JsonObject, JsonValue} from './types';
 
 export interface ToolInit extends SpanInitBase {
   name: string;
-  /** String values are recorded as-is; other values are JSON-serialized. */
-  args?: unknown;
+  /** A JSON object, or a pre-serialized string recorded as-is. */
+  args?: JsonObject | string;
   toolCallId?: string;
 }
 
 export interface ToolEndOptions extends SpanEndOptions {
-  /** String values are recorded as-is; other values are JSON-serialized. */
-  result?: unknown;
+  /** A JSON value. Strings are recorded as-is; other values are serialized. */
+  result?: JsonValue;
   /** Stable failure classification recorded on the `error.type` attribute. */
   errorType?: string;
 }
 
-function serializeToolValue(value: unknown): string | undefined {
+function serializeToolValue(value: JsonValue | undefined): string | undefined {
   if (value === undefined) {
     return undefined;
   }
@@ -36,20 +37,16 @@ function serializeToolValue(value: unknown): string | undefined {
     return value;
   }
   try {
-    return JSON.stringify(value) ?? String(value);
+    return JSON.stringify(value) ?? '[unserializable]';
   } catch {
-    try {
-      return String(value);
-    } catch {
-      return '[unserializable]';
-    }
+    return '[unserializable]';
   }
 }
 
 /**
  * A tool invocation. Emits an `execute_tool` span carrying the tool name,
  * the arguments, the tool-call id, and the result. String arguments and
- * results are recorded as-is; other values are JSON-serialized when possible.
+ * results are recorded as-is; other JSON values are serialized.
  *
  * Created by `weave.startTool()` (or `turn.startTool()`, or
  * `llm.startTool()`) and terminated with `end()`, which accepts the result and
@@ -93,7 +90,7 @@ export class Tool extends SpanBase {
     if (opts.toolCallId) {
       attributes[ATTR_GEN_AI_TOOL_CALL_ID] = opts.toolCallId;
     }
-    if (args) {
+    if (args !== undefined) {
       attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS] = args;
     }
     if (opts.conversationId) {

--- a/sdks/node/src/genai/tool.ts
+++ b/sdks/node/src/genai/tool.ts
@@ -4,6 +4,7 @@ import type {ChildSpanContext} from './common';
 import {getWeaveTracer} from './provider';
 import {SpanBase, type SpanEndOptions, type SpanInitBase} from './spanBase';
 import {
+  ATTR_ERROR_TYPE,
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
@@ -15,33 +16,60 @@ import {
 
 export interface ToolInit extends SpanInitBase {
   name: string;
-  args?: string;
+  /** String values are recorded as-is; other values are JSON-serialized. */
+  args?: unknown;
   toolCallId?: string;
+}
+
+export interface ToolEndOptions extends SpanEndOptions {
+  /** String values are recorded as-is; other values are JSON-serialized. */
+  result?: unknown;
+  /** Stable failure classification recorded on the `error.type` attribute. */
+  errorType?: string;
+}
+
+function serializeToolValue(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return '[unserializable]';
+    }
+  }
 }
 
 /**
  * A tool invocation. Emits an `execute_tool` span carrying the tool name,
- * the JSON-encoded arguments, the tool-call id, and the result.
+ * the arguments, the tool-call id, and the result. String arguments and
+ * results are recorded as-is; other values are JSON-serialized when possible.
  *
  * Created by `weave.startTool()` (or `turn.startTool()`, or
- * `llm.startTool()`) and terminated with `end()`. Assign `result` before
- * calling `end()` to record the tool's output on the span.
+ * `llm.startTool()`) and terminated with `end()`, which accepts the result and
+ * optional error metadata.
  *
  * @example
- * const tool = weave.startTool({
- *   name: tc.function.name,
- *   args: tc.function.arguments,
- *   toolCallId: tc.id,
- * });
+ * const tool = weave.startTool({name: 'get_weather', args: {city: 'Tokyo'}});
  * try {
- *   tool.result = await wikipediaSearch(JSON.parse(tc.function.arguments));
- * } finally {
- *   tool.end();
+ *   const result = await getWeather('Tokyo');
+ *   tool.end({result});
+ * } catch (error) {
+ *   tool.end({error: error as Error, errorType: 'weather_error'});
+ *   throw error;
  * }
  */
 export class Tool extends SpanBase {
   /**
-   * Tool output as a string. Recorded on `gen_ai.tool.call.result` at `end()`.
+   * Tool output as a string. Prefer passing `result` to `end()`.
+   *
+   * @deprecated Pass `result` to `end()` instead.
    */
   result?: string;
 
@@ -56,6 +84,7 @@ export class Tool extends SpanBase {
 
   static create(opts: ToolInit & ChildSpanContext): Tool {
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
+    const args = serializeToolValue(opts.args);
     const attributes: Attributes = {
       ...(opts.attributes ?? {}),
       [ATTR_GEN_AI_OPERATION_NAME]: 'execute_tool',
@@ -64,8 +93,8 @@ export class Tool extends SpanBase {
     if (opts.toolCallId) {
       attributes[ATTR_GEN_AI_TOOL_CALL_ID] = opts.toolCallId;
     }
-    if (opts.args) {
-      attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS] = opts.args;
+    if (args) {
+      attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS] = args;
     }
     if (opts.conversationId) {
       attributes[ATTR_GEN_AI_CONVERSATION_ID] = opts.conversationId;
@@ -75,20 +104,28 @@ export class Tool extends SpanBase {
       {kind: SpanKind.INTERNAL, attributes, startTime: opts.startTime},
       opts.parentContext
     );
-    return new Tool(span, opts.name, opts.args ?? '', opts.toolCallId ?? '');
+    return new Tool(span, opts.name, args ?? '', opts.toolCallId ?? '');
   }
 
   /**
-   * Flush `result` to the span and close it. Idempotent. Pass `error` to mark
-   * the span as failed; pass `endTime` to backdate the close.
+   * Record an optional result and error type, then close the span. Idempotent.
+   * Pass `error` to mark the span as failed and `endTime` to backdate the close.
    */
-  end(opts?: SpanEndOptions): void {
+  end(opts?: ToolEndOptions): void {
     if (this._ended) {
       return;
     }
     this._ended = true;
-    if (this.result !== undefined) {
-      this.span.setAttribute(ATTR_GEN_AI_TOOL_CALL_RESULT, this.result);
+    const result =
+      opts?.result === undefined
+        ? this.result
+        : serializeToolValue(opts.result);
+    if (result !== undefined) {
+      this.result = result;
+      this.span.setAttribute(ATTR_GEN_AI_TOOL_CALL_RESULT, result);
+    }
+    if (opts?.errorType) {
+      this.span.setAttribute(ATTR_ERROR_TYPE, opts.errorType);
     }
     this._closeSpan(opts);
   }

--- a/sdks/node/src/genai/types.ts
+++ b/sdks/node/src/genai/types.ts
@@ -8,7 +8,6 @@ export type JsonValue =
   | boolean
   | number
   | string
-  | JsonValue[]
   | readonly JsonValue[]
   | JsonObject;
 

--- a/sdks/node/src/genai/types.ts
+++ b/sdks/node/src/genai/types.ts
@@ -2,6 +2,19 @@
  * Public data types for the Weave GenAI conversation SDK.
  */
 
+/** A value representable in JSON. */
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | readonly JsonValue[]
+  | JsonObject;
+
+/** An object whose properties are representable in JSON. */
+export type JsonObject = {[key: string]: JsonValue};
+
 export type Role =
   | 'user'
   | 'assistant'

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -77,6 +77,8 @@ export {
 export type {
   Conversation,
   ConversationInit,
+  JsonObject,
+  JsonValue,
   LLM,
   LLMInit,
   Message,

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -87,6 +87,7 @@ export type {
   SubAgent,
   SubAgentInit,
   Tool,
+  ToolEndOptions,
   ToolInit,
   Turn,
   TurnInit,


### PR DESCRIPTION
## Summary

- add exported `JsonValue` and `JsonObject` types for JSON-compatible tool data
- accept a JSON object or pre-serialized string in `ToolInit.args`
- accept a JSON value in `Tool.end({result})` and serialize structured values inside the SDK
- record `result`, `error`, and `errorType` together when a tool ends
- preserve string arguments/results and deprecated mutable `Tool.result` compatibility

## Testing

- `pnpm exec jest --runInBand src/__tests__/genai` (9 suites, 101 tests, 13 snapshots)
- `pnpm exec jest --runInBand src/__tests__/genai/tool.test.ts` (8 tests)
- `pnpm run typecheck:cjs`
- `pnpm run typecheck:esm`
- `pnpm run lint`
- `pnpm run prettier-check`

## Breaking changes

None. Existing string arguments and mutable `Tool.result` assignments continue to work.

## Related

- wandb/weave-claude-code#147
