### PR TITLE
refactor(weave): key intent_records on the embedding version, not the pipeline

### DIFF
--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -599,7 +599,12 @@ def test_all_production_migrations_distributed(ch_client):
 
 
 def test_intent_records_schema_and_replacement_lifecycle(ch_client):
-    """Intent records retain pipeline history while replacing row versions."""
+    """Intent records isolate embedding versions and replace everything else.
+
+    Pins the contract the schema exists to express: a changed embedding version
+    coexists so an old one stays serveable and can be retired by DROP PARTITION,
+    while a changed judge or prompt replaces its predecessor in place.
+    """
     mgmt_db = _unique_name("db_mgmt_intents")
     target_db = _unique_name("intents")
     ch_client.track_db(mgmt_db)
@@ -624,9 +629,9 @@ def test_intent_records_schema_and_replacement_lifecycle(ch_client):
     assert table_metadata == [
         (
             "ReplacingMergeTree",
-            "toYYYYMM(source_started_at)",
-            "project_id, pipeline_version, lens, toDate(source_started_at), id",
-            "project_id, pipeline_version, lens, toDate(source_started_at), id",
+            "(toYYYYMM(source_started_at), embedding_version)",
+            "project_id, embedding_version, lens, toDate(source_started_at), id",
+            "project_id, embedding_version, lens, toDate(source_started_at), id",
             "expire_at",
         )
     ]
@@ -641,9 +646,20 @@ def test_intent_records_schema_and_replacement_lifecycle(ch_client):
         ("id", "String"),
         ("signature_id", "FixedString(16)"),
         ("lens", "LowCardinality(String)"),
-        ("pipeline_version", "UInt32"),
+        ("embedding_version", "UInt32"),
         ("record_version", "UInt64"),
-        ("category", "String"),
+        (
+            "category",
+            "Enum8('' = 0, 'action_request' = 1, 'information_request' = 2, "
+            "'problem_report' = 3, 'feedback' = 4, 'approval' = 5, "
+            "'rejection' = 6, 'correction' = 7, 'clarification' = 8, "
+            "'bad_faith' = 9, 'other' = 10, 'task_misunderstanding' = 21, "
+            "'context_loss' = 22, 'wrong_output' = 23, "
+            "'requirement_violation' = 24, 'tool_misuse' = 25, "
+            "'tool_failure' = 26, 'system_error' = 27, "
+            "'unproductive_loop' = 28, 'capability_gap' = 29, "
+            "'improper_refusal' = 30, 'safety_violation' = 31)",
+        ),
         ("signature", "String"),
         ("language", "LowCardinality(String)"),
         ("sentiment", "LowCardinality(String)"),
@@ -696,7 +712,7 @@ def test_intent_records_schema_and_replacement_lifecycle(ch_client):
     ]
 
     insert_columns = """
-        project_id, id, signature_id, lens, pipeline_version,
+        project_id, id, signature_id, lens, embedding_version,
         record_version, category, signature, language,
         sentiment, sentiment_confidence,
         embedding_model, vector, judge_model, prompt_version, pipeline_recipe_sha256,
@@ -710,42 +726,64 @@ def test_intent_records_schema_and_replacement_lifecycle(ch_client):
     row_template = """
         SELECT
             'project-1', 'intent-1', unhex('00112233445566778899aabbccddeeff'),
-            'intent', {pipeline_version}, {record_version}, '{category}',
+            'intent', {embedding_version}, {record_version}, '{category}',
             'Add Stripe checkout', 'es',
             'frustrated', toFloat32(0.75),
             'text-embedding-3-large', arrayResize([toFloat32(1)], 1024, toFloat32(0)),
