### PR TITLE
fix(weave_ts): report inclusive Anthropic prompt tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,22 @@ deterministic.
   reconfigures the mock it captured before patching, or reaches it through
   `__wrappedFunction`.
 
+### TypeScript Anthropic token accounting
+
+- Anthropic reports `input_tokens` as fresh, uncached prompt only and bills the
+  rest through `cache_read_input_tokens` and `cache_creation_input_tokens`.
+  Weave's cost math subtracts those two from the prompt total, so the usage
+  summary has to carry an inclusive `input_tokens`. `totalInputTokens()` in
+  `integrations/anthropicUsage.ts` is where that sum lives, for this integration
+  and for the Claude Agent SDK OTel tracer; it mirrors the Python
+  `total_input_tokens()`.
+- Only the summary is normalized. The provider's own `usage` object stays
+  untouched, so the response the caller receives keeps Anthropic's own numbers.
+- Streaming `message_delta` usage is cumulative, and every field except
+  `output_tokens` is nullable. Skip the null ones, as the vendor's own client
+  does, and overwrite rather than add — a delta carries the running total, not
+  an increment.
+
 ### TypeScript custom type round trip
 
 - `client.get()` rebuilds a `WeaveImage` from a `PIL.Image.Image` payload and a

--- a/sdks/node/src/__tests__/integrations/anthropic.test.ts
+++ b/sdks/node/src/__tests__/integrations/anthropic.test.ts
@@ -1,6 +1,31 @@
 import {InMemoryTraceServer} from '../helpers/inMemoryTraceServer';
 import {commonPatchAnthropic} from '../../integrations/anthropic';
+import {totalInputTokens} from '../../integrations/anthropicUsage';
 import {initWithCustomTraceServer} from '../clientMock';
+
+describe('Anthropic — totalInputTokens', () => {
+  test('adds the cache counts to the fresh input tokens', () => {
+    expect(
+      totalInputTokens({
+        input_tokens: 4,
+        cache_read_input_tokens: 20000,
+        cache_creation_input_tokens: 1500,
+      })
+    ).toBe(21504);
+  });
+
+  test('treats absent, null and missing usage as zero', () => {
+    expect(totalInputTokens({input_tokens: 10})).toBe(10);
+    expect(
+      totalInputTokens({
+        input_tokens: 10,
+        cache_read_input_tokens: null,
+        cache_creation_input_tokens: null,
+      })
+    ).toBe(10);
+    expect(totalInputTokens(undefined)).toBe(0);
+  });
+});
 
 // Mock Anthropic SDK
 function createMockAnthropic() {
@@ -15,6 +40,24 @@ function createMockAnthropic() {
     usage: {
       input_tokens: 10,
       output_tokens: 8,
+    },
+  };
+
+  // A cached call: Anthropic reports only the 4 fresh tokens in
+  // input_tokens and bills the other 21500 through the two cache fields.
+  const mockCachedMessage = {
+    id: 'msg_456',
+    role: 'assistant',
+    type: 'message',
+    model: 'claude-opus-5',
+    content: [{type: 'text', text: 'Hello again!'}],
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    usage: {
+      input_tokens: 4,
+      cache_creation_input_tokens: 1500,
+      cache_read_input_tokens: 20000,
+      output_tokens: 300,
     },
   };
 
@@ -193,7 +236,9 @@ function createMockAnthropic() {
     mockAnthropic,
     MockMessages,
     MockAnthropicStream,
+    MockAPIPromise,
     mockMessages,
+    mockCachedMessage,
     mockResults,
   };
 }
