### PR TITLE
fix(weave): surface OTel exception event details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -549,6 +549,10 @@ deterministic.
   OTel spans with an empty `gen_ai.operation.name` remain stored and queryable
   through `agent_spans_query`, but are omitted from that visual tree; use a
   semantic marker span when a UI-visible trace regression is required.
+- For spans with `ERROR` status, missing `error_type` and `status_message`
+  fall back to the latest OTel `exception` event. Explicit `error.type` and
+  status-message values take precedence, and handled exception events on
+  non-error spans remain raw-only.
 - Use the Trace tree view for parentage comparisons. The default flamegraph
   collapses overlapping siblings into synthetic groups, which can make flat
   and nested traces look deceptively similar; give live-example spans realistic

--- a/tests/trace_server/test_genai_extraction.py
+++ b/tests/trace_server/test_genai_extraction.py
@@ -241,6 +241,76 @@ def test_extract_genai_span_error_status() -> None:
     assert result.error_type == "RateLimitError"
 
 
+def test_extract_genai_span_error_details_fall_back_to_exception_event() -> None:
+    span = _make_span(
+        events=[
+            Event(
+                name="exception",
+                timestamp=0,
+                attributes={
+                    "exception": {
+                        "type": "asyncio.exceptions.CancelledError",
+                        "message": "stream cancelled",
+                    }
+                },
+            )
+        ],
+        status=Status(code=StatusCode.ERROR),
+    )
+
+    result = extract_genai_span(span, project_id="p1")
+
+    assert result.error_type == "asyncio.exceptions.CancelledError"
+    assert result.status_message == "stream cancelled"
+
+
+def test_extract_genai_span_error_details_prefer_explicit_fields() -> None:
+    span = _make_span(
+        attrs={"error.type": "RateLimitError"},
+        events=[
+            Event(
+                name="exception",
+                timestamp=0,
+                attributes={
+                    "exception": {
+                        "type": "FallbackError",
+                        "message": "fallback message",
+                    }
+                },
+            )
+        ],
+        status=Status(code=StatusCode.ERROR, message="rate limited"),
+    )
+
+    result = extract_genai_span(span, project_id="p1")
+
+    assert result.error_type == "RateLimitError"
+    assert result.status_message == "rate limited"
+
+
+def test_extract_genai_span_does_not_promote_handled_exception_event() -> None:
+    span = _make_span(
+        events=[
+            Event(
+                name="exception",
+                timestamp=0,
+                attributes={
+                    "exception": {
+                        "type": "HandledError",
+                        "message": "recovered",
+                    }
+                },
+            )
+        ]
+    )
+
+    result = extract_genai_span(span, project_id="p1")
+
+    assert result.status_code == "OK"
+    assert result.error_type == ""
+    assert result.status_message == ""
+
+
 def test_extract_genai_span_preserves_unset_status() -> None:
     span = _make_span(status=Status(code=StatusCode.UNSET))
     result = extract_genai_span(span, project_id="p1")

--- a/tests/trace_server/test_genai_helpers.py
+++ b/tests/trace_server/test_genai_helpers.py
@@ -1,6 +1,7 @@
 """Unit tests for GenAI agent helper functions."""
 
 import datetime
+import json
 
 import pytest
 
@@ -41,6 +42,62 @@ def test_normalize_span_row_returns_new_dict() -> None:
     assert normalized["input_messages"] == [
         {"role": "user", "content": "hi", "finish_reason": ""}
     ]
+
+
+def test_normalize_span_row_fills_error_details_from_raw_span_dump() -> None:
+    normalized = normalize_span_row(
+        {
+            "status_code": "ERROR",
+            "status_message": "",
+            "error_type": "",
+            "raw_span_dump": json.dumps(
+                {
+                    "events": [
+                        {
+                            "name": "exception",
+                            "attributes": {
+                                "exception": {
+                                    "type": "asyncio.exceptions.CancelledError",
+                                    "message": "stream cancelled",
+                                }
+                            },
+                        }
+                    ]
+                }
+            ),
+        }
+    )
+
+    assert normalized["error_type"] == "asyncio.exceptions.CancelledError"
+    assert normalized["status_message"] == "stream cancelled"
+
+
+def test_normalize_span_row_preserves_explicit_error_details() -> None:
+    normalized = normalize_span_row(
+        {
+            "status_code": "ERROR",
+            "status_message": "rate limited",
+            "error_type": "RateLimitError",
+            "raw_span_dump": json.dumps(
+                {
+                    "events": [
+                        {
+                            "name": "exception",
+                            "attributes": {
+                                "exception": {
+                                    "type": "FallbackError",
+                                    "message": "fallback message",
+                                }
+                            },
+                        }
+                    ]
+                }
+            ),
+        }
+    )
+
+    assert normalized["error_type"] == "RateLimitError"
+    assert normalized["status_message"] == "rate limited"
 
 
 def test_normalize_span_row_rejects_invalid_message_shape() -> None:

