### PR TITLE
fix(weave): guard None extra_headers in openai should_use_accumulator

### DIFF
--- a/tests/integrations/openai/test_openai_sdk.py
+++ b/tests/integrations/openai/test_openai_sdk.py
@@ -10,6 +10,7 @@ from weave.integrations.openai.openai_sdk import (
     create_wrapper_sync,
     openai_on_input_handler,
     serverless_inference_call_display_name,
+    should_use_accumulator,
 )
 from weave.trace.autopatch import OpSettings
 
@@ -252,3 +253,24 @@ async def test_stream_options_not_injected_for_non_openai_base_url_async() -> No
     await wrapped(DummyCompletion("https://api.mistral.ai"), stream=True)
 
     assert "stream_options" not in captured
+
+
+def test_should_use_accumulator_with_none_extra_headers() -> None:
+    # extra_headers is typed `Headers | None`; passing an explicit None must not
+    # crash the accumulator check and must still enable accumulation for streams.
+    assert should_use_accumulator({"stream": True, "extra_headers": None}) is True
+
+
+def test_should_use_accumulator_extra_headers_variants() -> None:
+    assert should_use_accumulator({"stream": True}) is True
+    assert should_use_accumulator({"stream": True, "extra_headers": {}}) is True
+    assert should_use_accumulator({"stream": False}) is False
+    assert (
+        should_use_accumulator(
+            {
+                "stream": True,
+                "extra_headers": {"X-Stainless-Raw-Response": "true"},
+            }
+        )
+        is False
+    )

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -371,7 +371,7 @@ def should_use_accumulator(inputs: dict) -> bool:
         # This is very critical. When `"X-Stainless-Raw-Response` is true, the response
         # is an APIResponse object. This is very hard to mock/patch for the streaming use
         # case, so we don't even try.
-        and not inputs.get("extra_headers", {}).get("X-Stainless-Raw-Response")
+        and not (inputs.get("extra_headers") or {}).get("X-Stainless-Raw-Response")
         == "true"
     )
 


### PR DESCRIPTION
### What

`should_use_accumulator` did `inputs.get("extra_headers", {}).get("X-Stainless-Raw-Response")`. When a streaming call passes `extra_headers=None` explicitly (valid — SDK type is `Headers | None`), the key is present with value `None`, the `{}` default doesn't apply, and `None.get(...)` raises `AttributeError`.

### Impact

The exception is swallowed by the op wrapper, so streaming is silently **not** accumulated: the trace records the raw un-consumed iterator instead of assembled content/usage. No error is surfaced — pure observability loss.

### Fix

One-line guard: `(inputs.get("extra_headers") or {}).get(...)`. This is the only occurrence of the pattern in the integration; sync + async both route through this function; the Responses API path (`should_use_responses_accumulator`) is unaffected.

### Tests

Added `test_should_use_accumulator_with_none_extra_headers` (regression: fails on master with `AttributeError`, passes with the fix) plus a small variants test covering absent / empty-dict / `stream=False` / raw-response-header cases. Verified locally with `pytest tests/integrations/openai/test_openai_sdk.py -k should_use_accumulator` (2 passed; the regression test fails without the source change) and `ruff check` clean.

Fixes #7731
