### PR TITLE
fix(weave_ts): skip non-succeeded Anthropic batch results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,6 +344,20 @@ deterministic.
   flattened `weave.integration.meta.*` provenance. OTel scalar metadata stays
   typed; non-scalar values are stringified.
 
+### TypeScript Anthropic message batches
+
+- A batch result is a discriminated union and only its `succeeded` variant
+  carries a `message`; a batch ends when every request has succeeded, errored,
+  been canceled or expired. Read `message` without checking the discriminator
+  and the reducer stores `undefined`, which the usage summarizer then throws on,
+  out of the stream iterator's `finally`.
+- `patchAnthropicMessagesCreate` wraps `Messages.prototype.create` in a `Proxy`,
+  so property reads still reach the mock behind it and a test can reconfigure it
+  through the patched prototype. `patchBatchApi` assigns `op()`'s plain wrapper
+  to `Batches` `create`, `retrieve` and `results` instead, so for those a test
+  reconfigures the mock it captured before patching, or reaches it through
+  `__wrappedFunction`.
+
 ### TypeScript custom type round trip
 
 - `client.get()` rebuilds a `WeaveImage` from a `PIL.Image.Image` payload and a

--- a/sdks/node/src/__tests__/integrations/anthropic.test.ts
+++ b/sdks/node/src/__tests__/integrations/anthropic.test.ts
@@ -72,10 +72,9 @@ function createMockAnthropic() {
 
   const mockBatchResultsChunks = [
     {
-      type: undefined,
       custom_id: 'request_1',
       result: {
-        type: 'message',
+        type: 'succeeded',
         message: mockMessages,
       },
     },
@@ -173,11 +172,13 @@ function createMockAnthropic() {
     // Constructor function
   }
 
-  MockBatches.prototype.create = jest.fn().mockResolvedValue(mockBatchResult);
-  MockBatches.prototype.retrieve = jest.fn().mockResolvedValue(mockBatchResult);
-  MockBatches.prototype.results = jest.fn().mockImplementation(async () => {
+  const mockResults = jest.fn().mockImplementation(async () => {
     return new MockAnthropicStream(mockBatchResultsChunks);
   });
+
+  MockBatches.prototype.create = jest.fn().mockResolvedValue(mockBatchResult);
+  MockBatches.prototype.retrieve = jest.fn().mockResolvedValue(mockBatchResult);
+  MockBatches.prototype.results = mockResults;
 
   // Set up static reference
   MockMessages.Batches = MockBatches;
@@ -188,7 +189,13 @@ function createMockAnthropic() {
     },
   };
 
-  return {mockAnthropic, MockMessages, MockBatches};
+  return {
+    mockAnthropic,
+    MockMessages,
+    MockAnthropicStream,
+    mockMessages,
+    mockResults,
+  };
 }
 
 describe('Anthropic Integration', () => {
@@ -196,7 +203,9 @@ describe('Anthropic Integration', () => {
   const testProjectName = 'test-project';
   let mockAnthropic: any;
   let MockMessages: any;
-  let _MockBatches: any;
+  let MockAnthropicStream: any;
+  let mockMessages: any;
+  let mockResults: jest.Mock;
   let patchedAnthropic: any;
 
   beforeEach(() => {
@@ -206,7 +215,9 @@ describe('Anthropic Integration', () => {
     const mockData = createMockAnthropic();
     mockAnthropic = mockData.mockAnthropic;
     MockMessages = mockData.MockMessages;
-    _MockBatches = mockData.MockBatches;
+    MockAnthropicStream = mockData.MockAnthropicStream;
+    mockMessages = mockData.mockMessages;
+    mockResults = mockData.mockResults;
 
     // Apply patching
     patchedAnthropic = commonPatchAnthropic(mockAnthropic);
@@ -452,7 +463,7 @@ describe('Anthropic Integration', () => {
       if (chunk.custom_id) {
         resultCount++;
         expect(chunk.custom_id).toBe('request_1');
-        expect(chunk.result.type).toBe('message');
+        expect(chunk.result.type).toBe('succeeded');
         expect(chunk.result.message).toMatchObject({
           id: 'msg_123',
           role: 'assistant',
@@ -489,6 +500,118 @@ describe('Anthropic Integration', () => {
         },
       },
     });
+  });
+
+  test('batch results operation with mixed outcomes', async () => {
+    const batchId = 'batch_123';
+
+    mockResults.mockImplementationOnce(
+      async () =>
+        new MockAnthropicStream([
+          {
+            custom_id: 'request_1',
+            result: {
+              type: 'errored',
+              error: {
+                type: 'error',
+                request_id: null,
+                error: {type: 'invalid_request_error', message: 'too long'},
+              },
+            },
+          },
+          {custom_id: 'request_2', result: {type: 'canceled'}},
+          {custom_id: 'request_3', result: {type: 'expired'}},
+          {
+            custom_id: 'request_4',
+            result: {type: 'succeeded', message: mockMessages},
+          },
+        ])
+    );
+
+    const batches = new patchedAnthropic.Anthropic.Messages.Batches();
+    const stream = await batches.results(batchId);
+
+    const seen: string[] = [];
+    for await (const chunk of stream) {
+      seen.push(chunk.result.type);
+    }
+    expect(seen).toEqual(['errored', 'canceled', 'expired', 'succeeded']);
+
+    const calls = await traceServer.getCalls(testProjectName);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].ended_at).toBeDefined();
+    expect(calls[0].exception ?? null).toBeNull();
+    expect(calls[0].output).toEqual({messages: [mockMessages]});
+    expect(calls[0].summary).toEqual({
+      usage: {
+        'claude-3-opus-20240229': {
+          input_tokens: 10,
+          output_tokens: 8,
+          requests: 1,
+        },
+      },
+    });
+  });
+
+  test('batch results operation with no succeeded entries', async () => {
+    const batchId = 'batch_123';
+
+    mockResults.mockImplementationOnce(
+      async () =>
+        new MockAnthropicStream([
+          {custom_id: 'request_1', result: {type: 'canceled'}},
+          {custom_id: 'request_2', result: {type: 'expired'}},
+        ])
+    );
+
+    const batches = new patchedAnthropic.Anthropic.Messages.Batches();
+    const stream = await batches.results(batchId);
+
+    const seen: string[] = [];
+    for await (const chunk of stream) {
+      seen.push(chunk.result.type);
+    }
+    expect(seen).toEqual(['canceled', 'expired']);
+
+    const calls = await traceServer.getCalls(testProjectName);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].ended_at).toBeDefined();
+    expect(calls[0].exception ?? null).toBeNull();
+    expect(calls[0].output).toEqual({messages: []});
+    expect(calls[0].summary).toEqual({});
+  });
+
+  test('batch results operation with an early break', async () => {
+    const batchId = 'batch_123';
+
+    mockResults.mockImplementationOnce(
+      async () =>
+        new MockAnthropicStream([
+          {custom_id: 'request_1', result: {type: 'canceled'}},
+          {
+            custom_id: 'request_2',
+            result: {type: 'succeeded', message: mockMessages},
+          },
+        ])
+    );
+
+    const batches = new patchedAnthropic.Anthropic.Messages.Batches();
+    const stream = await batches.results(batchId);
+
+    const seen: string[] = [];
+    // Breaking runs the same finally block, by way of the iterator's return().
+    for await (const chunk of stream) {
+      seen.push(chunk.custom_id);
+      break;
+    }
+    expect(seen).toEqual(['request_1']);
+
+    const calls = await traceServer.getCalls(testProjectName);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].ended_at).toBeDefined();
+    expect(calls[0].exception ?? null).toBeNull();
+    expect(calls[0].output).toEqual({messages: []});
+    expect(calls[0].summary).toEqual({});
   });
 
   test('error handling in non-streaming mode', async () => {

--- a/sdks/node/src/integrations/anthropic.ts
+++ b/sdks/node/src/integrations/anthropic.ts
@@ -188,16 +188,17 @@ function patchStreamHelper(exports: any) {
 }
 
 type BatchChunk = {
-  type: undefined;
   custom_id: string;
-  result: {type: string; message: Message};
+  result:
+    | {type: 'succeeded'; message: Message}
+    | {type: 'errored' | 'canceled' | 'expired'};
 };
 
 const batchStreamReducer: StreamReducer<BatchChunk, ResultState> = {
   initialStateFn: streamReducer.initialStateFn,
   reduceFn: (state, chunk) => {
-    // batch message type
-    if (typeof chunk.result == 'object' && chunk.result != null) {
+    // Chunks arrive as untyped JSON; only a succeeded result carries a message.
+    if (chunk.result?.type === 'succeeded' && chunk.result.message != null) {
       state.messages.push(chunk.result.message);
     }
     return state;


### PR DESCRIPTION
## Description

- Fixes [WB-38528](https://coreweave.atlassian.net/browse/WB-38528)

This is a prerequisite for the next change in this file, which fixes token and cost counts for cached Anthropic calls. That change adds to the same summarizer, so this path needs to stop throwing first.

Anthropic has a batch API: you send a pile of requests, then read the results back one by one. Some can fail, get canceled, or expire — normal, the API has a counter for each.

Only a successful result carries a `message`. Our code read `message` off every result, so for the failed ones it got `undefined`. Then it crashed.

The crash lands badly. It comes out of the user's own `for await` loop, so their process dies unless they wrapped it. And the trace vanishes — not a broken one, nothing at all, because a call's start and end are sent together by default. One failed request out of a hundred is enough.

I found it reading this file for that token change, not from a report — there are none, so I do not know how often it hits. One hit is bad enough.

The obvious patch is to skip the empty ones in the summarizer, where the crash happens. That stops the crash, but the bad value is already in the recorded state by then. So the fix goes earlier, where results are collected: the type now spells out the four kinds the API really returns, and the code checks which one it got before reading it.

There is a test for batches and it passes. It used `result.type: 'message'`, which the API never sends — a batch that cannot exist, so the failed case was never covered.

Bottom line: one failed request used to kill the caller and lose the trace. Now the failed ones are skipped and the rest is recorded. The trace still does not say how many were skipped; that needs a new field.

## Testing

Three new tests cover a batch with all four outcomes, a batch where everything failed, and a `break` halfway through; all three crash on master and pass here. Locally that file is 11/11 and the full default Jest project is 490 passed, with 4 pre-existing failures in the OpenAI instrumentation suites that also fail on master, and tsc, eslint and prettier are clean.


[WB-38528]: https://coreweave.atlassian.net/browse/WB-38528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