### PR TITLE
refactor(weave): move label definitions into the taxonomy files

### DIFF
--- a/tests/trace_server/test_insights_config.py
+++ b/tests/trace_server/test_insights_config.py
@@ -27,21 +27,38 @@ def test_spaces_have_distinct_digests():
 
 
 @pytest.mark.parametrize("space", config.SPACES)
-def test_prompt_renders_and_cannot_drift_from_its_taxonomy(space):
-    """Every token resolves, and the prose describes exactly the declared labels.
+def test_prompt_renders_every_declared_label_and_its_definition(space):
+    """Every token resolves, and the taxonomy supplies both halves of a label.
 
     The label list reaches the judge twice: as the alternation it must choose
-    from, and as the descriptions it reasons with. Only the first is generated,
-    so this is what stops the second from describing a retired label.
+    from, and as the definition it reasons with. Both are generated from the one
+    file, so the two cannot describe different vocabularies.
     """
     rendered = prompt.render_prompt(space)
     assert "$" not in rendered
 
     extraction = config.load_config(space).extraction
     labels = extraction.taxonomy.labels()
-    assert "|".join(labels) in rendered
-    assert all(f"`{label}`" in rendered for label in labels)
+    assert "|".join(label.name for label in labels) in rendered
+    assert all(f"- `{label.name}`: {label.definition}" in rendered for label in labels)
     assert f"up to {extraction.history_turns} " in rendered
+
+
+def test_a_new_label_reaches_the_judge_without_touching_the_prompt(config_dir):
+    """A label carries its own meaning, so adding one is a taxonomy edit alone.
+
+    This is what a customer-supplied taxonomy needs: the new category reaches the
+    judge as both a choosable value and a definition, and no prompt text is
+    editable to get there.
+    """
+    with _edit_json(_taxonomy_path(config_dir)) as raw:
+        raw["labels"].append(
+            {"name": "billing_dispute", "definition": "disputes a charge."}
+        )
+
+    rendered = prompt.render_prompt("intent")
+    assert "|billing_dispute" in rendered
+    assert "- `billing_dispute`: disputes a charge." in rendered
 
 
 def test_editing_the_prompt_moves_the_digest(config_dir):
@@ -75,9 +92,8 @@ def test_digest_follows_referenced_files_not_the_config_text(config_dir):
         raw.update(reordered)
     assert _digest("intent") == before
 
-    taxonomy = os.path.join(config_dir, "taxonomies", "intent_categories.json")
-    with _edit_json(taxonomy) as raw:
-        raw["labels"].append("newly_added_intent")
+    with _edit_json(_taxonomy_path(config_dir)) as raw:
+        raw["labels"].append({"name": "newly_added_intent", "definition": "a new ask."})
     assert _digest("intent") != before
 
 
@@ -106,6 +122,10 @@ def test_an_unknown_space_is_rejected():
 
 def _digest(space: str) -> str:
     return config.config_sha(config.load_config(space))
+
+
+def _taxonomy_path(config_dir: str) -> str:
+    return os.path.join(config_dir, "taxonomies", "intent_categories.json")
 
 
 def _append(path: str, text: str) -> None:

--- a/weave/trace_server/insights/config.py
+++ b/weave/trace_server/insights/config.py
@@ -44,9 +44,20 @@ class Reference(_Strict):
         return {"path": self.path, "sha256": self.sha256()}
 
 
+class Label(_Strict):
+    """One categorical value, carrying the prose a judge needs to apply it.
+
+    The definition lives here rather than in the prompt so that adding a label is
+    one config edit, which is what a customer-supplied taxonomy will be.
+    """
+
+    name: str
+    definition: str
+
+
 class _Taxonomy(_Strict):
     description: str
-    labels: list[str]
+    labels: list[Label]
 
 
 class TaxonomyRef(Reference):
@@ -55,7 +66,7 @@ class TaxonomyRef(Reference):
     Its own type because taxonomies are the references that render into a prompt.
     """
 
-    def labels(self) -> list[str]:
+    def labels(self) -> list[Label]:
         return _Taxonomy.model_validate_json(self.read()).labels
 
 

--- a/weave/trace_server/insights/configs/prompts/failure.txt
+++ b/weave/trace_server/insights/configs/prompts/failure.txt
@@ -42,38 +42,10 @@ not embedded and does not enter the row id. The short boundary examples below om
 it is still expected.
 
 Failure categories:
