### PR TITLE
fix(weave): include OTEL spans in root usage stats

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -276,6 +276,14 @@ jobs:
         run: |
           nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.nox-shard }}')" -- \
             -m "trace_server" --trace-server=fake
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
+        with:
+          files: ./coverage.xml
+          flags: fake-trace-tests
+          name: fake-trace-tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}-${{ matrix.nox-shard }}
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
   trace-server-migrator-1s1r:
     name: Trace server migrator tests (1s1r)
     timeout-minutes: 10

--- a/tests/trace_server/query_builder/test_usage_query_builder.py
+++ b/tests/trace_server/query_builder/test_usage_query_builder.py
@@ -971,15 +971,17 @@ def test_trace_roots_only_filter():
                         JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
                  FROM
                    (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
+                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump,
+                           anyIf(cm.parent_id, cm.parent_id IS NOT NULL) AS parent_id,
+                           anyIf(cm.otel_dump, cm.otel_dump IS NOT NULL) AS otel_dump
                     FROM calls_merged AS cm
                     WHERE cm.project_id = {pb_0:String}
                       AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
                       AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
                       AND cm.deleted_at IS NULL
-                      AND parent_id IS NULL
                     GROUP BY project_id,
-                             id)) ARRAY
+                             id)
+                 WHERE (parent_id IS NULL OR otel_dump IS NOT NULL) ) ARRAY
               JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
            GROUP BY bucket,
                     model),
@@ -1260,11 +1262,10 @@ def test_calls_complete_basic():
 
 
 def test_calls_complete_trace_roots_only_filter():
-    """Test trace_roots_only filter uses sentinel check for calls_complete.
+    """Test root-only usage includes OTEL rows for calls_complete.
 
     In calls_complete, parent_id is a non-nullable String with '' as the
