### PR TITLE
fix(weave): warn once per ignored-field set instead of per request

### DIFF
--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -18,6 +18,7 @@ from tests.trace_server.workers.evaluate_model_test_worker import (
 from weave.trace_server import (
     base64_content_conversion,
     clickhouse_trace_server_batched,
+    common_interface,
 )
 from weave.trace_server import clickhouse_trace_server_migrator as wf_migrator
 from weave.trace_server import (
@@ -118,6 +119,14 @@ def reset_content_ref_cache():
     yield
     base64_content_conversion._content_ref_cache.clear()
     base64_content_conversion._rejected_blob_cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def reset_extra_field_warnings():
+    """The memo of reported ignored-field sets would silence later tests."""
+    common_interface._warned_field_sets.clear()
+    yield
+    common_interface._warned_field_sets.clear()
 
 
 def _get_worker_db_suffix(request, default: str = "_test") -> str:

--- a/tests/trace_server/test_trace_server_interface_util.py
+++ b/tests/trace_server/test_trace_server_interface_util.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import Field, ValidationError
 
 from weave.shared.trace_server_interface_util import extract_refs_from_values
+from weave.trace_server import common_interface
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import BaseModelStrict
 from weave.trace_server.errors import NotFoundError
@@ -23,6 +24,21 @@ REF_B = "weave-trace-internal:///test_project/object/obj_b:def456"
 class _BaseModelStrictTestModel(BaseModelStrict):
     required_field: str
     aliased_field: str = Field(alias="aliasedField")
+
+
+class _SecondBaseModelStrictTestModel(BaseModelStrict):
+    required_field: str
+
+
+def _validate_with_extra_field(extra_field: str) -> None:
+    """Validate `_BaseModelStrictTestModel` with one unknown field attached."""
+    _BaseModelStrictTestModel.model_validate(
+        {
+            "required_field": "required",
+            "aliasedField": "aliased",
+            extra_field: "value",
+        }
+    )
 
 
 def test_base_model_strict_ignores_and_warns_on_unknown_fields(
@@ -49,6 +65,127 @@ def test_base_model_strict_ignores_and_warns_on_unknown_fields(
 def test_base_model_strict_preserves_required_field_validation() -> None:
     with pytest.raises(ValidationError, match="required_field"):
         _BaseModelStrictTestModel.model_validate({"aliasedField": "aliased"})
+
+
+def test_base_model_strict_warns_once_for_a_repeated_field_set(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("WARNING", logger="weave.trace_server.common_interface"):
+        for _ in range(3):
+            _validate_with_extra_field("future_sdk_field")
+
+    assert caplog.messages == [
+        "Ignoring unexpected fields while validating _BaseModelStrictTestModel: "
+        "future_sdk_field"
+    ]
+
+
+def test_base_model_strict_warns_again_for_a_different_field_set(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("WARNING", logger="weave.trace_server.common_interface"):
+        _validate_with_extra_field("future_sdk_field")
+        _validate_with_extra_field("another_sdk_field")
+
+    assert caplog.messages == [
+        "Ignoring unexpected fields while validating _BaseModelStrictTestModel: "
+        "future_sdk_field",
+        "Ignoring unexpected fields while validating _BaseModelStrictTestModel: "
+        "another_sdk_field",
+    ]
+
+
+def test_base_model_strict_warns_again_for_a_different_model(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("WARNING", logger="weave.trace_server.common_interface"):
+        _validate_with_extra_field("future_sdk_field")
+        _SecondBaseModelStrictTestModel.model_validate(
+            {"required_field": "required", "future_sdk_field": "value"}
+        )
+
+    assert caplog.messages == [
+        "Ignoring unexpected fields while validating _BaseModelStrictTestModel: "
+        "future_sdk_field",
+        "Ignoring unexpected fields while validating _SecondBaseModelStrictTestModel: "
+        "future_sdk_field",
+    ]
+
+
+def test_base_model_strict_warns_for_a_field_name_utf8_cannot_encode(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A JSON body can carry a lone surrogate as a key, and keying the memo on one
+    must not raise where warning on every request did not.
+    """
+    with caplog.at_level("WARNING", logger="weave.trace_server.common_interface"):
+        _validate_with_extra_field("\ud800")
+
+    assert caplog.messages == [
+        "Ignoring unexpected fields while validating _BaseModelStrictTestModel: \ud800"
+    ]
+
+
+def test_base_model_strict_keeps_raising_on_unformattable_field_names(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The message is built before anything is remembered or skipped, so a payload the
+    warning cannot render fails the same way every time and at any log level.
+    """
+    logger_name = "weave.trace_server.common_interface"
+    payload = {"required_field": "required", "aliasedField": "aliased", 7: "value"}
+
+    with caplog.at_level("WARNING", logger=logger_name):
+        with pytest.raises(TypeError, match="expected str instance"):
+            _BaseModelStrictTestModel.model_validate(payload)
+
+    with caplog.at_level("ERROR", logger=logger_name):
+        with pytest.raises(TypeError, match="expected str instance"):
+            _BaseModelStrictTestModel.model_validate(payload)
+
+
+def test_base_model_strict_warns_after_the_log_level_is_raised(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A discrepancy nobody could see is not remembered, so turning warnings back
+    on still reports it.
+    """
+    logger_name = "weave.trace_server.common_interface"
+    with caplog.at_level("ERROR", logger=logger_name):
+        _validate_with_extra_field("future_sdk_field")
+    assert caplog.messages == []
+
+    with caplog.at_level("WARNING", logger=logger_name):
+        _validate_with_extra_field("future_sdk_field")
+
+    assert caplog.messages == [
+        "Ignoring unexpected fields while validating _BaseModelStrictTestModel: "
+        "future_sdk_field"
+    ]
+
+
+def test_base_model_strict_stops_warning_once_the_memo_is_full(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A memo that fills up says so once and then stays quiet. Evicting instead would
+    let the next request for an evicted field set warn all over again.
+    """
+    monkeypatch.setattr(common_interface, "MAX_WARNED_FIELD_SETS", 2)
+
+    with caplog.at_level("WARNING", logger="weave.trace_server.common_interface"):
+        _validate_with_extra_field("first_sdk_field")
+        _validate_with_extra_field("second_sdk_field")
+        _validate_with_extra_field("third_sdk_field")
+        _validate_with_extra_field("fourth_sdk_field")
+
+    assert caplog.messages == [
+        "Ignoring unexpected fields while validating _BaseModelStrictTestModel: "
+        "first_sdk_field",
+        "Ignoring unexpected fields while validating _BaseModelStrictTestModel: "
+        "second_sdk_field",
+        "Reached 2 distinct ignored-field sets; further sets will not be reported",
+    ]
 
 
 def test_extract_refs_from_values_deduplicates():

--- a/weave/trace_server/common_interface.py
+++ b/weave/trace_server/common_interface.py
@@ -4,7 +4,9 @@ This module contains base classes and common types used by both
 trace_server_interface.py and http_service_interface.py to avoid circular dependencies.
 """
 
+import hashlib
 import logging
+import threading
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -14,6 +16,49 @@ WB_USER_ID_DESCRIPTION = (
 )
 
 logger = logging.getLogger(__name__)
+
+# One warning per distinct model-and-fields message for the life of the process instead
+# of one per request. The names are caller-controlled, so the memo is capped — far above
+# the handful of distinct messages a fleet actually produces — and never evicted, since
+# forgetting one would let it warn all over again.
+MAX_WARNED_FIELD_SETS = 1024
+_warned_field_sets: set[tuple[str, str]] = set()
+_warned_field_sets_lock = threading.Lock()
+
+
+def _warn_ignored_fields_once(model_name: str, extra_fields: set[str]) -> None:
+    """Warn about a model's ignored fields the first time this warning would be sent."""
+    # Built before anything else, so a payload the warning cannot render fails the same
+    # way it did before this memo existed, whatever the log level. Sorted because equal
+    # sets can still iterate in different orders, which would key the same fields twice.
+    message = ", ".join(sorted(extra_fields))
+
+    # Do not remember what the level suppressed; raising it later must still report.
+    if not logger.isEnabledFor(logging.WARNING):
+        return
+
+    # Keyed on the message, so two field sets that read the same warn once. The names
+    # are caller-controlled, hence the digest and surrogatepass: they can be long, and
+    # a JSON body can carry a lone surrogate that UTF-8 alone cannot encode.
+    digest = hashlib.sha256(message.encode("utf-8", "surrogatepass")).hexdigest()
+    key = (model_name, digest)
+    with _warned_field_sets_lock:
+        if (
+            key in _warned_field_sets
+            or len(_warned_field_sets) >= MAX_WARNED_FIELD_SETS
+        ):
+            return
+        _warned_field_sets.add(key)
+        filled = len(_warned_field_sets) == MAX_WARNED_FIELD_SETS
+
+    logger.warning(
+        "Ignoring unexpected fields while validating %s: %s", model_name, message
+    )
+    if filled:
+        logger.warning(
+            "Reached %d distinct ignored-field sets; further sets will not be reported",
+            MAX_WARNED_FIELD_SETS,
+        )
 
 
 class BaseModelStrict(BaseModel):
@@ -33,13 +78,9 @@ class BaseModelStrict(BaseModel):
             for field in cls.model_fields.values()
             if field.alias is not None
         )
-        extra_fields = sorted(set(values) - known_fields)
+        extra_fields = set(values) - known_fields
         if extra_fields:
-            logger.warning(
-                "Ignoring unexpected fields while validating %s: %s",
-                cls.__name__,
-                ", ".join(extra_fields),
-            )
+            _warn_ignored_fields_once(cls.__name__, extra_fields)
         return values
 
 


### PR DESCRIPTION
## JIRA Issue(s)

[WB-38488](https://coreweave.atlassian.net/browse/WB-38488)

## Description

Our trace server writes a warning every time a request carries a field it does not know. Turns out we do this to ourselves. The batch ingest endpoint takes a list of items, each one either a call start or a call end, and that union has no discriminator — so pydantic tries every item against both shapes, and the shape that loses logs a warning about the other one's field. That is one warning for every call we ingest. Over the last seven days it came to 13.2M lines, out of the 13.6M warnings the whole service wrote — 97% of them, about 2M a day — see [datadog](https://us5.datadoghq.com/logs?query=service%3Aweave-trace%20env%3Aprod%20%22Ignoring%20unexpected%20fields%20while%20validating%22&live=true). Everything else at warn level put together is 397k. The warning channel is dead as a channel.

The easy fix is to delete the warning. I did not want to. In those same seven days it also caught nine lines — nine, out of 13.2M — where a caller misspelled a query parameter: `fields` instead of `columns`, `digest` instead of `digests`. The server drops those and still returns success, so they are real bugs. Nobody is ever going to find nine lines in thirteen million. WB-38398 covers fixing that part.

So I kept the warning and killed the repeating. The server now remembers what it already said, and says each thing once.

Giving that union a discriminator would remove these warnings at the source, and it is the same `Field(discriminator=...)` we already use elsewhere in this repo. I left it out: it turns `mode` into a `Literal`, which narrows the accepted API and means regenerating the schema and the Node SDK. That belongs in its own PR.

The obvious move was to reuse `log_once`, which already exists in `weave/trace/util.py`. Turned out I could not: the trace server is not allowed to import the client SDK, and there is an import-linter rule that fails the build if you try. It also appends a suffix to the message, which would change the text. So I wrote a small memo in the same file — a set of what has already been reported, behind a lock, the same shape as the other caches in that package.

One thing needed care. The field names come from the request body, so a caller decides what goes into that set. It is capped at 1024 entries and it never evicts. Evicting is the normal thing to do, but here it would undo the fix: drop an entry and that caller's next request warns again. When the cap fills, it says so once and then stays quiet.

Bottom line: same warning, same wording, but you see it once per process instead of two million times a day. One thing to know — a repeat now shows up once, so if you are tailing logs it will look like the problem stopped.

## Testing

`uv run --group test python -m pytest tests/trace_server/ tests/shared/` passes. Seven new tests cover it: the same field set warns once, a different set or a different model still warns, a full memo says so and then goes quiet, and nothing is remembered that never got logged. They are plain unit tests and need no ClickHouse.


[WB-38488]: https://coreweave.atlassian.net/browse/WB-38488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