### PR TITLE
feat(weave): record the agent span that invoked a call

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,18 @@ Evaluation result rows merge agent span links from two sources: legacy
 trial. Keep the promoted-column hydration best-effort so eval results remain
 available during rolling deploys.
 
+`weave.invoking_span` (`{trace_id, span_id}`, hex) points the other way, from a
+call to the OTel span that was current when it started — an agent's
+`execute_tool` span in the case it is built for, but any ambient instrumentation
+qualifies. `create_call` writes it on *every* call started inside that span, not
+just the outermost one: skipping when the parent call already carries it marks
+every other level, because the check reads the parent's recorded state and the
+parent may itself have skipped. A reader must treat a missing key and a pair
+that matches no span as normal — the write does not check that the span reaches
+our backend. Spans opened by `trace_server.tracing` are the one exclusion, and
+they are recognised through `WEAVE_SERVER_SPAN_KEY` on the context rather than
+off the span object, which under the OTel→DD bridge is not an SDK span.
+
 If `sdks/node/node_modules` is missing, run `pnpm install --frozen-lockfile` in `sdks/node` first. Do not use `npm install`; this SDK is pinned to pnpm.
 
 ## Python Testing Guidelines

--- a/tests/integrations/google_adk/test_google_adk.py
+++ b/tests/integrations/google_adk/test_google_adk.py
@@ -11,10 +11,14 @@ Organised by the layer each class exercises:
   ``BaseLlm`` so ADK itself opens every span, tees an
   ``InMemorySpanExporter`` onto the global ``TracerProvider``, and asserts
   the patched attributes land where they should.
+- :class:`TestSpanToCallLinkage` runs the same stub agent with a ``@weave.op``
+  tool and asserts the call records the ``execute_tool`` span ADK opened
+  around it, through both the async and the sync entry point.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import AsyncGenerator, Generator
 from dataclasses import dataclass, field
@@ -26,6 +30,7 @@ from google.adk.models.base_llm import BaseLlm
 from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.adk.runners import InMemoryRunner
+from google.adk.telemetry import tracing as adk_tracing
 from google.adk.tools import FunctionTool
 from google.genai import types
 from opentelemetry import trace as otel_trace
@@ -36,6 +41,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
 