-    sentinel for NULL, so trace_roots_only must check parent_id = '' instead
-    of parent_id IS NULL.
+    sentinel for NULL and otel_dump uses '' for a missing span.
     """
     start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
     end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
@@ -1298,13 +1299,15 @@ def test_calls_complete_trace_roots_only_filter():
                         JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
                  FROM
                    (SELECT cm.started_at AS started_at,
-                           cm.summary_dump AS summary_dump
+                           cm.summary_dump AS summary_dump,
+                           cm.parent_id AS parent_id,
+                           cm.otel_dump AS otel_dump
                     FROM calls_complete AS cm
                     WHERE cm.project_id = {pb_0:String}
                       AND cm.started_at >= toDateTime({pb_1:Float64}, {pb_3:String})
                       AND cm.started_at < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at = toDateTime64(0, 3)
-                      AND parent_id = {pb_5:String} )) ARRAY
+                      AND cm.deleted_at = toDateTime64(0, 3) )
+                 WHERE (parent_id = '' OR otel_dump != '') ) ARRAY
               JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
            GROUP BY bucket,
                     model),
@@ -1328,7 +1331,6 @@ def test_calls_complete_trace_roots_only_filter():
             "pb_2": 1733097600.0,
             "pb_3": "UTC",
             "pb_4": 3600,
-            "pb_5": "",
         },
         ["timestamp", "model", "sum_total_tokens", "count"],
         3600,

--- a/tests/trace_server/test_call_stats.py
+++ b/tests/trace_server/test_call_stats.py
@@ -517,73 +517,77 @@ def test_call_stats_op_names_filter(client: weave_client.WeaveClient):
 
 
 def test_call_stats_trace_roots_only_filter(client: weave_client.WeaveClient):
-    """Test trace_roots_only filter excludes child calls."""
+    """Root-only stats keep native root usage and OTEL span usage."""
     project_id = client.project_id
     model_name = "gpt-4o-roots-test"
-
     start_time = _BASE_TIME
 
-    # Create a root call
-    root_call_id = str(uuid.uuid4())
-    trace_id = str(uuid.uuid4())
+    def create_call(
+        trace_id: str,
+        parent_id: str | None,
+        offset_seconds: int,
+        prompt_tokens: int,
+        *,
+        is_otel: bool = False,
+        attributes: dict | None = None,
+    ) -> str:
+        call_id = str(uuid.uuid4())
+        started_at = start_time + datetime.timedelta(seconds=offset_seconds)
+        client.server.call_start(
+            tsi.CallStartReq(
+                start=tsi.StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=call_id,
+                    trace_id=trace_id,
+                    started_at=started_at,
+                    op_name=f"weave:///{project_id}/op/test_op:v1",
+                    parent_id=parent_id,
+                    attributes=attributes or {},
+                    inputs={},
+                    otel_dump={"name": "span"} if is_otel else None,
+                )
+            )
+        )
+        usage = (
+            {
+                model_name: {
+                    "prompt_tokens": prompt_tokens,
+                    "total_tokens": prompt_tokens,
+                }
+            }
+            if prompt_tokens
+            else {}
+        )
+        client.server.call_end(
+            tsi.CallEndReq(
+                end=tsi.EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=call_id,
+                    ended_at=started_at + datetime.timedelta(seconds=1),
+                    summary={"usage": usage},
+                )
+            )
+        )
+        return call_id
 
-    client.server.call_start(
-        tsi.CallStartReq(
-            start=tsi.StartedCallSchemaForInsert(
-                project_id=project_id,
-                id=root_call_id,
-                trace_id=trace_id,
-                started_at=start_time,
-                op_name=f"weave:///{project_id}/op/root_op:v1",
-                parent_id=None,
-                attributes={},
-                inputs={},
-            )
-        )
-    )
-    client.server.call_end(
-        tsi.CallEndReq(
-            end=tsi.EndedCallSchemaForInsert(
-                project_id=project_id,
-                id=root_call_id,
-                ended_at=start_time + datetime.timedelta(seconds=1),
-                summary={
-                    "usage": {model_name: {"prompt_tokens": 100, "total_tokens": 100}}
-                },
-            )
-        )
+    # Native SDK usage is already aggregated on the root.
+    native_trace_id = str(uuid.uuid4())
+    native_root_id = create_call(native_trace_id, None, 0, 100)
+    create_call(native_trace_id, native_root_id, 2, 200)
+    # A caller-supplied compatibility attribute does not make a native call OTEL.
+    create_call(
+        native_trace_id,
+        native_root_id,
+        3,
+        400,
+        attributes={"otel_span": {"name": "caller-supplied"}},
     )
 
-    # Create a child call
-    child_call_id = str(uuid.uuid4())
-    client.server.call_start(
-        tsi.CallStartReq(
-            start=tsi.StartedCallSchemaForInsert(
-                project_id=project_id,
-                id=child_call_id,
-                trace_id=trace_id,
-                started_at=start_time + datetime.timedelta(seconds=2),
-                op_name=f"weave:///{project_id}/op/child_op:v1",
-                parent_id=root_call_id,
-                attributes={},
-                inputs={},
-            )
-        )
-    )
-    client.server.call_end(
-        tsi.CallEndReq(
-            end=tsi.EndedCallSchemaForInsert(
-                project_id=project_id,
-                id=child_call_id,
-                ended_at=start_time + datetime.timedelta(seconds=3),
-                summary={
-                    "usage": {model_name: {"prompt_tokens": 200, "total_tokens": 200}}
-                },
-            )
-        )
-    )
+    # OTEL usage remains on descendant spans.
+    otel_trace_id = str(uuid.uuid4())
+    otel_root_id = create_call(otel_trace_id, None, 4, 0, is_otel=True)
+    create_call(otel_trace_id, otel_root_id, 6, 300, is_otel=True)
 
-    # Query with trace_roots_only=True should only get root call (100 tokens)
     force_merge_calls(client)
     result = client.server.call_stats(
         CallStatsReq(
@@ -596,14 +600,19 @@ def test_call_stats_trace_roots_only_filter(client: weave_client.WeaveClient):
                     metric="input_tokens", aggregations=[AggregationType.SUM]
                 ),
             ],
+            call_metrics=[
+                CallMetricSpec(metric="call_count", aggregations=[AggregationType.SUM])
+            ],
             filter=CallsFilter(trace_roots_only=True),
         )
     )
 
     model_buckets = [b for b in result.usage_buckets if b.get("model") == model_name]
     total_sum = sum(b.get("sum_input_tokens", 0) for b in model_buckets)
+    total_call_count = sum(b.get("sum_call_count", 0) for b in result.call_buckets)
 
-    assert total_sum == 100, f"Expected 100 (root only), got {total_sum}"
+    assert total_sum == 400
+    assert total_call_count == 2
 
 
 def test_call_stats_trace_ids_filter(client: weave_client.WeaveClient):

--- a/weave/trace_server/calls_query_builder/stats_query_base.py
+++ b/weave/trace_server/calls_query_builder/stats_query_base.py
@@ -190,6 +190,7 @@ def build_calls_filter_sql(
     calls_filter: CallsFilter | None,
     pb: ParamBuilder,
     read_table: ReadTable = ReadTable.CALLS_MERGED,
+    force_all_spans: bool = False,
 ) -> str:
     """Build WHERE clause SQL for CallsFilter.
 
