### PR TITLE
security(weave): redact PII in Call and Agent writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -738,6 +738,12 @@ deterministic.
 - An authorized server route may set `pii-v1` from the owning organization's
   policy. Never populate the field from caller-controlled OTLP content or a
   process environment fallback.
+- Agent OTel ingest applies the policy before credential redaction, blob
+  stripping, derived-column extraction, and insertion. A detector failure
+  rejects the complete request before any insert.
+- PII redaction covers span, resource, event, and link attributes plus the
+  status message. Span names, event names, IDs, trace state, and timestamps are
+  structural and remain unchanged.
 
 ### Credential-shaped fields in agent span columns
 - The agents OTel ingest calls `redact_credentials_from_span` before

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -738,12 +738,21 @@ deterministic.
 - An authorized server route may set `pii-v1` from the owning organization's
   policy. Never populate the field from caller-controlled OTLP content or a
   process environment fallback.
-- Agent OTel ingest applies the policy before credential redaction, blob
-  stripping, derived-column extraction, and insertion. A detector failure
-  rejects the complete request before any insert.
+- Agent OTel ingest parses and redacts every span in the request (each shared
+  resource once) before credential redaction, blob stripping, derived-column
+  extraction, or insertion starts for any of them. A value nested too deeply
+  to scan rejects the complete request as `RequestTooLarge` (HTTP 413), and
+  any other detector failure also fails the whole request, before any Content
+  file write or insert.
 - PII redaction covers span, resource, event, and link attributes plus the
   status message. Span names, event names, IDs, trace state, and timestamps are
-  structural and remain unchanged.
+  structural and remain unchanged: names are low-cardinality grouping keys
+  (they feed the `span_name`, `operation_name`, and `agent_name` columns), so
+  rewriting them would break span grouping and agent identity.
+- `pii-v1` scans strings and never decodes payloads: non-string leaves,
+  including raw bytes values (stored base64-encoded in dumps), pass through
+  unchanged, the same boundary as preserved data URLs and standalone base64
+  strings.
 
 ### Credential-shaped fields in agent span columns
 - The agents OTel ingest calls `redact_credentials_from_span` before

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -738,22 +738,19 @@ deterministic.
 - An authorized server route may set `pii-v1` from the owning organization's
   policy. Never populate the field from caller-controlled OTLP content or a
   process environment fallback.
-- Agent OTel ingest parses and redacts every span in the request (each shared
-  resource once) before credential redaction, blob stripping, derived-column
-  extraction, or insertion starts for any of them. A value nested too deeply
-  to scan rejects the complete request as `RequestTooLarge` (HTTP 413), and
-  any other detector failure also fails the whole request, before any Content
-  file write or insert.
-- PII redaction covers span and event names, span, resource, event, and link
-  attributes, and the status message. Names feed the `span_name`,
-  `operation_name`, and `agent_name` grouping columns, so a PII-bearing name
-  changes grouping and agent identity after redaction; keeping PII out of
-  storage wins over grouping continuity. IDs, trace state, and timestamps are
-  structural and remain unchanged.
+- Agent OTel ingest parses and redacts every span (each shared resource once)
+  before credential redaction, blob stripping, derived-column extraction, or
+  insertion starts for any of them. A redaction failure rejects the whole
+  request before any Content file write or insert; a value nested too deeply
+  to scan is rejected as `RequestTooLarge` (HTTP 413).
+- PII redaction covers span and event names, all four attribute containers,
+  and the status message. Names feed the `span_name`, `operation_name`, and
+  `agent_name` grouping columns, so a PII-bearing name changes grouping and
+  agent identity; redaction wins that trade-off. IDs, trace state, and
+  timestamps are structural and remain unchanged.
 - `pii-v1` scans strings and never decodes payloads: non-string leaves,
-  including raw bytes values (stored base64-encoded in dumps), pass through
-  unchanged, the same boundary as preserved data URLs and standalone base64
-  strings.
+  including raw bytes (stored base64-encoded in dumps), pass through
+  unchanged, like the preserved data URLs and standalone base64.
 
 ### Credential-shaped fields in agent span columns
 - The agents OTel ingest calls `redact_credentials_from_span` before

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -744,11 +744,12 @@ deterministic.
   to scan rejects the complete request as `RequestTooLarge` (HTTP 413), and
   any other detector failure also fails the whole request, before any Content
   file write or insert.
-- PII redaction covers span, resource, event, and link attributes plus the
-  status message. Span names, event names, IDs, trace state, and timestamps are
-  structural and remain unchanged: names are low-cardinality grouping keys
-  (they feed the `span_name`, `operation_name`, and `agent_name` columns), so
-  rewriting them would break span grouping and agent identity.
+- PII redaction covers span and event names, span, resource, event, and link
+  attributes, and the status message. Names feed the `span_name`,
+  `operation_name`, and `agent_name` grouping columns, so a PII-bearing name
+  changes grouping and agent identity after redaction; keeping PII out of
+  storage wins over grouping continuity. IDs, trace state, and timestamps are
+  structural and remain unchanged.
 - `pii-v1` scans strings and never decodes payloads: non-string leaves,
   including raw bytes values (stored base64-encoded in dumps), pass through
   unchanged, the same boundary as preserved data URLs and standalone base64

--- a/tests/trace_server/test_sensitive_data_adapters.py
+++ b/tests/trace_server/test_sensitive_data_adapters.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import datetime
 