+import weave
 from weave.integrations.google_adk import _semconv
 from weave.integrations.google_adk.extractors import (
     _provider_name,
@@ -47,7 +53,9 @@ from weave.integrations.google_adk.google_adk_sdk import (
     _wrap_trace_tool_call,
     get_google_adk_patcher,
 )
+from weave.trace.weave_client import WeaveClient
 from weave.trace_server.agents import semconv as server_semconv
+from weave.trace_server.constants import INVOKING_SPAN_ATTR_KEY
 
 # The mocks below mirror the duck-typed surface our extractors inspect on
 # ``google.genai.types.*`` objects and ADK's ``LlmRequest`` / ``LlmResponse``
@@ -753,3 +761,103 @@ class TestVendoredSemconv:
             assert _semconv.PROVIDER_GEMINI == system_values.GEMINI.value
         if output_values is not None:
             assert _semconv.OUTPUT_TYPE_TEXT == output_values.TEXT.value
+
+
+@pytest.fixture
+def adk_own_spans(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[InMemorySpanExporter, None, None]:
+    """Route the spans ADK opens itself into an in-memory exporter.
+
+    ``set_tracer_provider`` only takes effect once per process, so overriding
+    ``_TRACER_PROVIDER`` is the mechanism, as elsewhere in the repo. That alone
+    is not enough here: ADK resolves its tracer once and caches it, then
+    re-exports it *by value* into the modules that open spans, so mutating the
+    shared ``ProxyTracer`` is the only seam that reaches
+    ``flows/llm_flows/functions.py``.
+    """
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", provider)
+    monkeypatch.setattr(adk_tracing.tracer, "_real_tracer", None)
+    try:
+        yield exporter
+    finally:
+        provider.shutdown()
+
+
+class TestSpanToCallLinkage:
+    """A ``@weave.op`` tool records the ADK ``execute_tool`` span that ran it.
+
+    ADK opens that span itself via ``record_tool_execution``, so this holds
+    with or without the Weave patcher installed.
+    """
+
+    @staticmethod
+    def _runner() -> InMemoryRunner:
+        # ``weave.op`` keeps ``__name__``, so the tool is still called
+        # ``_get_weather`` and ``_StubLlm``'s scripted function call matches.
+        agent = LlmAgent(
+            name="trip_planner",
+            description="Tests span-to-call linkage end-to-end.",
+            model=_StubLlm(model="stub-llm"),
+            tools=[FunctionTool(weave.op(_get_weather))],
+        )
+        return InMemoryRunner(agent=agent, app_name="adk-link-app")
+
+    @staticmethod
+    def _assert_tool_call_points_at_the_tool_span(
+        client: WeaveClient, exporter: InMemorySpanExporter
+    ) -> None:
+        tool_span = next(
+            span
+            for span in exporter.get_finished_spans()
+            if span.name == "execute_tool _get_weather"
+        )
+        span_ctx = tool_span.get_span_context()
+        # The tool is the only op in the run — the stub LLM is not patched.
+        calls = client.get_calls()
+
+        assert len(calls) == 1
+        assert calls[0].attributes["weave"][INVOKING_SPAN_ATTR_KEY] == {
+            "trace_id": otel_trace.format_trace_id(span_ctx.trace_id),
+            "span_id": otel_trace.format_span_id(span_ctx.span_id),
+        }
+
+    @pytest.mark.asyncio
+    async def test_recorded_via_run_async(
+        self, client: WeaveClient, adk_own_spans: InMemorySpanExporter
+    ) -> None:
+        """The production entry point, where the tool runs on the calling thread."""
+        runner = self._runner()
+        await runner.session_service.create_session(
+            app_name="adk-link-app", user_id="u1", session_id="s1"
+        )
+        msg = types.Content(role="user", parts=[types.Part(text="Weather in Paris?")])
+        async for _ in runner.run_async(user_id="u1", session_id="s1", new_message=msg):
+            pass
+
+        self._assert_tool_call_points_at_the_tool_span(client, adk_own_spans)
+
+    def test_recorded_via_sync_run(
+        self, client: WeaveClient, adk_own_spans: InMemorySpanExporter
+    ) -> None:
+        """The sync entry point runs the agent in a fresh thread.
+
+        Weave's own call stack is a contextvar and does not cross that
+        boundary, so this is the case the call-to-spans direction misses. The
+        OTel context does not have to cross it: ADK opens the tool span inside
+        the same new thread that then runs the tool.
+        """
+        runner = self._runner()
+        asyncio.run(
+            runner.session_service.create_session(
+                app_name="adk-link-app", user_id="u1", session_id="s1"
+            )
+        )
+        msg = types.Content(role="user", parts=[types.Part(text="Weather in Paris?")])
+        for _ in runner.run(user_id="u1", session_id="s1", new_message=msg):
+            pass
+
+        self._assert_tool_call_points_at_the_tool_span(client, adk_own_spans)

--- a/tests/integrations/openai_agents/openai_agents_otel_test.py
+++ b/tests/integrations/openai_agents/openai_agents_otel_test.py
@@ -15,7 +15,7 @@ from unittest.mock import Mock
 
 import httpx
 import pytest
-from agents import Agent, Runner
+from agents import Agent, Runner, function_tool
 from agents.models.openai_responses import OpenAIResponsesModel
 from agents.tracing import (
     AgentSpanData,
@@ -45,6 +45,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.sdk.trace.sampling import Decision, StaticSampler
 
+import weave
 from weave.conversation import agent_name_override
 from weave.integrations.integration_utilities import op_name_from_ref
 from weave.integrations.openai.openai_sdk import get_openai_patcher
@@ -53,6 +54,7 @@ from weave.integrations.openai_agents.otel_processor import (
     _iso_to_ns,
 )
 from weave.trace.weave_client import WeaveClient
+from weave.trace_server.constants import INVOKING_SPAN_ATTR_KEY
 
 
 @pytest.fixture
@@ -219,6 +221,24 @@ def _chat_completion_payload(response_id: str) -> dict[str, Any]:
             "total_tokens": 3,
         },
     }
+
+
+def _tool_call_payload(
+    response_id: str, tool_name: str, arguments: str
+) -> dict[str, Any]:
+    """A Responses payload whose only output item calls ``tool_name``."""
+    payload = _response_payload(response_id, "")
+    payload["output"] = [
+        {
+            "type": "function_call",
+            "id": f"fc_{response_id}",
+            "call_id": f"call_{response_id}",
+            "name": tool_name,
+            "arguments": arguments,
+            "status": "completed",
+        }
+    ]
+    return payload
 
 
 def _mock_transport(
@@ -1351,3 +1371,49 @@ async def test_model_span_context_is_isolated_between_asyncio_tasks(
     assert len(model_chats) == 1
     assert len(openai_calls) == 1
     assert openai_calls[0].output["id"] == "resp_direct_task"
+
+
+@pytest.mark.asyncio
+async def test_op_tool_records_the_execute_tool_span_that_invoked_it(
+    client: WeaveClient,
+    setup_tests: WeaveOtelTracingProcessor,
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    """A ``@weave.op`` tool records the span the agent opened around its call.
+
+    The assertion names the ``execute_tool`` span rather than "some span": the
+    agent span is current further up the stack too, and a reference to that one
+    would point at the wrong level of the tree.
+    """
+    transport, _ = _mock_transport(
+        _tool_call_payload("resp_tool", "lookup", '{"query": "papers"}'),
+        _response_payload("resp_final", "done"),
+    )
+    openai_client = AsyncOpenAI(
+        api_key="test",
+        http_client=httpx.AsyncClient(transport=transport),
+    )
+
+    @function_tool
+    @weave.op
+    def lookup(query: str) -> str:
+        return "ok"
+
+    try:
+        model = OpenAIResponsesModel(model="gpt-4o", openai_client=openai_client)
+        agent = Agent(name="researcher", model=model, tools=[lookup])
+        await Runner.run(agent, "find papers")
+    finally:
+        await openai_client.close()
+
+    tool_span = next(
+        s for s in otel_spans.get_finished_spans() if s.name == "execute_tool lookup"
+    )
+    span_ctx = tool_span.get_span_context()
+    lookup_calls = _calls_named(client, "lookup")
+
+    assert len(lookup_calls) == 1
+    assert lookup_calls[0].attributes["weave"][INVOKING_SPAN_ATTR_KEY] == {
+        "trace_id": otel_trace.format_trace_id(span_ctx.trace_id),
+        "span_id": otel_trace.format_span_id(span_ctx.span_id),
+    }

--- a/tests/trace/test_op_span_linking.py
+++ b/tests/trace/test_op_span_linking.py
@@ -1,0 +1,407 @@
+"""Tests for recording the invoking OTel span on the call it triggered."""
+
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.id_generator import IdGenerator
+from opentelemetry.sdk.trace.sampling import Decision, StaticSampler
+from opentelemetry.trace import NonRecordingSpan, Span, SpanContext, TraceFlags
+
+import weave
+from weave.trace.call import Call
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server import tracing as server_tracing
+from weave.trace_server.constants import INVOKING_SPAN_ATTR_KEY
+
+FORGED = {"trace_id": "f" * 32, "span_id": "f" * 16}
+
+
+class _ZeroIdGenerator(IdGenerator):
+    """Hands out the all-zero identity, which is sampled but not valid."""
+
+    def generate_span_id(self) -> int:
+        return 0
+
+    def generate_trace_id(self) -> int:
+        return 0
+
+
+class _BridgeSpan(NonRecordingSpan):
+    """Live and sampled, but not an SDK span — the shape the DD bridge hands out."""
+
+    def is_recording(self) -> bool:
+        return True
+
+
+class _BridgeTracer:
+    """Minimal tracer yielding `_BridgeSpan`, standing in for a bridged provider."""
+
+    @contextmanager
+    def start_as_current_span(self, name: str, *args, **kwargs) -> Iterator[Span]:
+        span = _BridgeSpan(
+            SpanContext(
+                trace_id=0x0F1E2D3C4B5A69788796A5B4C3D2E1F0,
+                span_id=0xA1B2C3D4E5F60718,
+                is_remote=False,
+                trace_flags=TraceFlags(TraceFlags.SAMPLED),
+            )
+        )
+        with otel_trace.use_span(span, end_on_exit=False):
+            yield span
+
+
+@pytest.fixture
+def install_otel_spans(monkeypatch: pytest.MonkeyPatch):
+    """Install an isolated OTel provider and return its span exporter.
+
+    A factory rather than a plain fixture because the sampler and id generator
+    are chosen at ``TracerProvider`` construction. Isolation is required rather
+    than convenient: on a shared provider the trace server's own spans are
+    current while a query stream is consumed, so these assertions would depend
+    on unrelated server work.
+    """
+    providers = []
+
+    def install(**provider_kwargs) -> InMemorySpanExporter:
+        exporter = InMemorySpanExporter()
+        provider = SDKTracerProvider(**provider_kwargs)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", provider)
+        providers.append(provider)
+        return exporter
+
+    yield install
+
+    for provider in providers:
+        provider.shutdown()
+
+
+def _invoking_span(call: Call) -> dict | None:
+    return call.attributes["weave"].get(INVOKING_SPAN_ATTR_KEY)
+
+
+def _expected_invoking_span(span: otel_trace.Span) -> dict[str, str]:
+    ctx = span.get_span_context()
+    return {
+        "trace_id": otel_trace.format_trace_id(ctx.trace_id),
+        "span_id": otel_trace.format_span_id(ctx.span_id),
+    }
+
+
+def test_written_for_op_inside_span(client, install_otel_spans):
+    install_otel_spans()
+    tracer = otel_trace.get_tracer("test")
+
+    @weave.op
+    def lookup(query: str) -> str:
+        return query
+
+    with tracer.start_as_current_span("execute_tool lookup") as span:
+        with weave.attributes({"env": "test"}):
+            _, call = lookup.call("papers")
+        expected = _expected_invoking_span(span)
+
+    assert _invoking_span(call) == expected
+    assert call.attributes["env"] == "test"
+
+
+def test_absent_outside_any_span(client, install_otel_spans):
+    install_otel_spans()
+
+    @weave.op
+    def lookup(query: str) -> str:
+        return query
+
+    _, call = lookup.call("papers")
+
+    assert INVOKING_SPAN_ATTR_KEY not in call.attributes["weave"]
+
+
+def test_nested_ops_share_one_invoking_span(client, install_otel_spans):
+    """Every call started inside the span carries it, not just the outermost.
+
+    Skipping the write when the parent call already carries the same value
+    would mark every other level (root yes, child no, grandchild yes), because
+    such a check reads the parent's *recorded* state and the parent may itself
+    have skipped the write.
+    """
+    install_otel_spans()
+    tracer = otel_trace.get_tracer("test")
+    nested_calls: list[Call] = []
+
+    @weave.op
+    def inner(x: int) -> int:
+        nested_calls.append(weave.require_current_call())
+        return x
+
+    @weave.op
+    def middle(x: int) -> int:
+        nested_calls.append(weave.require_current_call())
+        return inner(x)
+
+    @weave.op
+    def outer(x: int) -> int:
+        return middle(x)
+
+    with tracer.start_as_current_span("execute_tool outer") as span:
+        _, outer_call = outer.call(1)
+        expected = _expected_invoking_span(span)
+
+    assert _invoking_span(outer_call) == expected
+    assert [_invoking_span(c) for c in nested_calls] == [expected, expected]
+
+
+def test_absent_for_record_only_span(client, install_otel_spans):
+    """RECORD_ONLY records the span but never exports it, so nothing resolves."""
+    install_otel_spans(sampler=StaticSampler(Decision.RECORD_ONLY))
+    tracer = otel_trace.get_tracer("test")
+
+    @weave.op
+    def lookup(query: str) -> str:
+        return query
+
+    with tracer.start_as_current_span("execute_tool lookup") as span:
+        assert span.is_recording()
+        assert not span.get_span_context().trace_flags.sampled
+        _, call = lookup.call("papers")
+
+    assert INVOKING_SPAN_ATTR_KEY not in call.attributes["weave"]
+
+
+def test_absent_for_all_zero_span_identity(client, install_otel_spans):
+    """A custom id generator can hand out an identity that is sampled but invalid.
+
+    All-zero ids would match every other all-zero pair in the project, so the
+    reference would resolve to the wrong calls rather than to none.
+    """
+    install_otel_spans(id_generator=_ZeroIdGenerator())
+    tracer = otel_trace.get_tracer("test")
+
+    @weave.op
+    def lookup(query: str) -> str:
+        return query
+
+    with tracer.start_as_current_span("execute_tool lookup") as span:
+        ctx = span.get_span_context()
+        assert span.is_recording()
+        assert ctx.trace_flags.sampled
+        assert not ctx.is_valid
+        _, call = lookup.call("papers")
+
+    assert INVOKING_SPAN_ATTR_KEY not in call.attributes["weave"]
+
+
+def test_absent_when_span_already_ended(client, install_otel_spans):
+    install_otel_spans()
+    tracer = otel_trace.get_tracer("test")
+
+    @weave.op
+    def lookup(query: str) -> str:
+        return query
+
+    span = tracer.start_span("execute_tool lookup")
+    with otel_trace.use_span(span, end_on_exit=False):
+        span.end()
+        _, call = lookup.call("papers")
+
+    assert INVOKING_SPAN_ATTR_KEY not in call.attributes["weave"]
+
+
+def test_absent_inside_a_weave_server_span(client, install_otel_spans):
+    """A trace server span is not an agent span, and in-process it is current.
+
+    Driven through the real `@traced` decorator: the recognition depends on
+    the server marking its own context, so testing the mechanism rather than a
+    copy of it is what keeps the two sides from drifting apart.
+    """
+    install_otel_spans()
+
+    @weave.op
+    def lookup(query: str) -> str:
+        return query
+
+    @server_tracing.traced(name="clickhouse_trace_server_batched.calls_query_stream")
+    def server_frame() -> Call:
+        return lookup.call("papers")[1]
+
+    call = server_frame()
+
+    assert INVOKING_SPAN_ATTR_KEY not in call.attributes["weave"]
+
+
+def test_absent_inside_a_server_span_that_is_not_an_sdk_span(
+    client, install_otel_spans, monkeypatch: pytest.MonkeyPatch
+):
+    """Recognising our own server frame must not depend on the span's type.
+
+    Under the OTel→DD bridge the current span is not an SDK span and carries
+    no instrumentation scope, so anything read off the span object would pass
+    straight through exactly where this matters. `tracing` documents `_tracer`
+    as the seam tests swap.
+    """
+    install_otel_spans()
+
+    @weave.op
+    def lookup(query: str) -> str:
+        return query
+
+    @server_tracing.traced(name="evaluate_model_worker.evaluate_model.run_evaluation")
+    def server_frame() -> tuple[Call, otel_trace.Span]:
+        return lookup.call("papers")[1], otel_trace.get_current_span()
+
+    monkeypatch.setattr(server_tracing, "_tracer", _BridgeTracer())
+    call, span = server_frame()
+
+    assert not hasattr(span, "instrumentation_scope")
+    assert INVOKING_SPAN_ATTR_KEY not in call.attributes["weave"]
+
+
+def test_written_for_an_agent_span_inside_a_server_span(client, install_otel_spans):
+    """A hosted evaluation runs an agent inside a `@traced` frame.
+
+    Suppressing on "somewhere inside a server frame" would lose the link in
+    exactly the case it is most wanted, so the check compares against the
+    server's own span rather than a flag.
+    """
+    install_otel_spans()
+    tracer = otel_trace.get_tracer("test")
+
+    @weave.op
+    def lookup(query: str) -> str:
+        return query
+
+    @server_tracing.traced(name="evaluate_model_worker.evaluate_model.run_evaluation")
+    def server_frame() -> tuple[Call, dict[str, str]]:
+        with tracer.start_as_current_span("execute_tool lookup") as span:
+            return lookup.call("papers")[1], _expected_invoking_span(span)
+
+    call, expected = server_frame()
+
+    assert _invoking_span(call) == expected
+
+
+def test_caller_supplied_value_is_never_kept(client, install_otel_spans):
+    """The key is ours to write, so a caller's value loses either way.
+
+    ``create_call`` is the seam that accepts one: on the ``@weave.op`` path the
+    SDK replaces the whole ``weave`` sub-dict, so nothing a caller passes there
+    ever arrives.
+    """
+    install_otel_spans()
+    tracer = otel_trace.get_tracer("test")
+    attributes = {"weave": {INVOKING_SPAN_ATTR_KEY: FORGED}}
+
+    with tracer.start_as_current_span("execute_tool lookup") as span:
+        inside = client.create_call(
+            "inside", {}, attributes=attributes, use_stack=False
+        )
+        expected = _expected_invoking_span(span)
+    outside = client.create_call("outside", {}, attributes=attributes, use_stack=False)
+
+    assert _invoking_span(inside) == expected
+    assert INVOKING_SPAN_ATTR_KEY not in outside.attributes["weave"]
+
+
+def test_bare_thread_loses_it_but_weave_executor_keeps_it(client, install_otel_spans):
+    """OTel context does not cross a raw thread; ``weave.ThreadPoolExecutor`` copies it."""
+    install_otel_spans()
+    tracer = otel_trace.get_tracer("test")
+
+    @weave.op
+    def lookup(query: str) -> str:
+        return query
+
+    with tracer.start_as_current_span("execute_tool lookup") as span:
+        bare_calls: list[Call] = []
+        thread = threading.Thread(
+            target=lambda: bare_calls.append(lookup.call("papers")[1])
+        )
+        thread.start()
+        thread.join()
+
+        with weave.ThreadPoolExecutor(max_workers=1) as executor:
+            copied_call = executor.submit(lambda: lookup.call("papers")[1]).result()
+
+        expected = _expected_invoking_span(span)
+
+    assert INVOKING_SPAN_ATTR_KEY not in bare_calls[0].attributes["weave"]
+    assert _invoking_span(copied_call) == expected
+
+
+def test_points_at_the_conversation_sdk_tool_span(client, install_otel_spans):
+    """``weave.Tool`` opens ``execute_tool <name>`` and makes it current."""
+    exporter = install_otel_spans()
+
+    @weave.op
+    def lookup(query: str) -> str:
+        return query
+
+    with weave.Tool(name="lookup"):
+        _, call = lookup.call("papers")
+
+    tool_span = next(
+        s for s in exporter.get_finished_spans() if s.name == "execute_tool lookup"
+    )
+
+    assert _invoking_span(call) == _expected_invoking_span(tool_span)
+
+
+def test_survives_the_round_trip_and_is_queryable(client, install_otel_spans):
+    """It reaches the stored column and the pair filter finds that exact call.
+
+    A typo in the attribute path returns zero rows rather than an error, which
+    is indistinguishable from "it was never written", so this pins the id.
+    """
+    install_otel_spans()
+    tracer = otel_trace.get_tracer("test")
+
+    @weave.op
+    def lookup(query: str) -> str:
+        return query
+
+    with tracer.start_as_current_span("execute_tool lookup") as span:
+        _, call = lookup.call("papers")
+        expected = _expected_invoking_span(span)
+
+    client.flush()
+
+    calls = list(
+        client.server.calls_query_stream(
+            tsi.CallsQueryReq(
+                project_id=client.project_id,
+                query=tsi.Query.model_validate(
+                    {
+                        "$expr": {
+                            "$and": [
+                                {
+                                    "$eq": [
+                                        {
+                                            "$getField": f"attributes.weave.{INVOKING_SPAN_ATTR_KEY}.trace_id"
+                                        },
+                                        {"$literal": expected["trace_id"]},
+                                    ]
+                                },
+                                {
+                                    "$eq": [
+                                        {
+                                            "$getField": f"attributes.weave.{INVOKING_SPAN_ATTR_KEY}.span_id"
+                                        },
+                                        {"$literal": expected["span_id"]},
+                                    ]
+                                },
+                            ]
+                        }
+                    }
+                ),
+            )
+        )
+    )
+
+    assert [c.id for c in calls] == [call.id]
+    assert calls[0].attributes["weave"][INVOKING_SPAN_ATTR_KEY] == expected

--- a/weave/shared/otel_context_keys.py
+++ b/weave/shared/otel_context_keys.py
@@ -1,0 +1,17 @@
+"""OTel context keys shared between the Weave client SDK and the trace server.
+
+`otel_context.create_key` mints a fresh unique string on every call, so a key
+both sides must agree on has to be created exactly once, in a module both are
+allowed to import.
+"""
+
+from opentelemetry import context as otel_context
+
+# Holds the innermost `weave.trace_server` span while it is current, so the
+# client SDK can tell one of our own server spans from an agent's. It stores the
+# span rather than a flag because an agent span opened inside a server frame —
+# a hosted evaluation running an agent — is a legitimate link target, and only
+# an identity comparison distinguishes the two. Inspecting the span object alone
+# would not work: under the OTel→DD bridge it is not an SDK span and carries no
+# instrumentation scope.
+WEAVE_SERVER_SPAN_KEY = otel_context.create_key("weave.trace_server.span")

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -111,7 +111,10 @@ from weave.trace.wandb_run_context import (
 )
 from weave.trace.weave_client_send_file_cache import WeaveClientSendFileCache
 from weave.trace_server.common_interface import AnnotationQueueItemsFilter, SortBy
-from weave.trace_server.constants import MAX_OBJECT_NAME_LENGTH
+from weave.trace_server.constants import (
+    INVOKING_SPAN_ATTR_KEY,
+    MAX_OBJECT_NAME_LENGTH,
+)
 from weave.trace_server.errors import DigestMismatchError, InvalidExternalRef
 from weave.trace_server.ids import generate_id
 from weave.trace_server.interface.feedback_types import (
@@ -203,6 +206,19 @@ from weave.utils.paginated_iterator import PaginatedIterator
 from weave.utils.project_id import from_project_id, to_project_id
 from weave.utils.sanitize import REDACTED_VALUE, redact_dataclass_fields, should_redact
 
+# OTel imports — kept top-level under a try/except guard so the module
+# loads cleanly when opentelemetry is not installed. When unavailable,
+# calls simply carry no invoking-span reference.
+try:
+    from opentelemetry import context as otel_context
+    from opentelemetry import trace as otel_trace
+
+    from weave.shared.otel_context_keys import WEAVE_SERVER_SPAN_KEY
+
+    _OTEL_AVAILABLE = True
+except ImportError:
+    _OTEL_AVAILABLE = False
+
 if TYPE_CHECKING:
     from weave.evaluation.eval import Evaluation
 
@@ -232,6 +248,44 @@ class CrossProjectRefError(Exception):
 def print_call_link(call: Call) -> None:
     if settings.should_print_call_link():
         logger.info("%s %s", TRACE_CALL_EMOJI, call.ui_url)
+
+
+def _invoking_span_attr() -> dict[str, str] | None:
+    """Identity of the OTel span a call starting now was invoked from.
+
+    Recorded on the call so a reader can walk from an agent's `execute_tool`
+    span to the op call it invoked. The pair means "this span was current",
+    not "this span called exactly this call", so one span maps to every call
+    started inside it.
+
+    Nothing is recorded for a span a reader could not use. `is_recording()`
+    says the span is alive; `sampled` says it will be exported, which a
+    RECORD_ONLY sampler decision withholds; `is_valid` rejects the all-zero
+    identity a custom `IdGenerator` can produce. Weave's own server spans are
+    skipped because they are not agent spans and an in-process server holds
+    one current while user code runs — the hosted eval worker runs
+    `Evaluation.evaluate` inside a `@traced` frame. That last one compares
+    against the span the server put on the context, not against a flag, so an
+    agent span opened *inside* a server frame still links.
+
+    Who installed the tracer provider is deliberately not checked: that is
+    process state while the question is about one span, and a user who
+    configures OTel themselves and exports to Weave has a reference that does
+    resolve. So a missing key and a reference that resolves to nothing are
+    both normal states.
+    """
+    if not _OTEL_AVAILABLE:
+        return None
+    span = otel_trace.get_current_span()
+    if span is otel_context.get_value(WEAVE_SERVER_SPAN_KEY):
+        return None
+    ctx = span.get_span_context()
+    if not (ctx.is_valid and span.is_recording() and ctx.trace_flags.sampled):
+        return None
+    return {
+        "trace_id": otel_trace.format_trace_id(ctx.trace_id),
+        "span_id": otel_trace.format_span_id(ctx.span_id),
+    }
 
 
 def _add_scored_by_to_calls_query(
@@ -1486,6 +1540,11 @@ class WeaveClient:
 
         for k, v in get_capture_info().items():
             attributes_dict._set_weave_item(k, v)
+
+        # Dropped first: this key is ours to write, never a caller's to supply.
+        attributes_dict["weave"].pop(INVOKING_SPAN_ATTR_KEY, None)
+        if (invoking_span := _invoking_span_attr()) is not None:
+            attributes_dict._set_weave_item(INVOKING_SPAN_ATTR_KEY, invoking_span)
 
         # Skip the future allocation once the op's digest is resolved (any
         # call after the first). Reading `.uri` directly is a no-op string

--- a/weave/trace_server/constants.py
+++ b/weave/trace_server/constants.py
@@ -48,6 +48,9 @@ SCORE_EVALUATION_RUN_ID_ATTR_KEY = "evaluation_run_id"
 # Weave attributes namespace
 WEAVE_ATTRIBUTES_NAMESPACE = "weave"
 
+# Identity of the OTel span a call was invoked from: {"trace_id", "span_id"} hex
+INVOKING_SPAN_ATTR_KEY = "invoking_span"
+
 # OTel span attribute keys for eval context
 EVAL_SPAN_ATTR_PREFIX = "weave.eval"
 EVAL_RUN_ID_SPAN_ATTR = "weave.eval.run_id"

--- a/weave/trace_server/tracing.py
+++ b/weave/trace_server/tracing.py
@@ -33,10 +33,14 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Callable, Generator, Iterator
+from contextlib import contextmanager
 from functools import wraps
 from typing import Any, TypeVar, cast
 
+from opentelemetry import context as otel_context
 from opentelemetry import trace
+
+from weave.shared.otel_context_keys import WEAVE_SERVER_SPAN_KEY
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -45,6 +49,22 @@ F = TypeVar("F", bound=Callable[..., Any])
 # dozens of spans per request. Tests swap this binding via
 # `monkeypatch.setattr(tracing, "_tracer", ...)`.
 _tracer = trace.get_tracer("weave.trace_server")
+
+
+@contextmanager
+def _server_span(name: str) -> Iterator[None]:
+    """Open the span and mark the context for the duration it is current.
+
+    The mark is how the client SDK tells one of our spans from an agent's when
+    it records the invoking span on a call; without it a call created under an
+    in-process server would claim Weave's own telemetry as its caller.
+    """
+    with _tracer.start_as_current_span(name) as span:
+        token = otel_context.attach(otel_context.set_value(WEAVE_SERVER_SPAN_KEY, span))
+        try:
+            yield
+        finally:
+            otel_context.detach(token)
 
 
 def _reject_unsupported_shape(
@@ -89,14 +109,14 @@ def traced(name: str) -> Callable[[F], F]:
 
             @wraps(fn)
             async def awrap(*args: Any, **kwargs: Any) -> Any:
-                with _tracer.start_as_current_span(name):
+                with _server_span(name):
                     return await fn(*args, **kwargs)
 
             return cast(F, awrap)
 
         @wraps(fn)
         def swrap(*args: Any, **kwargs: Any) -> Any:
-            with _tracer.start_as_current_span(name):
+            with _server_span(name):
                 return fn(*args, **kwargs)
 
         return cast(F, swrap)
@@ -126,7 +146,7 @@ def traced_generator(
 
         @wraps(fn)
         def wrapper(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
-            with _tracer.start_as_current_span(name):
+            with _server_span(name):
                 yield from fn(*args, **kwargs)
 
         return wrapper


### PR DESCRIPTION
Jira: [WB-38616](https://coreweave.atlassian.net/browse/WB-38616)

## Description

We have two models. `calls` holds every `@weave.op` call. `spans` holds the OTel spans an agent run makes. An agent that calls a tool writes to both, because the tool itself is a `@weave.op`. Nothing used to join the two. The call row has no weave parent, so it opens a trace of its own, and the UI shows it as an orphan next to the agent trace.

#7730 did the first half. A span now carries the id of the call it ran under, so from a call you can find its spans. This PR does the second half. We want to start at an agent span and find the call it invoked, and for that the id of the span has to sit on the call.

So that is what this PR writes. When a call starts, `create_call` reads the OTel span that is open at that moment and saves its id on the call:

```json
{"weave": {"invoking_span": {"trace_id": "41512b73...", "span_id": "31b3c094..."}}}
```

The ids are lowercase hex, the same form `spans.trace_id` and `spans.span_id` already use, so a reader compares strings and nothing more. To find the calls a span made, filter `/calls/stream_query` on the pair. No new endpoint, and no work on the read side at all.

## Why this approach

I first looked for the place to add code per integration. There is none to add. Every framework opens a span for the tool and makes it current before it runs the tool body. So `create_call` only has to read the span that is already there. `openai_agents`, `google_adk` and the Conversation SDK's `weave.Tool` all work that way, and all three link for free. `log_turn` and `openai_realtime` build their spans after the fact, so they link nothing, which is what they did before.

Then I tried to save writes. The plan was to store the id on the outermost call only and skip the calls under it. It does not work. The check reads what the parent recorded, and the parent may have skipped as well, so you mark every second level. So every call started inside the span gets the id. It costs about 90 bytes per call, and a test fails if someone brings the old plan back.

## Why it is safe

The one case that had to be cut out is our own server. `weave.trace_server` opens OTel spans, and with an in-process server one of them is open while user code runs. Without the fix, every call of every hosted evaluation would name Weave's own telemetry as its caller. The server now marks its span on the OTel context, and `create_call` skips that one span. It compares the span itself, not a "we are inside the server" flag, because an agent span opened inside a server frame is a real target. It reads the context, not the span object: under the OTel to Datadog bridge the current span is a `ddtrace` span, so anything read off the object would pass straight through.

Nothing changes shape. Call attributes are free-form JSON all the way into `attributes_dump`, so there is no schema change, no migration and no new bindings. A caller cannot supply the key, because it is dropped before it is written. An ended span, an unsampled span and an all-zero id all record nothing. The check costs about 0.5 µs when a span is open. The OTel import sits under `try/except`, since `import weave` works today with `opentelemetry` absent. One thing a reader has to accept: the pair can name a span we never stored, when someone runs their own OTel and exports it elsewhere. A missing key and a dead pair are both normal.

Before this, a call and an agent span shared no field. Now the call carries the span it came from, and one filter takes you across. The read API, the UI and TypeScript parity are separate work.

## Testing

New file `tests/trace/test_op_span_linking.py`: the id is there inside a live span, and absent with no span, an unsampled span, an all-zero id, an ended span, or a Weave server span. The `openai_agents` and `google_adk` tests round-trip through ClickHouse and check the pair names the `execute_tool` span, not the agent span above it.


[WB-38616]: https://coreweave.atlassian.net/browse/WB-38616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