### PR TITLE
fix(weave): insert pending model costs when the schema is already current

### DIFF
--- a/tests/trace_server/costs/test_insert_costs.py
+++ b/tests/trace_server/costs/test_insert_costs.py
@@ -177,7 +177,6 @@ class TestInsertCosts(unittest.TestCase):
         mock_insert_db.assert_called_once_with(
             self.client, mock_filter_costs.return_value
         )
-        mock_logger.info.assert_any_call("Loaded %d costs from json", 2)
         mock_logger.info.assert_any_call(
             "There are %d costs to insert, after filtering out existing costs", 1
         )
@@ -258,7 +257,6 @@ class TestInsertCosts(unittest.TestCase):
         mock_load_json.assert_called_once()
         mock_filter_costs.assert_called_once_with(self.client, self.sample_costs_json)
         mock_insert_db.assert_not_called()
-        mock_logger.info.assert_any_call("Loaded %d costs from json", 2)
         mock_logger.info.assert_any_call(
             "There are %d costs to insert, after filtering out existing costs", 0
         )

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -466,6 +466,32 @@ def test_apply_migrations_costs_disabled_does_not_call_costs(mock_migration_lock
     mock_insert_costs.assert_not_called()
 
 
+def test_apply_migrations_work_check_inert_without_a_hook():
+    """A work check is meaningless without a hook to act on it.
+
+    A caller that opts out of the hook (post_migration_hook=None) but leaves a
+    work check configured must not have that check invoked by the lock-free
+    pre-check, even at a schema version where it would otherwise fire.
+    """
+    ch_client = _make_ch_client()
+    work_check = Mock(return_value=True)
+    migrator = trace_server_migrator.get_clickhouse_trace_server_migrator(
+        ch_client, post_migration_hook=None, post_migration_work_check=work_check
+    )
+    migrator._has_migrations_to_apply = Mock(return_value=False)
+    migrator._read_migration_status = Mock(
+        return_value={"curr_version": 10, "partially_applied_version": None}
+    )
+
+    with patch(
+        "weave.trace_server.clickhouse_trace_server_migrator.migration_lock"
+    ) as mock_lock:
+        migrator.apply_migrations("test_db")
+
+    work_check.assert_not_called()
+    mock_lock.assert_not_called()
+
+
 def test_apply_migrations_skips_lock_when_nothing_pending():
     """The lock-free pre-check short-circuits when no schema migration is due,
     so rolling replicas don't serialize through the lock for a no-op.
@@ -475,6 +501,7 @@ def test_apply_migrations_skips_lock_when_nothing_pending():
         ch_client, post_migration_hook=None
     )
     migrator._has_migrations_to_apply = Mock(return_value=False)
+    migrator._has_post_migration_work = Mock(return_value=False)
     migrator._apply_migrations_locked = Mock()
 
     with patch(

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -113,7 +113,7 @@ def mock_migration_lock():
 def mock_costs():
     with (
         patch(
-            "weave.trace_server.clickhouse_trace_server_migrator.should_insert_costs",
+            "weave.trace_server.clickhouse_trace_server_migrator.costs_schema_is_ready",
             return_value=False,
         ),
         patch("weave.trace_server.clickhouse_trace_server_migrator.insert_costs"),
@@ -454,15 +454,15 @@ def test_apply_migrations_costs_disabled_does_not_call_costs(mock_migration_lock
 
     with (
         patch(
-            "weave.trace_server.clickhouse_trace_server_migrator.should_insert_costs"
-        ) as mock_should_insert_costs,
+            "weave.trace_server.clickhouse_trace_server_migrator.costs_schema_is_ready"
+        ) as mock_costs_schema_is_ready,
         patch(
             "weave.trace_server.clickhouse_trace_server_migrator.insert_costs"
         ) as mock_insert_costs,
     ):
         migrator.apply_migrations("test_db")
 
-    mock_should_insert_costs.assert_not_called()
+    mock_costs_schema_is_ready.assert_not_called()
     mock_insert_costs.assert_not_called()
 
 

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -885,3 +885,61 @@ def test_migrations_refuse_populated_db_without_history(
         f"SELECT count() FROM {mgmt_b}.migrations WHERE db_name = '{target_db}'"
     ).result_rows[0][0]
     assert orphan_rows == 0
+
+
+def _system_cost_row_count(ch_client, target_db: str, llm_id: str) -> int:
+    result = ch_client.query(
+        f"SELECT count() FROM {target_db}.llm_token_prices "
+        f"WHERE llm_id = %(llm_id)s AND created_by = 'system'",
+        parameters={"llm_id": llm_id},
+    )
+    return int(result.result_rows[0][0])
+
+
+def test_apply_migrations_backfills_costs_on_an_already_current_schema(ch_client):
+    """Regression: a checkpoint-only cost change lands without a schema migration.
+
+    `apply_migrations` used to lock-free pre-check purely on schema version and
+    return before the post-migration hook ever ran, so once a database reached
+    the latest migration, new/changed rows in `cost_checkpoint.json` were never
+    inserted again. This reproduces that by migrating to latest (inserting
+    costs once), deleting one model's seeded rows to simulate a checkpoint
+    addition made after the schema was already current, then calling
+    `apply_migrations` again with no version bump and asserting the row comes
+    back.
+    """
+    mgmt_db = _unique_name("db_mgmt_cost_backfill")
+    target_db = _unique_name("cost_backfill")
+    ch_client.track_db(mgmt_db)
+    ch_client.track_db(target_db)
+    llm_id = "gpt-4"
+
+    # Uses the factory's real default hook + work-check (not disabled), since
+    # this test is exercising exactly that wiring.
+    migrator = get_clickhouse_trace_server_migrator(
+        ch_client,
+        replicated=False,
+        use_distributed=False,
+        management_db=mgmt_db,
+        migration_dir=_PROD_MIGRATION_DIR,
+    )
+    migrator.apply_migrations(target_db)
+    latest = _get_latest_migration_version(_PROD_MIGRATION_DIR)
+    assert _get_migration_version(ch_client, mgmt_db, target_db) == latest
+    # Migration 006 also seeds a `gpt-4` row with a different effective_date,
+    # so a fresh migrate can leave more than one `system` row for this llm_id.
+    assert _system_cost_row_count(ch_client, target_db, llm_id) >= 1
+
+    # Simulate the checkpoint gaining this model's price after the schema was
+    # already at `latest`: no migration to apply, only a pending cost row.
+    ch_client.command(
+        f"DELETE FROM {target_db}.llm_token_prices "
+        f"WHERE llm_id = '{llm_id}' AND created_by = 'system'",
+        settings={"mutations_sync": 2},
+    )
+    assert _system_cost_row_count(ch_client, target_db, llm_id) == 0
+
+    migrator.apply_migrations(target_db)
+
+    assert _system_cost_row_count(ch_client, target_db, llm_id) >= 1
+    assert _get_migration_version(ch_client, mgmt_db, target_db) == latest

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -9,12 +9,18 @@ import uuid
 
 import clickhouse_connect
 import pytest
+from clickhouse_connect.driver.exceptions import DatabaseError
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.clickhouse_trace_server_migrator import (
     _NON_RECOVERABLE_MIGRATION_VERSIONS,
     MigrationError,
     get_clickhouse_trace_server_migrator,
+)
+from weave.trace_server.costs.insert_costs import (
+    COSTS_TABLE,
+    costs_schema_is_ready,
+    get_current_costs,
 )
 
 _TEST_MIGRATION_DIR = os.path.abspath(
@@ -943,3 +949,54 @@ def test_apply_migrations_backfills_costs_on_an_already_current_schema(ch_client
 
     assert _system_cost_row_count(ch_client, target_db, llm_id) >= 1
     assert _get_migration_version(ch_client, mgmt_db, target_db) == latest
+
+
+@pytest.mark.parametrize(
+    ("target_version", "expect_table", "expect_ready"),
+    [(4, False, False), (26, True, False), (None, True, True)],
+)
+def test_costs_schema_gate_tracks_the_columns_the_cost_code_reads(
+    ch_client, target_version, expect_table, expect_ready
+):
+    """The costs gate approves a database exactly when the cost read works there.
+
+    Migration 5 creates `llm_token_prices`, but 27 adds the two cache cost
+    columns that `get_current_costs` selects, so a gate hardcoded to version 5
+    approved versions 5 through 26, where that read fails. Version 4 has no
+    table at all, 26 has the table without the cache columns, and latest has
+    every column.
+    """
+    mgmt_db = _unique_name("db_mgmt_cost_gate")
+    target_db = _unique_name(f"cost_gate_{target_version or 'latest'}")
+    ch_client.track_db(mgmt_db)
+    ch_client.track_db(target_db)
+
+    migrator = get_clickhouse_trace_server_migrator(
+        ch_client,
+        replicated=False,
+        use_distributed=False,
+        management_db=mgmt_db,
+        migration_dir=_PROD_MIGRATION_DIR,
+    )
+    migrator.apply_migrations(target_db, target_version=target_version)
+
+    # `expect_table and not expect_ready` is the case a version-5 gate got wrong:
+    # the table is there, so it approved a database the cost read cannot use.
+    table_rows = ch_client.query(
+        "SELECT count() FROM system.tables "
+        "WHERE database = %(database)s AND name = %(table)s",
+        parameters={"database": target_db, "table": COSTS_TABLE},
+    ).result_rows[0][0]
+    assert bool(table_rows) is expect_table
+    assert costs_schema_is_ready(ch_client, target_db) is expect_ready
+
+    prev_database = ch_client.database
+    ch_client.database = target_db
+    try:
+        if expect_ready:
+            get_current_costs(ch_client)
+        else:
+            with pytest.raises(DatabaseError):
+                get_current_costs(ch_client)
+    finally:
+        ch_client.database = prev_database

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -102,9 +102,9 @@ from tenacity import (
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.clickhouse.utilities import split_migration_sql
 from weave.trace_server.costs.insert_costs import (
+    costs_schema_is_ready,
     has_pending_costs,
     insert_costs,
-    should_insert_costs,
 )
 from weave.trace_server.database_engine import (
     ENGINE_DISCOVERY_MAX_WAIT_SECONDS,
@@ -215,7 +215,7 @@ PostMigrationWorkCheck = Callable[[PostMigrationHookContext], bool]
 def _default_trace_server_costs_post_migration_hook(
     ctx: PostMigrationHookContext,
 ) -> None:
-    if should_insert_costs(ctx.current_version, ctx.target_version):
+    if costs_schema_is_ready(ctx.ch_client, ctx.target_db):
         insert_costs(ctx.ch_client, ctx.target_db)
 
 
@@ -224,12 +224,12 @@ def _default_trace_server_costs_post_migration_work_check(
 ) -> bool:
     """Whether the costs hook has anything to do, checked before the migration lock.
 
-    Checks the cheap version gate first so the ClickHouse read in
-    `has_pending_costs` only runs once the schema is known to have the table.
+    Checks the schema gate first so the checkpoint diff in `has_pending_costs`
+    only reads a table that has the columns the diff compares.
     """
-    return should_insert_costs(
-        ctx.current_version, ctx.target_version
-    ) and has_pending_costs(ctx.ch_client, ctx.target_db)
+    return costs_schema_is_ready(ctx.ch_client, ctx.target_db) and has_pending_costs(
+        ctx.ch_client, ctx.target_db
+    )
 
 
 class MigrationStatus(TypedDict):

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -101,7 +101,11 @@ from tenacity import (
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.clickhouse.utilities import split_migration_sql
-from weave.trace_server.costs.insert_costs import insert_costs, should_insert_costs
+from weave.trace_server.costs.insert_costs import (
+    has_pending_costs,
+    insert_costs,
+    should_insert_costs,
+)
 from weave.trace_server.database_engine import (
     ENGINE_DISCOVERY_MAX_WAIT_SECONDS,
     EngineDiscoveryError,
@@ -205,6 +209,7 @@ class PostMigrationHookContext:
 
 
 PostMigrationHook = Callable[[PostMigrationHookContext], None]
+PostMigrationWorkCheck = Callable[[PostMigrationHookContext], bool]
 
 
 def _default_trace_server_costs_post_migration_hook(
@@ -212,6 +217,19 @@ def _default_trace_server_costs_post_migration_hook(
 ) -> None:
     if should_insert_costs(ctx.current_version, ctx.target_version):
         insert_costs(ctx.ch_client, ctx.target_db)
+
+
+def _default_trace_server_costs_post_migration_work_check(
+    ctx: PostMigrationHookContext,
+) -> bool:
+    """Whether the costs hook has anything to do, checked before the migration lock.
+
+    Checks the cheap version gate first so the ClickHouse read in
+    `has_pending_costs` only runs once the schema is known to have the table.
+    """
+    return should_insert_costs(
+        ctx.current_version, ctx.target_version
+    ) and has_pending_costs(ctx.ch_client, ctx.target_db)
 
 
 class MigrationStatus(TypedDict):
@@ -233,6 +251,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
     management_db: str
     migration_dir: str
     post_migration_hook: PostMigrationHook | None
+    post_migration_work_check: PostMigrationWorkCheck | None
 
     def __init__(
         self,
@@ -241,6 +260,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
         *,
         migration_dir: str,
         post_migration_hook: PostMigrationHook | None = None,
+        post_migration_work_check: PostMigrationWorkCheck | None = None,
         heartbeat_client_factory: Callable[[], CHClient] | None = None,
     ):
         super().__init__()
@@ -248,6 +268,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
         self.management_db = management_db
         self.migration_dir = self._resolve_migration_dir(migration_dir)
         self.post_migration_hook = post_migration_hook
+        self.post_migration_work_check = post_migration_work_check
         self._heartbeat_client_factory = heartbeat_client_factory
         self._initialize_migration_db()
 
@@ -320,8 +341,15 @@ class BaseClickHouseTraceServerMigrator(ABC):
         # Lock-free pre-check: on a rolling deploy N replicas call this
         # concurrently. If there is nothing to apply, skip the lock entirely so
         # they do not serialize through it just to discover there is no work.
-        if not self._has_migrations_to_apply(target_db, target_version):
-            logger.info("No migrations to apply to `%s`; skipping lock", target_db)
+        # `_has_post_migration_work` only runs when no migration is pending, since
+        # the target db may not have the relevant tables yet otherwise.
+        if not self._has_migrations_to_apply(
+            target_db, target_version
+        ) and not self._has_post_migration_work(target_db, target_version):
+            logger.info(
+                "No migrations or pending post-migration work for `%s`; skipping lock",
+                target_db,
+            )
             return
         with migration_lock(
             self.ch_client,
@@ -349,6 +377,27 @@ class BaseClickHouseTraceServerMigrator(ABC):
                 )
             )
             > 0
+        )
+
+    def _has_post_migration_work(
+        self, target_db: str, target_version: int | None = None
+    ) -> bool:
+        """Read-only check for whether the post-migration hook has pending work.
+
+        A work check is meaningless without a hook to act on it, so both must
+        be configured. Only called when no schema migration is pending, so the
+        current version read here reflects the already-settled schema.
+        """
+        if self.post_migration_hook is None or self.post_migration_work_check is None:
+            return False
+        status = self._read_migration_status(target_db)
+        return self.post_migration_work_check(
+            PostMigrationHookContext(
+                ch_client=self.ch_client,
+                target_db=target_db,
+                current_version=status["curr_version"],
+                target_version=target_version,
+            )
         )
 
     def _migration_row_exists(self, db_name: str) -> bool:
@@ -776,6 +825,7 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
         *,
         migration_dir: str,
         post_migration_hook: PostMigrationHook | None = None,
+        post_migration_work_check: PostMigrationWorkCheck | None = None,
         heartbeat_client_factory: Callable[[], CHClient] | None = None,
     ):
         self.replicated_path = (
@@ -808,6 +858,7 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
             management_db,
             migration_dir=migration_dir,
             post_migration_hook=post_migration_hook,
+            post_migration_work_check=post_migration_work_check,
             heartbeat_client_factory=heartbeat_client_factory,
         )
 
@@ -1066,6 +1117,7 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
         *,
         migration_dir: str,
         post_migration_hook: PostMigrationHook | None = None,
+        post_migration_work_check: PostMigrationWorkCheck | None = None,
         heartbeat_client_factory: Callable[[], CHClient] | None = None,
     ):
         logger.info(
@@ -1079,6 +1131,7 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
             management_db,
             migration_dir=migration_dir,
             post_migration_hook=post_migration_hook,
+            post_migration_work_check=post_migration_work_check,
             heartbeat_client_factory=heartbeat_client_factory,
         )
 
@@ -1607,6 +1660,8 @@ def get_clickhouse_trace_server_migrator(
     migration_dir: str | None = None,
     post_migration_hook: PostMigrationHook
     | None = _default_trace_server_costs_post_migration_hook,
+    post_migration_work_check: PostMigrationWorkCheck
+    | None = _default_trace_server_costs_post_migration_work_check,
     heartbeat_client_factory: Callable[[], CHClient] | None = None,
 ) -> BaseClickHouseTraceServerMigrator:
     """Factory function to create the appropriate migrator based on configuration.
@@ -1620,6 +1675,7 @@ def get_clickhouse_trace_server_migrator(
         management_db: Database name for migration management
         migration_dir: Absolute path to a directory containing `*.up.sql` / `*.down.sql`
         post_migration_hook: Optional callable run after migrations; defaults to the Weave costs backfill hook (pass None to disable)
+        post_migration_work_check: Optional callable checked before the lock, so the migrator does not skip the hook when it would have work to do; defaults to the costs backfill's pending-work check (pass None to disable)
 
     Returns:
         An instance of the appropriate migrator class
@@ -1668,6 +1724,7 @@ def get_clickhouse_trace_server_migrator(
             management_db,
             migration_dir=migration_dir,
             post_migration_hook=post_migration_hook,
+            post_migration_work_check=post_migration_work_check,
             heartbeat_client_factory=heartbeat_client_factory,
         )
     if replicated:
@@ -1678,6 +1735,7 @@ def get_clickhouse_trace_server_migrator(
             management_db,
             migration_dir=migration_dir,
             post_migration_hook=post_migration_hook,
+            post_migration_work_check=post_migration_work_check,
             heartbeat_client_factory=heartbeat_client_factory,
         )
 
@@ -1686,6 +1744,7 @@ def get_clickhouse_trace_server_migrator(
         management_db,
         migration_dir=migration_dir,
         post_migration_hook=post_migration_hook,
+        post_migration_work_check=post_migration_work_check,
         heartbeat_client_factory=heartbeat_client_factory,
     )
 

--- a/weave/trace_server/costs/insert_costs.py
+++ b/weave/trace_server/costs/insert_costs.py
@@ -173,28 +173,36 @@ def sum_costs(data: dict[str, list[CostDetails]]) -> float:
     return total_costs
 
 
-def insert_costs(client: Client, target_db: str) -> None:
+def pending_costs(client: Client, target_db: str) -> dict[str, list[CostDetails]]:
+    """Costs from `cost_checkpoint.json` not yet present in `target_db`.
+
+    Defensive by design: a failure loading or diffing the checkpoint logs and
+    returns no pending costs rather than raising, since both callers below
+    (the migration hook and the lock-free pre-check) must never crash on it.
+    Silent otherwise: this also runs from the read-only pre-check on every
+    boot once the schema is caught up, so summary logging belongs to
+    `insert_costs`, the one caller that actually inserts.
+    """
     client.database = target_db
-    # Get costs from json
     try:
         new_costs = load_costs_from_json()
     except Exception as e:
         logger.exception("Failed to load costs from json")
-        return
-    logger.info("Loaded %d costs from json", sum_costs(new_costs))
+        return {}
 
-    # filter out current costs
     try:
-        new_costs = filter_out_current_costs(client, new_costs)
+        return filter_out_current_costs(client, new_costs)
     except Exception as e:
         logger.exception("Failed to filter out current costs")
-        return
+        return {}
 
+
+def insert_costs(client: Client, target_db: str) -> None:
+    new_costs = pending_costs(client, target_db)
     logger.info(
         "There are %d costs to insert, after filtering out existing costs",
         sum_costs(new_costs),
     )
-
     if len(new_costs) == 0:
         return
 
@@ -207,11 +215,32 @@ def insert_costs(client: Client, target_db: str) -> None:
     logger.info("Inserted %d costs", sum_costs(new_costs))
 
 
-# We only want to insert costs if the target db version is 5 or higher
-# because the costs table was added in migration 5
+def has_pending_costs(client: Client, target_db: str) -> bool:
+    """Read-only check for whether any checkpoint costs are missing from `target_db`.
+
+    Runs on the shared migrator client outside the normal migration flow (the
+    lock-free pre-check in apply_migrations), so it saves and restores the
+    caller's `client.database` instead of leaving it pointed at `target_db`.
+    Never raises: a broken check must not break server startup.
+    """
+    prev_database = client.database
+    try:
+        return len(pending_costs(client, target_db)) > 0
+    except Exception:
+        logger.exception("Failed to check for pending costs")
+        return False
+    finally:
+        client.database = prev_database
+
+
 def should_insert_costs(
     db_curr_version: int, db_target_version: int | None = None
 ) -> bool:
-    return db_target_version is None or (
-        db_target_version >= 5 and db_curr_version < db_target_version
+    """Costs are insertable once `llm_token_prices` exists (migration 5)."""
+    effective_version = (
+        db_target_version if db_target_version is not None else db_curr_version
     )
+    return effective_version >= COSTS_TABLE_MIGRATION_VERSION
+
+
+COSTS_TABLE_MIGRATION_VERSION = 5

--- a/weave/trace_server/costs/insert_costs.py
+++ b/weave/trace_server/costs/insert_costs.py
@@ -31,7 +31,7 @@ def get_current_costs(
             cache_read_input_token_cost,
             cache_creation_input_token_cost,
             effective_date
-        FROM llm_token_prices
+        FROM {COSTS_TABLE}
         WHERE
         created_by = 'system'
         -- There should not ever be more than {MAX_DEFAULT_COST_ROWS} default rows in the table, but just in case we limit
@@ -99,27 +99,8 @@ def insert_costs_into_db(client: Client, data: dict[str, list[CostDetails]]) -> 
                     created_at,
                 ),
             )
-    # Insert the data into the table
-    client.insert(
-        "llm_token_prices",
-        rows,
-        column_names=[
-            "id",
-            "pricing_level",
-            "pricing_level_id",
-            "provider_id",
-            "llm_id",
-            "effective_date",
-            "prompt_token_cost",
-            "prompt_token_cost_unit",
-            "completion_token_cost",
-            "completion_token_cost_unit",
-            "cache_read_input_token_cost",
-            "cache_creation_input_token_cost",
-            "created_by",
-            "created_at",
-        ],
-    )
+    # `rows` above is built in `COST_COLUMNS` order.
+    client.insert(COSTS_TABLE, rows, column_names=list(COST_COLUMNS))
 
 
 def filter_out_current_costs(
@@ -233,14 +214,51 @@ def has_pending_costs(client: Client, target_db: str) -> bool:
         client.database = prev_database
 
 
-def should_insert_costs(
-    db_curr_version: int, db_target_version: int | None = None
-) -> bool:
-    """Costs are insertable once `llm_token_prices` exists (migration 5)."""
-    effective_version = (
-        db_target_version if db_target_version is not None else db_curr_version
-    )
-    return effective_version >= COSTS_TABLE_MIGRATION_VERSION
+def costs_schema_is_ready(client: Client, target_db: str) -> bool:
+    """Whether `target_db` has a `COSTS_TABLE` carrying every `COST_COLUMNS` column.
+
+    Asks the schema rather than comparing against a hardcoded migration version,
+    so adding a cost column cannot leave this gate approving a database whose
+    table predates it. Never raises, for the same reason as `has_pending_costs`.
+    """
+    try:
+        result = client.query(
+            """
+            SELECT count()
+            FROM system.columns
+            WHERE database = %(database)s
+                AND table = %(table)s
+                AND name IN %(columns)s
+            """,
+            parameters={
+                "database": target_db,
+                "table": COSTS_TABLE,
+                "columns": COST_COLUMNS,
+            },
+        )
+    except Exception:
+        logger.exception("Failed to check the costs table schema")
+        return False
+    return int(result.result_rows[0][0]) == len(COST_COLUMNS)
 
 
-COSTS_TABLE_MIGRATION_VERSION = 5
+COSTS_TABLE = "llm_token_prices"
+
+# Every column the cost code touches, in the order `insert_costs_into_db` builds
+# rows. `get_current_costs` reads a subset, so gating on all of them covers both.
+COST_COLUMNS = (
+    "id",
+    "pricing_level",
+    "pricing_level_id",
+    "provider_id",
+    "llm_id",
+    "effective_date",
+    "prompt_token_cost",
+    "prompt_token_cost_unit",
+    "completion_token_cost",
+    "completion_token_cost_unit",
+    "cache_read_input_token_cost",
+    "cache_creation_input_token_cost",
+    "created_by",
+    "created_at",
+)


### PR DESCRIPTION
## What breaks today

Model cost changes shipped in `cost_checkpoint.json` (new model ids, updated price history) with no accompanying schema migration were never applied once a database's schema was already at the latest migration version. New model ids render NULL costs and updated prices stay stale.

## Mechanism

`BaseClickHouseTraceServerMigrator.apply_migrations` has a lock-free pre-check that returns before acquiring the migration lock when there are no pending schema migrations:

```python
if not self._has_migrations_to_apply(target_db, target_version):
    logger.info("No migrations to apply to `%s`; skipping lock", target_db)
    return
```

That `return` happens before the post-migration hook (which is what inserts checkpoint costs) ever runs. The hook only fires from inside `_apply_migrations_locked`, which is unreachable once the pre-check short-circuits. So on any database that is already caught up on schema, a checkpoint-only cost change is silently never applied.

## What applies on merge

Three coordinated changes:

1. **`weave/trace_server/costs/insert_costs.py`**: extracted a `pending_costs()` helper (load, then diff against what's already in the table) shared by `insert_costs()` and a new read-only `has_pending_costs()` check. `has_pending_costs` saves/restores the caller's `client.database` (it runs on the shared migrator client outside the normal flow) and never raises, since a broken check must not break server startup. The old `should_insert_costs()` version gate is replaced by `costs_schema_is_ready()`, a `system.columns` probe: the gate's only real question is whether this database has the columns the cost code reads and writes, so it now asks the schema instead of comparing against a hardcoded migration number. `COST_COLUMNS` is the single source of truth, used both as the probe's column set and as the insert's `column_names`.

2. **`weave/trace_server/clickhouse_trace_server_migrator.py`**: added an optional `post_migration_work_check` threaded alongside the existing `post_migration_hook` through all migrator constructors and the factory function. The lock-free pre-check now also asks `_has_post_migration_work`, so pending cost work takes the lock even when there's no schema migration to apply. The check is short-circuited to run only when no migration is pending (the target db may not have the relevant tables otherwise), and is a no-op unless both a hook and a work check are configured, so callers that already pass `post_migration_hook=None` to opt out of the costs hook are unaffected by this change.

3. **`tests/trace_server_migrator/test_migrator_functional.py`**: two real-ClickHouse regression tests. There was previously no test covering the post-migration hook at all, and the existing migrator unit tests use mocked clients, which is why this shipped unnoticed. `tests/trace_server/test_clickhouse_trace_server_migrator.py` also gains a case asserting the work check is never invoked when no hook is configured.

The actual insert still runs inside the migration lock, unchanged from before. Running `insert_costs` unlocked on N rolling-deploy replicas would make the read-then-write cost diff a race, inserting N duplicate rows per model on every deploy.

## Why the version gate went away

`should_insert_costs` required migration 5, where `llm_token_prices` is created. But `get_current_costs` selects `cache_read_input_token_cost` and `cache_creation_input_token_cost`, which migration 27 adds. The gate therefore approved versions 5 through 26, where the read fails and `filter_out_current_costs` swallows the error. That is how the stale 5 survived migration 27: the failure mode is a caught exception nobody reads.

Bumping 5 to 27 would fix the instance and leave the mechanism, so the version number is gone instead. A new parameterized functional test pins the coupling at the three interesting points, and the middle row is exactly the case the old gate got wrong:

| Schema | `llm_token_prices` exists | Gate ready | Cost read works |
| --- | --- | --- | --- |
| 4 | no | no | raises |
| 26 | yes | no | raises |
| latest | yes | yes | yes |

Two related notes:

- `has_pending_costs` is new steady-state work. The checkpoint diff used to run only when a migration was actually applied; it now runs once per replica boot, alongside the small `_read_migration_status` read the pre-check needs. `llm_token_prices` holds a few thousand `system` rows, so this is a cheap read on a path that already talks to ClickHouse, but it is new per-boot work.
- `PostMigrationHookContext` keeps its `current_version` / `target_version` fields even though the default costs hook no longer reads them. They describe the migration that just ran and remain useful to any other hook, so they stay part of the hook contract rather than being removed as dead code.

## Testing

- `uv run --group test python -m pytest tests/trace_server/costs/test_insert_costs.py tests/trace_server/test_clickhouse_trace_server_migrator.py -q`: 118 passed
- `uv run --group test python -m pytest tests/trace_server_migrator/test_migrator_functional.py -q` (real ClickHouse): 25 passed, 1 pre-existing unrelated failure deselected (see below). Includes the backfill regression test, which migrates a scratch database to latest, deletes a model's seeded `created_by='system'` rows to simulate a checkpoint change made after the schema was already current, and asserts the row is restored by a second `apply_migrations` call with no version bump. Verified this test fails (0 rows restored) against the pre-fix code and passes against the fix.
- The schema-gate test was strengthened after that full-file run (adding the table-existence column of the table above) and re-run with the backfill test: 4 passed. The edit touched only that test function and an import, not the source or any shared fixture.
- `uvx ruff check` / `uvx ruff format --check` on touched files: clean
- `nox --no-install -e lint` (ty, import-linter, pyright, mypy, ruff): passed, with the changes staged so `prek` did not stash them out from under the type checkers
- Deselected `test_distributed_legacy_replicated_management_db`: pre-existing failure in this environment unrelated to this change (an `ORDER BY (db_name)` vs `ORDER BY db_name` engine-string formatting difference, reproduces identically on an unmodified checkout with this branch's changes absent, so it is a local ClickHouse version difference in how the engine string is rendered).
