### PR TITLE
fix(weave): show contentless agent errors in conversations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -561,6 +561,9 @@ deterministic.
   fall back to the latest OTel `exception` event. Explicit `error.type` and
   status-message values take precedence, and handled exception events on
   non-error spans remain raw-only.
+- Content spans with `ERROR` status emit a chat message even without text or
+  reasoning so the conversation timeline retains the failure. Successful empty
+  tool-calling steps remain omitted.
 - Use the Trace tree view for parentage comparisons. The default flamegraph
   collapses overlapping siblings into synthetic groups, which can make flat
   and nested traces look deceptively similar; give live-example spans realistic

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -46,6 +46,7 @@ def _span(
     compaction_summary: str = "",
     compaction_items_before: int = 0,
     compaction_items_after: int = 0,
+    status_code: str = "OK",
     started_at: datetime.datetime | None = None,
     ended_at: datetime.datetime | None = None,
     **kwargs: object,
@@ -68,7 +69,7 @@ def _span(
         compaction_summary=compaction_summary,
         compaction_items_before=compaction_items_before,
         compaction_items_after=compaction_items_after,
-        status_code="OK",
+        status_code=status_code,
         started_at=started_at
         or datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
         ended_at=ended_at
@@ -1146,6 +1147,36 @@ def test_tool_call_step_without_reasoning_emits_no_assistant_message() -> None:
 
     messages = build_chat_messages(spans)
     assert [m.type for m in messages if m.type == "assistant_message"] == []
+
+
+def test_contentless_error_span_emits_assistant_message() -> None:
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="wb-agent",
+            input_messages=[{"role": "user", "content": "run it"}],
+        ),
+        _span(
+            span_id="llm-error",
+            parent_span_id="agent",
+            operation_name="chat",
+            status_code="ERROR",
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+
+    assert [message.type for message in messages] == [
+        "user_message",
+        "agent_start",
+        "assistant_message",
+    ]
+    error_message = messages[-1]
+    assert error_message.span_id == "llm-error"
+    assert error_message.status_code == "ERROR"
+    assert _assistant_payload(error_message).text == ""
+    assert _assistant_payload(error_message).status == "ERROR"
 
 
 def test_subagent_spans_render_inline_with_agent_label_inheritance() -> None:

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -1308,15 +1308,16 @@ def _emit_assistant_message(
 
     A span that produced reasoning but no assistant text (e.g. an LLM step that
     only emitted a tool call) still yields a message carrying that reasoning, so
-    thinking interleaved between tool calls is surfaced rather than dropped.
-    Returns None only when there is neither output text nor reasoning content.
+    thinking interleaved between tool calls is surfaced rather than dropped. An
+    errored span also yields a message without content so its failure remains
+    visible in the conversation projection. Successful empty spans are omitted.
     """
     text = (
         _extract_non_user_output_text(span.output_messages)
         if span.output_messages
         else ""
     )
-    if not text and not span.reasoning_content:
+    if not text and not span.reasoning_content and span.status_code != "ERROR":
         return None
 
     if aggregate_node:


### PR DESCRIPTION
## What

Keep errored chat spans in the agent conversation projection even when they have no output text or reasoning. The API emits an empty assistant message carrying the span ID, timing, model, and `ERROR` status, so the existing conversation and turn timeline can show the failure.

## Why

The conversation badge counts every `ERROR` span, but `build_chat_messages` previously dropped content spans without renderable content. A failed streaming chat call could therefore contribute to the badge while disappearing from the turn timeline and conversation view.

## How

`_emit_assistant_message` still omits empty successful spans. It now emits a message when `status_code == "ERROR"`, using the existing assistant-message schema and status rendering.

This does not require an API schema change or migration.

## Testing

- `uv run --group test python -m pytest tests/trace_server/test_genai_chat_view.py -q` (56 passed, 1 expected failure)
- `uvx ruff check weave/trace_server/agents/chat_view.py tests/trace_server/test_genai_chat_view.py`
- `uvx ruff format --check weave/trace_server/agents/chat_view.py tests/trace_server/test_genai_chat_view.py`

## Anything Else?

This PR is stacked on the exception-event detail fallback because the same contentless error span should expose its exception details when opened from the conversation.
