### PR TITLE
feat(weave): Allow a whitelisted set of private network IP addresses for remote scoring

### DIFF
--- a/tests/trace_server/test_environment.py
+++ b/tests/trace_server/test_environment.py
@@ -241,20 +241,24 @@ def test_wf_scoring_worker_remote_scorer_allowed_hosts(monkeypatch):
     ("raw", "expected"),
     [
         # None means the variable is absent rather than set to a value.
-        (None, []),
-        ("", []),
-        ("10.0.0.0/8", ["10.0.0.0/8"]),
-        ("10.0.0.0/8,fd00::/8", ["10.0.0.0/8", "fd00::/8"]),
-        (" 10.0.0.0/8 ,\tfd00::/8 ", ["10.0.0.0/8", "fd00::/8"]),
-        ("10.0.0.0/8,,  ,fd00::/8", ["10.0.0.0/8", "fd00::/8"]),
-    ],
-    ids=[
-        "unset",
-        "empty",
-        "single_network",
-        "comma_separated",
-        "surrounding_whitespace",
-        "empty_entries",
+        pytest.param(None, [], id="unset"),
+        pytest.param("", [], id="empty"),
+        pytest.param("10.0.0.0/8", ["10.0.0.0/8"], id="single_network"),
+        pytest.param(
+            "10.0.0.0/8,fd00::/8",
+            ["10.0.0.0/8", "fd00::/8"],
+            id="comma_separated",
+        ),
+        pytest.param(
+            " 10.0.0.0/8 ,\tfd00::/8 ",
+            ["10.0.0.0/8", "fd00::/8"],
+            id="surrounding_whitespace",
+        ),
+        pytest.param(
+            "10.0.0.0/8,,  ,fd00::/8",
+            ["10.0.0.0/8", "fd00::/8"],
+            id="empty_entries",
+        ),
     ],
 )
 @pytest.mark.disable_logging_error_check

--- a/tests/trace_server/test_environment.py
+++ b/tests/trace_server/test_environment.py
@@ -238,16 +238,52 @@ def test_wf_scoring_worker_remote_scorer_allowed_hosts(monkeypatch):
 
 
 @pytest.mark.disable_logging_error_check
-def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs(monkeypatch):
-    """Allowed private CIDRs are comma-separated network strings, empty by default."""
-    key = REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV
-    monkeypatch.delenv(key, raising=False)
+def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs_defaults_to_empty(
+    monkeypatch,
+):
+    monkeypatch.delenv(REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV, raising=False)
     assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == []
 
-    monkeypatch.setenv(key, "")
+
+@pytest.mark.disable_logging_error_check
+def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs_treats_empty_as_unset(
+    monkeypatch,
+):
+    monkeypatch.setenv(REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV, "")
     assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == []
 
-    monkeypatch.setenv(key, " 10.0.0.0/8 , ,fd00::/8 ")
+
+@pytest.mark.disable_logging_error_check
+def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs_splits_on_commas(
+    monkeypatch,
+):
+    monkeypatch.setenv(REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV, "10.0.0.0/8,fd00::/8")
+    assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == [
+        "10.0.0.0/8",
+        "fd00::/8",
+    ]
+
+
+@pytest.mark.disable_logging_error_check
+def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs_strips_whitespace(
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV, " 10.0.0.0/8 ,\tfd00::/8 "
+    )
+    assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == [
+        "10.0.0.0/8",
+        "fd00::/8",
+    ]
+
+
+@pytest.mark.disable_logging_error_check
+def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs_skips_empty_entries(
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV, "10.0.0.0/8,,  ,fd00::/8"
+    )
     assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == [
         "10.0.0.0/8",
         "fd00::/8",

--- a/tests/trace_server/test_environment.py
+++ b/tests/trace_server/test_environment.py
@@ -237,57 +237,36 @@ def test_wf_scoring_worker_remote_scorer_allowed_hosts(monkeypatch):
     ]
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # None means the variable is absent rather than set to a value.
+        (None, []),
+        ("", []),
+        ("10.0.0.0/8", ["10.0.0.0/8"]),
+        ("10.0.0.0/8,fd00::/8", ["10.0.0.0/8", "fd00::/8"]),
+        (" 10.0.0.0/8 ,\tfd00::/8 ", ["10.0.0.0/8", "fd00::/8"]),
+        ("10.0.0.0/8,,  ,fd00::/8", ["10.0.0.0/8", "fd00::/8"]),
+    ],
+    ids=[
+        "unset",
+        "empty",
+        "single_network",
+        "comma_separated",
+        "surrounding_whitespace",
+        "empty_entries",
+    ],
+)
 @pytest.mark.disable_logging_error_check
