### PR TITLE
feat(weave): add record_error to Python GenAI spans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -561,6 +561,9 @@ deterministic.
   arguments/result. Integrations populate them through `SubAgent.record()` so
   `_build_attrs()` applies `include_content` and PII redaction; do not write
   those content attributes directly with `set_attributes()`.
+- `Tool`, `LLM`, `SubAgent`, and `Turn` expose `record_error(error)` to mark a
+  failure without ending the span. It derives `error.type` from the exception;
+  call `end()` separately. Context managers do both for escaping exceptions.
 - Mypy requires explicit `return None` paths in functions annotated with
   `T | None`; bare `return` and implicit fallthrough trigger return-value
   errors.

--- a/tests/conversation/test_conversation_otel.py
+++ b/tests/conversation/test_conversation_otel.py
@@ -1264,6 +1264,7 @@ class TestErrorRecording:
         )
         assert chat_span.status.status_code == StatusCode.ERROR
         assert "LLM call failed" in chat_span.status.description
+        assert chat_span.attributes["error.type"] == "ValueError"
         assert len(chat_span.events) >= 1
         assert chat_span.events[0].name == "exception"
 

--- a/tests/conversation/test_span_attributes.py
+++ b/tests/conversation/test_span_attributes.py
@@ -1,9 +1,7 @@
-"""Tests for ``set_attributes`` and ``add_event``.
+"""Tests for the public span mutation methods.
 
