### PR TITLE
perf(weave): cut migrator test shard wall clock

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -241,9 +241,11 @@ def tests(session: nox.Session, shard: str):
         if not os.path.exists(test_dir):
             raise ValueError(f"Test directory {test_dir} does not exist")
 
-    # Each worker gets its own isolated database namespace
-    # Only use parallel workers for the trace shard if we have more than 1 CPU core
-    if shard in {"trace", "trace_calls_merged_only"}:
+    # Each worker gets its own isolated database namespace, so these shards are
+    # safe to run in parallel when we have more than 1 CPU core. The migrator
+    # shard is dominated by round-trip DDL latency rather than CPU, so it gains
+    # the most: every test builds its own uniquely-named databases.
+    if shard in {"trace", "trace_calls_merged_only", "trace_server_migrator"}:
         cpu_count = os.cpu_count()
         if cpu_count is not None and cpu_count > 1:
             session.posargs.insert(0, f"-n{cpu_count}")

--- a/tests/trace_server/conftest_lib/clickhouse_keeper_config.xml
+++ b/tests/trace_server/conftest_lib/clickhouse_keeper_config.xml
@@ -9,6 +9,11 @@
             <operation_timeout_ms>10000</operation_timeout_ms>
             <session_timeout_ms>30000</session_timeout_ms>
             <raft_logs_level>warning</raft_logs_level>
+            <!-- Every ON CLUSTER statement writes to the Keeper DDL queue, and
+                 force_sync fsyncs the raft log on each append. This is a
+                 throwaway single-node Keeper whose state never needs to
+                 survive a crash, so the durability buys nothing. -->
+            <force_sync>false</force_sync>
         </coordination_settings>
         <raft_configuration>
             <server>

--- a/tests/trace_server_migrator/conftest.py
+++ b/tests/trace_server_migrator/conftest.py
@@ -15,10 +15,6 @@ _KEEPER_CONFIG_PATH = os.path.join(
     "clickhouse_keeper_config.xml",
 )
 _DEFAULT_PORT = 8130
-# Pinned to the version CI runs (see .github/scripts/ch-image.sh). Following
-# `latest` locally drifts off CI and breaks engine_full assertions, which
-# reformat between releases.
-_CH_IMAGE = "clickhouse/clickhouse-server:26.4"
 
 
 @pytest.fixture(scope="session")
@@ -117,7 +113,7 @@ def _start_keeper_container(port: int) -> None:
             _CONTAINER_NAME,
             "--ulimit",
             "nofile=262144:262144",
-            _CH_IMAGE,
+            "clickhouse/clickhouse-server",
         ],
         capture_output=True,
         check=False,

--- a/tests/trace_server_migrator/conftest.py
+++ b/tests/trace_server_migrator/conftest.py
@@ -15,10 +15,14 @@ _KEEPER_CONFIG_PATH = os.path.join(
     "clickhouse_keeper_config.xml",
 )
 _DEFAULT_PORT = 8130
+# Pinned to the version CI runs (see .github/scripts/ch-image.sh). Following
+# `latest` locally drifts off CI and breaks engine_full assertions, which
+# reformat between releases.
+_CH_IMAGE = "clickhouse/clickhouse-server:26.4"
 
 
 @pytest.fixture(scope="session")
-def ch_keeper_server():
+def ch_keeper_server(worker_id):
     """Start a single-node ClickHouse with embedded Keeper for replicated tests."""
     host = "localhost"
     port = int(os.environ.get("WF_CLICKHOUSE_KEEPER_PORT", _DEFAULT_PORT))
@@ -27,66 +31,33 @@ def ch_keeper_server():
         yield host, port
         return
 
-    server_up = check_server_up(host, port, 1)
+    # Under xdist every worker runs this session fixture, so exactly one worker
+    # owns the container and the rest wait on it. The owner leaves it running on
+    # teardown when distributed: workers exit independently, and stopping the
+    # server under a sibling still running its tests would fail that worker.
+    owns_container = worker_id in {"master", "gw0"}
     started_container = False
 