-def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs_defaults_to_empty(
-    monkeypatch,
+def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs(
+    raw, expected, monkeypatch
 ):
-    monkeypatch.delenv(REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV, raising=False)
-    assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == []
+    if raw is None:
+        monkeypatch.delenv(REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV, raising=False)
+    else:
+        monkeypatch.setenv(REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV, raw)
 
-
-@pytest.mark.disable_logging_error_check
-def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs_treats_empty_as_unset(
-    monkeypatch,
-):
-    monkeypatch.setenv(REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV, "")
-    assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == []
-
-
-@pytest.mark.disable_logging_error_check
-def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs_splits_on_commas(
-    monkeypatch,
-):
-    monkeypatch.setenv(REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV, "10.0.0.0/8,fd00::/8")
-    assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == [
-        "10.0.0.0/8",
-        "fd00::/8",
-    ]
-
-
-@pytest.mark.disable_logging_error_check
-def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs_strips_whitespace(
-    monkeypatch,
-):
-    monkeypatch.setenv(
-        REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV, " 10.0.0.0/8 ,\tfd00::/8 "
-    )
-    assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == [
-        "10.0.0.0/8",
-        "fd00::/8",
-    ]
-
-
-@pytest.mark.disable_logging_error_check
-def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs_skips_empty_entries(
-    monkeypatch,
-):
-    monkeypatch.setenv(
-        REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV, "10.0.0.0/8,,  ,fd00::/8"
-    )
-    assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == [
-        "10.0.0.0/8",
-        "fd00::/8",
-    ]
+    assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == expected
 
 
 @pytest.mark.disable_logging_error_check

--- a/tests/trace_server/test_environment.py
+++ b/tests/trace_server/test_environment.py
@@ -6,6 +6,7 @@ from weave.trace_server.environment import (
     DEFAULT_REMOTE_SCORER_HTTP_TIMEOUT_SECONDS,
     REMOTE_SCORER_ALLOW_INSECURE_HTTP_ENV,
     REMOTE_SCORER_ALLOWED_HOSTS_ENV,
+    REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV,
     REMOTE_SCORER_REQUIRE_STRUCTURED_RESULT_SCHEMA_ENV,
     REMOTE_SCORER_VALIDATE_HOSTS_ENV,
     VALID_CALLS_SHARD_KEYS,
@@ -19,6 +20,7 @@ from weave.trace_server.environment import (
     wf_scoring_worker_kafka_consumer_group_id_override,
     wf_scoring_worker_remote_scorer_allow_insecure_http,
     wf_scoring_worker_remote_scorer_allowed_hosts,
+    wf_scoring_worker_remote_scorer_allowed_private_cidrs,
     wf_scoring_worker_remote_scorer_bearer_token,
     wf_scoring_worker_remote_scorer_enabled,
     wf_scoring_worker_remote_scorer_http_timeout_seconds,
@@ -232,6 +234,23 @@ def test_wf_scoring_worker_remote_scorer_allowed_hosts(monkeypatch):
         "scoring.example.com",
         "api.example.com:8443",
         "localhost",
+    ]
+
+
+@pytest.mark.disable_logging_error_check
+def test_wf_scoring_worker_remote_scorer_allowed_private_cidrs(monkeypatch):
+    """Allowed private CIDRs are comma-separated network strings, empty by default."""
+    key = REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV
+    monkeypatch.delenv(key, raising=False)
+    assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == []
+
+    monkeypatch.setenv(key, "")
+    assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == []
+
+    monkeypatch.setenv(key, " 10.0.0.0/8 , ,fd00::/8 ")
+    assert wf_scoring_worker_remote_scorer_allowed_private_cidrs() == [
+        "10.0.0.0/8",
+        "fd00::/8",
     ]
 
 

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -174,6 +174,9 @@ REMOTE_SCORER_VALIDATE_HOSTS_ENV = "WF_SCORING_WORKER_REMOTE_SCORER_VALIDATE_HOS
 REMOTE_SCORER_ALLOW_INSECURE_HTTP_ENV = (
     "WF_SCORING_WORKER_REMOTE_SCORER_ALLOW_INSECURE_HTTP"
 )
+REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV = (
+    "WF_SCORING_WORKER_REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS"
+)
 REMOTE_SCORER_REQUIRE_STRUCTURED_RESULT_SCHEMA_ENV = (
     "WF_SCORING_WORKER_REMOTE_SCORER_REQUIRE_STRUCTURED_RESULT_SCHEMA"
 )
@@ -231,14 +234,36 @@ def wf_scoring_worker_remote_scorer_validate_hosts() -> bool:
 
 
 def wf_scoring_worker_remote_scorer_allow_insecure_http() -> bool:
-    """Whether remote scorer URLs may use insecure http.
+    """Whether remote scorer URLs may use the http scheme instead of https.
 
-    This is intended as an explicit operator waiver for local/dev testing. The
-    worker still applies the host allowlist when this is enabled.
+    That is the only thing this setting controls. The host allowlist still
+    applies when it is enabled, and private IP addresses are governed
+    independently by wf_scoring_worker_remote_scorer_allowed_private_cidrs.
     """
     return (
         os.environ.get(REMOTE_SCORER_ALLOW_INSECURE_HTTP_ENV, "false").lower() == "true"
     )
+
+
+def wf_scoring_worker_remote_scorer_allowed_private_cidrs() -> list[str]:
+    """Networks exempt from the remote scorer private IP address deny.
+
+    Values are comma-separated CIDR networks, for example "10.0.0.0/8". Empty
+    and whitespace-only entries are ignored, and the default empty list keeps
+    every private IP address denied. Entries are validated by the scoring
+    worker, which rejects malformed networks and any network overlapping the
+    ranges that can never be exempted (link-local, multicast, unspecified).
+
+    This does not affect the http/https requirement: an exempted address is
+    still reachable only over https unless the insecure-http waiver is also
+    set. Combining a broad network here with host validation disabled removes
+    both the address and the allowlist control, leaving outbound requests
+    unconstrained.
+    """
+    raw = os.environ.get(REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV)
+    if raw is None:
+        return []
+    return [entry.strip() for entry in raw.split(",") if entry.strip()]
 
 
 def wf_scoring_worker_remote_scorer_require_structured_result_schema() -> bool:

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -236,9 +236,9 @@ def wf_scoring_worker_remote_scorer_validate_hosts() -> bool:
 def wf_scoring_worker_remote_scorer_allow_insecure_http() -> bool:
     """Whether remote scorer URLs may use the http scheme instead of https.
 
-    That is the only thing this setting controls. The host allowlist still
-    applies when it is enabled, and private IP addresses are governed
-    independently by wf_scoring_worker_remote_scorer_allowed_private_cidrs.
+    The host allowlist still applies when it is enabled, and private IP
+    addresses are governed independently by
+    wf_scoring_worker_remote_scorer_allowed_private_cidrs.
     """
     return (
         os.environ.get(REMOTE_SCORER_ALLOW_INSECURE_HTTP_ENV, "false").lower() == "true"

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -250,15 +250,11 @@ def wf_scoring_worker_remote_scorer_allowed_private_cidrs() -> list[str]:
 
     Values are comma-separated CIDR networks, for example "10.0.0.0/8". Empty
     and whitespace-only entries are ignored, and the default empty list keeps
-    every private IP address denied. Entries are validated by the scoring
-    worker, which rejects malformed networks and any network overlapping the
-    ranges that can never be exempted (link-local, multicast, unspecified).
+    every private IP address denied.
 
     This does not affect the http/https requirement: an exempted address is
-    still reachable only over https unless the insecure-http waiver is also
-    set. Combining a broad network here with host validation disabled removes
-    both the address and the allowlist control, leaving outbound requests
-    unconstrained.
+    still reachable only over https unless
+    wf_scoring_worker_remote_scorer_allow_insecure_http is also set.
     """
     raw = os.environ.get(REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV)
     if raw is None:

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -251,10 +251,6 @@ def wf_scoring_worker_remote_scorer_allowed_private_cidrs() -> list[str]:
     Values are comma-separated CIDR networks, for example "10.0.0.0/8". Empty
     and whitespace-only entries are ignored, and the default empty list keeps
     every private IP address denied.
-
-    This does not affect the http/https requirement: an exempted address is
-    still reachable only over https unless
-    wf_scoring_worker_remote_scorer_allow_insecure_http is also set.
     """
     raw = os.environ.get(REMOTE_SCORER_ALLOWED_PRIVATE_CIDRS_ENV)
     if raw is None:


### PR DESCRIPTION

## Description
- Fixes [WB-38435](https://coreweave.atlassian.net/browse/WB-38435)

Allow a whitelisted set of private network IP addresses for remote scoring. Specify using an env var containing comma-separated CIDR (eg 10.0.0.0/8).

## Testing

Unit tests


[WB-38435]: https://coreweave.atlassian.net/browse/WB-38435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