-Both live on ``_SpanBase`` so every span class (Tool, LLM, SubAgent, Turn)
-gets identical behavior. Tests are parametrized across the four span
-classes; the two methods get one test each so each test reads
-top-to-bottom without indirection.
+They live on ``_SpanBase`` so every span class (Tool, LLM, SubAgent, Turn)
+gets identical behavior. Tests are parametrized across all four classes.
 """
 
 from __future__ import annotations
@@ -12,6 +10,7 @@ import logging
 
 import pytest
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 
 from weave.conversation.conversation import (
     LLM,
@@ -85,6 +84,31 @@ def test_set_attributes_accepts_sequence_value(
 
 
 # ---------------------------------------------------------------------------
+# record_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
+)
+def test_record_error_marks_span_failed_without_ending(
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
+) -> None:
+    with Conversation(conversation_id="test-conversation"), factory() as span_obj:
+        assert span_obj.record_error(ValueError("invalid response")) is span_obj
+        span_obj.set_attributes({"weave.after_error": True})
+
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert finished_span.attributes["error.type"] == "ValueError"
+    assert finished_span.attributes["weave.after_error"] is True
+    assert finished_span.status.status_code == StatusCode.ERROR
+    assert finished_span.status.description == "invalid response"
+    assert len(finished_span.events) == 1
+    assert finished_span.events[0].name == "exception"
+    assert finished_span.events[0].attributes["exception.type"] == "ValueError"
+
+
+# ---------------------------------------------------------------------------
 # add_event
 # ---------------------------------------------------------------------------
 
@@ -147,37 +171,42 @@ def test_add_event_emits_deprecation_warning(
 def test_returns_self_for_chaining(
     otel_spans: InMemorySpanExporter, _class_label, factory, _span_name
 ) -> None:
-    """Both mutators return ``self`` for fluent chaining on a live span."""
+    """Span mutation methods return ``self`` for fluent chaining."""
     with Conversation(conversation_id="test-conversation"), factory() as span_obj:
         assert span_obj.set_attributes({"key": "value"}) is span_obj
+        assert span_obj.record_error(RuntimeError("boom")) is span_obj
         assert span_obj.add_event("event-name") is span_obj
 
 
 def test_warns_when_span_not_started(
     caplog: pytest.LogCaptureFixture, otel_spans: InMemorySpanExporter
 ) -> None:
-    """Both mutators warn and emit no span when called before ``with``."""
+    """Span mutation methods warn and emit no span before ``with``."""
     caplog.set_level(logging.WARNING, logger="weave.conversation.conversation")
     tool = Tool(name="test-tool")
     tool.set_attributes({"weave.first": "one"})
+    tool.record_error(RuntimeError("boom"))
     tool.add_event("weave.evt")
     messages = [record.message for record in caplog.records]
     assert any("set_attributes" in m and "span not started" in m for m in messages)
+    assert any("record_error" in m and "span not started" in m for m in messages)
     assert any("add_event" in m and "span not started" in m for m in messages)
     assert len(otel_spans.get_finished_spans()) == 0
 
 
 def test_warns_when_span_already_ended(caplog: pytest.LogCaptureFixture) -> None:
-    """Both mutators warn when called after ``end()``."""
+    """Span mutation methods warn when called after ``end()``."""
     caplog.set_level(logging.WARNING, logger="weave.conversation.conversation")
     with Conversation(conversation_id="test-conversation"):
         tool = Tool(name="test-tool")
         with tool:
             pass
         tool.set_attributes({"weave.first": "one"})
+        tool.record_error(RuntimeError("boom"))
         tool.add_event("weave.evt")
     messages = [record.message for record in caplog.records]
     assert any("set_attributes" in m and "span already ended" in m for m in messages)
+    assert any("record_error" in m and "span already ended" in m for m in messages)
     assert any("add_event" in m and "span already ended" in m for m in messages)
 
 

--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
@@ -451,7 +451,7 @@ async def test_subagent_query_content_is_pii_redacted_otel(
             True,
             StatusCode.ERROR,
             "background subagent failed",
-            "claude_agent_sdk.task_failed",
+            "RuntimeError",
             id="failed-agent-direct-tool-use-id",
         ),
         pytest.param(
@@ -462,7 +462,7 @@ async def test_subagent_query_content_is_pii_redacted_otel(
             False,
             StatusCode.ERROR,
             "background subagent stopped",
-            "claude_agent_sdk.task_stopped",
+            "RuntimeError",
             id="stopped-legacy-task-task-id-fallback",
         ),
     ],

--- a/weave/conversation/conversation.py
+++ b/weave/conversation/conversation.py
@@ -226,13 +226,6 @@ class _SpanBase(BaseModel):
             otel_context.detach(self._otel_token)
             self._otel_token = None
 
-    def _record_otel_error(self, exc_val: BaseException) -> None:
-        """Record an exception on the OTel span."""
-        if not _OTEL_AVAILABLE or self._otel_span is None:
-            return
-        self._otel_span.set_status(StatusCode.ERROR, str(exc_val))
-        self._otel_span.record_exception(exc_val)
-
     def _recording_span(self, operation: str, key: str | list[str]) -> _OTelSpan | None:
         """Return the OTel span if it's recording, else ``None``.
 
@@ -258,13 +251,25 @@ class _SpanBase(BaseModel):
             return None
         if not self._otel_span.is_recording():
             logger.warning(
-                "%s(%s) ignored: span already ended. Set attributes before "
+                "%s(%s) ignored: span already ended. Call it before "
                 "exiting `with` or calling .end().",
                 operation,
                 key_repr,
             )
             return None
         return self._otel_span