-
-Comprehension
-- `task_misunderstanding`: misread the current request and solved the wrong problem.
-- `context_loss`: forgot or contradicted an established referent, constraint, answer, or instruction.
-
-Output
-- `wrong_output`: produced incorrect content, including factual errors, fabricated APIs/data/
-  capabilities, or code that does not work.
-- `requirement_violation`: produced otherwise plausible content but dropped a stated or standing
-  requirement, format, scope, language, or required piece.
-
-Execution
-- `tool_misuse`: selected the wrong tool, sent malformed arguments, failed to use an available tool,
-  or ignored/misread a tool result.
-- `tool_failure`: a well-formed tool call failed inside the tool through an error, timeout, or rate
-  limit that the assistant could observe.
-- `system_error`: infrastructure outside the assistant failed, such as a crash, model timeout,
-  truncated response, or raw platform error exposed to the user.
-- `unproductive_loop`: repeated calls, retries, or approaches without meaningful progress.
-
-Scope and behavior
-- `capability_gap`: the request exceeds what the product can do, even if declined correctly.
-- `refusal`: declined, hedged, or evaded a request, whether or not the decline was correct.
-- `unsafe_behavior`: took a destructive or unauthorized action or disclosed sensitive information,
-  including credentials, PII, or another user's data.
-- `other`: a real, observable failure that fits none of the above. Use it sparingly. A growing
-  `other` cluster is a missing category, not a durable label.
+$taxonomy_definitions
 
 Severity, judged per failure:
-- `info`: notable behavior that is not necessarily wrong. Default for `refusal` and `capability_gap`.
-- `minor`: degraded the turn, but the user still got what they asked for.
-- `major`: the user did not get what they asked for, or was harmed.
+$severity_definitions
 - You cannot see the product's capability limits or its safety policy. Never decide whether a refusal
   was proper or whether a policy was violated. Record the observable behavior, set severity from
   observable impact, and leave propriety to the reviewer.

--- a/weave/trace_server/insights/configs/prompts/intent.txt
+++ b/weave/trace_server/insights/configs/prompts/intent.txt
@@ -31,21 +31,7 @@ traces are not prose; a turn that is only pasted material is `und`. When a turn 
 the one the user's own instruction is written in. Every example below emits it.
 
 Intent categories:
-- `action_request`: asks the agent to do, create, change, remove, or execute something, including a
-  requested capability that does not exist yet.
-- `information_request`: asks for information, explanation, instructions, comparison, or analysis.
-- `problem_report`: reports broken or incorrect behavior without requesting a remedy.
-- `positive_feedback`: praises or expresses satisfaction with behavior working as designed, without
-  requesting action.
-- `negative_feedback`: complains about or expresses dissatisfaction with behavior working as
-  designed, including naming a capability the product lacks, without requesting action.
-- `approval`: authorizes or agrees to a proposed action.
-- `rejection`: declines, cancels, stops, or aborts a proposed or in-flight action.
-- `refinement`: redirects the agent, either by contradicting its output, its understanding, or an
-  earlier user request, or by supplying requested or additional detail.
-- `bad_faith`: intentional misuse of the agent, including jailbreak or prompt-injection attempts,
-  attempts to extract system instructions or another user's data, or sandbox escape.
-- `other`: a meaningful intent that fits none of the above.
+$taxonomy_definitions
 
 Boundary rules:
 - Broken behavior is `problem_report`; opinion about behavior working as designed is
