### PR TITLE
fix(weave): map ClickHouse stream failures to 502 and read structured error codes

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -1856,7 +1856,7 @@ def test_is_transient_ch_error():
     assert not _is_transient_ch_error(DatabaseError(""))
     assert not _is_transient_ch_error(ConnectionError("not a db error"))
 
-    # clickhouse-connect >= 1.3 sets a structured `code`; it is authoritative.
+    # clickhouse-connect >= 1.3 sets an int `code`.
     coded = DatabaseError("replica sync pending")
     coded.code = 999
     assert _is_transient_ch_error(coded)

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -1856,6 +1856,19 @@ def test_is_transient_ch_error():
     assert not _is_transient_ch_error(DatabaseError(""))
     assert not _is_transient_ch_error(ConnectionError("not a db error"))
 
+    # clickhouse-connect >= 1.3 sets a structured `code`; it is authoritative.
+    coded = DatabaseError("replica sync pending")
+    coded.code = 999
+    assert _is_transient_ch_error(coded)
+    coded.code = 62
+    assert not _is_transient_ch_error(coded)
+    # A non-int code attr falls back to message parsing.
+    coded.code = "999"
+    assert not _is_transient_ch_error(DatabaseError("no code here"))
+    coded_msg = DatabaseError("Code: 517. DB::Exception: ...")
+    coded_msg.code = None
+    assert _is_transient_ch_error(coded_msg)
+
 
 def test_split_migration_sql() -> None:
     """One dense case exercising every rule the splitter cares about.

--- a/tests/trace_server/test_errors.py
+++ b/tests/trace_server/test_errors.py
@@ -2,6 +2,9 @@ from collections.abc import Callable
 
 import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError as CHDatabaseError
+from clickhouse_connect.driver.exceptions import (
+    StreamFailureError as CHStreamFailureError,
+)
 from gql.transport.exceptions import TransportServerError
 from pydantic import ValidationError
 
@@ -40,6 +43,16 @@ def test_transport_server_error_5xx_or_none_returns_500(code: int | None):
     exc = TransportServerError("Server error", code=code)
     result = handle_server_exception(exc)
     assert result.status_code == 500
+
+
+def test_clickhouse_stream_failure_returns_502() -> None:
+    """Mid-stream connection failures (clickhouse-connect >= 1.4) subclass
+    Exception, not DatabaseError, and must map to 502 like other CH faults.
+    """
+    exc = CHStreamFailureError("stream failed after first block")
+    result = handle_server_exception(exc)
+    assert result.status_code == 502
+    assert result.message == {"reason": "Temporary backend error"}
 
 
 def test_clickhouse_type_mismatch_returns_400() -> None:

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -150,8 +150,8 @@ def _is_transient_ch_error(exc: BaseException) -> bool:
     """Check if a ClickHouse error is a known transient replication error."""
     if not isinstance(exc, DatabaseError):
         return False
-    # clickhouse-connect >= 1.3 carries a structured code; older versions and
-    # wrapped messages need the regex fallback.
+    # clickhouse-connect >= 1.3 sets an int `code`; older versions and wrapped
+    # messages need the regex fallback.
     code = getattr(exc, "code", None)
     if isinstance(code, int):
         return code in _TRANSIENT_CH_ERROR_CODES

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -150,7 +150,11 @@ def _is_transient_ch_error(exc: BaseException) -> bool:
     """Check if a ClickHouse error is a known transient replication error."""
     if not isinstance(exc, DatabaseError):
         return False
-    # clickhouse_connect.DatabaseError has no structured error code attr; parse from message.
+    # clickhouse-connect >= 1.3 carries a structured code; older versions and
+    # wrapped messages need the regex fallback.
+    code = getattr(exc, "code", None)
+    if isinstance(code, int):
+        return code in _TRANSIENT_CH_ERROR_CODES
     match = re.search(r"Code:\s*(\d+)", str(exc))
     if match is None:
         return False

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -151,7 +151,7 @@ def _is_transient_ch_error(exc: BaseException) -> bool:
     if not isinstance(exc, DatabaseError):
         return False
     # clickhouse-connect >= 1.3 sets an int `code`; older clickhouse-connect
-    # versions and wrapped messages need the regex fallback.
+    # versions need the regex fallback.
     code = getattr(exc, "code", None)
     if isinstance(code, int):
         return code in _TRANSIENT_CH_ERROR_CODES

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -150,8 +150,8 @@ def _is_transient_ch_error(exc: BaseException) -> bool:
     """Check if a ClickHouse error is a known transient replication error."""
     if not isinstance(exc, DatabaseError):
         return False
-    # clickhouse-connect >= 1.3 sets an int `code`; older versions and wrapped
-    # messages need the regex fallback.
+    # clickhouse-connect >= 1.3 sets an int `code`; older clickhouse-connect
+    # versions and wrapped messages need the regex fallback.
     code = getattr(exc, "code", None)
     if isinstance(code, int):
         return code in _TRANSIENT_CH_ERROR_CODES

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -402,9 +402,6 @@ class ErrorRegistry:
         self.register(
             CHOperationalError, 502, lambda exc: {"reason": "Temporary backend error"}
         )
-        # Subclasses Exception, not DatabaseError; raised on mid-stream
-        # connection failure (clickhouse-connect >= 1.4 raises instead of
-        # returning a silently truncated stream).
         self.register(
             CHStreamFailureError, 502, lambda exc: {"reason": "Temporary backend error"}
         )
@@ -420,7 +417,7 @@ class ErrorRegistry:
 
 def _get_error_registry() -> ErrorRegistry:
     """Get the global error registry, initializing it if needed."""
-    global _error_registry  # ruff: ignore[global-statement]
+    global _error_registry  # noqa: PLW0603
     if _error_registry is None:
         _error_registry = ErrorRegistry()
     return _error_registry

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -392,12 +392,21 @@ class ErrorRegistry:
         from clickhouse_connect.driver.exceptions import (
             OperationalError as CHOperationalError,
         )
+        from clickhouse_connect.driver.exceptions import (
+            StreamFailureError as CHStreamFailureError,
+        )
 
         self.register(
             CHDatabaseError, 502, lambda exc: {"reason": "Temporary backend error"}
         )
         self.register(
             CHOperationalError, 502, lambda exc: {"reason": "Temporary backend error"}
+        )
+        # Subclasses Exception, not DatabaseError; raised on mid-stream
+        # connection failure (clickhouse-connect >= 1.4 raises instead of
+        # returning a silently truncated stream).
+        self.register(
+            CHStreamFailureError, 502, lambda exc: {"reason": "Temporary backend error"}
         )
 
         # GraphQL transport errors
@@ -411,7 +420,7 @@ class ErrorRegistry:
 
 def _get_error_registry() -> ErrorRegistry:
     """Get the global error registry, initializing it if needed."""
-    global _error_registry  # noqa: PLW0603
+    global _error_registry  # ruff: ignore[global-statement]
     if _error_registry is None:
         _error_registry = ErrorRegistry()
     return _error_registry


### PR DESCRIPTION
## What

Two small server-side hardenings ahead of the clickhouse-connect 0.8 → 1.6 upgrade (wandb/core side), both compatible with the currently pinned 0.8.18:

- Register `StreamFailureError` → 502 in the error registry. Since clickhouse-connect 1.4, a mid-stream connection failure raises it (previously: silently truncated results); it subclasses `Exception`, not `DatabaseError`, so today it would surface as a 500.
- `_is_transient_ch_error` now prefers the structured `DatabaseError.code` attribute (added in clickhouse-connect 1.3) over regex-parsing the message, keeping the regex as fallback for 0.x.

## Why

The 1.x driver changes both mid-stream failure semantics and error message formats.

## Testing

- Unit tests
- QA