@@ -200,6 +201,8 @@ def build_calls_filter_sql(
         calls_filter: The filter to convert to SQL.
         pb: Parameter builder for parameterized queries.
         read_table: Which table is being queried; affects NULL vs sentinel checks.
+        force_all_spans: Drop the `trace_roots_only` clause so descendant spans
+            are selected too, for callers that apply their own row filter.
 
     Returns:
         SQL fragment with leading `` AND `` if any filters apply, or empty string.
@@ -217,7 +220,7 @@ def build_calls_filter_sql(
         )
 
     # Handle trace_roots_only
-    if calls_filter.trace_roots_only:
+    if calls_filter.trace_roots_only and not force_all_spans:
         where_clauses.append(null_check_sql("parent_id", "parent_id", read_table, pb))
 
     # Handle trace_ids

--- a/weave/trace_server/calls_query_builder/usage_query_builder.py
+++ b/weave/trace_server/calls_query_builder/usage_query_builder.py
@@ -106,14 +106,14 @@ def build_usage_query(
     tz_param = pb.add_param(req.timezone or "UTC")
     bucket_interval_param = pb.add_param(granularity_seconds)
 
-    # Root-only usage keeps native root summaries plus individual OTEL span usage.
-    calls_filter = req.filter
-    include_otel_span_usage = bool(calls_filter and calls_filter.trace_roots_only)
-    if calls_filter is not None and calls_filter.trace_roots_only:
-        calls_filter = calls_filter.model_copy(update={"trace_roots_only": None})
+    # Root-only usage keeps native root summaries plus individual OTEL span usage,
+    # so the root filter is re-applied below instead of by the shared filter builder.
+    include_otel_span_usage = bool(req.filter and req.filter.trace_roots_only)
 
     # Build filter clauses - applied directly in WHERE
-    where_filter_sql = build_calls_filter_sql(calls_filter, pb, read_table)
+    where_filter_sql = build_calls_filter_sql(
+        req.filter, pb, read_table, force_all_spans=include_otel_span_usage
+    )
 
     normalized_metrics = _normalize_usage_metrics(metrics)
 

--- a/weave/trace_server/calls_query_builder/usage_query_builder.py
+++ b/weave/trace_server/calls_query_builder/usage_query_builder.py
@@ -17,6 +17,7 @@ from weave.trace_server.calls_query_builder.stats_query_base import (
     determine_bounds_and_bucket,
 )
 from weave.trace_server.calls_query_builder.utils import param_slot, safely_format_sql
+from weave.trace_server.ch_sentinel_values import null_check_literal_sql
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.project_version.types import ReadTable, TableConfig
 from weave.trace_server.trace_server_interface import (
@@ -105,8 +106,14 @@ def build_usage_query(
     tz_param = pb.add_param(req.timezone or "UTC")
     bucket_interval_param = pb.add_param(granularity_seconds)
 
+    # Root-only usage keeps native root summaries plus individual OTEL span usage.
+    calls_filter = req.filter
+    include_otel_span_usage = bool(calls_filter and calls_filter.trace_roots_only)
+    if calls_filter is not None and calls_filter.trace_roots_only:
+        calls_filter = calls_filter.model_copy(update={"trace_roots_only": None})
+
     # Build filter clauses - applied directly in WHERE
-    where_filter_sql = build_calls_filter_sql(req.filter, pb, read_table)
+    where_filter_sql = build_calls_filter_sql(calls_filter, pb, read_table)
 
     normalized_metrics = _normalize_usage_metrics(metrics)
 
@@ -154,13 +161,23 @@ def build_usage_query(
     # Select the appropriate datetime field based on the table
     table_config = TableConfig.from_read_table(read_table)
     datetime_field = table_config.datetime_filter_field
+    select_columns = [datetime_field, "summary_dump"]
+    usage_row_filter_sql = ""
+    if include_otel_span_usage:
+        select_columns.extend(["parent_id", "otel_dump"])
+        root_check = null_check_literal_sql("parent_id", "parent_id", read_table)
+        otel_check = null_check_literal_sql(
+            "otel_dump", "otel_dump", read_table, negate=True
+        )
+        usage_row_filter_sql = f"WHERE ({root_check} OR {otel_check})"
+
     grouped_calls_sql = build_grouped_calls_subquery(
         project_param=project_param,
         start_param=start_param,
         end_param=end_param,
         tz_param=tz_param,
         where_filter_sql=where_filter_sql,
-        select_columns=[datetime_field, "summary_dump"],
+        select_columns=select_columns,
         read_table=read_table,
     )
 
@@ -202,6 +219,7 @@ def build_usage_query(
             FROM (
               {grouped_calls_sql}
             )
+            {usage_row_filter_sql}
           )
           ARRAY JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{{}}')) AS kv
         )

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -2540,11 +2540,16 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
         if granularity <= 0:
             granularity = 1
 
+        calls_filter = req.filter
+        include_otel_span_usage = bool(calls_filter and calls_filter.trace_roots_only)
+        if calls_filter is not None and calls_filter.trace_roots_only:
+            calls_filter = calls_filter.model_copy(update={"trace_roots_only": None})
+
         calls = list(
             self.calls_query_stream(
                 tsi.CallsQueryReq(
                     project_id=req.project_id,
-                    filter=req.filter,
+                    filter=calls_filter,
                 )
             )
         )
@@ -2556,6 +2561,22 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             and c.started_at >= req.start
             and c.started_at < end
         ]
+        usage_calls = calls
+        metric_calls = calls
+        if include_otel_span_usage:
+            # Use otel_dump, not caller-supplied attributes.otel_span, as OTEL source.
+            with self.lock:
+                otel_call_ids = {
+                    rec.id
+                    for rec in self._calls.values()
+                    if rec.project_id == req.project_id and rec.otel_dump is not None
+                }
+            usage_calls = [
+                call
+                for call in calls
+                if call.parent_id is None or call.id in otel_call_ids
+            ]
+            metric_calls = [call for call in calls if call.parent_id is None]
 
         token_keys_map: dict[str, list[str]] = {
             "input_tokens": ["prompt_tokens", "input_tokens"],
@@ -2577,7 +2598,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                 tuple[str, str], dict[str, list[int]]
             ] = {}  # (ts, model) -> metric -> values
 
-            for call in calls:
+            for call in usage_calls:
                 if not call.summary or not isinstance(call.summary, dict):
                     continue
                 usage = call.summary.get("usage")
@@ -2614,7 +2635,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
         if req.call_metrics:
             bucket_data: dict[str, dict[str, list[Any]]] = {}
 
-            for call in calls:
+            for call in metric_calls:
                 ts = _bucket_ts(call.started_at)
                 if ts not in bucket_data:
                     bucket_data[ts] = {}


### PR DESCRIPTION
## Summary
- Root-only call stats keep native SDK root summaries and include OTEL span usage, where usage remains on descendants.
- Call metrics remain root-only; OTEL detection uses `otel_dump` in both ClickHouse and in-memory backends.

## Testing
ClickHouse and fake-backend call-stats tests; complete SQL assertions for `calls_merged` and `calls_complete`.