### PR TITLE
fix(weave_ts): link an evaluation to the agent spans it produced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,10 +381,10 @@ deterministic.
   builds, never the OTel global registry. A processor that must see them belongs
   in that provider's `spanProcessors`, which is built lazily on the first span
   and rebuilt on a project switch — registering once from `init()` misses both.
-- OTel JS drops the *incoming* attribute once a span is at its attribute limit,
-  the opposite of Python's evict-the-oldest `BoundedAttributes`. Write order is
-  therefore load-bearing and inverted between the two SDKs: whatever a
-  processor sets first is what survives.
+- At a span's attribute limit OTel JS drops the *incoming* attribute, where
+  Python's `BoundedAttributes` evicts the oldest. A processor writing several
+  attributes therefore keeps its most important one first in JS and last in
+  Python.
 - For callback or generator integrations, create `Conversation`, `Turn`, and
   `LLM` in short `runIsolated()` scopes, then retain and pass explicit handles.
   `Tool` and `SubAgent` do not use ambient state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,6 +377,14 @@ deterministic.
 - `Conversation`, `Turn`, `LLM`, `Tool`, and `SubAgent` emit canonical
   `invoke_agent`, `chat`, and `execute_tool` spans through
   `/agents/otel/v1/traces`.
+- These spans go through the `BasicTracerProvider` that `genai/provider.ts`
+  builds, never the OTel global registry. A processor that must see them belongs
+  in that provider's `spanProcessors`, which is built lazily on the first span
+  and rebuilt on a project switch — registering once from `init()` misses both.
+- OTel JS drops the *incoming* attribute once a span is at its attribute limit,
+  the opposite of Python's evict-the-oldest `BoundedAttributes`. Write order is
+  therefore load-bearing and inverted between the two SDKs: whatever a
+  processor sets first is what survives.
 - For callback or generator integrations, create `Conversation`, `Turn`, and
   `LLM` in short `runIsolated()` scopes, then retain and pass explicit handles.
   `Tool` and `SubAgent` do not use ambient state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,9 +382,9 @@ deterministic.
   in that provider's `spanProcessors`, which is built lazily on the first span
   and rebuilt on a project switch — registering once from `init()` misses both.
 - At a span's attribute limit OTel JS drops the *incoming* attribute, where
-  Python's `BoundedAttributes` evicts the oldest. A processor writing several
-  attributes therefore keeps its most important one first in JS and last in
-  Python.
+  Python's `BoundedAttributes` evicts the oldest, so the two SDKs keep different
+  halves of an overflowing set. The eval linker writes the pair eval results
+  match on before its display-only attributes for that reason.
 - For callback or generator integrations, create `Conversation`, `Turn`, and
   `LLM` in short `runIsolated()` scopes, then retain and pass explicit handles.
   `Tool` and `SubAgent` do not use ambient state.

--- a/sdks/node/src/__tests__/evalLinkSpanProcessor.test.ts
+++ b/sdks/node/src/__tests__/evalLinkSpanProcessor.test.ts
@@ -1,17 +1,33 @@
 import {ROOT_CONTEXT, TraceFlags} from '@opentelemetry/api';
-import type {ReadableSpan, Span} from '@opentelemetry/sdk-trace-base';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type ReadableSpan,
+  type Span,
+} from '@opentelemetry/sdk-trace-base';
 
 import {requireGlobalClient} from '../clientApi';
+import {
+  EVAL_EVALUATION_NAME_SPAN_ATTR,
+  EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR,
+  EVAL_PROJECT_ID_SPAN_ATTR,
+  EVAL_RUN_ID_SPAN_ATTR,
+} from '../constants';
 import {Dataset} from '../dataset';
 import {Evaluation} from '../evaluation';
+import {EvalLinkSpanProcessor} from '../evalLinkSpanProcessor';
+import {runIsolated} from '../genai/context';
 import {
-  EvalLinkSpanProcessor,
-  registerEvalLinkSpanProcessor,
-} from '../evalLinkSpanProcessor';
+  getWeaveTracer,
+  getWeaveTracerProvider,
+  shutdownWeaveTracerProvider,
+} from '../genai/provider';
+import {Turn} from '../genai/turn';
 import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 import {op} from '../op';
 import {CallStack, type CallStackEntry} from '../weaveClient';
 import {initWithCustomTraceServer} from './clientMock';
+import {installFakeClient, setupGenAITestEnvironment} from './genai/common';
 
 const TRACE_ID = '1234567890abcdef1234567890abcdef';
 const SPAN_ID = '1234567890abcdef';
@@ -64,18 +80,14 @@ describe('EvalLinkSpanProcessor', () => {
       }
     );
 
