### PR TITLE
fix(weave): enforce calls usage limits per trace

### DIFF
--- a/sdks/node/src/generated/traceServerApi.ts
+++ b/sdks/node/src/generated/traceServerApi.ts
@@ -2342,9 +2342,8 @@ export type CallsUpsertCompleteRes = object;
  * This endpoint returns usage metrics for each requested root call, where each
  * root's metrics include the sum of its own usage plus all descendants' usage.
  *
- * Note: All matching calls are loaded into memory for aggregation. For very large
- * result sets (>10k calls), consider batching root call IDs or using narrower
- * filters at the application layer.
+ * Note: Matching calls are loaded into memory for aggregation. The per-trace
+ * limit prevents any one trace from creating an unbounded result set.
  */
 export interface CallsUsageReq {
   /** Project Id */
@@ -2362,7 +2361,7 @@ export interface CallsUsageReq {
   include_costs?: boolean;
   /**
    * Limit
-   * Maximum number of calls to process across all traces. Acts as a safety limit to prevent unbounded memory usage.
+   * Maximum number of calls to process per trace. Acts as a safety limit to prevent unbounded memory usage.
    * @default 10000
    */
   limit?: number;

--- a/sdks/node/weave.openapi.json
+++ b/sdks/node/weave.openapi.json
@@ -11864,6 +11864,7 @@
           },
           "limit": {
             "type": "integer",
+            "minimum": 1.0,
             "title": "Limit",
             "description": "Maximum number of calls to process per trace. Acts as a safety limit to prevent unbounded memory usage.",
             "default": 10000

--- a/sdks/node/weave.openapi.json
+++ b/sdks/node/weave.openapi.json
@@ -11865,7 +11865,7 @@
           "limit": {
             "type": "integer",
             "title": "Limit",
-            "description": "Maximum number of calls to process across all traces. Acts as a safety limit to prevent unbounded memory usage.",
+            "description": "Maximum number of calls to process per trace. Acts as a safety limit to prevent unbounded memory usage.",
             "default": 10000
           }
         },
@@ -11876,7 +11876,7 @@
           "call_ids"
         ],
         "title": "CallsUsageReq",
-        "description": "Request to compute aggregated usage for multiple root calls.\n\nThis endpoint returns usage metrics for each requested root call, where each\nroot's metrics include the sum of its own usage plus all descendants' usage.\n\nNote: All matching calls are loaded into memory for aggregation. For very large\nresult sets (>10k calls), consider batching root call IDs or using narrower\nfilters at the application layer."
+        "description": "Request to compute aggregated usage for multiple root calls.\n\nThis endpoint returns usage metrics for each requested root call, where each\nroot's metrics include the sum of its own usage plus all descendants' usage.\n\nNote: Matching calls are loaded into memory for aggregation. The per-trace\nlimit prevents any one trace from creating an unbounded result set."
       },
       "CallsUsageRes": {
         "properties": {

--- a/tests/trace_server/test_trace_usage.py
+++ b/tests/trace_server/test_trace_usage.py
@@ -3,6 +3,7 @@ import uuid
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
@@ -639,6 +640,16 @@ def test_calls_usage_rolls_up_descendants(client: weave_client.WeaveClient) -> N
                 limit=2,
             )
         )
+
+
+def test_calls_usage_rejects_non_positive_limit() -> None:
+    for invalid_limit in (0, -1):
+        with pytest.raises(ValidationError):
+            tsi.CallsUsageReq(
+                project_id="entity/project",
+                call_ids=["root"],
+                limit=invalid_limit,
+            )
 
 
 def test_calls_usage_include_costs_flag(client: weave_client.WeaveClient) -> None:

--- a/tests/trace_server/test_trace_usage.py
+++ b/tests/trace_server/test_trace_usage.py
@@ -7,6 +7,7 @@ import pytest
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server import usage_utils
+from weave.trace_server.errors import InvalidRequest
 
 _REQUIRED_COST_FIELDS = (
     "prompt_tokens",
@@ -616,6 +617,7 @@ def test_calls_usage_rolls_up_descendants(client: weave_client.WeaveClient) -> N
         tsi.CallsUsageReq(
             project_id=project_id,
             call_ids=[root_id, root_id_two],
+            limit=3,
         )
     )
 
@@ -628,6 +630,15 @@ def test_calls_usage_rolls_up_descendants(client: weave_client.WeaveClient) -> N
     assert root_two_usage.prompt_tokens == 2
     assert root_two_usage.completion_tokens == 1
     assert root_two_usage.total_tokens == 3
+
+    with pytest.raises(InvalidRequest, match="exceeds the calls_usage limit"):
+        client.server.calls_usage(
+            tsi.CallsUsageReq(
+                project_id=project_id,
+                call_ids=[root_id, root_id_two],
+                limit=2,
+            )
+        )
 
 
 def test_calls_usage_include_costs_flag(client: weave_client.WeaveClient) -> None:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1808,6 +1808,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             }
             return tsi.CallsUsageRes(call_usage=root_usage, unfinished_call_ids=[])
 
