### PR TITLE
fix(trace_server): return 4xx not 500 for OTLP resource-attribute collisions

### DIFF
--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -374,6 +374,45 @@ def test_otel_export_with_turn_no_thread(client: weave_client.WeaveClient):
     )
 
 
+def test_otel_export_resource_attribute_collision_is_soft_rejected(
+    client: weave_client.WeaveClient,
+):
+    """Colliding resource attributes (e.g. deployment.environment=<str> and
+    deployment.environment.name=<str> from an OTel Collector that emits both
+    the deprecated and new semconv) used to escape as 500. Every span in the
+    affected resource is now soft-rejected and reported via partial_success,
+    matching the OTLP contract. Regression test for WB-38308.
+    """
+    export_req = create_test_export_request()
+    project_id = client._project_id()
+    export_req.project_id = project_id
+    export_req.wb_user_id = "abcd123"
+
+    # Materialize to avoid iterator exhaustion, then add the collision.
+    processed_spans_list = export_req.processed_spans
+    resource = processed_spans_list[0].resource_spans.resource
+    scalar = KeyValue()
+    scalar.key = "deployment.environment"
+    scalar.value.string_value = "prod"
+    resource.attributes.append(scalar)
+    nested = KeyValue()
+    nested.key = "deployment.environment.name"
+    nested.value.string_value = "prod"
+    resource.attributes.append(nested)
+    export_req.processed_spans = processed_spans_list
+
+    response = client.server.otel_export(export_req)
+
+    assert isinstance(response, tsi.OTelExportRes)
+    assert response.partial_success is not None
+    assert response.partial_success.rejected_spans == 1
+    assert "deployment.environment" in response.partial_success.error_message
+
+    # No calls should have landed.
+    res = client.server.calls_query(tsi.CallsQueryReq(project_id=project_id))
+    assert len(res.calls) == 0
+
+
 class TestPythonSpans:
     def test_span_from_proto(self):
         """Test converting a protobuf Span to a Python Span."""

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -813,7 +813,20 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 )
 
             proto_resource_spans = processed_span.resource_spans
-            resource = Resource.from_proto(proto_resource_spans.resource)
+            try:
+                resource = Resource.from_proto(proto_resource_spans.resource)
+            except AttributePathConflictError as e:
+                # The whole resource is unusable, so soft-reject every span it
+                # carries instead of failing the batch with a 5xx. Mirrors the
+                # per-span reject pattern below.
+                span_count = sum(
+                    len(s.spans) for s in proto_resource_spans.scope_spans
+                )
+                rejected_spans += span_count
+                error_messages.append(
+                    f"Rejected {span_count} span(s) from resource with conflicting attributes: {e!s}"
+                )
+                continue
             for proto_scope_spans in proto_resource_spans.scope_spans:
                 for proto_span in proto_scope_spans.spans:
                     try:


### PR DESCRIPTION
## Description

- Fixes WB-38308

`POST /otel/v1/traces` used to return **HTTP 500** when an incoming OTLP payload carried colliding resource attribute keys — e.g. both `deployment.environment=<string>` and `deployment.environment.name=<string>` from an OpenTelemetry Collector that emits both the deprecated and the new semconv. The `AttributePathConflictError` was raised on `Resource.from_proto(...)` in `_otel_proto_to_calls`, outside the existing per-span reject `try/except`, so the entire batch failed as a 5xx to the client (surfaced 7 times in 3 days from a single customer, seen in Datadog against `@error.type:AttributePathConflictError`).

This PR catches the collision at the resource level: every span the offending `ResourceSpans` carries is soft-rejected and reported via `error_messages` / `rejected_spans`, mirroring the per-span reject pattern immediately below. The endpoint then returns the standard OTLP `partial_success` response instead of a 5xx.

The bad-payload class stops contributing to the 5xx error budget, and the client learns exactly what to fix (the exception's own message already names the colliding key).

## Testing

- New integration test in `tests/trace_server/test_opentelemetry.py::test_otel_export_resource_attribute_collision_is_soft_rejected` builds a `ResourceSpans` with both `deployment.environment` and `deployment.environment.name`, asserts `partial_success.rejected_spans == 1` and that no calls landed.
- Existing per-span reject tests continue to cover the case where the resource is fine but individual spans have colliding attributes.

There is a companion `wandb/core` PR that bumps the submodule pointer to this commit and adds the HTTP-layer regression test on the weave-trace side (`AttributePathConflictError` → 400 defense-in-depth for the genai path).