@@ -76,11 +62,7 @@ Sentiment is independent of category. It measures affect, while `positive_feedba
 `negative_feedback` at `neutral`; a delighted "omg finally" approving a plan is `approval` at
 `delighted`. Never infer one from the other.
 
-- `frustrated`: explicit exasperation, a repetition callout, profanity, or emphatic insistence.
-- `dissatisfied`: reports something broken, wrong, or unwanted, without explicit heat.
-- `neutral`: task-focused with no affect. Plain corrections, approvals, and cancellations are neutral.
-- `satisfied`: brief thanks, warm agreement, or a short positive acknowledgement.
-- `delighted`: emphatic or unprompted praise.
+$sentiment_definitions
 
 Sentiment boundary rules:
 - Judge affect from the user's wording, not from the act. Rejecting, correcting, or cancelling is

--- a/weave/trace_server/insights/configs/taxonomies/failure_categories.json
+++ b/weave/trace_server/insights/configs/taxonomies/failure_categories.json
@@ -1,17 +1,53 @@
 {
   "description": "Categories a failure signature may carry. `refusal` and `capability_gap` name observable behavior rather than error, because the judge cannot see the product's capability limits or its safety policy and so cannot decide what counts as improper or as a violation. Impact is carried by `severity`, not by the category name.",
   "labels": [
-    "task_misunderstanding",
-    "context_loss",
-    "wrong_output",
-    "requirement_violation",
-    "tool_misuse",
-    "tool_failure",
-    "system_error",
-    "unproductive_loop",
-    "capability_gap",
-    "refusal",
-    "unsafe_behavior",
-    "other"
+    {
+      "name": "task_misunderstanding",
+      "definition": "misread the current request and solved the wrong problem."
+    },
+    {
+      "name": "context_loss",
+      "definition": "forgot or contradicted an established referent, constraint, answer, or instruction."
+    },
+    {
+      "name": "wrong_output",
+      "definition": "produced incorrect content, including factual errors, fabricated APIs/data/capabilities, or code that does not work."
+    },
+    {
+      "name": "requirement_violation",
+      "definition": "produced otherwise plausible content but dropped a stated or standing requirement, format, scope, language, or required piece."
+    },
+    {
+      "name": "tool_misuse",
+      "definition": "selected the wrong tool, sent malformed arguments, failed to use an available tool, or ignored/misread a tool result."
+    },
+    {
+      "name": "tool_failure",
+      "definition": "a well-formed tool call failed inside the tool through an error, timeout, or rate limit that the assistant could observe."
+    },
+    {
+      "name": "system_error",
+      "definition": "infrastructure outside the assistant failed, such as a crash, model timeout, truncated response, or raw platform error exposed to the user."
+    },
+    {
+      "name": "unproductive_loop",
+      "definition": "repeated calls, retries, or approaches without meaningful progress."
+    },
+    {
+      "name": "capability_gap",
+      "definition": "the request exceeds what the product can do, even if declined correctly."
+    },
+    {
+      "name": "refusal",
+      "definition": "declined, hedged, or evaded a request, whether or not the decline was correct."
+    },
+    {
+      "name": "unsafe_behavior",
+      "definition": "took a destructive or unauthorized action or disclosed sensitive information, including credentials, PII, or another user's data."
+    },
+    {
+      "name": "other",
+      "definition": "a real, observable failure that fits none of the above. Use it sparingly. A growing `other` cluster is a missing category, not a durable label."
+    }
   ]
 }

--- a/weave/trace_server/insights/configs/taxonomies/intent_categories.json
+++ b/weave/trace_server/insights/configs/taxonomies/intent_categories.json
@@ -1,15 +1,45 @@
 {
   "description": "Categories an intent signature may carry. `feedback` is split on polarity because the two halves cluster separately, and `correction` plus `clarification` are merged into `refinement` because the contradiction-versus-added-detail boundary produced label noise that a join against the failure space recovers anyway.",
   "labels": [
-    "action_request",
-    "information_request",
-    "problem_report",
-    "positive_feedback",
-    "negative_feedback",
-    "approval",
-    "rejection",
-    "refinement",
-    "bad_faith",
-    "other"
+    {
+      "name": "action_request",
+      "definition": "asks the agent to do, create, change, remove, or execute something, including a requested capability that does not exist yet."
+    },
+    {
+      "name": "information_request",
+      "definition": "asks for information, explanation, instructions, comparison, or analysis."
+    },
+    {
+      "name": "problem_report",
+      "definition": "reports broken or incorrect behavior without requesting a remedy."
+    },
+    {
+      "name": "positive_feedback",
+      "definition": "praises or expresses satisfaction with behavior working as designed, without requesting action."
+    },
+    {
+      "name": "negative_feedback",
+      "definition": "complains about or expresses dissatisfaction with behavior working as designed, including naming a capability the product lacks, without requesting action."
+    },
+    {
+      "name": "approval",
+      "definition": "authorizes or agrees to a proposed action."
+    },
+    {
+      "name": "rejection",
+      "definition": "declines, cancels, stops, or aborts a proposed or in-flight action."
+    },
+    {
+      "name": "refinement",
+      "definition": "redirects the agent, either by contradicting its output, its understanding, or an earlier user request, or by supplying requested or additional detail."
+    },
+    {
+      "name": "bad_faith",
+      "definition": "intentional misuse of the agent, including jailbreak or prompt-injection attempts, attempts to extract system instructions or another user's data, or sandbox escape."
+    },
+    {
+      "name": "other",
+      "definition": "a meaningful intent that fits none of the above."
+    }
   ]
 }

--- a/weave/trace_server/insights/configs/taxonomies/sentiment.json
+++ b/weave/trace_server/insights/configs/taxonomies/sentiment.json
@@ -1,10 +1,25 @@
 {
   "description": "Sentiment labels an intent signature may carry. Ordered worst to best, but deliberately not scored: averaging a numeric encoding of ordinal labels asserts distances this taxonomy does not define. Aggregate the distribution instead.",
   "labels": [
-    "frustrated",
-    "dissatisfied",
-    "neutral",
-    "satisfied",
-    "delighted"
+    {
+      "name": "frustrated",
+      "definition": "explicit exasperation, a repetition callout, profanity, or emphatic insistence."
+    },
+    {
+      "name": "dissatisfied",
+      "definition": "reports something broken, wrong, or unwanted, without explicit heat."
+    },
+    {
+      "name": "neutral",
+      "definition": "task-focused with no affect. Plain corrections, approvals, and cancellations are neutral."
+    },
+    {
+      "name": "satisfied",
+      "definition": "brief thanks, warm agreement, or a short positive acknowledgement."
+    },
+    {
+      "name": "delighted",
+      "definition": "emphatic or unprompted praise."
+    }
   ]
 }

--- a/weave/trace_server/insights/configs/taxonomies/severity.json
+++ b/weave/trace_server/insights/configs/taxonomies/severity.json
@@ -1,8 +1,17 @@
 {
   "description": "Severity labels a failure signature may carry, ordered least to most impactful. `info` is the bottom rung rather than `low` because two categories, `refusal` and `capability_gap`, record behavior that is not necessarily wrong; a ladder whose floor still reads as a problem would misreport them.",
   "labels": [
-    "info",
-    "minor",
-    "major"
+    {
+      "name": "info",
+      "definition": "notable behavior that is not necessarily wrong. Default for `refusal` and `capability_gap`."
+    },
+    {
+      "name": "minor",
+      "definition": "degraded the turn, but the user still got what they asked for."
+    },
+    {
+      "name": "major",
+      "definition": "the user did not get what they asked for, or was harmed."
+    }
   ]
 }

--- a/weave/trace_server/insights/prompt.py
+++ b/weave/trace_server/insights/prompt.py
@@ -21,7 +21,8 @@ def render_prompt(space: str) -> str:
 
 
 def _tokens(extraction: config.Extraction) -> dict[str, str]:
-    """Every numeric knob as `$name`, every taxonomy as `$name_labels`.
+    """Every numeric knob as `$name`, every taxonomy as `$name_labels` and
+    `$name_definitions`.
 
     Derived from the declared fields rather than listed, so reaching a new knob
     from an asset is a config edit and a token. An asset is free to ignore any of
@@ -31,7 +32,11 @@ def _tokens(extraction: config.Extraction) -> dict[str, str]:
     for name in type(extraction).model_fields:
         value = getattr(extraction, name)
         if isinstance(value, config.TaxonomyRef):
-            tokens[f"{name}_labels"] = "|".join(value.labels())
+            labels = value.labels()
+            tokens[f"{name}_labels"] = "|".join(label.name for label in labels)
+            tokens[f"{name}_definitions"] = "\n".join(
+                f"- `{label.name}`: {label.definition}" for label in labels
+            )
         elif isinstance(value, int):
             tokens[name] = str(value)
     return tokens


### PR DESCRIPTION
## Description

Stacked on #7598, so the diff to read is this branch against `griffin/intent-records-migration`.

A taxonomy label is a bare string today, so the meaning a judge needs in order to apply it lives as hand-written prose in the prompt asset. `prompt.py` interpolates only the label list into `$taxonomy_labels`. That splits one vocabulary across two files kept in sync by hand, and it makes a customer-supplied taxonomy impossible: handing a judge a bare label with no definition produces a category it cannot apply consistently.

A label becomes an object with a `name` and a `definition`:

```json
{"name": "action_request", "definition": "asks the agent to do, create, change, remove, or execute something, ..."}
```

`prompt.py` renders both halves from that one file, so each prompt's hand-written definition block is replaced by a `$taxonomy_definitions` token. Boundary rules and examples stay as prose in the asset. They are cross-cutting rather than per-label (six of the nine intent boundary rules name two or more labels, and one is a precedence rule between them), and adding a category does not require touching them.

Doing this now is what makes it cheap. `config_schema_version` is pinned to `Literal[1]` and no rows have been written, so the taxonomy shape can change without a version bump or a migration. `config_sha` needs no change at all: references already digest by content, so a per-customer taxonomy file already produces a per-customer digest.

## Testing

- `tests/trace_server/test_insights_config.py` passes, 11 tests.
- `test_a_new_label_reaches_the_judge_without_touching_the_prompt` is the new one, and is the contract a customer taxonomy needs: appending a label to the JSON makes it reachable as both a choosable value and a definition, with no prompt text edited.
- Rendered both prompts before and after and diffed them. After normalizing line wrapping, they are word for word identical apart from the four failure-category group headings (Comprehension / Output / Execution / Scope and behavior), which a flat list has nowhere to put. If those turn out to read worse to the judge, an optional `group` field is a three-line follow-up.

## Note on injection

Structured entries bound the blast radius of a customer-supplied taxonomy; they do not sanitize it. A `definition` still lands in the system prompt verbatim. What the customer cannot reach is the output contract, the status ladder, or the treat-input-as-data clause, and their text can only appear as one bullet inside a list.