+        # Fetch one row beyond each per-trace cap so oversized traces fail.
+        combined_limit = (req.limit + 1) * len(trace_ids)
+
         # Stream all calls in those traces with minimal columns for aggregation.
         calls = self.calls_query_stream(
             tsi.CallsQueryReq(
@@ -1815,13 +1818,15 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 filter=tsi.CallsFilter(trace_ids=list(trace_ids)),
                 columns=["id", "parent_id", "summary"],
                 include_costs=req.include_costs,
-                limit=req.limit,
+                limit=combined_limit,
             )
         )
 
         usage_calls: list[usage_utils.UsageCall] = []
         unfinished_call_ids: set[str] = set()
+        calls_per_trace: defaultdict[str, int] = defaultdict(int)
         for call in calls:
+            calls_per_trace[call.trace_id] += 1
             usage_calls.append(
                 usage_utils.UsageCall(
                     id=call.id,
@@ -1831,6 +1836,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             )
             if call.ended_at is None:
                 unfinished_call_ids.add(call.id)
+
+        if any(call_count > req.limit for call_count in calls_per_trace.values()):
+            raise InvalidRequest(
+                "At least one requested trace exceeds the calls_usage limit; "
+                "increase limit or request fewer roots"
+            )
 
         # Aggregate usage bottom-up to include descendants.
         aggregated_usage = usage_utils.aggregate_usage_with_descendants(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1808,7 +1808,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             }
             return tsi.CallsUsageRes(call_usage=root_usage, unfinished_call_ids=[])
 
-        # Fetch one row beyond each per-trace cap so oversized traces fail.
+        # Scale per trace to avoid truncation; +1 detects oversized traces.
         combined_limit = (req.limit + 1) * len(trace_ids)
 
         # Stream all calls in those traces with minimal columns for aggregation.

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -2713,7 +2713,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             }
             return tsi.CallsUsageRes(call_usage=root_usage, unfinished_call_ids=[])
 
-        # ---- Fetch every call in those traces and aggregate usage with descendants ----
+        # Scale per trace to avoid truncation; +1 detects oversized traces.
         calls = self.calls_query_stream(
             tsi.CallsQueryReq(
                 project_id=req.project_id,

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -2720,13 +2720,15 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                 filter=tsi.CallsFilter(trace_ids=list(trace_ids)),
                 columns=["id", "parent_id", "summary"],
                 include_costs=req.include_costs,
-                limit=req.limit,
+                limit=(req.limit + 1) * len(trace_ids),
             )
         )
 
         usage_calls: list[usage_utils.UsageCall] = []
         unfinished_call_ids: set[str] = set()
+        calls_per_trace: dict[str, int] = {}
         for call in calls:
+            calls_per_trace[call.trace_id] = calls_per_trace.get(call.trace_id, 0) + 1
             usage_calls.append(
                 usage_utils.UsageCall(
                     id=call.id,
@@ -2736,6 +2738,12 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
             )
             if call.ended_at is None:
                 unfinished_call_ids.add(call.id)
+
+        if any(call_count > req.limit for call_count in calls_per_trace.values()):
+            raise InvalidRequest(
+                "At least one requested trace exceeds the calls_usage limit; "
+                "increase limit or request fewer roots"
+            )
 
         aggregated_usage = usage_utils.aggregate_usage_with_descendants(
             usage_calls, req.include_costs

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -4120,6 +4120,7 @@ class CallsUsageReq(BaseModelStrict):
     )
     limit: int = Field(
         default=10_000,
+        ge=1,
         description="Maximum number of calls to process per trace. Acts as a safety limit to prevent unbounded memory usage.",
     )
 

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -4106,9 +4106,8 @@ class CallsUsageReq(BaseModelStrict):
     This endpoint returns usage metrics for each requested root call, where each
     root's metrics include the sum of its own usage plus all descendants' usage.
 
-    Note: All matching calls are loaded into memory for aggregation. For very large
-    result sets (>10k calls), consider batching root call IDs or using narrower
-    filters at the application layer.
+    Note: Matching calls are loaded into memory for aggregation. The per-trace
+    limit prevents any one trace from creating an unbounded result set.
     """
 
     project_id: str
@@ -4121,7 +4120,7 @@ class CallsUsageReq(BaseModelStrict):
     )
     limit: int = Field(
         default=10_000,
-        description="Maximum number of calls to process across all traces. Acts as a safety limit to prevent unbounded memory usage.",
+        description="Maximum number of calls to process per trace. Acts as a safety limit to prevent unbounded memory usage.",
     )
 
 


### PR DESCRIPTION
## Summary
- `/calls/usage` applies `limit` per trace, so bounded traces are aggregated completely even when their combined call count exceeds `limit`.
- The combined query cap intentionally scales as `(limit + 1) * trace_count`: scaling avoids silent cross-trace truncation, and the extra row detects an oversized trace.
- A trace with more than `limit` calls raises `InvalidRequest`; `limit` values below 1 fail request validation.
- Public contract change: `CallsUsageReq.limit` now means calls per trace; OpenAPI and Node types are updated.

## Testing
ClickHouse and fake-backend calls-usage tests, including multi-trace aggregation, oversized traces, and non-positive limits; Node CJS and ESM typechecks and Prettier.