--- a/weave/trace_server/agents/error_details.py
+++ b/weave/trace_server/agents/error_details.py
@@ -1,0 +1,45 @@
+"""Extract displayable error details from OTel exception events."""
+
+import json
+from typing import Any
+
+from weave.trace_server.opentelemetry.helpers import get_attribute
+
+
+def exception_event_details(
+    events: list[dict[str, Any]],
+) -> tuple[str, str]:
+    """Return the latest exception event's type and message."""
+    for event in reversed(events):
+        if event.get("name") != "exception":
+            continue
+        attributes = event.get("attributes")
+        if not isinstance(attributes, dict):
+            continue
+        exception_type = get_attribute(attributes, "exception.type")
+        exception_message = get_attribute(attributes, "exception.message")
+        type_text = str(exception_type) if exception_type is not None else ""
+        message_text = str(exception_message) if exception_message is not None else ""
+        if type_text or message_text:
+            return type_text, message_text
+    return "", ""
+
+
+def exception_event_details_from_span_dump(
+    raw_span_dump: object,
+) -> tuple[str, str]:
+    """Extract exception details from a stored raw OTel span dump."""
+    if not isinstance(raw_span_dump, str) or not raw_span_dump:
+        return "", ""
+    try:
+        raw_span = json.loads(raw_span_dump)
+    except (json.JSONDecodeError, TypeError):
+        return "", ""
+    if not isinstance(raw_span, dict):
+        return "", ""
+    events = raw_span.get("events")
+    if not isinstance(events, list):
+        return "", ""
+    return exception_event_details(
+        [event for event in events if isinstance(event, dict)]
+    )

--- a/weave/trace_server/agents/helpers.py
+++ b/weave/trace_server/agents/helpers.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 from typing import Any, NamedTuple
 
+from weave.trace_server.agents.error_details import (
+    exception_event_details_from_span_dump,
+)
 from weave.trace_server.agents.schema import (
     ALL_SPAN_INSERT_COLUMNS,
     AgentSpanCHInsertable,
@@ -92,6 +95,14 @@ def normalize_span_row(d: dict[str, Any]) -> dict[str, Any]:
     Handles message tuple->dict conversion.
     """
     normalized_row = dict(d)
+    if normalized_row.get("status_code") == "ERROR":
+        event_error_type, event_status_message = exception_event_details_from_span_dump(
+            normalized_row.get("raw_span_dump")
+        )
+        if not normalized_row.get("error_type") and event_error_type:
+            normalized_row["error_type"] = event_error_type
+        if not normalized_row.get("status_message") and event_status_message:
+            normalized_row["status_message"] = event_status_message
     for key in ("input_messages", "output_messages"):
         msgs = normalized_row.get(key)
         if not msgs or not isinstance(msgs, list):

--- a/weave/trace_server/opentelemetry/genai_extraction.py
+++ b/weave/trace_server/opentelemetry/genai_extraction.py
@@ -20,6 +20,7 @@ from weave.trace_server.agents.constants import (
     MAX_CUSTOM_ATTR_VALUE_CHARS,
     MAX_CUSTOM_ATTRS_PER_SPAN,
 )
+from weave.trace_server.agents.error_details import exception_event_details
 from weave.trace_server.agents.schema import (
     AgentSpanCHInsertable,
     NormalizedMessage,
@@ -612,6 +613,9 @@ def extract_genai_span(
     reasoning_t = extract_reasoning_tokens(attrs)
 
     status_code = span.status.code.name
+    event_error_type, event_status_message = (
+        exception_event_details(events_dicts) if status_code == "ERROR" else ("", "")
+    )
 
     raw_output = _extract_raw_output(attrs, events_dicts)
     raw_input = _extract_raw_input(attrs)
@@ -630,7 +634,7 @@ def extract_genai_span(
         started_at=span.start_time,
         ended_at=span.end_time,
         status_code=status_code,
-        status_message=span.status.message or "",
+        status_message=span.status.message or event_status_message,
         operation_name=extract_operation_name(attrs, span.name),
         provider_name=extract_provider(attrs),
         agent_name=extract_agent_name(attrs, span.name),
@@ -669,7 +673,9 @@ def extract_genai_span(
         tool_description=_get_str(attrs, *semconv.TOOL_DESCRIPTION.lookup_keys),
         tool_definitions=_json_str(_get(attrs, *semconv.TOOL_DEFINITIONS.lookup_keys)),
         finish_reasons=extract_finish_reasons(attrs),
-        error_type=_get_str(attrs, *semconv.ERROR_TYPE.lookup_keys),
+        error_type=(
+            _get_str(attrs, *semconv.ERROR_TYPE.lookup_keys) or event_error_type
+        ),
         request_temperature=safe_float(
             _get(attrs, *semconv.REQUEST_TEMPERATURE.lookup_keys)
         ),


### PR DESCRIPTION
## What

Populate missing agent-span `error_type` and `status_message` fields from the latest OpenTelemetry `exception` event. Detailed span reads also derive the fallback from `raw_span_dump`, so already-stored spans gain the same display fields without a backfill.

## Why

Some instrumentations mark spans as `ERROR` but leave the OpenTelemetry status message and `error.type` span attribute empty. The exception type and message are present only on an exception event, so the Agents span detail can show an error state without useful details.

## How

- Preserve explicit `error.type` attributes and OpenTelemetry status messages.
- For `ERROR` spans only, use the latest exception event when either field is missing.
- Apply the fallback during ingestion and during detailed row normalization.
- Do not promote handled exception events on `OK` or `UNSET` spans.

This does not require a schema change, migration, or backfill.

## Testing

- `uv run --group test python -m pytest tests/trace_server/test_genai_extraction.py tests/trace_server/test_genai_helpers.py -q` (36 passed)
- `uvx ruff check weave/trace_server/agents/error_details.py weave/trace_server/agents/helpers.py weave/trace_server/opentelemetry/genai_extraction.py tests/trace_server/test_genai_extraction.py tests/trace_server/test_genai_helpers.py`
- `uvx ruff format --check weave/trace_server/agents/error_details.py weave/trace_server/agents/helpers.py weave/trace_server/opentelemetry/genai_extraction.py tests/trace_server/test_genai_extraction.py tests/trace_server/test_genai_helpers.py`

## Anything Else?

The read-time fallback covers existing spans when their raw dump is included in the detailed query.
