### PR TITLE
chore(weave_ts): hide deprecated Session const from TypeDoc output

### DIFF
--- a/sdks/node/src/genai/conversation.ts
+++ b/sdks/node/src/genai/conversation.ts
@@ -193,5 +193,11 @@ export class Conversation {
 export type SessionInit = ConversationInit;
 /** @deprecated Use {@link Conversation} instead. */
 export type Session = Conversation;
-/** @deprecated Use {@link Conversation} instead. */
+/**
+* Hidden to keep TypeDoc from emitting a duplicate `Session` docs page for
+* the constructor type.
+* @deprecated Use {@link Conversation} instead. 
+* @hidden
+*/
+
 export const Session = Conversation;

--- a/sdks/node/src/genai/conversation.ts
+++ b/sdks/node/src/genai/conversation.ts
@@ -194,10 +194,12 @@ export type SessionInit = ConversationInit;
 /** @deprecated Use {@link Conversation} instead. */
 export type Session = Conversation;
 /**
-* Hidden to keep TypeDoc from emitting a duplicate `Session` docs page for
-* the constructor type.
-* @deprecated Use {@link Conversation} instead. 
-* @hidden
-*/
+ * Hidden to keep TypeDoc from emitting a duplicate `Session` docs page for
+ * the constructor type.
+ *
+ * @deprecated Use {@link Conversation} instead.
+ * @hidden
+ */
+export const Session = Conversation;
 
 export const Session = Conversation;

--- a/sdks/node/src/genai/conversation.ts
+++ b/sdks/node/src/genai/conversation.ts
@@ -201,5 +201,3 @@ export type Session = Conversation;
  * @hidden
  */
 export const Session = Conversation;
-
-export const Session = Conversation;


### PR DESCRIPTION
## Description
Adds the `@hidden` tag to `export type Session = Conversation;` to keep TypeDoc from duplicating it i[n the docs](https://wb-21fd5541-typedoc-upgrade.mintlify.site/weave/reference/typescript-sdk/type-aliases/session-1).
