### PR TITLE
fix(weave): generate cost timestamps in UTC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,8 @@ for workload identity.
 
 `weave/trace_server/model_providers/model_providers.json` and `weave/trace_server/costs/cost_checkpoint.json` are generated. Never edit them by hand — regenerate with `make update_model_providers` / `make update_costs` (see `weave/Makefile`).
 
+Generate implicit cost `created_at` values in UTC because insertion interprets naive checkpoint timestamps as UTC.
+
 Note: the scripts read `modelsBegin.json`/`modelsFinal.json`, which are symlinks into wandb/core and only resolve when this repo is checked out as the submodule inside wandb/core (`services/weave-trace/weave-python/weave-public`).
 
 Persisted `AgentDashboard` objects intentionally use a closed, discriminated

--- a/tests/trace_server/costs/test_insert_costs.py
+++ b/tests/trace_server/costs/test_insert_costs.py
@@ -155,6 +155,33 @@ class TestInsertCosts(unittest.TestCase):
             ],
         )
 
+    @patch("weave.trace_server.costs.insert_costs.uuid.uuid4")
+    @patch("weave.trace_server.costs.insert_costs.datetime")
+    def test_insert_costs_without_created_at_uses_utc(self, mock_datetime, mock_uuid4):
+        frozen_time = datetime(2025, 1, 1, 12, 0, 0)
+        mock_uuid4.return_value = self.mock_uuid
+        mock_datetime.now.return_value = frozen_time
+        mock_datetime.strptime.side_effect = datetime.strptime
+
+        insert_costs.insert_costs_into_db(
+            self.client,
+            {
+                "llm_model": [
+                    {
+                        "input": 0.01,
+                        "output": 0.02,
+                        "provider": "provider",
+                    }
+                ]
+            },
+        )
+
+        mock_datetime.now.assert_called_once_with(timezone.utc)
+        inserted_row = self.client.insert.call_args.args[1][0]
+        expected_timestamp = frozen_time.replace(tzinfo=timezone.utc)
+        assert inserted_row[5] == expected_timestamp
+        assert inserted_row[13] == expected_timestamp
+
     @patch("weave.trace_server.costs.insert_costs.logger")
     @patch("weave.trace_server.costs.insert_costs.insert_costs_into_db")
     @patch("weave.trace_server.costs.insert_costs.filter_out_current_costs")

--- a/tests/trace_server/costs/test_update_costs.py
+++ b/tests/trace_server/costs/test_update_costs.py
@@ -1,6 +1,6 @@
 import json
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import ANY, MagicMock, mock_open, patch
 
 import httpx
@@ -73,6 +73,7 @@ class TestUpdateCosts(unittest.TestCase):
             mock_datetime.now.return_value = frozen_time
             mock_datetime.side_effect = datetime
             costs = fetch_new_costs()
+            mock_datetime.now.assert_called_once_with(timezone.utc)
         assert "model1" in costs
         assert costs["model1"]["input"] == 0.01
         assert costs["model1"]["output"] == 0.02
@@ -430,6 +431,25 @@ class TestFetchManualCosts(unittest.TestCase):
         assert costs["model-with-history"]["output"] == 4e-06
         assert costs["model-with-history"]["created_at"] == "2026-05-19 00:00:00"
 
+    @patch("weave.trace_server.costs.update_costs.os.path.exists")
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data=json.dumps(
+            {"model-without-date": [{"input": 1e-06, "output": 2e-06}]}
+        ),
+    )
+    def test_missing_created_at_uses_utc(self, mock_file, mock_exists):
+        mock_exists.return_value = True
+        frozen_time = datetime(2025, 1, 1, 12, 0, 0)
+
+        with patch("weave.trace_server.costs.update_costs.datetime") as mock_datetime:
+            mock_datetime.now.return_value = frozen_time
+            costs = fetch_manual_costs()
+            mock_datetime.now.assert_called_once_with(timezone.utc)
+
+        assert costs["model-without-date"]["created_at"] == "2025-01-01 12:00:00"
+
     @patch("builtins.open", new_callable=mock_open)
     @patch("os.path.exists")
     @patch("weave.trace_server.costs.update_costs.fetch_manual_costs")