+
+    def record_error(self, error: BaseException) -> Self:
+        """Record a failure without ending the span; call ``end()`` when ready."""
+        if span := self._recording_span("record_error", type(error).__name__):
+            error_class = type(error)
+            error_type = error_class.__qualname__
+            if error_class.__module__ != "builtins":
+                error_type = f"{error_class.__module__}.{error_type}"
+            span.set_attribute("error.type", error_type)
+            span.set_status(StatusCode.ERROR, str(error))
+            span.record_exception(error)
+        return self
 
     def set_attributes(self, attributes: dict[str, Any]) -> Self:
         """Stamp arbitrary OTel attributes on this span.
@@ -438,7 +443,7 @@ class Tool(_SpanBase):
         exc_tb: types.TracebackType | None,
     ) -> Literal[False]:
         if exc_val is not None:
-            self._record_otel_error(exc_val)
+            self.record_error(exc_val)
         self.end()
         return False
 
@@ -755,7 +760,7 @@ class LLM(_SpanBase):
         exc_tb: types.TracebackType | None,
     ) -> Literal[False]:
         if exc_val is not None:
-            self._record_otel_error(exc_val)
+            self.record_error(exc_val)
         self.end()
         return False
 
@@ -1014,7 +1019,7 @@ class SubAgent(_SpanBase):
         exc_tb: types.TracebackType | None,
     ) -> Literal[False]:
         if exc_val is not None:
-            self._record_otel_error(exc_val)
+            self.record_error(exc_val)
         self.end()
         return False
 
@@ -1278,7 +1283,7 @@ class Turn(_SpanBase):
         exc_tb: types.TracebackType | None,
     ) -> Literal[False]:
         if exc_val is not None:
-            self._record_otel_error(exc_val)
+            self.record_error(exc_val)
         self.end()
         return False
 

--- a/weave/integrations/claude_agent_sdk/otel_integration.py
+++ b/weave/integrations/claude_agent_sdk/otel_integration.py
@@ -459,14 +459,9 @@ def _finish_task_notification(data: dict[str, Any], state: _TurnState) -> None:
         tool_call_result=summary,
     )
     if status:
-        attributes = {_TASK_STATUS_ATTRIBUTE: status}
-        if status in _TASK_ERROR_STATUSES:
-            attributes["error.type"] = f"claude_agent_sdk.task_{status}"
-        open_subagent.span.set_attributes(attributes)
+        open_subagent.span.set_attributes({_TASK_STATUS_ATTRIBUTE: status})
     if status in _TASK_ERROR_STATUSES:
-        open_subagent.span._record_otel_error(  # pyright: ignore[reportPrivateUsage]
-            RuntimeError(f"background subagent {status}")
-        )
+        open_subagent.span.record_error(RuntimeError(f"background subagent {status}"))
     open_subagent.span.end()
     del state.open_subagents[tool_use_id]
     _discard_task_mappings(tool_use_id, state)
@@ -595,7 +590,7 @@ def _process_message(msg: Any, state: _TurnState) -> str | None:
                     tool_call_result=result_text,
                 )
                 if block.is_error:
-                    open_subagent.span._record_otel_error(  # pyright: ignore[reportPrivateUsage]
+                    open_subagent.span.record_error(
                         RuntimeError("subagent reported an error")
                     )
                 open_subagent.span.end()
@@ -609,9 +604,7 @@ def _process_message(msg: Any, state: _TurnState) -> str | None:
             with open_tool:
                 open_tool.result = result_text
                 if block.is_error:
-                    open_tool._record_otel_error(  # pyright: ignore[reportPrivateUsage]
-                        RuntimeError("tool reported an error")
-                    )
+                    open_tool.record_error(RuntimeError("tool reported an error"))
         return None
 
     if isinstance(msg, ResultMessage):
@@ -644,9 +637,7 @@ def _finalize_turn(state: _TurnState) -> None:
         else None,
     )
     if state.is_error:
-        state.turn._record_otel_error(  # pyright: ignore[reportPrivateUsage]
-            RuntimeError(state.final_text or "agent run failed")
-        )
+        state.turn.record_error(RuntimeError(state.final_text or "agent run failed"))
 
 
 def _start_tracked_turn(


### PR DESCRIPTION
## Summary

- expose `record_error(error)` on Python `Tool`, `LLM`, `SubAgent`, and `Turn` spans
- derive `error.type` from the exception and record the failure without ending the span
- migrate the Claude Agent SDK integration off the private error helper

Companion to #7738.

## Testing

- 380 Conversation and Claude Agent SDK tests passed
- Ruff, format, Ty, Pyright, and Mypy passed