+import pytest
+
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.errors import RequestTooLarge
 from weave.trace_server.opentelemetry.python_spans import (
     Event,
     Link,
@@ -14,14 +17,16 @@ from weave.trace_server.opentelemetry.python_spans import (
     Resource as SpanResource,
 )
 from weave.trace_server.sensitive_data.call_redaction import (
-    redact_call_batch,
     redact_call_end,
     redact_call_start,
     redact_call_update,
     redact_calls_complete,
 )
 from weave.trace_server.sensitive_data.policy import SensitiveDataPolicy
-from weave.trace_server.sensitive_data.span_redaction import redact_pii_from_span
+from weave.trace_server.sensitive_data.span_redaction import (
+    redact_pii_from_resource,
+    redact_pii_from_span,
+)
 
 NOW = datetime.datetime(2026, 8, 12, tzinfo=datetime.timezone.utc)
 
@@ -50,7 +55,7 @@ def test_call_start_preserves_ref_op_names() -> None:
     assert redacted.start.op_name == "weave:///entity/project/op/my-op:v1"
 
 
-def test_call_end_update_complete_and_batch_redact_content() -> None:
+def test_call_end_update_and_complete_redact_content() -> None:
     end_req = _call_end_req()
     update_req = tsi.CallUpdateReq(
         project_id="ada@example.com/project",
@@ -58,17 +63,10 @@ def test_call_end_update_complete_and_batch_redact_content() -> None:
         display_name="Email ada@example.com",
     )
     complete_req = tsi.CallsUpsertCompleteReq(batch=[_completed_call()])
-    batch_req = tsi.CallCreateBatchReq(
-        batch=[
-            tsi.CallBatchStartMode(req=_call_start_req()),
-            tsi.CallBatchEndMode(req=end_req),
-        ]
-    )
 
     redacted_end = redact_call_end(end_req, SensitiveDataPolicy.PII_V1)
     redacted_update = redact_call_update(update_req, SensitiveDataPolicy.PII_V1)
     redacted_complete = redact_calls_complete(complete_req, SensitiveDataPolicy.PII_V1)
-    redacted_batch = redact_call_batch(batch_req, SensitiveDataPolicy.PII_V1)
 
     assert redacted_end.end.output == {"card": "<CREDIT_CARD>"}
     assert redacted_end.end.summary == {"contact": "<EMAIL_ADDRESS>"}
@@ -79,14 +77,33 @@ def test_call_end_update_complete_and_batch_redact_content() -> None:
     assert redacted_complete.batch[0].inputs == {"email": "<EMAIL_ADDRESS>"}
     assert redacted_complete.batch[0].output == {"card": "<CREDIT_CARD>"}
     assert redacted_complete.batch[0].op_name == "<EMAIL_ADDRESS>"
-    assert redacted_batch.batch[0].req.start.inputs == {"email": "<EMAIL_ADDRESS>"}
-    assert redacted_batch.batch[1].req.end.output == {"card": "<CREDIT_CARD>"}
 
 
 def test_off_policy_skips_the_walker() -> None:
-    req = _call_start_req()
+    start_req = _call_start_req()
+    end_req = _call_end_req()
+    update_req = tsi.CallUpdateReq(
+        project_id="ada@example.com/project",
+        call_id="call-id",
+        display_name="Email ada@example.com",
+    )
+    complete_req = tsi.CallsUpsertCompleteReq(batch=[_completed_call()])
 
-    assert redact_call_start(req, SensitiveDataPolicy.OFF) is req
+    assert redact_call_start(start_req, SensitiveDataPolicy.OFF) is start_req
+    assert redact_call_end(end_req, SensitiveDataPolicy.OFF) is end_req
+    assert redact_call_update(update_req, SensitiveDataPolicy.OFF) is update_req
+    assert redact_calls_complete(complete_req, SensitiveDataPolicy.OFF) is complete_req
+
+
+def test_deep_call_value_raises_request_too_large() -> None:
+    req = _call_start_req()
+    deep: dict[str, object] = {"leaf": "x"}
+    for _ in range(2000):
+        deep = {"k": deep}
+    req.start.inputs = deep
+
+    with pytest.raises(RequestTooLarge, match="nesting limit"):
+        redact_call_start(req, SensitiveDataPolicy.PII_V1)
 
 
 def _call_start_req() -> tsi.CallStartReq:
@@ -169,11 +186,16 @@ def test_redacts_pii_from_every_span_container() -> None:
 
     redact_pii_from_span(span, SensitiveDataPolicy.PII_V1)
 
+    # The shared resource is redacted once per resource-spans group, not here.
+    assert span.resource is not None
+    assert span.resource.attributes == {"service.owner": "ada@example.com"}
+
+    redact_pii_from_resource(span.resource, SensitiveDataPolicy.PII_V1)
+
     assert span.attributes == {
         "gen_ai.prompt": "Email <EMAIL_ADDRESS>",
         "payload": {"image": "data:image/png;base64,QUJD"},
     }
-    assert span.resource is not None
     assert span.resource.attributes == {"service.owner": "<EMAIL_ADDRESS>"}
     assert span.events[0].attributes == {"note": "call <PHONE_NUMBER>"}
     assert span.links[0].attributes == {"context": "ssn <US_SSN>"}
@@ -185,8 +207,35 @@ def test_redacts_pii_from_every_span_container() -> None:
 def test_span_redaction_off_policy_is_a_noop() -> None:
     span = _span_with_pii()
     original_attributes = span.attributes
+    assert span.resource is not None
+    original_resource_attributes = span.resource.attributes
 
     redact_pii_from_span(span, SensitiveDataPolicy.OFF)
+    redact_pii_from_resource(span.resource, SensitiveDataPolicy.OFF)
 
     assert span.attributes is original_attributes
+    assert span.resource.attributes is original_resource_attributes
     assert span.status.message == "card 4111 1111 1111 1111"
+
+
+def test_bytes_attribute_values_pass_through_unscanned() -> None:
+    # pii-v1 scans strings and never decodes payloads: raw bytes values are a
+    # documented boundary (like data URLs), stored base64-encoded in dumps.
+    span = _span_with_pii()
+    payload = b"reach ada@example.com or 4111 1111 1111 1111"
+    span.attributes = {"gen_ai.blob": payload}
+
+    redact_pii_from_span(span, SensitiveDataPolicy.PII_V1)
+
+    assert span.attributes == {"gen_ai.blob": payload}
+
+
+def test_deep_span_value_raises_request_too_large() -> None:
+    span = _span_with_pii()
+    deep: dict[str, object] = {"leaf": "x"}
+    for _ in range(2000):
+        deep = {"k": deep}
+    span.attributes = {"payload": deep}
+
+    with pytest.raises(RequestTooLarge, match="nesting limit"):
+        redact_pii_from_span(span, SensitiveDataPolicy.PII_V1)

--- a/tests/trace_server/test_sensitive_data_adapters.py
+++ b/tests/trace_server/test_sensitive_data_adapters.py
@@ -154,7 +154,7 @@ def _completed_call() -> tsi.CompletedCallSchemaForInsert:
 def _span_with_pii() -> Span:
     return Span(
         resource=SpanResource(attributes={"service.owner": "ada@example.com"}),
-        name="agents_pii_surface",
+        name="surface for ada@example.com",
         trace_id="a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
         span_id="b2b2b2b2b2b2b2b2",
         start_time_unix_nano=1,
@@ -165,7 +165,7 @@ def _span_with_pii() -> Span:
         },
         events=[
             Event(
-                name="exception",
+                name="notify (415) 555-2671",
                 timestamp=1,
                 attributes={"note": "call (415) 555-2671"},
             )
@@ -185,7 +185,7 @@ def _redacted_span(resource_attributes: dict[str, str]) -> Span:
     """The full expected shape of `_span_with_pii()` after redaction."""
     return Span(
         resource=SpanResource(attributes=resource_attributes),
-        name="agents_pii_surface",
+        name="surface for <EMAIL_ADDRESS>",
         trace_id="a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
         span_id="b2b2b2b2b2b2b2b2",
         start_time_unix_nano=1,
@@ -196,7 +196,7 @@ def _redacted_span(resource_attributes: dict[str, str]) -> Span:
         },
         events=[
             Event(
-                name="exception",
+                name="notify <PHONE_NUMBER>",
                 timestamp=1,
                 attributes={"note": "call <PHONE_NUMBER>"},
             )

--- a/tests/trace_server/test_sensitive_data_adapters.py
+++ b/tests/trace_server/test_sensitive_data_adapters.py
@@ -245,8 +245,7 @@ def test_span_redaction_off_policy_is_a_noop() -> None:
 
 
 def test_bytes_attribute_values_pass_through_unscanned() -> None:
-    # pii-v1 scans strings and never decodes payloads: raw bytes values are a
-    # documented boundary (like data URLs), stored base64-encoded in dumps.
+    # pii-v1 scans strings only; bytes are a documented pass-through boundary.
     span = _span_with_pii()
     payload = b"reach ada@example.com or 4111 1111 1111 1111"
     span.attributes = {"gen_ai.blob": payload}

--- a/tests/trace_server/test_sensitive_data_adapters.py
+++ b/tests/trace_server/test_sensitive_data_adapters.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import datetime
+
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.opentelemetry.python_spans import (
+    Event,
+    Link,
+    Span,
+    Status,
+    StatusCode,
+)
+from weave.trace_server.opentelemetry.python_spans import (
+    Resource as SpanResource,
+)
+from weave.trace_server.sensitive_data.call_redaction import (
+    redact_call_batch,
+    redact_call_end,
+    redact_call_start,
+    redact_call_update,
+    redact_calls_complete,
+)
+from weave.trace_server.sensitive_data.policy import SensitiveDataPolicy
+from weave.trace_server.sensitive_data.span_redaction import redact_pii_from_span
+
+NOW = datetime.datetime(2026, 8, 12, tzinfo=datetime.timezone.utc)
+
+
+def test_call_start_redacts_content_but_not_structural_fields() -> None:
+    req = _call_start_req()
+
+    redacted = redact_call_start(req, SensitiveDataPolicy.PII_V1)
+
+    assert isinstance(redacted, tsi.CallStartReq)
+    assert redacted.start.inputs == {"email": "<EMAIL_ADDRESS>"}
+    assert redacted.start.attributes == {"phone": "<PHONE_NUMBER>"}
+    assert redacted.start.otel_dump == {"ssn": "<US_SSN>"}
+    assert redacted.start.display_name == "Contact <EMAIL_ADDRESS>"
+    assert redacted.start.op_name == "<EMAIL_ADDRESS>"
+    assert redacted.start.project_id == "ada@example.com/project"
+    assert req.start.inputs == {"email": "ada@example.com"}
+
+
+def test_call_start_preserves_ref_op_names() -> None:
+    req = _call_start_req()
+    req.start.op_name = "weave:///entity/project/op/my-op:v1"
+
+    redacted = redact_call_start(req, SensitiveDataPolicy.PII_V1)
+
+    assert redacted.start.op_name == "weave:///entity/project/op/my-op:v1"
+
+
+def test_call_end_update_complete_and_batch_redact_content() -> None:
+    end_req = _call_end_req()
+    update_req = tsi.CallUpdateReq(
+        project_id="ada@example.com/project",
+        call_id="ada@example.com",
+        display_name="Email ada@example.com",
+    )
+    complete_req = tsi.CallsUpsertCompleteReq(batch=[_completed_call()])
+    batch_req = tsi.CallCreateBatchReq(
+        batch=[
+            tsi.CallBatchStartMode(req=_call_start_req()),
+            tsi.CallBatchEndMode(req=end_req),
+        ]
+    )
+
+    redacted_end = redact_call_end(end_req, SensitiveDataPolicy.PII_V1)
+    redacted_update = redact_call_update(update_req, SensitiveDataPolicy.PII_V1)
+    redacted_complete = redact_calls_complete(complete_req, SensitiveDataPolicy.PII_V1)
+    redacted_batch = redact_call_batch(batch_req, SensitiveDataPolicy.PII_V1)
+
+    assert redacted_end.end.output == {"card": "<CREDIT_CARD>"}
+    assert redacted_end.end.summary == {"contact": "<EMAIL_ADDRESS>"}
+    assert redacted_end.end.exception == "Failed for <EMAIL_ADDRESS>"
+    assert redacted_update.display_name == "Email <EMAIL_ADDRESS>"
+    assert redacted_update.project_id == "ada@example.com/project"
+    assert redacted_update.call_id == "ada@example.com"
+    assert redacted_complete.batch[0].inputs == {"email": "<EMAIL_ADDRESS>"}
+    assert redacted_complete.batch[0].output == {"card": "<CREDIT_CARD>"}
+    assert redacted_complete.batch[0].op_name == "<EMAIL_ADDRESS>"
+    assert redacted_batch.batch[0].req.start.inputs == {"email": "<EMAIL_ADDRESS>"}
+    assert redacted_batch.batch[1].req.end.output == {"card": "<CREDIT_CARD>"}
+
+
+def test_off_policy_skips_the_walker() -> None:
+    req = _call_start_req()
+
+    assert redact_call_start(req, SensitiveDataPolicy.OFF) is req
+
+
+def _call_start_req() -> tsi.CallStartReq:
+    return tsi.CallStartReq(
+        start=tsi.StartedCallSchemaForInsert(
+            project_id="ada@example.com/project",
+            id="call-id",
+            trace_id="trace-id",
+            op_name="ada@example.com",
+            display_name="Contact ada@example.com",
+            started_at=NOW,
+            attributes={"phone": "(415) 555-2671"},
+            inputs={"email": "ada@example.com"},
+            otel_dump={"ssn": "123-45-6789"},
+        )
+    )
+
+
+def _call_end_req() -> tsi.CallEndReq:
+    return tsi.CallEndReq(
+        end=tsi.EndedCallSchemaForInsert(
+            project_id="ada@example.com/project",
+            id="call-id",
+            trace_id="trace-id",
+            ended_at=NOW,
+            output={"card": "4111 1111 1111 1111"},
+            summary={"contact": "ada@example.com"},
+            exception="Failed for ada@example.com",
+        )
+    )
+
+
+def _completed_call() -> tsi.CompletedCallSchemaForInsert:
+    return tsi.CompletedCallSchemaForInsert(
+        project_id="ada@example.com/project",
+        id="call-id",
+        trace_id="trace-id",
+        op_name="ada@example.com",
+        started_at=NOW,
+        ended_at=NOW,
+        attributes={"phone": "(415) 555-2671"},
+        inputs={"email": "ada@example.com"},
+        output={"card": "4111 1111 1111 1111"},
+        summary={"ssn": "123-45-6789"},
+    )
+
+
+def _span_with_pii() -> Span:
+    return Span(
+        resource=SpanResource(attributes={"service.owner": "ada@example.com"}),
+        name="agents_pii_surface",
+        trace_id="a1" * 16,
+        span_id="b2" * 8,
+        start_time_unix_nano=1,
+        end_time_unix_nano=2,
+        attributes={
+            "gen_ai.prompt": "Email ada@example.com",
+            "payload": {"image": "data:image/png;base64,QUJD"},
+        },
+        events=[
+            Event(
+                name="exception",
+                timestamp=1,
+                attributes={"note": "call (415) 555-2671"},
+            )
+        ],
+        links=[
+            Link(
+                trace_id="c3" * 16,
+                span_id="d4" * 8,
+                attributes={"context": "ssn 123-45-6789"},
+            )
+        ],
+        status=Status(code=StatusCode.ERROR, message="card 4111 1111 1111 1111"),
+    )
+
+
+def test_redacts_pii_from_every_span_container() -> None:
+    span = _span_with_pii()
+
+    redact_pii_from_span(span, SensitiveDataPolicy.PII_V1)
+
+    assert span.attributes == {
+        "gen_ai.prompt": "Email <EMAIL_ADDRESS>",
+        "payload": {"image": "data:image/png;base64,QUJD"},
+    }
+    assert span.resource is not None
+    assert span.resource.attributes == {"service.owner": "<EMAIL_ADDRESS>"}
+    assert span.events[0].attributes == {"note": "call <PHONE_NUMBER>"}
+    assert span.links[0].attributes == {"context": "ssn <US_SSN>"}
+    assert span.status.message == "card <CREDIT_CARD>"
+    assert span.name == "agents_pii_surface"
+    assert span.span_id == "b2" * 8
+
+
+def test_span_redaction_off_policy_is_a_noop() -> None:
+    span = _span_with_pii()
+    original_attributes = span.attributes
+
+    redact_pii_from_span(span, SensitiveDataPolicy.OFF)
+
+    assert span.attributes is original_attributes
+    assert span.status.message == "card 4111 1111 1111 1111"

--- a/tests/trace_server/test_sensitive_data_adapters.py
+++ b/tests/trace_server/test_sensitive_data_adapters.py
@@ -181,27 +181,53 @@ def _span_with_pii() -> Span:
     )
 
 
+def _redacted_span(resource_attributes: dict[str, str]) -> Span:
+    """The full expected shape of `_span_with_pii()` after redaction."""
+    return Span(
+        resource=SpanResource(attributes=resource_attributes),
+        name="agents_pii_surface",
+        trace_id="a1" * 16,
+        span_id="b2" * 8,
+        start_time_unix_nano=1,
+        end_time_unix_nano=2,
+        attributes={
+            "gen_ai.prompt": "Email <EMAIL_ADDRESS>",
+            "payload": {"image": "data:image/png;base64,QUJD"},
+        },
+        events=[
+            Event(
+                name="exception",
+                timestamp=1,
+                attributes={"note": "call <PHONE_NUMBER>"},
+            )
+        ],
+        links=[
+            Link(
+                trace_id="c3" * 16,
+                span_id="d4" * 8,
+                attributes={"context": "ssn <US_SSN>"},
+            )
+        ],
+        status=Status(code=StatusCode.ERROR, message="card <CREDIT_CARD>"),
+    )
+
+
 def test_redacts_pii_from_every_span_container() -> None:
     span = _span_with_pii()
 
     redact_pii_from_span(span, SensitiveDataPolicy.PII_V1)
 
     # The shared resource is redacted once per resource-spans group, not here.
-    assert span.resource is not None
-    assert span.resource.attributes == {"service.owner": "ada@example.com"}
+    assert span == _redacted_span(
+        resource_attributes={"service.owner": "ada@example.com"}
+    )
 
+    assert span.resource is not None
     redact_pii_from_resource(span.resource, SensitiveDataPolicy.PII_V1)
 
-    assert span.attributes == {
-        "gen_ai.prompt": "Email <EMAIL_ADDRESS>",
-        "payload": {"image": "data:image/png;base64,QUJD"},
-    }
-    assert span.resource.attributes == {"service.owner": "<EMAIL_ADDRESS>"}
-    assert span.events[0].attributes == {"note": "call <PHONE_NUMBER>"}
-    assert span.links[0].attributes == {"context": "ssn <US_SSN>"}
-    assert span.status.message == "card <CREDIT_CARD>"
-    assert span.name == "agents_pii_surface"
-    assert span.span_id == "b2" * 8
+    assert span == _redacted_span(
+        resource_attributes={"service.owner": "<EMAIL_ADDRESS>"}
+    )
 
 
 def test_span_redaction_off_policy_is_a_noop() -> None:
@@ -213,9 +239,9 @@ def test_span_redaction_off_policy_is_a_noop() -> None:
     redact_pii_from_span(span, SensitiveDataPolicy.OFF)
     redact_pii_from_resource(span.resource, SensitiveDataPolicy.OFF)
 
+    assert span == _span_with_pii()
     assert span.attributes is original_attributes
     assert span.resource.attributes is original_resource_attributes
-    assert span.status.message == "card 4111 1111 1111 1111"
 
 
 def test_bytes_attribute_values_pass_through_unscanned() -> None:

--- a/tests/trace_server/test_sensitive_data_adapters.py
+++ b/tests/trace_server/test_sensitive_data_adapters.py
@@ -155,8 +155,8 @@ def _span_with_pii() -> Span:
     return Span(
         resource=SpanResource(attributes={"service.owner": "ada@example.com"}),
         name="agents_pii_surface",
-        trace_id="a1" * 16,
-        span_id="b2" * 8,
+        trace_id="a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+        span_id="b2b2b2b2b2b2b2b2",
         start_time_unix_nano=1,
         end_time_unix_nano=2,
         attributes={
@@ -172,8 +172,8 @@ def _span_with_pii() -> Span:
         ],
         links=[
             Link(
-                trace_id="c3" * 16,
-                span_id="d4" * 8,
+                trace_id="c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+                span_id="d4d4d4d4d4d4d4d4",
                 attributes={"context": "ssn 123-45-6789"},
             )
         ],
@@ -186,8 +186,8 @@ def _redacted_span(resource_attributes: dict[str, str]) -> Span:
     return Span(
         resource=SpanResource(attributes=resource_attributes),
         name="agents_pii_surface",
-        trace_id="a1" * 16,
-        span_id="b2" * 8,
+        trace_id="a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+        span_id="b2b2b2b2b2b2b2b2",
         start_time_unix_nano=1,
         end_time_unix_nano=2,
         attributes={
@@ -203,8 +203,8 @@ def _redacted_span(resource_attributes: dict[str, str]) -> Span:
         ],
         links=[
             Link(
-                trace_id="c3" * 16,
-                span_id="d4" * 8,
+                trace_id="c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+                span_id="d4d4d4d4d4d4d4d4",
                 attributes={"context": "ssn <US_SSN>"},
             )
         ],

--- a/tests/trace_server/test_sensitive_data_span_ingest.py
+++ b/tests/trace_server/test_sensitive_data_span_ingest.py
@@ -225,9 +225,8 @@ def test_redaction_failure_rejects_request_before_any_side_effect(
 ) -> None:
     """A span too deep to scan fails the whole request as RequestTooLarge.
 
-    The healthy sibling span parses first, yet extraction (which writes blob
-    Content files) must never start for it: every span is redacted before any
-    extraction begins, so nothing is stored and no side effect happens.
+    Extraction (which writes blob Content files) must never start for the
+    healthy sibling span, and nothing is stored.
     """
     extraction_started = False
     original_redact_credentials = agents_clickhouse.redact_credentials_from_span

--- a/tests/trace_server/test_sensitive_data_span_ingest.py
+++ b/tests/trace_server/test_sensitive_data_span_ingest.py
@@ -63,7 +63,7 @@ _PII_CONTENT_ATTRS = {
 
 def _pii_proto_span(span_id: bytes) -> PbSpan:
     span = PbSpan()
-    span.name = "agents_pii_ingest"
+    span.name = "ingest for ada@example.com"
     span.trace_id = (77).to_bytes(16, "big")
     span.span_id = span_id
     span.start_time_unix_nano = _NOW_NS
@@ -78,6 +78,10 @@ def _pii_proto_span(span_id: bytes) -> PbSpan:
         item.key = key
         item.value.string_value = value
         span.attributes.append(item)
+    event = PbSpan.Event()
+    event.name = "notify (415) 555-2671"
+    event.time_unix_nano = _NOW_NS
+    span.events.append(event)
     span.status.code = 2  # ERROR, so the status message persists
     span.status.message = _PII_STATUS_MESSAGE
     return span
@@ -139,6 +143,9 @@ def test_pii_policy_redacts_stored_span_details(ch_server) -> None:
     assert res.rejected_spans == 0
     row = _stored_span_details(ch_server, project_id)
     dump = json.loads(row.raw_span_dump)
+    assert row.span_name == "ingest for <EMAIL_ADDRESS>"
+    assert dump["name"] == "ingest for <EMAIL_ADDRESS>"
+    assert dump["events"][0]["name"] == "notify <PHONE_NUMBER>"
     assert dump["attributes"]["gen_ai"]["prompt"] == "Email <EMAIL_ADDRESS>"
     assert dump["resource"]["attributes"] == {
         "service": {"owner": "call <PHONE_NUMBER>"}
@@ -213,6 +220,8 @@ def test_off_policy_stores_span_values_unchanged(ch_server) -> None:
     assert res.rejected_spans == 0
     row = _stored_span_details(ch_server, project_id)
     dump = json.loads(row.raw_span_dump)
+    assert row.span_name == "ingest for ada@example.com"
+    assert dump["events"][0]["name"] == "notify (415) 555-2671"
     assert dump["attributes"]["gen_ai"]["prompt"] == _PII_ATTR_VALUE
     assert dump["status"]["message"] == _PII_STATUS_MESSAGE
     assert dump["resource"]["attributes"] == {"service": {"owner": _PII_RESOURCE_VALUE}}

--- a/tests/trace_server/test_sensitive_data_span_ingest.py
+++ b/tests/trace_server/test_sensitive_data_span_ingest.py
@@ -1,0 +1,170 @@
+"""End-to-end PII redaction on the agents OTel ingest path.
+
+Runs the real ``genai_otel_export`` against ClickHouse via the ``ch_server``
+fixture and reads the stored span details back, proving the ``pii-v1`` policy
+reaches ``raw_span_dump`` and the attribute-derived columns, and that an
+explicit ``off`` policy stores values unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+
+from opentelemetry.proto.common.v1.common_pb2 import InstrumentationScope, KeyValue
+from opentelemetry.proto.resource.v1.resource_pb2 import Resource as PbResource
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans
+from opentelemetry.proto.trace.v1.trace_pb2 import Span as PbSpan
+
+from tests.trace_server.helpers import make_project_id
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.agents.types import AgentSpansQueryReq, GenAIOTelExportReq
+from weave.trace_server.sensitive_data.policy import SensitiveDataPolicy
+
+_NOW_NS = 1_767_225_600_000_000_000
+_PII_ATTR_VALUE = "Email ada@example.com"
+_PII_STATUS_MESSAGE = "card 4111 1111 1111 1111"
+_PII_RESOURCE_VALUE = "call (415) 555-2671"
+_PII_CONVERSATION_NAME = "chat with ada@example.com"
+
+# One PII value per derived content column, so every column is observed.
+_PII_CONTENT_ATTRS = {
+    "gen_ai.conversation.name": _PII_CONVERSATION_NAME,
+    "gen_ai.system_instructions": json.dumps(["obey ada@example.com"]),
+    "gen_ai.output.messages": json.dumps(
+        [
+            {
+                "role": "assistant",
+                "content": "reply to ada@example.com",
+                "finish_reason": "stop",
+            },
+            {
+                "role": "assistant",
+                "parts": [{"type": "reasoning", "content": "think 123-45-6789"}],
+                "finish_reason": "stop",
+            },
+        ]
+    ),
+    "gen_ai.tool.call.arguments": json.dumps({"query": "email ada@example.com"}),
+    "gen_ai.tool.call.result": json.dumps({"answer": "call (415) 555-2671"}),
+    "gen_ai.tool.definitions": json.dumps(
+        [{"name": "lookup", "description": "for 4111 1111 1111 1111"}]
+    ),
+    "weave.compaction.summary": "card 4111 1111 1111 1111",
+}
+
+
+def _pii_proto_span(span_id: bytes) -> PbSpan:
+    span = PbSpan()
+    span.name = "agents_pii_ingest"
+    span.trace_id = (77).to_bytes(16, "big")
+    span.span_id = span_id
+    span.start_time_unix_nano = _NOW_NS
+    span.end_time_unix_nano = _NOW_NS + 1_000_000_000
+    span.kind = 1  # CLIENT
+    kv = KeyValue()
+    kv.key = "gen_ai.prompt"
+    kv.value.string_value = _PII_ATTR_VALUE
+    span.attributes.append(kv)
+    for key, value in _PII_CONTENT_ATTRS.items():
+        item = KeyValue()
+        item.key = key
+        item.value.string_value = value
+        span.attributes.append(item)
+    span.status.code = 2  # ERROR, so the status message persists
+    span.status.message = _PII_STATUS_MESSAGE
+    return span
+
+
+def _export_req(
+    project_id: str,
+    span: PbSpan,
+    policy: SensitiveDataPolicy,
+) -> GenAIOTelExportReq:
+    scope = InstrumentationScope()
+    scope.name = "test_instrumentation"
+    scope_spans = ScopeSpans()
+    scope_spans.scope.CopyFrom(scope)
+    scope_spans.spans.append(span)
+    resource = PbResource()
+    kv = KeyValue()
+    kv.key = "service.owner"
+    kv.value.string_value = _PII_RESOURCE_VALUE
+    resource.attributes.append(kv)
+    resource_spans = ResourceSpans()
+    resource_spans.resource.CopyFrom(resource)
+    resource_spans.scope_spans.append(scope_spans)
+    return GenAIOTelExportReq(
+        processed_spans=[
+            tsi.ProcessedResourceSpans(
+                entity="test-entity",
+                project="test-project",
+                run_id=None,
+                resource_spans=resource_spans,
+            )
+        ],
+        project_id=project_id,
+        wb_user_id="test-user",
+        sensitive_data_policy=policy,
+    )
+
+
+def _stored_span_details(ch_server, project_id: str):
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(project_id=project_id, include_details=True)
+    )
+    assert len(res.spans) == 1
+    return res.spans[0]
+
+
+def test_pii_policy_redacts_stored_span_details(ch_server) -> None:
+    project_id = make_project_id("span_pii_on")
+
+    res = ch_server.genai_otel_export(
+        _export_req(
+            project_id,
+            _pii_proto_span(b"\x41" * 8),
+            SensitiveDataPolicy.PII_V1,
+        )
+    )
+
+    assert res.rejected_spans == 0
+    row = _stored_span_details(ch_server, project_id)
+    dump = json.loads(row.raw_span_dump)
+    assert dump["attributes"]["gen_ai"]["prompt"] == "Email <EMAIL_ADDRESS>"
+    assert dump["resource"]["attributes"] == {
+        "service": {"owner": "call <PHONE_NUMBER>"}
+    }
+    assert dump["status"]["message"] == "card <CREDIT_CARD>"
+    assert row.status_message == "card <CREDIT_CARD>"
+    assert row.conversation_name == "chat with <EMAIL_ADDRESS>"
+    assert row.system_instructions == ["obey <EMAIL_ADDRESS>"]
+    assert row.output_messages[0].content == "reply to <EMAIL_ADDRESS>"
+    assert row.reasoning_content == "think <US_SSN>"
+    assert row.tool_call_arguments == '{"query": "email <EMAIL_ADDRESS>"}'
+    assert row.tool_call_result == '{"answer": "call <PHONE_NUMBER>"}'
+    assert (
+        row.tool_definitions
+        == '[{"name": "lookup", "description": "for <CREDIT_CARD>"}]'
+    )
+    assert row.compaction_summary == "card <CREDIT_CARD>"
+
+
+def test_off_policy_stores_span_values_unchanged(ch_server) -> None:
+    project_id = make_project_id("span_pii_off")
+
+    res = ch_server.genai_otel_export(
+        _export_req(
+            project_id,
+            _pii_proto_span(b"\x42" * 8),
+            SensitiveDataPolicy.OFF,
+        )
+    )
+
+    assert res.rejected_spans == 0
+    row = _stored_span_details(ch_server, project_id)
+    dump = json.loads(row.raw_span_dump)
+    assert dump["attributes"]["gen_ai"]["prompt"] == _PII_ATTR_VALUE
+    assert dump["status"]["message"] == _PII_STATUS_MESSAGE
+    assert dump["resource"]["attributes"] == {"service": {"owner": _PII_RESOURCE_VALUE}}
+    assert row.conversation_name == _PII_CONVERSATION_NAME
+    assert row.reasoning_content == "think 123-45-6789"

--- a/tests/trace_server/test_sensitive_data_span_ingest.py
+++ b/tests/trace_server/test_sensitive_data_span_ingest.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from opentelemetry.proto.common.v1.common_pb2 import InstrumentationScope, KeyValue
 from opentelemetry.proto.resource.v1.resource_pb2 import Resource as PbResource
 from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans
@@ -17,7 +18,9 @@ from opentelemetry.proto.trace.v1.trace_pb2 import Span as PbSpan
 
 from tests.trace_server.helpers import make_project_id
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.agents import ingest_sampling
 from weave.trace_server.agents.types import AgentSpansQueryReq, GenAIOTelExportReq
+from weave.trace_server.opentelemetry.python_spans import Span
 from weave.trace_server.sensitive_data.policy import SensitiveDataPolicy
 
 _NOW_NS = 1_767_225_600_000_000_000
@@ -147,6 +150,46 @@ def test_pii_policy_redacts_stored_span_details(ch_server) -> None:
         == '[{"name": "lookup", "description": "for <CREDIT_CARD>"}]'
     )
     assert row.compaction_summary == "card <CREDIT_CARD>"
+
+
+def test_pii_policy_redacts_before_ingest_sampling(
+    ch_server, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WEAVE_INGEST_SAMPLE_RATE", "0.0")
+    observed_redacted_span = False
+    original_decide_spans = ingest_sampling.decide_spans
+
+    def inspect_sampled_spans(
+        config: ingest_sampling.SamplingConfig,
+        spans: list[Span],
+        byte_sizes: list[int],
+    ) -> list[ingest_sampling.SpanDecision]:
+        nonlocal observed_redacted_span
+        observed_redacted_span = True
+        assert spans[0].attributes["gen_ai"]["prompt"] == "Email <EMAIL_ADDRESS>"
+        assert spans[0].resource is not None
+        assert spans[0].resource.attributes == {
+            "service": {"owner": "call <PHONE_NUMBER>"}
+        }
+        assert spans[0].status.message == "card <CREDIT_CARD>"
+        return original_decide_spans(config, spans, byte_sizes)
+
+    monkeypatch.setattr(ingest_sampling, "decide_spans", inspect_sampled_spans)
+
+    project_id = make_project_id("span_pii_before_sampling")
+    res = ch_server.genai_otel_export(
+        _export_req(
+            project_id,
+            _pii_proto_span(b"\x43" * 8),
+            SensitiveDataPolicy.PII_V1,
+        )
+    )
+
+    assert observed_redacted_span
+    assert res.accepted_spans == 1
+    assert res.rejected_spans == 0
+    stored = ch_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
+    assert stored.spans == []
 
 
 def test_off_policy_stores_span_values_unchanged(ch_server) -> None:

--- a/tests/trace_server/test_sensitive_data_span_ingest.py
+++ b/tests/trace_server/test_sensitive_data_span_ingest.py
@@ -18,8 +18,10 @@ from opentelemetry.proto.trace.v1.trace_pb2 import Span as PbSpan
 
 from tests.trace_server.helpers import make_project_id
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.agents import clickhouse as agents_clickhouse
 from weave.trace_server.agents import ingest_sampling
 from weave.trace_server.agents.types import AgentSpansQueryReq, GenAIOTelExportReq
+from weave.trace_server.errors import RequestTooLarge
 from weave.trace_server.opentelemetry.python_spans import Span
 from weave.trace_server.sensitive_data.policy import SensitiveDataPolicy
 
@@ -33,6 +35,9 @@ _PII_CONVERSATION_NAME = "chat with ada@example.com"
 _PII_CONTENT_ATTRS = {
     "gen_ai.conversation.name": _PII_CONVERSATION_NAME,
     "gen_ai.system_instructions": json.dumps(["obey ada@example.com"]),
+    "gen_ai.input.messages": json.dumps(
+        [{"role": "user", "content": "hi from ada@example.com"}]
+    ),
     "gen_ai.output.messages": json.dumps(
         [
             {
@@ -80,14 +85,15 @@ def _pii_proto_span(span_id: bytes) -> PbSpan:
 
 def _export_req(
     project_id: str,
-    span: PbSpan,
+    spans: list[PbSpan],
     policy: SensitiveDataPolicy,
 ) -> GenAIOTelExportReq:
     scope = InstrumentationScope()
     scope.name = "test_instrumentation"
     scope_spans = ScopeSpans()
     scope_spans.scope.CopyFrom(scope)
-    scope_spans.spans.append(span)
+    for span in spans:
+        scope_spans.spans.append(span)
     resource = PbResource()
     kv = KeyValue()
     kv.key = "service.owner"
@@ -125,7 +131,7 @@ def test_pii_policy_redacts_stored_span_details(ch_server) -> None:
     res = ch_server.genai_otel_export(
         _export_req(
             project_id,
-            _pii_proto_span(b"\x41" * 8),
+            [_pii_proto_span(b"\x41" * 8)],
             SensitiveDataPolicy.PII_V1,
         )
     )
@@ -141,6 +147,7 @@ def test_pii_policy_redacts_stored_span_details(ch_server) -> None:
     assert row.status_message == "card <CREDIT_CARD>"
     assert row.conversation_name == "chat with <EMAIL_ADDRESS>"
     assert row.system_instructions == ["obey <EMAIL_ADDRESS>"]
+    assert row.input_messages[0].content == "hi from <EMAIL_ADDRESS>"
     assert row.output_messages[0].content == "reply to <EMAIL_ADDRESS>"
     assert row.reasoning_content == "think <US_SSN>"
     assert row.tool_call_arguments == '{"query": "email <EMAIL_ADDRESS>"}'
@@ -180,7 +187,7 @@ def test_pii_policy_redacts_before_ingest_sampling(
     res = ch_server.genai_otel_export(
         _export_req(
             project_id,
-            _pii_proto_span(b"\x43" * 8),
+            [_pii_proto_span(b"\x43" * 8)],
             SensitiveDataPolicy.PII_V1,
         )
     )
@@ -198,7 +205,7 @@ def test_off_policy_stores_span_values_unchanged(ch_server) -> None:
     res = ch_server.genai_otel_export(
         _export_req(
             project_id,
-            _pii_proto_span(b"\x42" * 8),
+            [_pii_proto_span(b"\x42" * 8)],
             SensitiveDataPolicy.OFF,
         )
     )
@@ -211,3 +218,45 @@ def test_off_policy_stores_span_values_unchanged(ch_server) -> None:
     assert dump["resource"]["attributes"] == {"service": {"owner": _PII_RESOURCE_VALUE}}
     assert row.conversation_name == _PII_CONVERSATION_NAME
     assert row.reasoning_content == "think 123-45-6789"
+
+
+def test_redaction_failure_rejects_request_before_any_side_effect(
+    ch_server, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A span too deep to scan fails the whole request as RequestTooLarge.
+
+    The healthy sibling span parses first, yet extraction (which writes blob
+    Content files) must never start for it: every span is redacted before any
+    extraction begins, so nothing is stored and no side effect happens.
+    """
+    extraction_started = False
+    original_redact_credentials = agents_clickhouse.redact_credentials_from_span
+
+    def observe_extraction(span: Span) -> None:
+        nonlocal extraction_started
+        extraction_started = True
+        original_redact_credentials(span)
+
+    monkeypatch.setattr(
+        agents_clickhouse, "redact_credentials_from_span", observe_extraction
+    )
+
+    poison = _pii_proto_span(b"\x45" * 8)
+    deep_kv = KeyValue()
+    deep_kv.key = ".".join(["k"] * 2000)
+    deep_kv.value.string_value = "x"
+    poison.attributes.append(deep_kv)
+
+    project_id = make_project_id("span_pii_fail_closed")
+    with pytest.raises(RequestTooLarge, match="nesting limit"):
+        ch_server.genai_otel_export(
+            _export_req(
+                project_id,
+                [_pii_proto_span(b"\x44" * 8), poison],
+                SensitiveDataPolicy.PII_V1,
+            )
+        )
+
+    assert not extraction_started
+    stored = ch_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
+    assert stored.spans == []

--- a/tests/trace_server/test_spans_ingest_sampling.py
+++ b/tests/trace_server/test_spans_ingest_sampling.py
@@ -348,11 +348,14 @@ def test_sampler_off_is_inert(
     )
     assert res.accepted_spans == 2
     assert res.rejected_spans == 3
+    # Parse errors precede extraction errors: every span is parsed and
+    # redacted (pass 1) before any extraction runs (pass 2), so the disabled
+    # sampler now reports errors in the same order as the enabled one.
     assert res.error_message == "; ".join(
         [
             _conflict_error(conflict_a),
-            f"Extraction failed for span {extract_sid.hex()}: TypeError",
             _conflict_error(conflict_b),
+            f"Extraction failed for span {extract_sid.hex()}: TypeError",
         ]
     )
     assert len(_stored_spans(ch_server, project_id)) == 2

--- a/tests/trace_server/test_spans_ingest_sampling.py
+++ b/tests/trace_server/test_spans_ingest_sampling.py
@@ -348,9 +348,8 @@ def test_sampler_off_is_inert(
     )
     assert res.accepted_spans == 2
     assert res.rejected_spans == 3
-    # Parse errors precede extraction errors: every span is parsed and
-    # redacted (pass 1) before any extraction runs (pass 2), so the disabled
-    # sampler now reports errors in the same order as the enabled one.
+    # Parse errors precede extraction errors: all spans parse before any
+    # extraction runs, with or without the sampler.
     assert res.error_message == "; ".join(
         [
             _conflict_error(conflict_a),

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -874,8 +874,7 @@ class AgentWriteHandler:
                 errors.append(str(e))
                 return None
             # Outside the parse-error handler: a redaction failure rejects
-            # the whole request (RequestTooLarge for over-deep values) before
-            # sampling or any storage preparation.
+            # the whole request before sampling or any storage preparation.
             redact_pii_from_span(span, req.sensitive_data_policy)
             return span
 
@@ -921,9 +920,8 @@ class AgentWriteHandler:
 
         sampling = ingest_sampling.request_config()
 
-        # Pass 1: parse and redact everything (each shared resource once)
-        # before any extraction, so a redaction failure rejects the request
-        # before blob-strip Content writes happen for sibling spans.
+        # Pass 1: parse and redact everything, each shared resource once,
+        # before any extraction or blob-strip Content writes.
         parsed: list[tuple[Span, str | None]] = []
         byte_sizes: list[int] = []
         for processed_span in req.processed_spans:
@@ -945,8 +943,6 @@ class AgentWriteHandler:
                 if row is not None:
                     span_rows.append(row)
         else:
-            # Whole traces are kept or dropped per trace before any
-            # blob-strip/extraction work happens.
             decisions = ingest_sampling.decide_spans(
                 sampling, [span for span, _ in parsed], byte_sizes
             )

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -118,6 +118,7 @@ from weave.trace_server.query_builder.agent_query_builder import (
 from weave.trace_server.query_builder.agent_stats_query_builder import (
     build_agent_span_stats_query,
 )
+from weave.trace_server.sensitive_data.span_redaction import redact_pii_from_span
 from weave.trace_server.trace_server_common import (
     AgentFeedbackByTarget,
     group_agent_feedback_by_target,
@@ -869,6 +870,8 @@ class AgentWriteHandler:
 
         def extract_row(span: Span, run_id: str | None) -> AgentSpanCHInsertable | None:
             nonlocal accepted, rejected
+            # Outside the try: a scan failure rejects the whole request before any insert.
+            redact_pii_from_span(span, req.sensitive_data_policy)
             try:
                 # Before the blob strip: that step can move a value into file
                 # storage.

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -118,7 +118,10 @@ from weave.trace_server.query_builder.agent_query_builder import (
 from weave.trace_server.query_builder.agent_stats_query_builder import (
     build_agent_span_stats_query,
 )
-from weave.trace_server.sensitive_data.span_redaction import redact_pii_from_span
+from weave.trace_server.sensitive_data.span_redaction import (
+    redact_pii_from_resource,
+    redact_pii_from_span,
+)
 from weave.trace_server.trace_server_common import (
     AgentFeedbackByTarget,
     group_agent_feedback_by_target,
@@ -837,13 +840,16 @@ class AgentWriteHandler:
         The `messages` search table is populated by a ClickHouse
         materialized view off the spans table (migration 030).
 
-        Every parsed span is redacted before ingest sampling or any storage
-        preparation. When ingest sampling is enabled (rate < 1.0), whole
-        traces are then kept or dropped *before* the expensive
-        blob-strip/extraction steps run, so dropped traces never write Content
-        files. Dropped spans are neither stored nor returned (they never reach
-        the scoring Kafka emit) but still count as accepted — the client sees
-        an ordinary success. See agents/ingest_sampling.py (WB-36877).
+        Every span is parsed and redacted (each shared resource once) before
+        any extraction runs, so a redaction failure rejects the request, as
+        RequestTooLarge for over-deep values, before blob-strip Content
+        writes or inserts happen for any span in it. When ingest sampling is
+        enabled (rate < 1.0), whole traces are then kept or dropped *before*
+        the expensive blob-strip/extraction steps run, so dropped traces
+        never write Content files. Dropped spans are neither stored nor
+        returned (they never reach the scoring Kafka emit) but still count as
+        accepted — the client sees an ordinary success. See
+        agents/ingest_sampling.py (WB-36877).
         """
         span_rows: list[AgentSpanCHInsertable] = []
         accepted = 0
@@ -867,8 +873,9 @@ class AgentWriteHandler:
                 rejected += 1
                 errors.append(str(e))
                 return None
-            # Outside the parse-error handler: a detector failure rejects the
-            # whole request before sampling or any storage preparation.
+            # Outside the parse-error handler: a redaction failure rejects
+            # the whole request (RequestTooLarge for over-deep values) before
+            # sampling or any storage preparation.
             redact_pii_from_span(span, req.sensitive_data_policy)
             return span
 
@@ -913,33 +920,33 @@ class AgentWriteHandler:
             return genai_row
 
         sampling = ingest_sampling.request_config()
-        if not sampling.enabled:
-            # Sampler off (the default): the unmodified single-pass path.
-            for processed_span in req.processed_spans:
-                resource = Resource.from_proto(processed_span.resource_spans.resource)
-                for protobuf_scope_spans in processed_span.resource_spans.scope_spans:
-                    for protobuf_span in protobuf_scope_spans.spans:
-                        span = parse_span(protobuf_span, resource)
-                        if span is None:
-                            continue
-                        row = extract_row(span, processed_span.run_id)
-                        if row is not None:
-                            span_rows.append(row)
-        else:
-            # Pass 1: parse and redact everything, then decide keep/drop per
-            # trace before any blob-strip/extraction work happens.
-            parsed: list[tuple[Span, str | None]] = []
-            byte_sizes: list[int] = []
-            for processed_span in req.processed_spans:
-                resource = Resource.from_proto(processed_span.resource_spans.resource)
-                for protobuf_scope_spans in processed_span.resource_spans.scope_spans:
-                    for protobuf_span in protobuf_scope_spans.spans:
-                        span = parse_span(protobuf_span, resource)
-                        if span is None:
-                            continue
-                        parsed.append((span, processed_span.run_id))
+
+        # Pass 1: parse and redact everything (each shared resource once)
+        # before any extraction, so a redaction failure rejects the request
+        # before blob-strip Content writes happen for sibling spans.
+        parsed: list[tuple[Span, str | None]] = []
+        byte_sizes: list[int] = []
+        for processed_span in req.processed_spans:
+            resource = Resource.from_proto(processed_span.resource_spans.resource)
+            redact_pii_from_resource(resource, req.sensitive_data_policy)
+            for protobuf_scope_spans in processed_span.resource_spans.scope_spans:
+                for protobuf_span in protobuf_scope_spans.spans:
+                    span = parse_span(protobuf_span, resource)
+                    if span is None:
+                        continue
+                    parsed.append((span, processed_span.run_id))
+                    if sampling.enabled:
                         byte_sizes.append(protobuf_span.ByteSize())
 
+        if not sampling.enabled:
+            # Sampler off (the default): extract every parsed span.
+            for span, run_id in parsed:
+                row = extract_row(span, run_id)
+                if row is not None:
+                    span_rows.append(row)
+        else:
+            # Whole traces are kept or dropped per trace before any
+            # blob-strip/extraction work happens.
             decisions = ingest_sampling.decide_spans(
                 sampling, [span for span, _ in parsed], byte_sizes
             )

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -837,13 +837,13 @@ class AgentWriteHandler:
         The `messages` search table is populated by a ClickHouse
         materialized view off the spans table (migration 030).
 
-        When ingest sampling is enabled (rate < 1.0), spans are parsed first
-        and whole traces are kept or dropped *before* the expensive
-        blob-strip/extraction steps run, so dropped traces never write
-        Content files. Dropped spans are neither stored nor returned (they
-        never reach the scoring Kafka emit) but still count as accepted —
-        the client sees an ordinary success. See agents/ingest_sampling.py
-        (WB-36877).
+        Every parsed span is redacted before ingest sampling or any storage
+        preparation. When ingest sampling is enabled (rate < 1.0), whole
+        traces are then kept or dropped *before* the expensive
+        blob-strip/extraction steps run, so dropped traces never write Content
+        files. Dropped spans are neither stored nor returned (they never reach
+        the scoring Kafka emit) but still count as accepted — the client sees
+        an ordinary success. See agents/ingest_sampling.py (WB-36877).
         """
         span_rows: list[AgentSpanCHInsertable] = []
         accepted = 0
@@ -857,7 +857,7 @@ class AgentWriteHandler:
         def parse_span(protobuf_span: Any, resource: Resource) -> Span | None:
             nonlocal rejected
             try:
-                return Span.from_proto(protobuf_span, resource)
+                span = Span.from_proto(protobuf_span, resource)
             except AttributePathConflictError as e:
                 _record_ingest_failure(
                     failure_counts,
@@ -867,11 +867,13 @@ class AgentWriteHandler:
                 rejected += 1
                 errors.append(str(e))
                 return None
+            # Outside the parse-error handler: a detector failure rejects the
+            # whole request before sampling or any storage preparation.
+            redact_pii_from_span(span, req.sensitive_data_policy)
+            return span
 
         def extract_row(span: Span, run_id: str | None) -> AgentSpanCHInsertable | None:
             nonlocal accepted, rejected
-            # Outside the try: a scan failure rejects the whole request before any insert.
-            redact_pii_from_span(span, req.sensitive_data_policy)
             try:
                 # Before the blob strip: that step can move a value into file
                 # storage.
@@ -924,7 +926,7 @@ class AgentWriteHandler:
                         if row is not None:
                             span_rows.append(row)
         else:
-            # Pass 1 (cheap): parse everything, then decide keep/drop per
+            # Pass 1: parse and redact everything, then decide keep/drop per
             # trace before any blob-strip/extraction work happens.
             parsed: list[tuple[Span, str | None]] = []
             byte_sizes: list[int] = []

--- a/weave/trace_server/sensitive_data/call_redaction.py
+++ b/weave/trace_server/sensitive_data/call_redaction.py
@@ -3,15 +3,31 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, cast, overload
 
 from pydantic import BaseModel
 
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.errors import RequestTooLarge
 from weave.trace_server.sensitive_data.policy import SensitiveDataPolicy, pii_enabled
-from weave.trace_server.sensitive_data.walker import redact_pii_value
+from weave.trace_server.sensitive_data.walker import (
+    NESTING_LIMIT_MESSAGE,
+    redact_pii_value,
+)
 
 TModel = TypeVar("TModel", bound=BaseModel)
+
+
+@overload
+def redact_call_start(
+    req: tsi.CallStartReq, policy: SensitiveDataPolicy
+) -> tsi.CallStartReq: ...
+
+
+@overload
+def redact_call_start(
+    req: tsi.CallStartV2Req, policy: SensitiveDataPolicy
+) -> tsi.CallStartV2Req: ...
 
 
 def redact_call_start(
@@ -33,6 +49,18 @@ def redact_call_start(
     return req if start is req.start else req.model_copy(update={"start": start})
 
 
+@overload
+def redact_call_end(
+    req: tsi.CallEndReq, policy: SensitiveDataPolicy
+) -> tsi.CallEndReq: ...
+
+
+@overload
+def redact_call_end(
+    req: tsi.CallEndV2Req, policy: SensitiveDataPolicy
+) -> tsi.CallEndV2Req: ...
+
+
 def redact_call_end(
     req: tsi.CallEndReq | tsi.CallEndV2Req,
     policy: SensitiveDataPolicy,
@@ -42,36 +70,6 @@ def redact_call_end(
         return req
     end = _redact_fields(req.end, ("output", "summary", "exception"))
     return req if end is req.end else req.model_copy(update={"end": end})
-
-
-def redact_call_batch(
-    req: tsi.CallCreateBatchReq,
-    policy: SensitiveDataPolicy,
-) -> tsi.CallCreateBatchReq:
-    """Redact every item in the batch."""
-    if not pii_enabled(policy):
-        return req
-
-    def redact_item(
-        item: tsi.CallBatchStartMode | tsi.CallBatchEndMode,
-    ) -> tsi.CallBatchStartMode | tsi.CallBatchEndMode:
-        redacted_req: (
-            tsi.CallStartReq | tsi.CallStartV2Req | tsi.CallEndReq | tsi.CallEndV2Req
-        )
-        if isinstance(item, tsi.CallBatchStartMode):
-            redacted_req = redact_call_start(item.req, policy)
-        elif isinstance(item, tsi.CallBatchEndMode):
-            redacted_req = redact_call_end(item.req, policy)
-        else:
-            raise TypeError(f"Unknown call batch item type: {type(item).__name__}")
-        return (
-            item
-            if redacted_req is item.req
-            else item.model_copy(update={"req": redacted_req})
-        )
-
-    batch = _redact_sequence(req.batch, redact_item)
-    return req if batch is req.batch else req.model_copy(update={"batch": batch})
 
 
 def redact_calls_complete(
@@ -115,11 +113,14 @@ def redact_call_update(
 
 def _redact_fields(model: TModel, field_names: tuple[str, ...]) -> TModel:
     updates: dict[str, Any] = {}
-    for field_name in field_names:
-        original = getattr(model, field_name)
-        redacted = redact_pii_value(original)
-        if redacted is not original:
-            updates[field_name] = redacted
+    try:
+        for field_name in field_names:
+            original = getattr(model, field_name)
+            redacted = redact_pii_value(original)
+            if redacted is not original:
+                updates[field_name] = redacted
+    except RecursionError as error:
+        raise RequestTooLarge(NESTING_LIMIT_MESSAGE) from error
     return model if not updates else cast(TModel, model.model_copy(update=updates))
 
 

--- a/weave/trace_server/sensitive_data/call_redaction.py
+++ b/weave/trace_server/sensitive_data/call_redaction.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar, cast, overload
+from typing import Any, TypeVar, overload
 
 from pydantic import BaseModel
 
@@ -121,7 +121,7 @@ def _redact_fields(model: TModel, field_names: tuple[str, ...]) -> TModel:
                 updates[field_name] = redacted
     except RecursionError as error:
         raise RequestTooLarge(NESTING_LIMIT_MESSAGE) from error
-    return model if not updates else cast(TModel, model.model_copy(update=updates))
+    return model if not updates else model.model_copy(update=updates)
 
 
 TItem = TypeVar("TItem")

--- a/weave/trace_server/sensitive_data/call_redaction.py
+++ b/weave/trace_server/sensitive_data/call_redaction.py
@@ -1,0 +1,140 @@
+"""Field-selective credential and PII redaction for call writes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any, TypeVar, cast
+
+from pydantic import BaseModel
+
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.sensitive_data.policy import SensitiveDataPolicy, pii_enabled
+from weave.trace_server.sensitive_data.walker import redact_pii_value
+
+TModel = TypeVar("TModel", bound=BaseModel)
+
+
+def redact_call_start(
+    req: tsi.CallStartReq | tsi.CallStartV2Req,
+    policy: SensitiveDataPolicy,
+) -> tsi.CallStartReq | tsi.CallStartV2Req:
+    """Redact customer-authored fields on a v1 or v2 call start.
+
+    ``op_name`` is scanned as content: SDK-written op refs pass through the
+    walker's ref-preservation rule unchanged, so only free-string op names
+    from direct writers can be rewritten.
+    """
+    if not pii_enabled(policy):
+        return req
+    start = _redact_fields(
+        req.start,
+        ("inputs", "attributes", "otel_dump", "display_name", "op_name"),
+    )
+    return req if start is req.start else req.model_copy(update={"start": start})
+
+
+def redact_call_end(
+    req: tsi.CallEndReq | tsi.CallEndV2Req,
+    policy: SensitiveDataPolicy,
+) -> tsi.CallEndReq | tsi.CallEndV2Req:
+    """Redact customer-authored fields on a v1 or v2 call end."""
+    if not pii_enabled(policy):
+        return req
+    end = _redact_fields(req.end, ("output", "summary", "exception"))
+    return req if end is req.end else req.model_copy(update={"end": end})
+
+
+def redact_call_batch(
+    req: tsi.CallCreateBatchReq,
+    policy: SensitiveDataPolicy,
+) -> tsi.CallCreateBatchReq:
+    """Redact every item in the batch."""
+    if not pii_enabled(policy):
+        return req
+
+    def redact_item(
+        item: tsi.CallBatchStartMode | tsi.CallBatchEndMode,
+    ) -> tsi.CallBatchStartMode | tsi.CallBatchEndMode:
+        redacted_req: (
+            tsi.CallStartReq | tsi.CallStartV2Req | tsi.CallEndReq | tsi.CallEndV2Req
+        )
+        if isinstance(item, tsi.CallBatchStartMode):
+            redacted_req = redact_call_start(item.req, policy)
+        elif isinstance(item, tsi.CallBatchEndMode):
+            redacted_req = redact_call_end(item.req, policy)
+        else:
+            raise TypeError(f"Unknown call batch item type: {type(item).__name__}")
+        return (
+            item
+            if redacted_req is item.req
+            else item.model_copy(update={"req": redacted_req})
+        )
+
+    batch = _redact_sequence(req.batch, redact_item)
+    return req if batch is req.batch else req.model_copy(update={"batch": batch})
+
+
+def redact_calls_complete(
+    req: tsi.CallsUpsertCompleteReq,
+    policy: SensitiveDataPolicy,
+) -> tsi.CallsUpsertCompleteReq:
+    """Redact every completed call in the batch."""
+    if not pii_enabled(policy):
+        return req
+
+    def redact_item(
+        item: tsi.CompletedCallSchemaForInsert,
+    ) -> tsi.CompletedCallSchemaForInsert:
+        return _redact_fields(
+            item,
+            (
+                "inputs",
+                "attributes",
+                "otel_dump",
+                "display_name",
+                "op_name",
+                "output",
+                "summary",
+                "exception",
+            ),
+        )
+
+    batch = _redact_sequence(req.batch, redact_item)
+    return req if batch is req.batch else req.model_copy(update={"batch": batch})
+
+
+def redact_call_update(
+    req: tsi.CallUpdateReq,
+    policy: SensitiveDataPolicy,
+) -> tsi.CallUpdateReq:
+    """Redact the customer-authored display name on a call update."""
+    if not pii_enabled(policy):
+        return req
+    return _redact_fields(req, ("display_name",))
+
+
+def _redact_fields(model: TModel, field_names: tuple[str, ...]) -> TModel:
+    updates: dict[str, Any] = {}
+    for field_name in field_names:
+        original = getattr(model, field_name)
+        redacted = redact_pii_value(original)
+        if redacted is not original:
+            updates[field_name] = redacted
+    return model if not updates else cast(TModel, model.model_copy(update=updates))
+
+
+TItem = TypeVar("TItem")
+
+
+def _redact_sequence(
+    values: Sequence[TItem], redact: Callable[[TItem], TItem]
+) -> Sequence[TItem]:
+    redacted: list[TItem] | None = None
+    for index, original in enumerate(values):
+        item = redact(original)
+        if item is original:
+            continue
+        if redacted is None:
+            redacted = list(values)
+        redacted[index] = item
+    return values if redacted is None else redacted

--- a/weave/trace_server/sensitive_data/call_redaction.py
+++ b/weave/trace_server/sensitive_data/call_redaction.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar
 
 from pydantic import BaseModel
 
@@ -16,24 +16,15 @@ from weave.trace_server.sensitive_data.walker import (
 )
 
 TModel = TypeVar("TModel", bound=BaseModel)
-
-
-@overload
-def redact_call_start(
-    req: tsi.CallStartReq, policy: SensitiveDataPolicy
-) -> tsi.CallStartReq: ...
-
-
-@overload
-def redact_call_start(
-    req: tsi.CallStartV2Req, policy: SensitiveDataPolicy
-) -> tsi.CallStartV2Req: ...
+# Constrained so v1 and v2 requests keep their exact type for consumers.
+TCallStartReq = TypeVar("TCallStartReq", tsi.CallStartReq, tsi.CallStartV2Req)
+TCallEndReq = TypeVar("TCallEndReq", tsi.CallEndReq, tsi.CallEndV2Req)
 
 
 def redact_call_start(
-    req: tsi.CallStartReq | tsi.CallStartV2Req,
+    req: TCallStartReq,
     policy: SensitiveDataPolicy,
-) -> tsi.CallStartReq | tsi.CallStartV2Req:
+) -> TCallStartReq:
     """Redact customer-authored fields on a v1 or v2 call start.
 
     ``op_name`` is scanned as content: SDK-written op refs pass through the
@@ -49,22 +40,10 @@ def redact_call_start(
     return req if start is req.start else req.model_copy(update={"start": start})
 
 
-@overload
 def redact_call_end(
-    req: tsi.CallEndReq, policy: SensitiveDataPolicy
-) -> tsi.CallEndReq: ...
-
-
-@overload
-def redact_call_end(
-    req: tsi.CallEndV2Req, policy: SensitiveDataPolicy
-) -> tsi.CallEndV2Req: ...
-
-
-def redact_call_end(
-    req: tsi.CallEndReq | tsi.CallEndV2Req,
+    req: TCallEndReq,
     policy: SensitiveDataPolicy,
-) -> tsi.CallEndReq | tsi.CallEndV2Req:
+) -> TCallEndReq:
     """Redact customer-authored fields on a v1 or v2 call end."""
     if not pii_enabled(policy):
         return req

--- a/weave/trace_server/sensitive_data/span_redaction.py
+++ b/weave/trace_server/sensitive_data/span_redaction.py
@@ -1,0 +1,35 @@
+"""PII redaction for parsed OTel spans on the trace-ingest write path."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from weave.trace_server.sensitive_data.policy import SensitiveDataPolicy, pii_enabled
+from weave.trace_server.sensitive_data.walker import redact_pii_value
+
+if TYPE_CHECKING:
+    from weave.trace_server.opentelemetry.python_spans import Span
+
+
+def redact_pii_from_span(span: Span, policy: SensitiveDataPolicy) -> None:
+    """Redact supported PII in a span's customer-authored string values.
+
+    Mirrors ``redact_credentials_from_span``: covers all four attribute
+    containers a span carries (its own, its resource's, its events' and its
+    links') plus the status message, because ``raw_span_dump`` and every
+    attribute-derived column read from them. Must run before
+    ``strip_inline_blobs_from_span`` so values are scanned while still inline,
+    and before extraction so derived columns read the redacted span. Span and
+    event names, IDs, trace state, and timestamps are structural and stay
+    unchanged.
+    """
+    if not pii_enabled(policy):
+        return
+    span.attributes = redact_pii_value(span.attributes)
+    if span.resource is not None:
+        span.resource.attributes = redact_pii_value(span.resource.attributes)
+    for event in span.events:
+        event.attributes = redact_pii_value(event.attributes)
+    for link in span.links:
+        link.attributes = redact_pii_value(link.attributes)
+    span.status.message = redact_pii_value(span.status.message)

--- a/weave/trace_server/sensitive_data/span_redaction.py
+++ b/weave/trace_server/sensitive_data/span_redaction.py
@@ -4,32 +4,62 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from weave.trace_server.errors import RequestTooLarge
 from weave.trace_server.sensitive_data.policy import SensitiveDataPolicy, pii_enabled
-from weave.trace_server.sensitive_data.walker import redact_pii_value
+from weave.trace_server.sensitive_data.walker import (
+    NESTING_LIMIT_MESSAGE,
+    redact_pii_value,
+)
 
 if TYPE_CHECKING:
-    from weave.trace_server.opentelemetry.python_spans import Span
+    from weave.trace_server.opentelemetry.python_spans import Resource, Span
 
 
 def redact_pii_from_span(span: Span, policy: SensitiveDataPolicy) -> None:
     """Redact supported PII in a span's customer-authored string values.
 
-    Mirrors ``redact_credentials_from_span``: covers all four attribute
-    containers a span carries (its own, its resource's, its events' and its
-    links') plus the status message, because ``raw_span_dump`` and every
-    attribute-derived column read from them. Must run before
-    ``strip_inline_blobs_from_span`` so values are scanned while still inline,
-    and before extraction so derived columns read the redacted span. Span and
-    event names, IDs, trace state, and timestamps are structural and stay
-    unchanged.
+    Mirrors ``redact_credentials_from_span`` for the containers each span
+    owns: its own, its events' and its links' attributes, plus the status
+    message, because ``raw_span_dump`` and every attribute-derived column
+    read from them. The shared ``Resource`` is redacted once per
+    resource-spans group by ``redact_pii_from_resource``, not here, so a
+    5000-span group scans its resource once instead of 5000 times. Must run
+    before ``strip_inline_blobs_from_span`` so values are scanned while still
+    inline, and before extraction so derived columns read the redacted span.
+    Span and event names, IDs, trace state, and timestamps are structural and
+    stay unchanged. Non-string leaves (numbers, bools, bytes) pass through:
+    ``pii-v1`` scans strings and never decodes payloads.
+
+    Raises ``RequestTooLarge`` for values nested too deeply to scan, so the
+    caller rejects the request as a 413 instead of an untyped failure.
     """
     if not pii_enabled(policy):
         return
-    span.attributes = redact_pii_value(span.attributes)
-    if span.resource is not None:
-        span.resource.attributes = redact_pii_value(span.resource.attributes)
-    for event in span.events:
-        event.attributes = redact_pii_value(event.attributes)
-    for link in span.links:
-        link.attributes = redact_pii_value(link.attributes)
-    span.status.message = redact_pii_value(span.status.message)
+    try:
+        span.attributes = redact_pii_value(span.attributes)
+        for event in span.events:
+            event.attributes = redact_pii_value(event.attributes)
+        for link in span.links:
+            link.attributes = redact_pii_value(link.attributes)
+        span.status.message = redact_pii_value(span.status.message)
+    except RecursionError as error:
+        raise RequestTooLarge(NESTING_LIMIT_MESSAGE) from error
+
+
+def redact_pii_from_resource(
+    resource: Resource | None, policy: SensitiveDataPolicy
+) -> None:
+    """Redact the shared ``Resource`` once per resource-spans group.
+
+    Every span parsed from one ``ResourceSpans`` holds the same ``Resource``
+    object, so redacting it once here instead of inside the per-span pass
+    avoids rescanning identical attribute values for every span.
+
+    Raises ``RequestTooLarge`` for values nested too deeply to scan.
+    """
+    if resource is None or not pii_enabled(policy):
+        return
+    try:
+        resource.attributes = redact_pii_value(resource.attributes)
+    except RecursionError as error:
+        raise RequestTooLarge(NESTING_LIMIT_MESSAGE) from error

--- a/weave/trace_server/sensitive_data/span_redaction.py
+++ b/weave/trace_server/sensitive_data/span_redaction.py
@@ -25,17 +25,22 @@ def redact_pii_from_span(span: Span, policy: SensitiveDataPolicy) -> None:
     resource-spans group by ``redact_pii_from_resource``, not per span. Must
     run before ``strip_inline_blobs_from_span`` so values are scanned while
     still inline, and before extraction so derived columns read the redacted
-    span. Span and event names, IDs, trace state, and timestamps are
-    structural and stay unchanged. Non-string leaves (numbers, bools, bytes)
-    pass through: ``pii-v1`` scans strings and never decodes payloads.
+    span. Span and event names are scanned like content, so a PII-bearing
+    name is rewritten even though names feed the ``span_name``,
+    ``operation_name``, and ``agent_name`` grouping columns. IDs, trace
+    state, and timestamps are structural and stay unchanged. Non-string
+    leaves (numbers, bools, bytes) pass through: ``pii-v1`` scans strings and
+    never decodes payloads.
 
     Raises ``RequestTooLarge`` for values nested too deeply to scan.
     """
     if not pii_enabled(policy):
         return
     try:
+        span.name = redact_pii_value(span.name)
         span.attributes = redact_pii_value(span.attributes)
         for event in span.events:
+            event.name = redact_pii_value(event.name)
             event.attributes = redact_pii_value(event.attributes)
         for link in span.links:
             link.attributes = redact_pii_value(link.attributes)

--- a/weave/trace_server/sensitive_data/span_redaction.py
+++ b/weave/trace_server/sensitive_data/span_redaction.py
@@ -22,16 +22,14 @@ def redact_pii_from_span(span: Span, policy: SensitiveDataPolicy) -> None:
     owns: its own, its events' and its links' attributes, plus the status
     message, because ``raw_span_dump`` and every attribute-derived column
     read from them. The shared ``Resource`` is redacted once per
-    resource-spans group by ``redact_pii_from_resource``, not here, so a
-    5000-span group scans its resource once instead of 5000 times. Must run
-    before ``strip_inline_blobs_from_span`` so values are scanned while still
-    inline, and before extraction so derived columns read the redacted span.
-    Span and event names, IDs, trace state, and timestamps are structural and
-    stay unchanged. Non-string leaves (numbers, bools, bytes) pass through:
-    ``pii-v1`` scans strings and never decodes payloads.
+    resource-spans group by ``redact_pii_from_resource``, not per span. Must
+    run before ``strip_inline_blobs_from_span`` so values are scanned while
+    still inline, and before extraction so derived columns read the redacted
+    span. Span and event names, IDs, trace state, and timestamps are
+    structural and stay unchanged. Non-string leaves (numbers, bools, bytes)
+    pass through: ``pii-v1`` scans strings and never decodes payloads.
 
-    Raises ``RequestTooLarge`` for values nested too deeply to scan, so the
-    caller rejects the request as a 413 instead of an untyped failure.
+    Raises ``RequestTooLarge`` for values nested too deeply to scan.
     """
     if not pii_enabled(policy):
         return
@@ -52,8 +50,7 @@ def redact_pii_from_resource(
     """Redact the shared ``Resource`` once per resource-spans group.
 
     Every span parsed from one ``ResourceSpans`` holds the same ``Resource``
-    object, so redacting it once here instead of inside the per-span pass
-    avoids rescanning identical attribute values for every span.
+    object, so one pass here avoids rescanning it for every span.
 
     Raises ``RequestTooLarge`` for values nested too deeply to scan.
     """

--- a/weave/trace_server/sensitive_data/walker.py
+++ b/weave/trace_server/sensitive_data/walker.py
@@ -27,6 +27,9 @@ _DATA_URL_RE = re.compile(
     r"(?P<base64>;base64)?,(?P<data>[^\r\n]*)",
     re.ASCII | re.IGNORECASE,
 )
+# Shared with the call/span adapters, which translate the RecursionError a
+# too-deep native structure raises into the same RequestTooLarge.
+NESTING_LIMIT_MESSAGE = "Sensitive-data nesting limit exceeded"
 _EXTERNAL_REF_PREFIX = f"{ri.WEAVE_SCHEME}:///"
 _INTERNAL_REF_PREFIX = f"{ri.WEAVE_INTERNAL_SCHEME}:///"
 _PRIVATE_REF_PREFIX = f"{ri.WEAVE_PRIVATE_SCHEME}://///"
@@ -80,7 +83,7 @@ def _redact_json_string(value: str) -> str:
     except ValueError:
         return redact_pii_string(value)
     except RecursionError as error:
-        raise RequestTooLarge("Sensitive-data nesting limit exceeded") from error
+        raise RequestTooLarge(NESTING_LIMIT_MESSAGE) from error
     if not isinstance(parsed, (dict, list, str)):
         return redact_pii_string(value)
     redacted = redact_pii_value(parsed)

--- a/weave/trace_server/sensitive_data/walker.py
+++ b/weave/trace_server/sensitive_data/walker.py
@@ -27,8 +27,7 @@ _DATA_URL_RE = re.compile(
     r"(?P<base64>;base64)?,(?P<data>[^\r\n]*)",
     re.ASCII | re.IGNORECASE,
 )
-# Shared with the call/span adapters, which translate the RecursionError a
-# too-deep native structure raises into the same RequestTooLarge.
+# Shared with the call and span adapters' RecursionError translation.
 NESTING_LIMIT_MESSAGE = "Sensitive-data nesting limit exceeded"
 _EXTERNAL_REF_PREFIX = f"{ri.WEAVE_SCHEME}:///"
 _INTERNAL_REF_PREFIX = f"{ri.WEAVE_INTERNAL_SCHEME}:///"


### PR DESCRIPTION
## What

Apply the parent stack's `pii-v1` policy to supported Weave Call models and parsed Agent OTel spans.

The Call helpers become active when the Core integration PR pins this commit. Agent OTel ingest consumes the internal request policy in this PR. An omitted policy remains `off` through the parent request contract.

## Why

Supported PII must be replaced before covered trace content reaches persistence. The backend policy covers direct Call writes and Agent OTel writes without trusting client-side redaction.

## How

- Add field-selective adapters for Call start, end, complete, and display-name update models, typed with constrained TypeVars so v1 and v2 requests keep their exact type. Structural IDs and project names remain unchanged. The batch endpoint keeps its Core-side adapter over Core's local batch types.
- Redact Agent span and event names, span, event, and link attributes, and the status message per span, and each shared resource once per resource-spans group. A PII-bearing name changes `span_name`, `operation_name`, and `agent_name` grouping; keeping PII out of storage wins that trade-off.
- Parse and redact every span in a request before ingest sampling, credential replacement, blob stripping, derived-column extraction, or insertion. The sampler sees redacted values even for spans it later drops, and a failing span cannot leave Content files behind for its siblings.
- Reject a value nested too deeply to scan as `RequestTooLarge` (HTTP 413). Any other detector failure also fails the complete request before any write.
- Leave standard OTel, completions, evaluation and scoring workers, objects, files, existing stored data, and operational telemetry unchanged.

## Testing

- 45 focused tests passed across the sensitive-data adapters, Agent policy contract, ingest sampler, and ClickHouse-backed Agent ingest path, including regression coverage for redaction before sampling at a zero rate, request rejection with no stored rows or extraction side effects, and name redaction end to end.
- The full repo lint session passes (`nox -s lint`: ruff, pyright, mypy, ty, import-linter).

## Anything Else

- Parents: https://github.com/wandb/weave/pull/7788 and https://github.com/wandb/weave/pull/7789 (merged). Core activation: [wandb/core#50579](https://github.com/wandb/core/pull/50579).
- Request logging and Datadog, OpenTelemetry, or Sentry operational telemetry are not scrubbed by this PR.
- No runtime dependency, migration, permission change, or public schema change.