-            'gemma-4-31b-it', 'intent-v1', repeat('ab', 32),
+            '{judge_model}', '{prompt_version}', repeat('ab', 32),
             'trace-1', 'span-1', 'conversation-1', 7, 'user-1',
             'checkout-agent', '1.4.2', 'anthropic', 'claude-sonnet-5', 'cli', 'OK',
             4200, toFloat64(0.0123), 'Wired up a Stripe checkout endpoint.',
             toDateTime64('2026-05-30 09:15:00', 6, 'UTC'),
             toDateTime64('2026-06-20 14:32:00', 6, 'UTC')
     """
-    for pipeline_version, record_version, category in [
-        (1, 1, "action_request"),
-        (1, 2, "payments"),
-        (2, 1, "action_request"),
+    for embedding_version, record_version, category, judge, prompt in [
+        (1, 1, "action_request", "gemma-4-31b-it", "intent-v1"),
+        (1, 2, "information_request", "gemma-4-31b-it", "intent-v1"),
+        # A new judge and prompt for the same occurrence: payload, so it must
+        # replace rather than coexist.
+        (1, 3, "information_request", "gemma-5-31b-it", "intent-v2"),
+        (2, 1, "action_request", "gemma-4-31b-it", "intent-v1"),
     ]:
         ch_client.command(
             f"INSERT INTO {target_db}.intent_records ({insert_columns}) "
             + row_template.format(
-                pipeline_version=pipeline_version,
+                embedding_version=embedding_version,
                 record_version=record_version,
                 category=category,
+                judge_model=judge,
+                prompt_version=prompt,
             )
         )
 
-    # Highest record_version wins within a pipeline_version, and each
-    # pipeline_version is retained as its own row.
+    # Highest record_version wins within an embedding_version, a changed
+    # extraction recipe leaves no second row, and each embedding_version is
+    # retained so an old space stays serveable until its cutover.
     current_rows = ch_client.query(
-        "SELECT pipeline_version, record_version, category, "
-        "formatDateTime(expire_at, '%F %T'), length(vector) "
+        "SELECT embedding_version, record_version, category, judge_model, "
+        "prompt_version, formatDateTime(expire_at, '%F %T'), length(vector) "
         f"FROM {target_db}.intent_records FINAL "
-        "WHERE project_id = 'project-1' ORDER BY pipeline_version"
+        "WHERE project_id = 'project-1' ORDER BY embedding_version"
     ).result_rows
     assert current_rows == [
-        (1, 2, "payments", "2100-01-01 00:00:00", 1024),
-        (2, 1, "action_request", "2100-01-01 00:00:00", 1024),
+        (
+            1,
+            3,
+            "information_request",
+            "gemma-5-31b-it",
+            "intent-v2",
+            "2100-01-01 00:00:00",
+            1024,
+        ),
+        (
+            2,
+            1,
+            "action_request",
+            "gemma-4-31b-it",
+            "intent-v1",
+            "2100-01-01 00:00:00",
+            1024,
+        ),
     ]
 
     # The promoted columns round-trip as typed values rather than Map strings.
@@ -758,7 +796,7 @@ def test_intent_records_schema_and_replacement_lifecycle(ch_client):
         "formatDateTime(source_started_at, '%F %T'), "
         "formatDateTime(intent_extracted_at, '%F %T') "
         f"FROM {target_db}.intent_records FINAL "
-        "WHERE project_id = 'project-1' AND pipeline_version = 2"
+        "WHERE project_id = 'project-1' AND embedding_version = 2"
     ).result_rows
     assert promoted == [
         (
@@ -785,13 +823,87 @@ def test_intent_records_schema_and_replacement_lifecycle(ch_client):
         )
     ]
 
-    active_partitions = ch_client.query(
-        "SELECT DISTINCT partition "
-        "FROM system.parts "
-        f"WHERE database = '{target_db}' AND table = 'intent_records' AND active "
-        "ORDER BY partition"
-    ).result_rows
-    assert active_partitions == [("202605",)]
+    # Source month, not extraction month, and one partition per embedding
+    # version. Both halves matter: the month makes retention follow user
+    # activity, the version makes a cutover a metadata operation.
+    def active_partitions() -> list[tuple]:
+        return ch_client.query(
+            "SELECT DISTINCT partition "
+            "FROM system.parts "
+            f"WHERE database = '{target_db}' AND table = 'intent_records' AND active "
+            "ORDER BY partition"
+        ).result_rows
+
+    assert active_partitions() == [("(202605,1)",), ("(202605,2)",)]
+
+    # The cutover this partition key exists for: retiring the superseded
+    # embedding version drops its vectors without rewriting the surviving parts.
+    ch_client.command(
+        f"ALTER TABLE {target_db}.intent_records DROP PARTITION (202605, 1)"
+    )
+    assert active_partitions() == [("(202605,2)",)]
+    assert ch_client.query(
+        "SELECT embedding_version, count() "
+        f"FROM {target_db}.intent_records FINAL "
+        "WHERE project_id = 'project-1' GROUP BY embedding_version"
+    ).result_rows == [(2, 1)]
+
+    # The taxonomy is enforced at write time, so a mislabeled row cannot land:
+    # the Enum rejects a label that is in neither taxonomy, and the constraint
+    # rejects one belonging to the other lens.
+    def insert_labeled(row_id: str, lens: str, category: str) -> None:
+        ch_client.command(
+            f"INSERT INTO {target_db}.intent_records "
+            "(project_id, id, lens, category, embedding_version, record_version, "
+            "source_started_at) VALUES "
+            f"('project-2', '{row_id}', '{lens}', '{category}', 2, 1, "
+            "toDateTime64('2026-05-30 09:15:00', 6, 'UTC'))"
+        )
+
+    for lens, category, expected_error in [
+        ("intent", "totally_new", "UNKNOWN_ELEMENT_OF_ENUM"),
+        ("intent", "tool_misuse", "VIOLATED_CONSTRAINT"),
+        ("failure", "action_request", "VIOLATED_CONSTRAINT"),
+    ]:
+        with pytest.raises(
+            clickhouse_connect.driver.exceptions.DatabaseError, match=expected_error
+        ):
+            insert_labeled("rejected", lens, category)
+
+    # 'other' is the shared escape hatch, so it is valid under either lens.
+    insert_labeled("escape-hatch", "failure", "other")
+    assert ch_client.query(
+        f"SELECT lens, category FROM {target_db}.intent_records "
+        "WHERE project_id = 'project-2'"
+    ).result_rows == [("failure", "other")]
+
+    # Growing the taxonomy must stay metadata-only, which is what makes a closed
+    # Enum affordable here. Appending a label creates no mutation and leaves the
+    # existing parts untouched.
+    def part_names() -> list[tuple]:
+        return ch_client.query(
+            "SELECT name FROM system.parts "
+            f"WHERE database = '{target_db}' AND table = 'intent_records' AND active "
+            "ORDER BY name"
+        ).result_rows
+
+    parts_before = part_names()
+    ch_client.command(
+        f"ALTER TABLE {target_db}.intent_records MODIFY COLUMN category "
+        "Enum8('' = 0, 'action_request' = 1, 'information_request' = 2, "
+        "'problem_report' = 3, 'feedback' = 4, 'approval' = 5, 'rejection' = 6, "
+        "'correction' = 7, 'clarification' = 8, 'bad_faith' = 9, 'other' = 10, "
+        "'newly_added_intent' = 11, "
+        "'task_misunderstanding' = 21, 'context_loss' = 22, 'wrong_output' = 23, "
+        "'requirement_violation' = 24, 'tool_misuse' = 25, 'tool_failure' = 26, "
+        "'system_error' = 27, 'unproductive_loop' = 28, 'capability_gap' = 29, "
+        "'improper_refusal' = 30, 'safety_violation' = 31)"
+    )
+    assert part_names() == parts_before
+    assert ch_client.query(
+        "SELECT count() FROM system.mutations "
+        f"WHERE database = '{target_db}' AND table = 'intent_records'"
+    ).result_rows == [(0,)]
 
 
 def test_all_production_down_migrations_replicated(ch_client):

--- a/weave/trace_server/migrations/040_add_intent_records.up.sql
+++ b/weave/trace_server/migrations/040_add_intent_records.up.sql
@@ -1,76 +1,136 @@
--- One row per distilled intent occurrence, including its embedding and trace
--- provenance. ReplacingMergeTree gives idempotent, append-only upserts keyed on
--- the full sorting key. The highest record_version wins, so a retry or re-embed
--- of the same occurrence collapses instead of duplicating.
+-- One row per distilled intent occurrence, with its embedding and trace
+-- provenance inline.
+--
+-- This table separates two kinds of pipeline change, because their consequences
+-- differ:
+--
+--   embedding_version   Embedding model, dimensions, output normalization.
+--                       Vectors under different values cannot be compared, and
+--                       a dimensionality change makes cosineDistance throw, so
+--                       these rows must coexist and must never meet in one
+--                       distance computation. In the sorting key AND the
+--                       partition key.
+--   judge_model,        Changes what text got embedded, not whether vectors
+--   prompt_version,     compare. Payload only. A re-extraction REPLACES its
+--   category            predecessor through record_version.
+--
+-- What that split buys, which is the whole point of it:
+--   * A judge or prompt change rewrites rows in place and adds no partition.
+--   * An embedding change is a backfill. Write the new version alongside the
+--     old, verify coverage, flip the server-side active version, then
+--     DROP PARTITION the old one. Neither PARTITION BY nor ORDER BY can be
+--     altered on a populated table, so that path has to exist up front.
+--   * Readers never pass a version. The server resolves one active
+--     embedding_version per project.
+--
+-- The one case replacement does not cover: id is content-addressed, so a
+-- re-extraction that stops producing a signature leaves its old row behind. A
+-- backfill therefore closes with a DELETE scoped to its window, selecting on
+-- pipeline_recipe_sha256.
 CREATE TABLE IF NOT EXISTS intent_records
 (
     project_id String,
-    -- Deterministic hash of (conversation_id, turn_index, lens, signature_id,
-    -- toDate(source_started_at)): every sorting-key term the writer controls. A
-    -- re-extraction that reorders or repeats a signature therefore collapses
-    -- instead of landing a second row under a supposedly unique id.
+    -- Hash of (conversation_id, turn_index, lens, signature_id,
+    -- toDate(source_started_at)). signature_id rather than an ordinal, so a
+    -- judge that reorders its output does not churn rows. Excludes
+    -- embedding_version so a re-embed reuses the id, which is how new-version
+    -- coverage is checked before a cutover.
     id String,
-    -- 128-bit hash of the canonicalized signature AND the lens, so it groups
-    -- every occurrence of the same intent while keeping the two lenses distinct.
-    -- The same text as an intent and as a failure are different objects, and a
-    -- shared id would let one lens inflate the other's counts. Downstream
-    -- cluster tables rely on this to key on signature_id with no lens column.
+    -- Hash of (lens, canonicalized signature): groups occurrences of one intent
+    -- while keeping the same text as an intent distinct from it as a failure.
+    -- Downstream cluster tables key on this with no lens column.
     signature_id FixedString(16),
-    -- Analysis lens, 'intent' or 'failure'. In the sorting key so a single-lens
-    -- read prunes, which costs nothing because it is already folded into id and
-    -- signature_id. No DEFAULT: an omitted lens matches no run, which is louder
-    -- than silently claiming to be an intent.
+    -- 'intent' or 'failure'. No DEFAULT: it is folded into id and signature_id,
+    -- so a row whose column disagrees with its own hashes is undetectable, and
+    -- an empty lens that matches no run fails louder.
     lens LowCardinality(String),
-    pipeline_version UInt32,                 -- recipe id, in ORDER BY so versions coexist during re-embed/backfill
+    embedding_version UInt32,                -- 32-bit digest of (embedding model, dimensions, output normalization)
     record_version UInt64,                   -- ReplacingMergeTree version, highest for a key wins
 
-    category String,                         -- mutable taxonomy label, excluded from identity, plain String because generated categories can be high-cardinality
+    -- Closed taxonomy, one Enum over the union of both lenses. Excluded from
+    -- identity because a label can be corrected without changing the text or
+    -- the embedding. Numbers are permanent: never renumber or reuse one, and
+    -- append new labels inside that lens's block (11-20 intent, 32+ failure).
+    -- Appending to an Enum is metadata-only, so growing this costs no rewrite.
+    -- 'other' is the escape hatch, valid under either lens, and the writer maps
+    -- an unrecognized judge label to it rather than failing the batch. '' = 0
+    -- has no DEFAULT for the same reason as lens: an omitted category reads
+    -- back empty instead of silently claiming to be the first label.
+    category Enum8(
+        '' = 0,
+        'action_request' = 1, 'information_request' = 2, 'problem_report' = 3,
+        'feedback' = 4, 'approval' = 5, 'rejection' = 6, 'correction' = 7,
+        'clarification' = 8, 'bad_faith' = 9, 'other' = 10,
+        'task_misunderstanding' = 21, 'context_loss' = 22, 'wrong_output' = 23,
+        'requirement_violation' = 24, 'tool_misuse' = 25, 'tool_failure' = 26,
+        'system_error' = 27, 'unproductive_loop' = 28, 'capability_gap' = 29,
+        'improper_refusal' = 30, 'safety_violation' = 31
+    ),
     signature String,
-    -- ISO 639-1 code of the source turn's prose, or the ISO 639-2 'und'
-    -- sentinel when indeterminate, which is also the DEFAULT so unknown has one
-    -- value. Signatures are English-normalized, so this is the only record of
-    -- the original and the only way to see judge quality vary by language.
+    -- ISO 639-1, or the ISO 639-2 'und' sentinel when indeterminate, which is
+    -- also the DEFAULT so unknown has one value. Signatures are
+    -- English-normalized, so this is the only record of the source language.
     language LowCardinality(String) DEFAULT 'und',
 
-    -- Judged sentiment of the source turn. sentiment_score is an ALIAS so the
-    -- ordinal scale has one home: rescoring is a migration, not a row rewrite.
+    -- sentiment_score is an ALIAS so the ordinal scale has one home: rescoring
+    -- is a migration, not a row rewrite.
     sentiment LowCardinality(String) DEFAULT '',
     sentiment_confidence Float32 DEFAULT 0,
     sentiment_score Float32 ALIAS transform(sentiment, ['frustrated', 'dissatisfied', 'neutral', 'satisfied', 'delighted'], [-1., -0.5, 0., 0.5, 1.], 0.),
 
-    embedding_model LowCardinality(String),
+    embedding_model LowCardinality(String),  -- human-readable companion to embedding_version
     vector Array(Float32),                   -- searched by exact cosine distance, intentionally no ANN index. length(vector) is the dimensionality
 
-    judge_model LowCardinality(String) DEFAULT '',
+    judge_model LowCardinality(String) DEFAULT '',   -- payload, see header: a new judge replaces, it does not coexist
     prompt_version LowCardinality(String) DEFAULT '',
-    -- Lowercase hex. pipeline_version is a 32-bit truncation of this digest and
-    -- there is no recipe registry table, so the full digest is the audit trail.
+    -- Lowercase hex over the whole recipe. There is no recipe registry table,
+    -- so this is the audit trail and the marker a backfill sweep selects on.
     pipeline_recipe_sha256 String DEFAULT '',
 
     trace_id String DEFAULT '',
     span_id String DEFAULT '',               -- root span of the source turn, the pointer back into spans
     conversation_id String DEFAULT '',
-    turn_index UInt16 DEFAULT 0,             -- position of the source turn in its conversation. (conversation_id, turn_index) is the turn identity
+    turn_index UInt16 DEFAULT 0,             -- (conversation_id, turn_index) is the turn identity
     user_id String DEFAULT '',               -- pseudonymous source subject, distinct from the writer
 
-    -- Execution context of the source turn, denormalized at extraction like
-    -- source_started_at. A turn's rows all repeat these, lens='failure' included.
+    -- Execution context of the source turn, denormalized at extraction. A
+    -- turn's rows all repeat these, lens='failure' included.
     agent_name LowCardinality(String) DEFAULT '',
-    agent_version String DEFAULT '',          -- free-form version label, so plain String rather than a bounded vocabulary
+    agent_version String DEFAULT '',          -- free-form version label, so plain String
     provider LowCardinality(String) DEFAULT '',
-    request_model LowCardinality(String) DEFAULT '', -- model the source turn called, distinct from judge_model and embedding_model
+    request_model LowCardinality(String) DEFAULT '', -- model the source turn called, not judge_model or embedding_model
     surface LowCardinality(String) DEFAULT '',
     status_code Enum8('UNSET' = 0, 'OK' = 1, 'ERROR' = 2) DEFAULT 'UNSET', -- same vocabulary as spans.status_code, so the two join without a cast
     turn_duration_ms UInt32 DEFAULT 0,
     turn_cost_usd Float64 DEFAULT 0,
     turn_summary String DEFAULT '',           -- describes the assistant response, so it repeats across a turn's rows
 
-    -- Denormalized SNAPSHOT of the source turn's start time, captured at
-    -- extraction and never re-read from the source. This is the analysis clock.
+    -- Snapshot of the source turn's start time, taken at extraction and never
+    -- re-read, so it is the analysis clock rather than the pipeline clock.
     source_started_at DateTime64(6, 'UTC'),
-    intent_extracted_at DateTime64(6, 'UTC'),           -- pipeline clock, set once at extraction, stable across retries
+    intent_extracted_at DateTime64(6, 'UTC'),
     inserted_at DateTime64(3, 'UTC') DEFAULT now64(3),
-    expire_at DateTime DEFAULT '2100-01-01 00:00:00',   -- per-row retention override, default effectively never
+    -- Per-row retention override, default effectively never. Retention only:
+    -- logical retraction uses a lightweight DELETE, because TTL is asynchronous
+    -- and a row still awaiting its merge still answers reads.
+    expire_at DateTime DEFAULT '2100-01-01 00:00:00',
+
+    -- The Enum alone cannot stop a failure label landing on an intent row, so
+    -- state the pairing. Listed explicitly rather than keyed off the number
+    -- blocks, so a new label omitted here is rejected loudly instead of being
+    -- silently gated to the wrong lens. ADD/DROP CONSTRAINT does not validate
+    -- existing rows, so amending this later is also metadata-only.
+    CONSTRAINT category_matches_lens CHECK
+        category = '' OR category = 'other'
+        OR (lens = 'intent' AND category IN (
+            'action_request', 'information_request', 'problem_report',
+            'feedback', 'approval', 'rejection', 'correction',
+            'clarification', 'bad_faith'))
+        OR (lens = 'failure' AND category IN (
+            'task_misunderstanding', 'context_loss', 'wrong_output',
+            'requirement_violation', 'tool_misuse', 'tool_failure',
+            'system_error', 'unproductive_loop', 'capability_gap',
+            'improper_refusal', 'safety_violation')),
 
     INDEX idx_signature_id signature_id TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1,
@@ -78,19 +138,15 @@ CREATE TABLE IF NOT EXISTS intent_records
     INDEX idx_conversation_id conversation_id TYPE bloom_filter(0.01) GRANULARITY 1
 )
 ENGINE = ReplacingMergeTree(record_version)
--- Partition on source time, not extraction time, so retention and time-range
--- reads follow user activity. A backfill spanning >100 months needs a raised
+-- Source month so retention and range reads follow user activity, and
+-- embedding_version so a cutover retires the old vectors as a metadata
+-- operation. A backfill spanning >100 months needs a raised
 -- max_partitions_per_insert_block.
-PARTITION BY toYYYYMM(source_started_at)
--- lens precedes the time term so a single-lens read prunes to one contiguous
--- block. toDate(source_started_at) precedes id so a sub-month read prunes
--- granules: without it, source time lives only in the partition key and any
--- window narrower than a month still scans the whole month.
---
--- Every term here is part of the replacement identity, so the id hash folds
--- them all in (see id above). Day rather than the raw timestamp keeps the
--- identity as coarse as it can be while still pruning: a microsecond key would
--- make every sub-second snapshot difference a distinct row.
-ORDER BY (project_id, pipeline_version, lens, toDate(source_started_at), id)
+PARTITION BY (toYYYYMM(source_started_at), embedding_version)
+-- embedding_version leads because every read pins exactly one, resolved
+-- server-side. toDate(source_started_at) precedes id so a sub-month read prunes
+-- granules. Day rather than the raw timestamp keeps the replacement identity as
+-- coarse as it can be while still pruning.
+ORDER BY (project_id, embedding_version, lens, toDate(source_started_at), id)
 TTL expire_at DELETE
 SETTINGS min_bytes_for_wide_part = 0;


### PR DESCRIPTION
## Summary
- Stacked on #7598. `pipeline_version` put two unrelated axes in the replacement identity, so a weekly prompt tweak forked every row and each read needed a version predicate.
- Only the embedding recipe must isolate: vectors across recipes are incomparable, and a dimensionality change makes `cosineDistance` throw mid-backfill. `embedding_version` takes its slot in the sorting key and joins the partition key, so a cutover retires old vectors via `DROP PARTITION`. Neither key is alterable on a populated table, so that path must exist up front.
- Judge, prompt and recipe digest become payload, replaced through `record_version`. Readers never pass a version. `category` becomes a closed `Enum8` over both taxonomies plus a `CONSTRAINT` for the lens pairing it cannot express.

## Performance
#7598's benchmark vectors are `arrayResize([1], 1024, 0)`, 1023 identical zeros, so its ~151 MB/1M rows understates real storage ~200x. CH 26.6, 200k rows, 1024 dims:

| vector shape | compressed | bytes/row |
| --- | ---: | ---: |
| benchmark | 3.92 MiB | 20.5 |
| L2-normalized pseudo-random | 785 MiB | 4116.5 |

Budget ~3.9 GB per million occurrences. Appending an Enum label is metadata-only: 0.02 s on 500k rows, zero mutations.

## Testing
The intent test now performs the `DROP PARTITION` cutover it documents, and asserts an unlisted label and a cross-lens pair are both rejected.