### PR TITLE
fix(weave): enable storage joins for selected columns

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -2297,6 +2297,107 @@ def test_storage_size_fields():
     )
 
 
+def test_selecting_storage_size_fields_enables_required_joins() -> None:
+    """Storage pseudo-columns must activate the joins that materialize them."""
+    # Reproduce the prod calls_complete two-pass query: the column is projected
+    # directly without the redundant include_storage_size request flag.
+    cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
+    cq.add_field("id")
+    cq.add_field("attributes")
+    cq.add_field("storage_size_bytes")
+    cq.add_order("started_at", "asc")
+    cq.set_limit(1000)
+
+    assert cq.include_storage_size is True
+    assert_sql(
+        cq,
+        """
+        WITH filtered_calls AS (
+            SELECT calls_complete.id AS id
+            FROM calls_complete
+            PREWHERE calls_complete.project_id = {pb_1:String}
+            WHERE 1
+                AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
+            ORDER BY calls_complete.started_at ASC
+            LIMIT 1000
+        )
+        SELECT
+            calls_complete.id AS id,
+            calls_complete.attributes_dump AS attributes_dump,
+            storage_size_tbl.storage_size_bytes AS storage_size_bytes
+        FROM calls_complete
+        LEFT JOIN (
+            SELECT
+                id,
+                sum(COALESCE(attributes_size_bytes, 0) + COALESCE(inputs_size_bytes, 0) + COALESCE(output_size_bytes, 0) + COALESCE(summary_size_bytes, 0) + COALESCE(otel_size_bytes, 0)) AS storage_size_bytes
+            FROM calls_complete_stats
+            WHERE project_id = {pb_1:String}
+            GROUP BY id
+        ) AS storage_size_tbl
+        ON calls_complete.id = storage_size_tbl.id
+        PREWHERE calls_complete.project_id = {pb_1:String}
+        WHERE (calls_complete.id IN filtered_calls)
+        ORDER BY calls_complete.started_at ASC
+        """,
+        {"pb_0": SENTINEL_EPOCH, "pb_1": "project"},
+    )
+
+    # The trace-level pseudo-column has the same field-to-join contract.
+    cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
+    cq.add_field("id")
+    cq.add_field("total_storage_size_bytes")
+
+    assert cq.include_total_storage_size is True
+    assert_sql(
+        cq,
+        """
+        WITH storage_scope_ids AS (
+            SELECT calls_complete.id AS id
+            FROM calls_complete
+            PREWHERE calls_complete.project_id = {pb_1:String}
+            WHERE 1
+                AND (calls_complete.deleted_at = {pb_0:DateTime64(3)}))
+        SELECT
+            calls_complete.id AS id,
+            CASE
+                WHEN calls_complete.parent_id = {pb_2:String}
+                THEN rolled_up_cms.total_storage_size_bytes
+                ELSE NULL
+            END AS total_storage_size_bytes
+        FROM calls_complete
+        LEFT JOIN (
+            SELECT
+                trace_id,
+                sum(COALESCE(attributes_size_bytes, 0) + COALESCE(inputs_size_bytes, 0) + COALESCE(output_size_bytes, 0) + COALESCE(summary_size_bytes, 0) + COALESCE(otel_size_bytes, 0)) AS total_storage_size_bytes
+            FROM calls_complete_stats
+            WHERE project_id = {pb_1:String}
+                AND id IN (
+                    SELECT id
+                    FROM calls_complete
+                    WHERE project_id = {pb_1:String}
+                        AND trace_id IN (
+                            SELECT trace_id
+                            FROM calls_complete
+                            WHERE project_id = {pb_1:String}
+                                AND id IN storage_scope_ids
+                        )
+                )
+            GROUP BY trace_id
+        ) AS rolled_up_cms
+        ON calls_complete.trace_id = rolled_up_cms.trace_id
+        PREWHERE calls_complete.project_id = {pb_1:String}
+        WHERE 1
+            AND (calls_complete.deleted_at = {pb_3:DateTime64(3)})
+        """,
+        {
+            "pb_0": SENTINEL_EPOCH,
+            "pb_1": "project",
+            "pb_2": "",
+            "pb_3": SENTINEL_EPOCH,
+        },
+    )
+
+
 def test_storage_size_includes_otel_dump_bytes():
     """Per-call storage_size_bytes must include OTel dump bytes, like project stats do.
 

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -910,6 +910,10 @@ class CallsQuery(BaseModel):
         if name in self.select_fields:
             return self
         self.select_fields.append(name)
+        if name.field == "storage_size_bytes":
+            self.include_storage_size = True
+        elif name.field == "total_storage_size_bytes":
+            self.include_total_storage_size = True
         return self
 
     def add_condition(self, operand: "tsi_query.Operand") -> "CallsQuery":


### PR DESCRIPTION
## Summary
- A `/calls/stream_query` request that selected `storage_size_bytes` through `columns` could emit `storage_size_tbl.storage_size_bytes` without the stats join, producing ClickHouse `UNKNOWN_IDENTIFIER` in production. Selecting either storage pseudo-column now activates its required join.
- The split contract came from #3998: field selection and join activation were independent. #7486 later routed the affected `calls_complete` read through `filtered_calls`, which is the SQL shape seen in this incident.
- Coverage gap in #3998: the builder test always paired the field with `include_storage_size=True`, the ClickHouse server test mocked the builder, and client coverage was SQLite-only. #7486 covered two-pass trace-total storage, not per-call storage selected through `columns`.

## Testing
Regression test compares the complete SQL and parameter maps for per-call two-pass and trace-total `calls_complete` projections without include flags. Full query-builder file and pre-push checks pass.