-    if not server_up:
-        subprocess.run(
-            ["docker", "stop", _CONTAINER_NAME], capture_output=True, check=False
-        )
-        subprocess.run(
-            ["docker", "rm", _CONTAINER_NAME], capture_output=True, check=False
-        )
-
-        config_path = os.path.abspath(_KEEPER_CONFIG_PATH)
-        process = subprocess.Popen(
-            [
-                "docker",
-                "run",
-                "-d",
-                "--rm",
-                "-e",
-                "CLICKHOUSE_DB=default",
-                "-e",
-                "CLICKHOUSE_USER=default",
-                "-e",
-                "CLICKHOUSE_PASSWORD=",
-                "-e",
-                "CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1",
-                "-p",
-                f"{port}:8123",
-                "-v",
-                f"{config_path}:/etc/clickhouse-server/config.d/keeper.xml",
-                "--name",
-                _CONTAINER_NAME,
-                "--ulimit",
-                "nofile=262144:262144",
-                "clickhouse/clickhouse-server",
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-
-        _, stderr = process.communicate()
-        if process.returncode != 0:
-            pytest.fail(
-                f"Failed to start ClickHouse Keeper container: {stderr.decode()}"
-            )
-
-        started_container = True
-
-        server_up = check_server_up(host, port)
-        if not server_up:
-            subprocess.run(
-                ["docker", "stop", _CONTAINER_NAME], capture_output=True, check=False
-            )
-            pytest.fail(
-                f"ClickHouse Keeper server failed to become healthy on {host}:{port}"
-            )
+    if not check_server_up(host, port, 1):
+        if not owns_container:
+            if not check_server_up(host, port):
+                pytest.fail(f"ClickHouse Keeper server never came up on {host}:{port}")
+        else:
+            _start_keeper_container(port)
+            started_container = True
+            if not check_server_up(host, port):
+                subprocess.run(
+                    ["docker", "stop", _CONTAINER_NAME],
+                    capture_output=True,
+                    check=False,
+                )
+                pytest.fail(
+                    f"ClickHouse Keeper server failed to become healthy on {host}:{port}"
+                )
 
     yield host, port
 
-    if started_container:
+    if started_container and worker_id == "master":
         subprocess.run(
             ["docker", "stop", _CONTAINER_NAME], capture_output=True, check=False
         )
@@ -114,3 +85,44 @@ def ch_client(ch_keeper_server):
         except Exception:
             pass
     client.close()
+
+
+def _start_keeper_container(port: int) -> None:
+    """Replace any stale container with a fresh Keeper-enabled ClickHouse."""
+    subprocess.run(
+        ["docker", "stop", _CONTAINER_NAME], capture_output=True, check=False
+    )
+    subprocess.run(["docker", "rm", _CONTAINER_NAME], capture_output=True, check=False)
+
+    config_path = os.path.abspath(_KEEPER_CONFIG_PATH)
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "-e",
+            "CLICKHOUSE_DB=default",
+            "-e",
+            "CLICKHOUSE_USER=default",
+            "-e",
+            "CLICKHOUSE_PASSWORD=",
+            "-e",
+            "CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1",
+            "-p",
+            f"{port}:8123",
+            "-v",
+            f"{config_path}:/etc/clickhouse-server/config.d/keeper.xml",
+            "--name",
+            _CONTAINER_NAME,
+            "--ulimit",
+            "nofile=262144:262144",
+            _CH_IMAGE,
+        ],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"Failed to start ClickHouse Keeper container: {result.stderr.decode()}"
+        )

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -545,17 +545,27 @@ def test_recent_production_upgrade_path(
     )
 
 
-def test_all_production_migrations_replicated(ch_client):
-    """All production migrations apply cleanly in replicated mode."""
-    mgmt_db = _unique_name("db_mgmt_prod_repl")
-    target_db = _unique_name("prod_repl")
+@pytest.mark.parametrize(
+    "use_distributed", [False, True], ids=["replicated", "distributed"]
+)
+def test_all_production_migrations_round_trip(ch_client, use_distributed: bool):
+    """Every production migration applies cleanly, then reverses cleanly.
+
+    Up and down live in one test because a completed up is the only valid
+    starting point for a down. Running them as separate tests replayed the same
+    full migration set twice per mode, and each statement carries a fixed
+    round-trip cost against Keeper.
+    """
+    suffix = "dist" if use_distributed else "repl"
+    mgmt_db = _unique_name(f"db_mgmt_prod_{suffix}")
+    target_db = _unique_name(f"prod_{suffix}")
     ch_client.track_db(mgmt_db)
     ch_client.track_db(target_db)
 
     migrator = get_clickhouse_trace_server_migrator(
         ch_client,
         replicated=True,
-        use_distributed=False,
+        use_distributed=use_distributed,
         replicated_cluster=_CLUSTER,
         replicated_path=_REPLICATED_PATH,
         management_db=mgmt_db,
@@ -564,6 +574,7 @@ def test_all_production_migrations_replicated(ch_client):
     )
     migrator.apply_migrations(target_db)
 
+    assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
     assert _get_db_engine(ch_client, target_db) == "Atomic"
     # On multi-replica topologies (1s3r / 2s2r in CI), the DB must exist on
     # every replica with a consistent engine. Historical failure modes this
@@ -574,84 +585,11 @@ def test_all_production_migrations_replicated(ch_client):
     #     only the migrator's entrypoint pod gets the DB, sibling replicas
     #     never join the ZK path).
     _assert_db_on_every_replica(ch_client, target_db, expected_engine="Atomic")