-    expect(span.setAttribute).toHaveBeenCalledWith(
-      'weave.eval.predict_and_score_call_id',
-      'predict-and-score-call'
-    );
-    expect(span.setAttribute).toHaveBeenCalledWith(
-      'weave.eval.project_id',
-      projectId
-    );
-    expect(span.setAttribute).toHaveBeenCalledWith(
-      'weave.eval.evaluation_name',
-      'my-eval-my-model'
-    );
+    // Ordered: a span that is already at its attribute limit drops whatever
+    // arrives next, and the server needs the first two to link the span at all.
+    expect((span.setAttribute as jest.Mock).mock.calls).toEqual([
+      ['weave.eval.run_id', 'eval-call'],
+      ['weave.eval.predict_and_score_call_id', 'predict-and-score-call'],
+      ['weave.eval.project_id', projectId],
+      ['weave.eval.evaluation_name', 'my-eval-my-model'],
+    ]);
     expect(predictAndScoreEntry.childSummary).toEqual({
       weave: {
         genai_span_ref: [
@@ -128,44 +140,6 @@ describe('EvalLinkSpanProcessor', () => {
     ]);
   });
 
-  test('registers on SDK tracer providers once', () => {
-    const provider = {
-      addSpanProcessor: jest.fn(),
-      getTracer: jest.fn(),
-    };
-
-    expect(
-      registerEvalLinkSpanProcessor(
-        () => requireGlobalClient(),
-        provider as any
-      )
-    ).toBe(true);
-    expect(
-      registerEvalLinkSpanProcessor(
-        () => requireGlobalClient(),
-        provider as any
-      )
-    ).toBe(true);
-
-    expect(provider.addSpanProcessor).toHaveBeenCalledTimes(1);
-    expect(provider.addSpanProcessor.mock.calls[0][0]).toBeInstanceOf(
-      EvalLinkSpanProcessor
-    );
-  });
-
-  test('does not register on API-only tracer providers', () => {
-    const provider = {
-      getTracer: jest.fn(),
-    };
-
-    expect(
-      registerEvalLinkSpanProcessor(
-        () => requireGlobalClient(),
-        provider as any
-      )
-    ).toBe(false);
-  });
-
   test('links GenAI spans to declarative Evaluation.predictAndScore calls', async () => {
     const processor = new EvalLinkSpanProcessor(() => requireGlobalClient());
     const dataset = new Dataset({rows: [{question: 'hello'}]});
@@ -192,5 +166,114 @@ describe('EvalLinkSpanProcessor', () => {
         span_id: SPAN_ID,
       },
     ]);
+  });
+});
+
+// Everything above drives the processor directly. These go through the public
+// path instead — emit a real GenAI span and read the exported span — because
+// the processor was wired to a provider Weave never emits through, and no
+// direct-call test can see that.
+describe('EvalLinkSpanProcessor wiring', () => {
+  setupGenAITestEnvironment();
+
+  const projectId = 'test-entity/test-project';
+  let traceServer: InMemoryTraceServer;
+  let exporter: InMemorySpanExporter;
+
+  beforeEach(() => {
+    traceServer = new InMemoryTraceServer();
+    exporter = new InMemorySpanExporter();
+    initWithCustomTraceServer(projectId, traceServer, {
+      genai: {spanProcessor: new SimpleSpanProcessor(exporter)},
+    });
+  });
+
+  function evalLinkProcessorCount(): number {
+    // No public API lists a provider's processors, and being in that list is
+    // the whole contract here, so read the SDK's own array.
+    const registered =
+      (getWeaveTracerProvider() as any)?._registeredSpanProcessors ?? [];
+    return registered.filter((p: unknown) => p instanceof EvalLinkSpanProcessor)
+      .length;
+  }
+
+  async function evaluateOnce(emitSpan: () => void): Promise<void> {
+    const dataset = new Dataset({rows: [{question: 'hello'}]});
+    const model = op(async function model({
+      datasetRow,
+    }: {
+      datasetRow: {question: string};
+    }) {
+      emitSpan();
+      return `answer: ${datasetRow.question}`;
+    });
+    await new Evaluation({dataset, scorers: []}).evaluate({
+      model,
+      maxConcurrency: 1,
+    });
+  }
+
+  test('stamps eval metadata on a span a declarative evaluation emits', async () => {
+    await evaluateOnce(() => Turn.create({}).end());
+
+    const calls = await traceServer.getCalls(projectId);
+    const evaluateCall = calls.find(c =>
+      c.op_name.includes('Evaluation.evaluate')
+    );
+    const predictAndScoreCall = calls.find(c =>
+      c.op_name.includes('Evaluation.predictAndScore')
+    );
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    const spanContext = spans[0].spanContext();
+
+    // The server only accepts a span as eval-linked when both run_id and
+    // predict_and_score_call_id are set, so assert the pair, not either half.
+    expect(spans[0].attributes[EVAL_RUN_ID_SPAN_ATTR]).toBe(evaluateCall!.id);
+    expect(spans[0].attributes[EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR]).toBe(
+      predictAndScoreCall!.id
+    );
+    expect(spans[0].attributes[EVAL_PROJECT_ID_SPAN_ATTR]).toBe(projectId);
+    expect(spans[0].attributes[EVAL_EVALUATION_NAME_SPAN_ATTR]).toBe(
+      evaluateCall!.display_name
+    );
+    // onEnd runs on the same span, so the trial also carries the legacy ref.
+    expect(predictAndScoreCall!.summary?.weave?.genai_span_ref).toEqual([
+      {trace_id: spanContext.traceId, span_id: spanContext.spanId},
+    ]);
+  });
+
+  test('stamps a span emitted inside runIsolated', async () => {
+    await evaluateOnce(() => runIsolated(() => Turn.create({}).end()));
+
+    const predictAndScoreCall = (await traceServer.getCalls(projectId)).find(
+      c => c.op_name.includes('Evaluation.predictAndScore')
+    );
+    const [span] = exporter.getFinishedSpans();
+
+    expect(span.attributes[EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR]).toBe(
+      predictAndScoreCall!.id
+    );
+  });
+
+  test('installs the processor on a provider built with default settings', () => {
+    installFakeClient();
+
+    getWeaveTracer('weave-genai');
+
+    expect(evalLinkProcessorCount()).toBe(1);
+  });
+
+  test('reinstalls the processor when a project switch rebuilds the provider', () => {
+    getWeaveTracer('weave-genai');
+    const first = getWeaveTracerProvider();
+
+    // What init() does when the project changes.
+    installFakeClient({projectId: 'test-entity/other-project'});
+    shutdownWeaveTracerProvider();
+    getWeaveTracer('weave-genai');
+
+    expect(getWeaveTracerProvider()).not.toBe(first);
+    expect(evalLinkProcessorCount()).toBe(1);
   });
 });

--- a/sdks/node/src/__tests__/evalLinkSpanProcessor.test.ts
+++ b/sdks/node/src/__tests__/evalLinkSpanProcessor.test.ts
@@ -1,8 +1,7 @@
-import {ROOT_CONTEXT, TraceFlags} from '@opentelemetry/api';
+import {ROOT_CONTEXT} from '@opentelemetry/api';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
-  type ReadableSpan,
   type Span,
 } from '@opentelemetry/sdk-trace-base';
 
@@ -17,43 +16,21 @@ import {Dataset} from '../dataset';
 import {Evaluation} from '../evaluation';
 import {EvalLinkSpanProcessor} from '../evalLinkSpanProcessor';
 import {runIsolated} from '../genai/context';
-import {
-  getWeaveTracer,
-  getWeaveTracerProvider,
-  shutdownWeaveTracerProvider,
-} from '../genai/provider';
 import {Turn} from '../genai/turn';
 import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 import {op} from '../op';
 import {CallStack, type CallStackEntry} from '../weaveClient';
 import {initWithCustomTraceServer} from './clientMock';