@@ -204,7 +249,9 @@ describe('Anthropic Integration', () => {
   let mockAnthropic: any;
   let MockMessages: any;
   let MockAnthropicStream: any;
+  let MockAPIPromise: any;
   let mockMessages: any;
+  let mockCachedMessage: any;
   let mockResults: jest.Mock;
   let patchedAnthropic: any;
 
@@ -216,7 +263,9 @@ describe('Anthropic Integration', () => {
     mockAnthropic = mockData.mockAnthropic;
     MockMessages = mockData.MockMessages;
     MockAnthropicStream = mockData.MockAnthropicStream;
+    MockAPIPromise = mockData.MockAPIPromise;
     mockMessages = mockData.mockMessages;
+    mockCachedMessage = mockData.mockCachedMessage;
     mockResults = mockData.mockResults;
 
     // Apply patching
@@ -273,6 +322,44 @@ describe('Anthropic Integration', () => {
         'claude-3-opus-20240229': {
           input_tokens: 10,
           output_tokens: 8,
+          requests: 1,
+        },
+      },
+    });
+  });
+
+  test('non-streaming message creation with prompt caching', async () => {
+    const options = {
+      model: 'claude-opus-5',
+      max_tokens: 100,
+      messages: [{role: 'user', content: 'Hello again, Claude!'}],
+    };
+
+    MockMessages.prototype.create.mockResolvedValueOnce(mockCachedMessage);
+
+    const anthropic = new patchedAnthropic.Anthropic.Messages();
+    const result = await anthropic.create(options);
+
+    // Only the summary is normalized; the provider's own numbers are kept.
+    const providerUsage = {
+      input_tokens: 4,
+      cache_creation_input_tokens: 1500,
+      cache_read_input_tokens: 20000,
+      output_tokens: 300,
+    };
+    expect(result.usage).toEqual(providerUsage);
+
+    const calls = await traceServer.getCalls(testProjectName);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].output.usage).toEqual(providerUsage);
+    expect(calls[0].summary).toEqual({
+      usage: {
+        'claude-opus-5': {
+          // 4 fresh + 20000 read from cache + 1500 written to cache
+          input_tokens: 21504,
+          output_tokens: 300,
+          cache_read_input_tokens: 20000,
+          cache_creation_input_tokens: 1500,
           requests: 1,
         },
       },
@@ -336,6 +423,78 @@ describe('Anthropic Integration', () => {
         'claude-3-opus-20240229': {
           input_tokens: 10,
           output_tokens: 8,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          requests: 1,
+        },
+      },
+    });
+  });
+
+  test('streaming message creation with prompt caching', async () => {
+    const options = {
+      model: 'claude-opus-5',
+      max_tokens: 100,
+      messages: [{role: 'user', content: 'Hello again, streaming Claude!'}],
+      stream: true,
+    };
+
+    MockMessages.prototype.create.mockImplementationOnce(
+      () =>
+        new MockAPIPromise(
+          new MockAnthropicStream([
+            {
+              type: 'message_start',
+              message: {
+                ...mockCachedMessage,
+                content: [],
+                stop_reason: null,
+                usage: {...mockCachedMessage.usage, output_tokens: 1},
+              },
+            },
+            {
+              type: 'content_block_start',
+              index: 0,
+              content_block: {type: 'text', text: 'Hello again!'},
+            },
+            {type: 'content_block_stop', index: 0},
+            {
+              type: 'message_delta',
+              delta: {stop_reason: 'end_turn', stop_sequence: null},
+              // Cumulative: the nulls are fields this delta is not restating.
+              usage: {
+                input_tokens: 4,
+                output_tokens: 300,
+                cache_creation_input_tokens: null,
+                cache_read_input_tokens: null,
+              },
+            },
+            {type: 'message_stop'},
+          ])
+        )
+    );
+
+    const anthropic = new patchedAnthropic.Anthropic.Messages();
+    const stream = await anthropic.create(options);
+    for await (const _chunk of stream) {
+      // Drain the stream so the call is recorded.
+    }
+
+    const calls = await traceServer.getCalls(testProjectName);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].output.messages[0].usage).toEqual({
+      input_tokens: 4,
+      cache_creation_input_tokens: 1500,
+      cache_read_input_tokens: 20000,
+      output_tokens: 300,
+    });
+    expect(calls[0].summary).toEqual({
+      usage: {
+        'claude-opus-5': {
+          input_tokens: 21504,
+          output_tokens: 300,
+          cache_read_input_tokens: 20000,
+          cache_creation_input_tokens: 1500,
           requests: 1,
         },
       },
@@ -387,6 +546,8 @@ describe('Anthropic Integration', () => {
         'claude-3-opus-20240229': {
           input_tokens: 10,
           output_tokens: 8,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
           requests: 1,
         },
       },
@@ -496,6 +657,8 @@ describe('Anthropic Integration', () => {
         'claude-3-opus-20240229': {
           input_tokens: 10,
           output_tokens: 8,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
           requests: 1,
         },
       },
@@ -547,6 +710,8 @@ describe('Anthropic Integration', () => {
         'claude-3-opus-20240229': {
           input_tokens: 10,
           output_tokens: 8,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
           requests: 1,
         },
       },
@@ -612,6 +777,45 @@ describe('Anthropic Integration', () => {
     expect(calls[0].exception ?? null).toBeNull();
     expect(calls[0].output).toEqual({messages: []});
     expect(calls[0].summary).toEqual({});
+  });
+
+  test('batch results operation with prompt caching', async () => {
+    const batchId = 'batch_123';
+
+    mockResults.mockImplementationOnce(
+      async () =>
+        new MockAnthropicStream([
+          {
+            custom_id: 'request_1',
+            result: {type: 'succeeded', message: mockCachedMessage},
+          },
+          {
+            custom_id: 'request_2',
+            result: {type: 'succeeded', message: mockCachedMessage},
+          },
+        ])
+    );
+
+    const batches = new patchedAnthropic.Anthropic.Messages.Batches();
+    const stream = await batches.results(batchId);
+    for await (const _chunk of stream) {
+      // Drain the stream so the call is recorded.
+    }
+
+    // Two results for one model: the token counts are the sum of both.
+    const calls = await traceServer.getCalls(testProjectName);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].summary).toEqual({
+      usage: {
+        'claude-opus-5': {
+          input_tokens: 43008,
+          output_tokens: 600,
+          cache_read_input_tokens: 40000,
+          cache_creation_input_tokens: 3000,
+          requests: 1,
+        },
+      },
+    });
   });
 
   test('error handling in non-streaming mode', async () => {

--- a/sdks/node/src/integrations/anthropic.ts
+++ b/sdks/node/src/integrations/anthropic.ts
@@ -1,3 +1,4 @@
+import {totalInputTokens} from './anthropicUsage';
 import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
 import {asAttributes, libraryIntegration} from './integrationMetadata';
 import {op} from '../op';
@@ -24,7 +25,12 @@ type StreamChunk =
   | {
       type: 'message_delta';
       delta: {stop_reason: string; stop_sequence: any};
-      usage: {output_tokens: number};
+      usage: {
+        input_tokens?: number | null;
+        output_tokens: number;
+        cache_read_input_tokens?: number | null;
+        cache_creation_input_tokens?: number | null;
+      };
     }
   | {type: 'message_stop'}
   | {
@@ -56,7 +62,13 @@ const streamReducer: StreamReducer<StreamChunk, ResultState> = {
       case 'message_delta':
         lastMessage = state.messages[state.messages.length - 1];
         Object.assign(lastMessage, chunk.delta);
-        Object.assign(lastMessage.usage ?? {}, chunk.usage);
+        // Delta usage is cumulative; skip nulls so earlier counts survive.
+        lastMessage.usage = {...lastMessage.usage};
+        for (const [field, value] of Object.entries(chunk.usage ?? {})) {
+          if (value != null) {
+            lastMessage.usage[field] = value;
+          }
+        }
         break;
       case 'content_block_start':
         lastMessage = state.messages[state.messages.length - 1];
@@ -79,14 +91,24 @@ function summarizer(result: any) {
   if (result.usage != null && result.usage != null) {
     return {
       usage: {
-        [result.model]: result.usage,
+        [result.model]: {
+          ...result.usage,
+          input_tokens: totalInputTokens(result.usage),
+        },
       },
     };
   }
   // Streaming mode
   if (result.messages != null && result.messages.length > 0) {
-    const usage: Record<string, {input_tokens: number; output_tokens: number}> =
-      {};
+    const usage: Record<
+      string,
+      {
+        input_tokens: number;
+        output_tokens: number;
+        cache_read_input_tokens: number;
+        cache_creation_input_tokens: number;
+      }
+    > = {};
     for (const message of result.messages) {
       const {usage: messageUsage, model} = message;
       if (model == undefined || usage == undefined) {
@@ -96,10 +118,16 @@ function summarizer(result: any) {
         usage[model] = {
           input_tokens: 0,
           output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
         };
       }
-      usage[model].input_tokens += messageUsage?.input_tokens ?? 0;
+      usage[model].input_tokens += totalInputTokens(messageUsage);
       usage[model].output_tokens += messageUsage?.output_tokens ?? 0;
+      usage[model].cache_read_input_tokens +=
+        messageUsage?.cache_read_input_tokens ?? 0;
+      usage[model].cache_creation_input_tokens +=
+        messageUsage?.cache_creation_input_tokens ?? 0;
     }
 
     return {

--- a/sdks/node/src/integrations/anthropicUsage.ts
+++ b/sdks/node/src/integrations/anthropicUsage.ts
@@ -1,0 +1,25 @@
+/**
+ * Prompt-token accounting shared by the Anthropic-shaped integrations.
+ *
+ * Mirrors the Python `weave/integrations/claude_agent_sdk/usage.py`. Anthropic
+ * reports fresh input tokens separately from cache-read and cache-creation
+ * tokens, while Weave records those cache counts as subsets of the full prompt,
+ * so its input token count must include all three values.
+ */
+
+/** The prompt-side subset of an Anthropic usage object. */
+type PromptUsage = {
+  input_tokens?: number | null;
+  cache_read_input_tokens?: number | null;
+  cache_creation_input_tokens?: number | null;
+};
+
+/** Weave's gross prompt count for an Anthropic usage payload. */
+export function totalInputTokens(usage?: PromptUsage | null): number {
+  const raw = usage ?? {};
+  return (
+    (raw.input_tokens ?? 0) +
+    (raw.cache_read_input_tokens ?? 0) +
+    (raw.cache_creation_input_tokens ?? 0)
+  );
+}

--- a/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
+++ b/sdks/node/src/integrations/claude-agent-sdk/otelTracer.ts
@@ -12,6 +12,7 @@ import {
   ATTR_ERROR_TYPE,
   ATTR_GEN_AI_USAGE_TOTAL_TOKENS,
 } from '../../genai/semconv';
+import {totalInputTokens} from '../anthropicUsage';
 import {asOtelAttributes, libraryIntegration} from '../integrationMetadata';
 import type {
   ModelUsage,
@@ -231,10 +232,7 @@ function normalizeUsage(
 ): NormalizedUsage {
   const usage = toWeaveUsage(rawUsage);
   // Anthropic excludes cache tokens from input tokens; Weave includes them.
-  const inputTokens =
-    usage.input_tokens +
-    usage.cache_read_input_tokens +
-    usage.cache_creation_input_tokens;
+  const inputTokens = totalInputTokens(usage);
   const outputTokens = usage.output_tokens;
 
   return {


### PR DESCRIPTION
## Description

- Fixes [WB-38555](https://coreweave.atlassian.net/browse/WB-38555)

If you turn on prompt caching with Anthropic in the TypeScript SDK, the traces lie about tokens. Say a call has 21,500 tokens of cached prompt and only 4 fresh ones. The trace shows 4. The cost is wrong too: near zero on streaming calls, negative on plain ones.

That is because Anthropic does not send one prompt number. From their [prompt caching docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching):

> The `input_tokens` field represents only the tokens that come **after the last cache breakpoint** in your request - not all the input tokens you sent.

> `total_input_tokens = cache_read_input_tokens + cache_creation_input_tokens + input_tokens`

So the real prompt size is those three added up. Weave wants that single total and subtracts the two cache numbers itself, because they are billed at their own rates. We were passing Anthropic's numbers through untouched, so Weave subtracted them from a total that never had them in it.

Python already fixed this in [#7561](https://github.com/wandb/weave/pull/7561) ([WB-37043](https://coreweave.atlassian.net/browse/WB-37043)), so I figured TypeScript should just do the same. It adds the three counters up now, and keeps the two cache counts next to the total so the server can still subtract them. That covers plain calls, streaming and batches.

Streaming still did not work after that, so I went digging. During a stream Anthropic keeps resending the usage as a running total, and puts `null` in the fields it is not restating. Our code copied each update over the stored usage, nulls and all, which wiped the cache counts that came in at the start. It now copies only the fields that have a value, which is what Anthropic's own client does.

I also found the Claude Agent SDK tracer already had this same sum written out by hand. I did not want to write it twice, so it moved into a small shared helper and both use it.

Bottom line: a cached call used to record 4 prompt tokens and a nonsense cost, now it records the real 21,504. The response your own code gets back still has Anthropic's numbers in it, untouched. The only other change is that streaming and batch summaries now always carry the two cache counts, zero when nothing was cached, which is why four old tests move.

## Testing

Three new tests, one for each way you can call Anthropic — plain, streaming and batch — all with caching on, and all three fail on master. Two more cover the helper on its own; locally this file is 16/16, the full Node suite picks up no new failures, and tsc, eslint and prettier are clean.


[WB-38555]: https://coreweave.atlassian.net/browse/WB-38555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-37043]: https://coreweave.atlassian.net/browse/WB-37043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