-
-
-def test_all_production_migrations_distributed(ch_client):
-    """All production migrations apply cleanly in distributed mode."""
-    mgmt_db = _unique_name("db_mgmt_prod_dist")
-    target_db = _unique_name("prod_dist")
-    ch_client.track_db(mgmt_db)
-    ch_client.track_db(target_db)
-
-    migrator = get_clickhouse_trace_server_migrator(
-        ch_client,
-        replicated=True,
-        use_distributed=True,
-        replicated_cluster=_CLUSTER,
-        replicated_path=_REPLICATED_PATH,
-        management_db=mgmt_db,
-        migration_dir=_PROD_MIGRATION_DIR,
-        post_migration_hook=None,
-    )
-    migrator.apply_migrations(target_db)
-
-    assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
-    assert _get_db_engine(ch_client, target_db) == "Atomic"
-    # Distributed mode uses ON CLUSTER to fan DBs to every shard/replica.
-    # If the fan-out is broken (e.g. the `ON CLUSTER + ENGINE = Replicated`
-    # collision), peer replicas never receive the CREATE DATABASE.
-    _assert_db_on_every_replica(ch_client, mgmt_db, expected_engine="Atomic")
-    _assert_db_on_every_replica(ch_client, target_db, expected_engine="Atomic")
-
-
-def test_all_production_down_migrations_replicated(ch_client):
-    """All production down migrations apply cleanly in replicated mode."""
-    mgmt_db = _unique_name("db_mgmt_down_repl")
-    target_db = _unique_name("down_repl")
-    ch_client.track_db(mgmt_db)
-    ch_client.track_db(target_db)
-
-    migrator = get_clickhouse_trace_server_migrator(
-        ch_client,
-        replicated=True,
-        use_distributed=False,
-        replicated_cluster=_CLUSTER,
-        replicated_path=_REPLICATED_PATH,
-        management_db=mgmt_db,
-        migration_dir=_PROD_MIGRATION_DIR,
-        post_migration_hook=None,
-    )
-
-    # Migrate up to latest
-    migrator.apply_migrations(target_db)
-    assert _get_db_engine(ch_client, target_db) == "Atomic"
-
-    # Migrate all the way back down
-    migrator.apply_migrations(target_db, target_version=0)
-
-
-def test_all_production_down_migrations_distributed(ch_client):
-    """All production down migrations apply cleanly in distributed mode."""
-    mgmt_db = _unique_name("db_mgmt_down_dist")
-    target_db = _unique_name("down_dist")
-    ch_client.track_db(mgmt_db)
-    ch_client.track_db(target_db)
-
-    migrator = get_clickhouse_trace_server_migrator(
-        ch_client,
-        replicated=True,
-        use_distributed=True,
-        replicated_cluster=_CLUSTER,
-        replicated_path=_REPLICATED_PATH,
-        management_db=mgmt_db,
-        migration_dir=_PROD_MIGRATION_DIR,
-        post_migration_hook=None,
-    )
-
-    # Migrate up to latest
-    migrator.apply_migrations(target_db)
-    assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
-    assert _get_db_engine(ch_client, target_db) == "Atomic"
+    if use_distributed:
+        # Distributed mode uses ON CLUSTER to fan DBs to every shard/replica.
+        # If the fan-out is broken, peer replicas never receive the management
+        # DB either.
+        _assert_db_on_every_replica(ch_client, mgmt_db, expected_engine="Atomic")
 
     # Migrate all the way back down
     migrator.apply_migrations(target_db, target_version=0)


### PR DESCRIPTION
## Summary
- The migrator shard is bound by DDL round trips, not CPU: each test rebuilds its databases from the full production migration set (~150 statements), and every `ON CLUSTER` statement pays a Keeper DDL-queue round trip.
- Run the shard under xdist, since every test already namespaces its own databases.
- Stop the throwaway single-node Keeper from fsyncing its raft log; CI mounts this same config.
- Fold the four production up/down tests into one parameterized round trip, so a full migration set is applied twice per run instead of four times.

## Performance
Local, ClickHouse 26.4, 10 cores:

| | wall clock | tests |
| --- | --- | --- |
| master, serial | 324s | 26 passed |
| this PR, serial | 193s | 24 passed |
| this PR, xdist `-n10` | **54s** | 24 passed |

Per-lever, from tests this PR does not touch (serial, before -> after): `idempotent[distributed]` 44.1s -> 34.9s, `partial_migration_auto_recovers[distributed]` 23.7s -> 17.8s, `recent_production_upgrade_path[distributed-atomic-db]` 25.2s -> 17.1s. That 20-30% is the Keeper fsync setting alone. Dropping the duplicate up-only tests removes another 38.9s of the baseline, and xdist takes the remainder from 193s to 54s.

## Testing
Full shard green serially and at `-n10`; the cold-container path was exercised with the container stopped, so one worker starts it and the rest wait on health.