### PR TITLE
fix(weave): support PyPI metadata 2.5 publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,13 +29,13 @@ jobs:
         run: |
           uv build
       - name: upload test distribution
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         if: ${{ inputs.is_test }}
         with:
           repository-url: https://test.pypi.org/legacy/
           verbose: true
       - name: upload distribution
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         if: ${{ !inputs.is_test }}
 
   # this job exists so that there's some traceability between weave SDk releases

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,14 @@ This project uses `uv` for dependency management. Dependencies are organized int
 - Ruff now enforces `PLW` rules. `PLW0602`, `PLW0603`, `PLW1641`, and `PLW3201` are handled with spot-level inline `# noqa` on specific lines (not global/per-file ignore). Prefer fixing code first; if intentional, suppress only the exact line.
 - Be careful with `PLW1514` autofixes on serialization-sensitive code (`weave/type_handlers/Content/content.py`, `weave/type_handlers/Audio/audio.py`) and mocked file I/O (`weave/trace_server/costs/update_costs.py`): adding `encoding=` changed behavior/tests, so these files are explicitly ignored for that rule.
 
+### PyPI release publishing
+
+`uv build` resolves the unconstrained `hatchling` build requirement in an
+isolated environment. Keep the pinned `pypa/gh-action-pypi-publish` action new
+enough to validate the Core Metadata version emitted by current Hatchling; for
+example, Hatchling 1.32 emits Metadata 2.5, which requires the action's Twine 7
+and Packaging 26 stack rather than Twine 6.1 and Packaging 25.
+
 ### Codex Development (nox)
 
 - Your machine should be setup for you automatically via `bin/codex_setup.sh`


### PR DESCRIPTION
## Summary

- Update both PyPI publishing steps to a pinned `pypa/gh-action-pypi-publish` revision with Core Metadata 2.5 support.
- Document the compatibility relationship between the unconstrained Hatchling build backend and the pinned publishing action.

## Context

Hatchling 1.32 now emits Core Metadata 2.5. The previously pinned publishing action bundles Twine 6.1 and Packaging 25, which reject that metadata version before upload. This caused [publish-pypi-release run #300](https://github.com/wandb/weave/actions/runs/31638711649) to fail while publishing Weave 0.53.5. The updated action bundles Twine 7 and Packaging 26.2, which accept the same artifacts.

## Testing

- `uv build --out-dir <temp-dir>`
- `uvx --from twine==7.0.0 --with packaging==26.2 twine check <dist-artifacts>` (wheel and sdist pass)
- Reproduced the original failure with Twine 6.1 and Packaging 25
- Parsed `.github/workflows/release.yaml` with the Ruby YAML parser
- `git diff --check`

## Breaking changes

None.