@@ -519,7 +539,11 @@ def test_fetch_models_begin_costs_prices_bare_and_prefixed_id(mock_file, mock_ex
     Cents-per-billion-tokens converts to dollars-per-token (divide by 1e11).
     """
     mock_exists.return_value = True
-    costs = fetch_models_begin_costs()
+    frozen_time = datetime(2025, 1, 1, 12, 0, 0)
+    with patch("weave.trace_server.costs.update_costs.datetime") as mock_datetime:
+        mock_datetime.now.return_value = frozen_time
+        costs = fetch_models_begin_costs()
+        mock_datetime.now.assert_called_once_with(timezone.utc)
 
     assert set(costs.keys()) == {
         "openai/gpt-oss-20b",
@@ -529,6 +553,7 @@ def test_fetch_models_begin_costs_prices_bare_and_prefixed_id(mock_file, mock_ex
         assert costs[key]["input"] == 5e-08
         assert costs[key]["output"] == 2e-07
         assert costs[key]["provider"] == "coreweave"
+        assert costs[key]["created_at"] == "2025-01-01 12:00:00"
 
 
 if __name__ == "__main__":

--- a/weave/trace_server/costs/insert_costs.py
+++ b/weave/trace_server/costs/insert_costs.py
@@ -76,7 +76,8 @@ def insert_costs_into_db(client: Client, data: dict[str, list[CostDetails]]) -> 
             cache_read_input_token_cost = cost.get("cache_read_input", 0)
             cache_creation_input_token_cost = cost.get("cache_creation_input", 0)
             date_str = cost.get(
-                "created_at", datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                "created_at",
+                datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
             )
             created_at = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S").replace(
                 tzinfo=timezone.utc

--- a/weave/trace_server/costs/update_costs.py
+++ b/weave/trace_server/costs/update_costs.py
@@ -3,7 +3,7 @@
 import json
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import TypedDict
 
@@ -69,7 +69,7 @@ def fetch_new_costs() -> dict[str, CostDetails]:
         raise
 
     costs: dict[str, CostDetails] = {}
-    current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    current_time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     for k in raw_costs:
         if (
             "input_cost_per_token" not in raw_costs[k]
@@ -125,7 +125,7 @@ def fetch_models_begin_costs() -> dict[str, CostDetails]:
         sys.exit(1)
 
     costs: dict[str, CostDetails] = {}
-    current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    current_time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
     for model in models_data:
         if not isinstance(model, dict):
@@ -208,7 +208,7 @@ def fetch_manual_costs() -> dict[str, CostDetails]:
         print(f"Failed to read {MANUAL_COSTS_FILE}: {e}")
         return {}
 
-    current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    current_time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     costs: dict[str, CostDetails] = {}
     for llm_id, entries in raw.items():
         if not isinstance(entries, list) or not entries:


### PR DESCRIPTION
## Description

Cost checkpoint generation used local wall-clock time, while the insertion path parsed the resulting naive timestamp as UTC. On a Pacific-time machine this made new prices effective seven hours early.

- Generate implicit timestamps in UTC for LiteLLM, modelsBegin, and manual-cost fallback records.
- Generate the insertion fallback timestamp in UTC.
- Preserve the existing `YYYY-MM-DD HH:MM:SS` format and all explicit or historical timestamps.
- Add regression coverage for all four implicit timestamp paths.

## Testing

- Red phase: 4 new assertions failed because `datetime.now()` received no timezone; 22 existing focused tests passed.
- Green phase: `26 passed` across `test_update_costs.py` and `test_insert_costs.py`.
- Ruff check and format check passed for the four changed Python files.