-import {installFakeClient, setupGenAITestEnvironment} from './genai/common';
-
-const TRACE_ID = '1234567890abcdef1234567890abcdef';
-const SPAN_ID = '1234567890abcdef';
-const SECOND_SPAN_ID = 'fedcba0987654321';
-
-function readableGenAISpan(spanId = SPAN_ID): ReadableSpan {
-  return {
-    attributes: {'gen_ai.operation.name': 'chat'},
-    spanContext: () => ({
-      traceId: TRACE_ID,
-      spanId,
-      traceFlags: TraceFlags.SAMPLED,
-    }),
-  } as unknown as ReadableSpan;
-}
+import {findSpan, setupGenAITestEnvironment} from './genai/common';
 
 describe('EvalLinkSpanProcessor', () => {
-  let traceServer: InMemoryTraceServer;
   const projectId = 'test-project';
 
   beforeEach(() => {
-    traceServer = new InMemoryTraceServer();
-    initWithCustomTraceServer(projectId, traceServer);
+    initWithCustomTraceServer(projectId, new InMemoryTraceServer());
   });
 
-  test('injects eval metadata on span start and stores GenAI span refs on end', () => {
+  test('injects eval metadata on span start', () => {
     const client = requireGlobalClient();
     const processor = new EvalLinkSpanProcessor(() => requireGlobalClient());
     const evaluateEntry: CallStackEntry = {
@@ -73,110 +50,28 @@ describe('EvalLinkSpanProcessor', () => {
 
     client.runWithCallStack(
       new CallStack([evaluateEntry, predictAndScoreEntry]),
-      () => {
-        processor.onStart(span, ROOT_CONTEXT);
-        processor.onEnd(readableGenAISpan());
-        processor.onEnd(readableGenAISpan(SECOND_SPAN_ID));
-      }
+      () => processor.onStart(span, ROOT_CONTEXT)
     );
 
-    // Ordered: a span that is already at its attribute limit drops whatever
-    // arrives next, and the server needs the first two to link the span at all.
+    // Ordered: a span at its attribute limit drops whatever arrives next, so the
+    // pair eval results match on has to be written before the display-only ones.
     expect((span.setAttribute as jest.Mock).mock.calls).toEqual([
       ['weave.eval.run_id', 'eval-call'],
       ['weave.eval.predict_and_score_call_id', 'predict-and-score-call'],
       ['weave.eval.project_id', projectId],
       ['weave.eval.evaluation_name', 'my-eval-my-model'],
     ]);
-    expect(predictAndScoreEntry.childSummary).toEqual({
-      weave: {
-        genai_span_ref: [
-          {
-            trace_id: TRACE_ID,
-            span_id: SPAN_ID,
-          },
-          {
-            trace_id: TRACE_ID,
-            span_id: SECOND_SPAN_ID,
-          },
-        ],
-      },
-    });
-  });
-
-  test('upgrades existing single GenAI span ref summary and deduplicates refs', () => {
-    const processor = new EvalLinkSpanProcessor(() => requireGlobalClient());
-    const predictAndScoreEntry: CallStackEntry = {
-      callId: 'predict-and-score-call',
-      traceId: 'weave-trace',
-      childSummary: {
-        weave: {
-          genai_span_ref: {
-            trace_id: TRACE_ID,
-            span_id: SPAN_ID,
-          },
-        },
-      },
-      opName: 'Evaluation.predictAndScore',
-    };
-
-    requireGlobalClient().runWithCallStack(
-      new CallStack([predictAndScoreEntry]),
-      () => {
-        processor.onEnd(readableGenAISpan());
-        processor.onEnd(readableGenAISpan(SECOND_SPAN_ID));
-      }
-    );
-
-    expect(predictAndScoreEntry.childSummary.weave.genai_span_ref).toEqual([
-      {
-        trace_id: TRACE_ID,
-        span_id: SPAN_ID,
-      },
-      {
-        trace_id: TRACE_ID,
-        span_id: SECOND_SPAN_ID,
-      },
-    ]);
-  });
-
-  test('links GenAI spans to declarative Evaluation.predictAndScore calls', async () => {
-    const processor = new EvalLinkSpanProcessor(() => requireGlobalClient());
-    const dataset = new Dataset({rows: [{question: 'hello'}]});
-    const model = op(async function model({
-      datasetRow,
-    }: {
-      datasetRow: {question: string};
-    }) {
-      processor.onEnd(readableGenAISpan());
-      return `answer: ${datasetRow.question}`;
-    });
-    const evaluation = new Evaluation({dataset, scorers: []});
-
-    await evaluation.evaluate({model, maxConcurrency: 1});
-
-    const calls = await traceServer.getCalls(projectId);
-    const predictAndScoreCall = calls.find(c =>
-      c.op_name.includes('Evaluation.predictAndScore')
-    );
-
-    expect(predictAndScoreCall?.summary?.weave?.genai_span_ref).toEqual([
-      {
-        trace_id: TRACE_ID,
-        span_id: SPAN_ID,
-      },
-    ]);
   });
 });
 
 // Everything above drives the processor directly. These go through the public
-// path instead — emit a real GenAI span and read the exported span — because
-// the processor was wired to a provider Weave never emits through, and no
-// direct-call test can see that.
-describe('EvalLinkSpanProcessor wiring', () => {
+// path instead — run an evaluation, emit a real GenAI span, read the exported
+// span — because the processor was wired to a provider Weave never emits
+// through, and no direct-call test can see that.
+describe('EvalLinkSpanProcessor - declarative Evaluation', () => {
   setupGenAITestEnvironment();
 
-  const projectId = 'test-entity/test-project';
+  const projectId = 'test-project';
   let traceServer: InMemoryTraceServer;
   let exporter: InMemorySpanExporter;
 
@@ -187,15 +82,6 @@ describe('EvalLinkSpanProcessor wiring', () => {
       genai: {spanProcessor: new SimpleSpanProcessor(exporter)},
     });
   });
-
-  function evalLinkProcessorCount(): number {
-    // No public API lists a provider's processors, and being in that list is
-    // the whole contract here, so read the SDK's own array.
-    const registered =
-      (getWeaveTracerProvider() as any)?._registeredSpanProcessors ?? [];
-    return registered.filter((p: unknown) => p instanceof EvalLinkSpanProcessor)
-      .length;
-  }
 
   async function evaluateOnce(emitSpan: () => void): Promise<void> {
     const dataset = new Dataset({rows: [{question: 'hello'}]});
@@ -213,8 +99,12 @@ describe('EvalLinkSpanProcessor wiring', () => {
     });
   }
 
-  test('stamps eval metadata on a span a declarative evaluation emits', async () => {
-    await evaluateOnce(() => Turn.create({}).end());
+  test('stamps eval metadata on the spans a declarative evaluation emits', async () => {
+    await evaluateOnce(() => {
+      const turn = Turn.create({});
+      turn.startLLM({model: 'gpt-4o'}).end();
+      turn.end();
+    });
 
     const calls = await traceServer.getCalls(projectId);
     const evaluateCall = calls.find(c =>
@@ -224,56 +114,37 @@ describe('EvalLinkSpanProcessor wiring', () => {
       c.op_name.includes('Evaluation.predictAndScore')
     );
     const spans = exporter.getFinishedSpans();
-    expect(spans).toHaveLength(1);
-    const spanContext = spans[0].spanContext();
+    const rootSpan = findSpan(spans, 'invoke_agent');
+    const childSpan = findSpan(spans, 'chat');
 
-    // The server only accepts a span as eval-linked when both run_id and
-    // predict_and_score_call_id are set, so assert the pair, not either half.
-    expect(spans[0].attributes[EVAL_RUN_ID_SPAN_ATTR]).toBe(evaluateCall!.id);
-    expect(spans[0].attributes[EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR]).toBe(
+    // Eval results match a span on the pair, so assert it, not either half.
+    expect(rootSpan.attributes[EVAL_RUN_ID_SPAN_ATTR]).toBe(evaluateCall!.id);
+    expect(rootSpan.attributes[EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR]).toBe(
       predictAndScoreCall!.id
     );
-    expect(spans[0].attributes[EVAL_PROJECT_ID_SPAN_ATTR]).toBe(projectId);
-    expect(spans[0].attributes[EVAL_EVALUATION_NAME_SPAN_ATTR]).toBe(
+    expect(rootSpan.attributes[EVAL_PROJECT_ID_SPAN_ATTR]).toBe(projectId);
+    expect(rootSpan.attributes[EVAL_EVALUATION_NAME_SPAN_ATTR]).toBe(
       evaluateCall!.display_name
     );
-    // onEnd runs on the same span, so the trial also carries the legacy ref.
-    expect(predictAndScoreCall!.summary?.weave?.genai_span_ref).toEqual([
-      {trace_id: spanContext.traceId, span_id: spanContext.spanId},
-    ]);
+    // Every span the prediction emits is stamped, not just the root.
+    expect(childSpan.attributes[EVAL_RUN_ID_SPAN_ATTR]).toBe(evaluateCall!.id);
   });
 
   test('stamps a span emitted inside runIsolated', async () => {
     await evaluateOnce(() => runIsolated(() => Turn.create({}).end()));
 
-    const predictAndScoreCall = (await traceServer.getCalls(projectId)).find(
-      c => c.op_name.includes('Evaluation.predictAndScore')
+    const calls = await traceServer.getCalls(projectId);
+    const evaluateCall = calls.find(c =>
+      c.op_name.includes('Evaluation.evaluate')
     );
-    const [span] = exporter.getFinishedSpans();
+    const predictAndScoreCall = calls.find(c =>
+      c.op_name.includes('Evaluation.predictAndScore')
+    );
+    const span = findSpan(exporter.getFinishedSpans(), 'invoke_agent');
 
+    expect(span.attributes[EVAL_RUN_ID_SPAN_ATTR]).toBe(evaluateCall!.id);
     expect(span.attributes[EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR]).toBe(
       predictAndScoreCall!.id
     );
-  });
-
-  test('installs the processor on a provider built with default settings', () => {
-    installFakeClient();
-
-    getWeaveTracer('weave-genai');
-
-    expect(evalLinkProcessorCount()).toBe(1);
-  });
-
-  test('reinstalls the processor when a project switch rebuilds the provider', () => {
-    getWeaveTracer('weave-genai');
-    const first = getWeaveTracerProvider();
-
-    // What init() does when the project changes.
-    installFakeClient({projectId: 'test-entity/other-project'});
-    shutdownWeaveTracerProvider();
-    getWeaveTracer('weave-genai');
-
-    expect(getWeaveTracerProvider()).not.toBe(first);
-    expect(evalLinkProcessorCount()).toBe(1);
   });
 });

--- a/sdks/node/src/__tests__/evalLinkSpanProcessor.test.ts
+++ b/sdks/node/src/__tests__/evalLinkSpanProcessor.test.ts
@@ -32,7 +32,7 @@ describe('EvalLinkSpanProcessor', () => {
     initWithCustomTraceServer(projectId, new InMemoryTraceServer());
   });
 
-  test('injects eval metadata on span start', () => {
+  test('writes eval metadata in overflow-safe order', () => {
     const client = requireGlobalClient();
     const processor = new EvalLinkSpanProcessor(() => requireGlobalClient());
     const evaluateEntry: CallStackEntry = {

--- a/sdks/node/src/__tests__/evalLinkSpanProcessor.test.ts
+++ b/sdks/node/src/__tests__/evalLinkSpanProcessor.test.ts
@@ -11,6 +11,8 @@ import {
   EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR,
   EVAL_PROJECT_ID_SPAN_ATTR,
   EVAL_RUN_ID_SPAN_ATTR,
+  EVALUATION_RUN_OP_NAME,
+  EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
 } from '../constants';
 import {Dataset} from '../dataset';
 import {Evaluation} from '../evaluation';
@@ -53,8 +55,7 @@ describe('EvalLinkSpanProcessor', () => {
       () => processor.onStart(span, ROOT_CONTEXT)
     );
 
-    // Ordered: a span at its attribute limit drops whatever arrives next, so the
-    // pair eval results match on has to be written before the display-only ones.
+    // Ordered on purpose — see the comment on onStart.
     expect((span.setAttribute as jest.Mock).mock.calls).toEqual([
       ['weave.eval.run_id', 'eval-call'],
       ['weave.eval.predict_and_score_call_id', 'predict-and-score-call'],
@@ -83,7 +84,8 @@ describe('EvalLinkSpanProcessor - declarative Evaluation', () => {
     });
   });
 
-  async function evaluateOnce(emitSpan: () => void): Promise<void> {
+  /** Evaluate one row, emitting `emitSpan()` inside the prediction. */
+  async function evaluateOnce(emitSpan: () => void) {
     const dataset = new Dataset({rows: [{question: 'hello'}]});
     const model = op(async function model({
       datasetRow,
@@ -97,54 +99,51 @@ describe('EvalLinkSpanProcessor - declarative Evaluation', () => {
       model,
       maxConcurrency: 1,
     });
+
+    const calls = await traceServer.getCalls(projectId);
+    return {
+      evaluateCall: calls.find(c =>
+        c.op_name.includes(EVALUATION_RUN_OP_NAME)
+      )!,
+      predictAndScoreCall: calls.find(c =>
+        c.op_name.includes(EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS)
+      )!,
+    };
   }
 
   test('stamps eval metadata on the spans a declarative evaluation emits', async () => {
-    await evaluateOnce(() => {
+    const {evaluateCall, predictAndScoreCall} = await evaluateOnce(() => {
       const turn = Turn.create({});
       turn.startLLM({model: 'gpt-4o'}).end();
       turn.end();
     });
 
-    const calls = await traceServer.getCalls(projectId);
-    const evaluateCall = calls.find(c =>
-      c.op_name.includes('Evaluation.evaluate')
-    );
-    const predictAndScoreCall = calls.find(c =>
-      c.op_name.includes('Evaluation.predictAndScore')
-    );
     const spans = exporter.getFinishedSpans();
     const rootSpan = findSpan(spans, 'invoke_agent');
     const childSpan = findSpan(spans, 'chat');
 
     // Eval results match a span on the pair, so assert it, not either half.
-    expect(rootSpan.attributes[EVAL_RUN_ID_SPAN_ATTR]).toBe(evaluateCall!.id);
+    expect(rootSpan.attributes[EVAL_RUN_ID_SPAN_ATTR]).toBe(evaluateCall.id);
     expect(rootSpan.attributes[EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR]).toBe(
-      predictAndScoreCall!.id
+      predictAndScoreCall.id
     );
     expect(rootSpan.attributes[EVAL_PROJECT_ID_SPAN_ATTR]).toBe(projectId);
     expect(rootSpan.attributes[EVAL_EVALUATION_NAME_SPAN_ATTR]).toBe(
-      evaluateCall!.display_name
+      evaluateCall.display_name
     );
     // Every span the prediction emits is stamped, not just the root.
-    expect(childSpan.attributes[EVAL_RUN_ID_SPAN_ATTR]).toBe(evaluateCall!.id);
+    expect(childSpan.attributes[EVAL_RUN_ID_SPAN_ATTR]).toBe(evaluateCall.id);
   });
 
   test('stamps a span emitted inside runIsolated', async () => {
-    await evaluateOnce(() => runIsolated(() => Turn.create({}).end()));
-
-    const calls = await traceServer.getCalls(projectId);
-    const evaluateCall = calls.find(c =>
-      c.op_name.includes('Evaluation.evaluate')
-    );
-    const predictAndScoreCall = calls.find(c =>
-      c.op_name.includes('Evaluation.predictAndScore')
+    const {evaluateCall, predictAndScoreCall} = await evaluateOnce(() =>
+      runIsolated(() => Turn.create({}).end())
     );
     const span = findSpan(exporter.getFinishedSpans(), 'invoke_agent');
 
-    expect(span.attributes[EVAL_RUN_ID_SPAN_ATTR]).toBe(evaluateCall!.id);
+    expect(span.attributes[EVAL_RUN_ID_SPAN_ATTR]).toBe(evaluateCall.id);
     expect(span.attributes[EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR]).toBe(
-      predictAndScoreCall!.id
+      predictAndScoreCall.id
     );
   });
 });

--- a/sdks/node/src/__tests__/genai/provider.test.ts
+++ b/sdks/node/src/__tests__/genai/provider.test.ts
@@ -4,6 +4,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 
+import {EvalLinkSpanProcessor} from '../../evalLinkSpanProcessor';
 import {flushOTel} from '../../genai/flush';
 import {
   getWeaveTracer,
@@ -15,6 +16,15 @@ import {WEAVE_RESOURCE_ATTR} from '../../genai/weaveResource';
 import {packageVersion} from '../../utils/packageVersion';
 
 import {installFakeClient, setupGenAITestEnvironment} from './common';
+
+// Same private-field caveat as exporterProjectId below: no public API lists a
+// provider's processors, and being in that list is the eval linker's whole
+// contract, so read the SDK's own array.
+function evalLinkProcessorCount(provider: BasicTracerProvider): number {
+  const registered = (provider as any)._registeredSpanProcessors ?? [];
+  return registered.filter((p: unknown) => p instanceof EvalLinkSpanProcessor)
+    .length;
+}
 
 describe('otel/provider', () => {
   setupGenAITestEnvironment();
@@ -54,6 +64,12 @@ describe('otel/provider', () => {
       [WEAVE_RESOURCE_ATTR.WEAVE_SDK_VERSION]: packageVersion,
       [WEAVE_RESOURCE_ATTR.WEAVE_SDK_LANGUAGE]: 'node',
     });
+  });
+
+  it('installs the eval link processor on every provider it builds', () => {
+    installFakeClient();
+    getWeaveTracer('weave-genai');
+    expect(evalLinkProcessorCount(getWeaveTracerProvider()!)).toBe(1);
   });
 
   it('honors a user-supplied SpanProcessor and routes spans through it', async () => {
@@ -108,8 +124,8 @@ describe('otel/provider', () => {
     // internals — better replaced by an integration test that asserts the
     // header on a captured export once we have that harness.
     function exporterProjectId(provider: BasicTracerProvider): string {
-      const processors = (provider as any)._registeredSpanProcessors ?? [];
-      const exporter = processors.find((p: any) => p._exporter)?._exporter;
+      const processor = (provider as any)._registeredSpanProcessors?.[0];
+      const exporter = processor?._exporter;
       const headers = exporter?._transport?._transport?._parameters?.headers;
       return headers?.project_id;
     }
@@ -155,6 +171,15 @@ describe('otel/provider', () => {
 
       reinit('ent/B');
       expect(exporterProjectId(getWeaveTracerProvider()!)).toBe('ent/B');
+    });
+
+    it('reinstalls the eval link processor on the rebuilt provider', () => {
+      reinit('ent/A');
+
+      // The linker is added where the provider is built, so a rebuild has to
+      // pick it up again — registering it once from init() would not.
+      reinit('ent/B');
+      expect(evalLinkProcessorCount(getWeaveTracerProvider()!)).toBe(1);
     });
   });
 });

--- a/sdks/node/src/__tests__/genai/provider.test.ts
+++ b/sdks/node/src/__tests__/genai/provider.test.ts
@@ -108,8 +108,8 @@ describe('otel/provider', () => {
     // internals — better replaced by an integration test that asserts the
     // header on a captured export once we have that harness.
     function exporterProjectId(provider: BasicTracerProvider): string {
-      const processor = (provider as any)._registeredSpanProcessors?.[0];
-      const exporter = processor?._exporter;
+      const processors = (provider as any)._registeredSpanProcessors ?? [];
+      const exporter = processors.find((p: any) => p._exporter)?._exporter;
       const headers = exporter?._transport?._transport?._parameters?.headers;
       return headers?.project_id;
     }

--- a/sdks/node/src/__tests__/genai/provider.test.ts
+++ b/sdks/node/src/__tests__/genai/provider.test.ts
@@ -18,7 +18,8 @@ import {packageVersion} from '../../utils/packageVersion';
 import {installFakeClient, setupGenAITestEnvironment} from './common';
 
 // No public API lists a provider's processors, and being in that list is the
-// eval linker's whole contract, so read the SDK's own array.
+// eval linker's whole contract, so read the SDK's own array — same internals
+// coupling as exporterProjectId below, and the same TODO applies.
 function evalLinkProcessorCount(provider: BasicTracerProvider): number {
   const registered = (provider as any)._registeredSpanProcessors ?? [];
   return registered.filter((p: unknown) => p instanceof EvalLinkSpanProcessor)
@@ -65,7 +66,7 @@ describe('otel/provider', () => {
     });
   });
 
-  it('installs the eval link processor on every provider it builds', () => {
+  it('installs the eval link processor on a default-settings provider', () => {
     installFakeClient();
     getWeaveTracer('weave-genai');
     expect(evalLinkProcessorCount(getWeaveTracerProvider()!)).toBe(1);

--- a/sdks/node/src/__tests__/genai/provider.test.ts
+++ b/sdks/node/src/__tests__/genai/provider.test.ts
@@ -17,9 +17,8 @@ import {packageVersion} from '../../utils/packageVersion';
 
 import {installFakeClient, setupGenAITestEnvironment} from './common';
 
-// Same private-field caveat as exporterProjectId below: no public API lists a
-// provider's processors, and being in that list is the eval linker's whole
-// contract, so read the SDK's own array.
+// No public API lists a provider's processors, and being in that list is the
+// eval linker's whole contract, so read the SDK's own array.
 function evalLinkProcessorCount(provider: BasicTracerProvider): number {
   const registered = (provider as any)._registeredSpanProcessors ?? [];
   return registered.filter((p: unknown) => p instanceof EvalLinkSpanProcessor)

--- a/sdks/node/src/clientApi.ts
+++ b/sdks/node/src/clientApi.ts
@@ -1,6 +1,5 @@
 import {Api as TraceServerApi} from './generated/traceServerApi';
 import {CLIENT_CAPABILITIES, CLIENT_CAPABILITIES_HEADER} from './constants';
-import {registerEvalLinkSpanProcessor} from './evalLinkSpanProcessor';
 import {
   getWeaveTracerProviderProjectId,
   shutdownWeaveTracerProvider,
@@ -151,7 +150,6 @@ export async function init(
     }
     setGlobalClient(client);
     setGlobalDomain(domain);
-    registerEvalLinkSpanProcessor(getGlobalClient);
     registerExitFlush();
     console.log(`View Weave data at https://${domain}/${projectId}/weave`);
     return client;

--- a/sdks/node/src/constants.ts
+++ b/sdks/node/src/constants.ts
@@ -24,6 +24,7 @@ export const EVAL_META_KEY = '_weave_eval_meta';
 export const WEAVE_ATTRIBUTES_NAMESPACE = 'weave';
 export const GENAI_SPAN_REF_ATTR_KEY = 'genai_span_ref';
 
+export const EVAL_RUN_ID_SPAN_ATTR = 'weave.eval.run_id';
 export const EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR =
   'weave.eval.predict_and_score_call_id';
 export const EVAL_PROJECT_ID_SPAN_ATTR = 'weave.eval.project_id';

--- a/sdks/node/src/constants.ts
+++ b/sdks/node/src/constants.ts
@@ -21,9 +21,6 @@ export const EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAMES = [
  */
 export const EVAL_META_KEY = '_weave_eval_meta';
 
-export const WEAVE_ATTRIBUTES_NAMESPACE = 'weave';
-export const GENAI_SPAN_REF_ATTR_KEY = 'genai_span_ref';
-
 export const EVAL_RUN_ID_SPAN_ATTR = 'weave.eval.run_id';
 export const EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR =
   'weave.eval.predict_and_score_call_id';

--- a/sdks/node/src/evalLinkSpanProcessor.ts
+++ b/sdks/node/src/evalLinkSpanProcessor.ts
@@ -1,9 +1,4 @@
-import {
-  isSpanContextValid,
-  trace,
-  type Context,
-  type TracerProvider,
-} from '@opentelemetry/api';
+import {isSpanContextValid, type Context} from '@opentelemetry/api';
 import type {
   ReadableSpan,
   Span,
@@ -14,6 +9,7 @@ import {
   EVAL_EVALUATION_NAME_SPAN_ATTR,
   EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR,
   EVAL_PROJECT_ID_SPAN_ATTR,
+  EVAL_RUN_ID_SPAN_ATTR,
   EVALUATION_RUN_OP_NAME,
   EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAMES,
   GENAI_SPAN_REF_ATTR_KEY,
@@ -21,23 +17,6 @@ import {
 } from './constants';
 import {ATTR_GEN_AI_OPERATION_NAME} from './genai/semconv';
 import type {CallStackEntry, WeaveClient} from './weaveClient';
-import state from './state';
-
-// The API TracerProvider type only exposes getTracer. addSpanProcessor is an
-// SDK-specific, deprecated late-registration hook, so we feature-detect it and
-// no-op for API-only or newer providers that do not support it.
-type SpanProcessorProvider = TracerProvider & {
-  addSpanProcessor: (processor: SpanProcessor) => void;
-};
-
-function isSpanProcessorProvider(
-  provider: TracerProvider
-): provider is SpanProcessorProvider {
-  return (
-    'addSpanProcessor' in provider &&
-    typeof provider.addSpanProcessor === 'function'
-  );
-}
 
 type ClientGetter = () => WeaveClient | null;
 
@@ -114,13 +93,22 @@ export class EvalLinkSpanProcessor implements SpanProcessor {
     if (!client || !call) {
       return;
     }
+    const evaluateCall = findEvaluateCall(this.getClient);
 
+    // A span already at its attribute limit drops whatever arrives next, and
+    // eval results only recognize a span carrying both the run ID and the
+    // predict-and-score call ID, so write that pair before the rest.
+    if (evaluateCall) {
+      span.setAttribute(EVAL_RUN_ID_SPAN_ATTR, evaluateCall.callId);
+    }
     span.setAttribute(EVAL_PREDICT_AND_SCORE_CALL_ID_SPAN_ATTR, call.callId);
     span.setAttribute(EVAL_PROJECT_ID_SPAN_ATTR, client.projectId);
 
-    const evalName = findEvaluateCall(this.getClient)?.displayName;
-    if (evalName) {
-      span.setAttribute(EVAL_EVALUATION_NAME_SPAN_ATTR, evalName);
+    if (evaluateCall?.displayName) {
+      span.setAttribute(
+        EVAL_EVALUATION_NAME_SPAN_ATTR,
+        evaluateCall.displayName
+      );
     }
   }
 
@@ -153,29 +141,4 @@ export class EvalLinkSpanProcessor implements SpanProcessor {
   shutdown(): Promise<void> {
     return Promise.resolve();
   }
-}
-
-/**
- * Register EvalLinkSpanProcessor on a TracerProvider when the provider exposes
- * the SDK addSpanProcessor API.
- *
- * Returns true when the processor is installed or was already installed.
- * Returns false for API-only proxy providers or other custom providers that do
- * not expose addSpanProcessor.
- */
-export function registerEvalLinkSpanProcessor(
-  getClient: ClientGetter,
-  provider: TracerProvider = trace.getTracerProvider()
-): boolean {
-  if (state.evalLink.registeredProviders.has(provider)) {
-    return true;
-  }
-
-  if (!isSpanProcessorProvider(provider)) {
-    return false;
-  }
-
-  provider.addSpanProcessor(new EvalLinkSpanProcessor(getClient));
-  state.evalLink.registeredProviders.add(provider);
-  return true;
 }

--- a/sdks/node/src/evalLinkSpanProcessor.ts
+++ b/sdks/node/src/evalLinkSpanProcessor.ts
@@ -1,4 +1,4 @@
-import {isSpanContextValid, type Context} from '@opentelemetry/api';
+import type {Context} from '@opentelemetry/api';
 import type {
   ReadableSpan,
   Span,
@@ -12,58 +12,16 @@ import {
   EVAL_RUN_ID_SPAN_ATTR,
   EVALUATION_RUN_OP_NAME,
   EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAMES,
-  GENAI_SPAN_REF_ATTR_KEY,
-  WEAVE_ATTRIBUTES_NAMESPACE,
 } from './constants';
-import {ATTR_GEN_AI_OPERATION_NAME} from './genai/semconv';
 import type {CallStackEntry, WeaveClient} from './weaveClient';
 
 type ClientGetter = () => WeaveClient | null;
-
-interface GenAISpanRef {
-  trace_id: string;
-  span_id: string;
-}
-
-function attachGenAISpanRefToCallSummary(
-  call: CallStackEntry,
-  genaiSpanRef: GenAISpanRef
-): void {
-  const existingWeaveSummary = call.childSummary[WEAVE_ATTRIBUTES_NAMESPACE];
-  const weaveSummary =
-    existingWeaveSummary != null &&
-    typeof existingWeaveSummary === 'object' &&
-    !Array.isArray(existingWeaveSummary)
-      ? existingWeaveSummary
-      : {};
-  const existingGenAISpanRefs = weaveSummary[GENAI_SPAN_REF_ATTR_KEY];
-  const genaiSpanRefs = Array.isArray(existingGenAISpanRefs)
-    ? existingGenAISpanRefs
-    : existingGenAISpanRefs != null
-      ? [existingGenAISpanRefs]
-      : [];
-
-  const alreadyAttached = genaiSpanRefs.some(
-    ref =>
-      ref != null &&
-      typeof ref === 'object' &&
-      ref.trace_id === genaiSpanRef.trace_id &&
-      ref.span_id === genaiSpanRef.span_id
-  );
-
-  call.childSummary[WEAVE_ATTRIBUTES_NAMESPACE] = {
-    ...weaveSummary,
-    [GENAI_SPAN_REF_ATTR_KEY]: alreadyAttached
-      ? genaiSpanRefs
-      : [...genaiSpanRefs, genaiSpanRef],
-  };
-}
 
 function findPredictAndScoreCall(
   getClient: ClientGetter
 ): CallStackEntry | null {
   // The predict-and-score call is the per-row eval call that owns the model
-  // prediction. This is where we store GenAI span refs for eval result rows.
+  // prediction. Its ID is what identifies an eval result row.
   return (
     getClient()
       ?.getCallStack()
@@ -72,8 +30,8 @@ function findPredictAndScoreCall(
 }
 
 function findEvaluateCall(getClient: ClientGetter): CallStackEntry | null {
-  // The evaluate call is the parent eval run. We only use it to attach the
-  // human-readable evaluation name onto GenAI spans for filtering/deep links.
+  // The evaluate call is the parent eval run: its ID is the run ID eval results
+  // match on, and its display name is the human-readable evaluation name.
   return (
     getClient()?.getCallStack().findLastByOpName([EVALUATION_RUN_OP_NAME]) ??
     null
@@ -95,9 +53,8 @@ export class EvalLinkSpanProcessor implements SpanProcessor {
     }
     const evaluateCall = findEvaluateCall(this.getClient);
 
-    // A span already at its attribute limit drops whatever arrives next, and
-    // eval results only recognize a span carrying both the run ID and the
-    // predict-and-score call ID, so write that pair before the rest.
+    // A span already at its attribute limit drops whatever arrives next, so the
+    // pair eval results match on goes on before the two display-only ones.
     if (evaluateCall) {
       span.setAttribute(EVAL_RUN_ID_SPAN_ATTR, evaluateCall.callId);
     }
@@ -112,27 +69,7 @@ export class EvalLinkSpanProcessor implements SpanProcessor {
     }
   }
 
-  onEnd(span: ReadableSpan): void {
-    const attrs = span.attributes || {};
-    if (!(ATTR_GEN_AI_OPERATION_NAME in attrs)) {
-      return;
-    }
-
-    const call = findPredictAndScoreCall(this.getClient);
-    if (!call) {
-      return;
-    }
-
-    const spanContext = span.spanContext();
-    if (!isSpanContextValid(spanContext)) {
-      return;
-    }
-
-    attachGenAISpanRefToCallSummary(call, {
-      trace_id: spanContext.traceId,
-      span_id: spanContext.spanId,
-    });
-  }
+  onEnd(_span: ReadableSpan): void {}
 
   forceFlush(): Promise<void> {
     return Promise.resolve();

--- a/sdks/node/src/evalLinkSpanProcessor.ts
+++ b/sdks/node/src/evalLinkSpanProcessor.ts
@@ -54,7 +54,7 @@ export class EvalLinkSpanProcessor implements SpanProcessor {
     const evaluateCall = findEvaluateCall(this.getClient);
 
     // A span already at its attribute limit drops whatever arrives next, so the
-    // pair eval results match on goes on before the two display-only ones.
+    // pair eval results match on is written before the two display-only ones.
     if (evaluateCall) {
       span.setAttribute(EVAL_RUN_ID_SPAN_ATTR, evaluateCall.callId);
     }

--- a/sdks/node/src/genai/provider.ts
+++ b/sdks/node/src/genai/provider.ts
@@ -102,8 +102,8 @@ function getOrBuildProvider(client: WeaveClient): BasicTracerProvider {
   const tracerProvider = new BasicTracerProvider({
     resource,
     spanProcessors: [
-      new EvalLinkSpanProcessor(getGlobalClient),
       buildSpanProcessor(client),
+      new EvalLinkSpanProcessor(getGlobalClient),
     ],
   });
   state.genAi.provider = {tracerProvider, projectId: client.projectId};

--- a/sdks/node/src/genai/provider.ts
+++ b/sdks/node/src/genai/provider.ts
@@ -96,9 +96,6 @@ function getOrBuildProvider(client: WeaveClient): BasicTracerProvider {
     [WEAVE_RESOURCE_ATTR.WEAVE_SDK_LANGUAGE]: SDK_LANGUAGE,
   });
 
-  // The eval linker is installed here, not once in init(), because this
-  // provider is built lazily and rebuilt on a project switch — a one-time
-  // registration would miss both.
   const tracerProvider = new BasicTracerProvider({
     resource,
     spanProcessors: [

--- a/sdks/node/src/genai/provider.ts
+++ b/sdks/node/src/genai/provider.ts
@@ -10,6 +10,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 
 import {getGlobalClient} from '../clientApi';
+import {EvalLinkSpanProcessor} from '../evalLinkSpanProcessor';
 import {packageVersion} from '../utils/packageVersion';
 import type {WeaveClient} from '../weaveClient';
 import {getWandbConfigs} from '../wandb/settings';
@@ -95,9 +96,15 @@ function getOrBuildProvider(client: WeaveClient): BasicTracerProvider {
     [WEAVE_RESOURCE_ATTR.WEAVE_SDK_LANGUAGE]: SDK_LANGUAGE,
   });
 
+  // The eval linker is installed here, not once in init(), because this
+  // provider is built lazily and rebuilt on a project switch — a one-time
+  // registration would miss both.
   const tracerProvider = new BasicTracerProvider({
     resource,
-    spanProcessors: [buildSpanProcessor(client)],
+    spanProcessors: [
+      new EvalLinkSpanProcessor(getGlobalClient),
+      buildSpanProcessor(client),
+    ],
   });
   state.genAi.provider = {tracerProvider, projectId: client.projectId};
   registerBeforeExitHookOnce();

--- a/sdks/node/src/state.ts
+++ b/sdks/node/src/state.ts
@@ -5,7 +5,6 @@ import {globalSingleton} from './utils/globalSingleton';
 import {type GenAIState} from './genai/context';
 import {type WeaveAdkPlugin} from './integrations/googleAdk';
 import {type WeaveClient} from './weaveClient';
-import {type TracerProvider} from '@opentelemetry/api';
 
 /**
  * Holds all SDK-wide mutable state.
@@ -109,10 +108,6 @@ type State = {
       plugin: WeaveAdkPlugin | null;
     };
   };
-
-  evalLink: {
-    registeredProviders: WeakSet<TracerProvider>;
-  };
 };
 
 function defaultState(): State {
@@ -125,10 +120,6 @@ function defaultState(): State {
       providerRegistered: false,
       state: new AsyncLocalStorage<GenAIState>(),
       defaultState: {conversation: null, turn: null, llm: null},
-    },
-
-    evalLink: {
-      registeredProviders: new WeakSet(),
     },
 
     integrations: {


### PR DESCRIPTION
Four PRs, in review order:

1. TypeScript evals: **this PR**. A prerequisite, separate from this work: it fixes existing eval linking.
2. Migration: [#7729](https://github.com/wandb/weave/pull/7729) — the two `spans` columns, split out so they land before the code that writes them.
3. Python + server: [#7730](https://github.com/wandb/weave/pull/7730).
4. TypeScript ops: [#7711](https://github.com/wandb/weave/pull/7711).

## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-38444

## Description

In TypeScript an evaluation never links to the agent spans its predictions produce. No "View spans" button, and the eval columns on `spans` stay empty. Python has had this link since May.

The code for it was here all along, just never connected. The processor registered on the OTel global provider, but weave emits through its own provider, which is kept out of that registry. The call never even ran: with no user-installed provider, `trace.getTracerProvider()` has no `addSpanProcessor`, so the helper returned `false` and nobody checked. Nothing regressed; the wire was never there.

The fix registers the processor where the provider is built, because that happens lazily on the first span and again when `init()` switches projects.

One attribute was missing too. The server counts a span as linked only with both `weave.eval.run_id` and `weave.eval.predict_and_score_call_id`, and TypeScript wrote only the second. It now writes both, run id first, since a full span drops whatever arrives next.

That is enough for the "View spans" drill-in. Full parity is a separate ticket, and so is `EvaluationLogger`, which cannot be linked this way at all.

## Why this approach

Turning the processor on also turns on its `onEnd` hook, which appended a span ref to the prediction call's `childSummary`. That hook has never run, and once it does the result is wrong: `childSummary` propagates to the parent, and merging two rows' arrays gives an object with numeric keys, so every multi-row eval would ship a malformed `weave.genai_span_ref` on its root call. So it is gone. An existing test already says an SDK must not write that field; the promoted columns carry the link.

The linker goes after the exporting processor, the same order Python uses. That is neutral for the default pipeline. A custom `settings.genai.spanProcessor` now runs before it and will not see `weave.eval.*`, but no processor has ever seen those attributes, so nothing is lost today.

## Testing

The new tests go through the public path: run an `Evaluation`, emit a real GenAI span, read the exported span. That is the only kind of test that catches this, since the old ones drove the processor directly and passed for months against a processor nobody had attached; the full `sdks/node` suite (503 tests), eslint, prettier and both typechecks are green.




