### PR TITLE
feat(weave): add parent-call columns to spans

### DIFF
--- a/weave/trace_server/migrations/040_add_span_parent_call_columns.down.sql
+++ b/weave/trace_server/migrations/040_add_span_parent_call_columns.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE spans
+    DROP INDEX IF EXISTS idx_parent_call_id,
+    DROP INDEX IF EXISTS idx_parent_call_trace_id;
+
+ALTER TABLE spans
+    DROP COLUMN IF EXISTS parent_call_id,
+    DROP COLUMN IF EXISTS parent_call_trace_id;

--- a/weave/trace_server/migrations/040_add_span_parent_call_columns.up.sql
+++ b/weave/trace_server/migrations/040_add_span_parent_call_columns.up.sql
@@ -1,18 +1,3 @@
--- Link a @weave.op call to the agent spans it produced. The SDK stamps
--- weave.parent_call.id / weave.parent_call.trace_id on spans that start while
--- a call is running, and these columns are the promoted form. Populated going
--- forward only, while `spans` remains the source of truth.
---
--- bloom_filter(0.001) rather than the 0.01 of idx_eval_run_id in 037: both
--- columns hold high-cardinality random ids, so a tighter filter pays for
--- itself the same way it does on calls_complete.trace_id in 036. On the
--- linkage benchmark 0.001 costs 22 granules against a 19-granule baseline,
--- where 0.01 costs ~41.
---
--- Both indexes ship here rather than one now and one later: ADD INDEX covers
--- only parts written or merged afterwards, so a later index would miss exactly
--- the rows this feature links. Both columns are empty on every existing part
--- today, so creating them now is free.
 ALTER TABLE spans
     ADD COLUMN IF NOT EXISTS parent_call_id       String DEFAULT '',
     ADD COLUMN IF NOT EXISTS parent_call_trace_id String DEFAULT '';

--- a/weave/trace_server/migrations/040_add_span_parent_call_columns.up.sql
+++ b/weave/trace_server/migrations/040_add_span_parent_call_columns.up.sql
@@ -1,0 +1,24 @@
+-- Link a @weave.op call to the agent spans it produced. The SDK stamps
+-- weave.parent_call.id / weave.parent_call.trace_id on spans that start while
+-- a call is running, and these columns are the promoted form. Populated going
+-- forward only, while `spans` remains the source of truth.
+--
+-- bloom_filter(0.001) rather than the 0.01 of idx_eval_run_id in 037: both
+-- columns hold high-cardinality random ids, so a tighter filter pays for
+-- itself the same way it does on calls_complete.trace_id in 036. On the
+-- linkage benchmark 0.001 costs 22 granules against a 19-granule baseline,
+-- where 0.01 costs ~41.
+--
+-- Both indexes ship here rather than one now and one later: ADD INDEX covers
+-- only parts written or merged afterwards, so a later index would miss exactly
+-- the rows this feature links. Both columns are empty on every existing part
+-- today, so creating them now is free.
+ALTER TABLE spans
+    ADD COLUMN IF NOT EXISTS parent_call_id       String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS parent_call_trace_id String DEFAULT '';
+
+ALTER TABLE spans
+    ADD INDEX IF NOT EXISTS idx_parent_call_id
+        parent_call_id TYPE bloom_filter(0.001) GRANULARITY 1,
+    ADD INDEX IF NOT EXISTS idx_parent_call_trace_id
+        parent_call_trace_id TYPE bloom_filter(0.001) GRANULARITY 1;


### PR DESCRIPTION
Four PRs, in review order:

1. TypeScript evals: [#7708](https://github.com/wandb/weave/pull/7708) — merged. A prerequisite, separate from this work: it fixes existing eval linking.
2. Migration: **this PR**.
3. Python + server: [#7730](https://github.com/wandb/weave/pull/7730).
4. TypeScript ops: [#7711](https://github.com/wandb/weave/pull/7711).

## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-38415

## Description

Migration `040`: two String columns on `spans`, `parent_call_id` and `parent_call_trace_id`, with a skip index on each. They hold the id of the `@weave.op` call that was running when a span started, which is what turns "show me the spans this call produced" into a normal filter.

This started inside #7704 and is split out on review feedback: if a migration fails we do not want merged code that references it. So the columns land first and the code that writes them follows in #7730. Nothing references them yet.

Several open PRs also claim `040`, so whoever merges second renames. Worth re-checking right before this one goes in.

## Backward compatibility

Additive and empty. Both columns default to `''`, existing rows need no backfill, and no code path reads or writes them until #7730 merges. The down migration drops both indexes and both columns.

## Testing

CI applies this against a real ClickHouse in three topologies (1s1r, 1s3r, 2s2r) and re-runs the ups to diff the schema either side; all three are green. Locally the migrator unit suite is 110 passed.
