### PR TITLE
fix(weave): reserve Python span error type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -577,7 +577,8 @@ deterministic.
   those content attributes directly with `set_attributes()`.
 - `Tool`, `LLM`, `SubAgent`, and `Turn` expose `record_error(error)` to mark a
   failure without ending the span. It derives `error.type` from the exception;
-  call `end()` separately. Context managers do both for escaping exceptions.
+  custom attribute attempts to set `error.type` are ignored. Call `end()`
+  separately. Context managers do both for escaping exceptions.
 - Mypy requires explicit `return None` paths in functions annotated with
   `T | None`; bare `return` and implicit fallthrough trigger return-value
   errors.

--- a/tests/conversation/test_span_attributes.py
+++ b/tests/conversation/test_span_attributes.py
@@ -83,6 +83,32 @@ def test_set_attributes_accepts_sequence_value(
     assert tuple(chat_span.attributes["gen_ai.response.finish_reasons"]) == ("stop",)
 
 
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
+)
+def test_set_attributes_cannot_override_error_type(
+    caplog: pytest.LogCaptureFixture,
+    otel_spans: InMemorySpanExporter,
+    _class_label,
+    factory,
+    span_name,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="weave.conversation.conversation")
+    with Conversation(conversation_id="test-conversation"), factory() as span_obj:
+        span_obj.record_error(ValueError("invalid response"))
+        span_obj.set_attributes(
+            {"error.type": "rate_limit", "app.failure.type": "rate_limit"}
+        )
+
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert finished_span.attributes["error.type"] == "ValueError"
+    assert finished_span.attributes["app.failure.type"] == "rate_limit"
+    assert any(
+        "set_attributes ignored 'error.type'" in record.message
+        for record in caplog.records
+    )
+
+
 # ---------------------------------------------------------------------------
 # record_error
 # ---------------------------------------------------------------------------
@@ -244,6 +270,26 @@ def test_conversation_attributes_on_every_streaming_span(
         assert span.attributes["custom.tier"] == "gold"
 
 
+def test_conversation_attributes_cannot_set_error_type(
+    caplog: pytest.LogCaptureFixture, otel_spans: InMemorySpanExporter
+) -> None:
+    caplog.set_level(logging.WARNING, logger="weave.conversation.conversation")
+    with Conversation(
+        conversation_id="convo-managed-error",
+        attributes={"error.type": "rate_limit", "app.failure.type": "rate_limit"},
+    ) as conversation:
+        with conversation.start_turn(agent_name="bot"):
+            pass
+
+    span = _only_span(otel_spans.get_finished_spans(), "invoke_agent bot")
+    assert "error.type" not in span.attributes
+    assert span.attributes["app.failure.type"] == "rate_limit"
+    assert any(
+        "Conversation.attributes ignored 'error.type'" in record.message
+        for record in caplog.records
+    )
+
+
 def test_conversation_attributes_on_every_batch_span(
     otel_spans: InMemorySpanExporter,
 ) -> None:
@@ -258,6 +304,25 @@ def test_conversation_attributes_on_every_batch_span(
     assert len(spans) == 3
     for span in spans:
         assert span.attributes["weave.integration.name"] == "wb-agent"
+
+
+def test_batch_attributes_cannot_set_error_type(
+    caplog: pytest.LogCaptureFixture, otel_spans: InMemorySpanExporter
+) -> None:
+    caplog.set_level(logging.WARNING, logger="weave.conversation.conversation")
+    log_turn(
+        conversation_id="convo-managed-error-batch",
+        agent_name="bot",
+        attributes={"error.type": "rate_limit", "app.failure.type": "rate_limit"},
+    )
+
+    span = _only_span(otel_spans.get_finished_spans(), "invoke_agent bot")
+    assert "error.type" not in span.attributes
+    assert span.attributes["app.failure.type"] == "rate_limit"
+    assert any(
+        "log_turn attributes ignored 'error.type'" in record.message
+        for record in caplog.records
+    )
 
 
 def test_conversation_attributes_on_every_log_conversation_span(

--- a/weave/conversation/conversation.py
+++ b/weave/conversation/conversation.py
@@ -112,8 +112,24 @@ __all__ = [
 
 # OTel tracer name — identifies the Conversation SDK as the source of these spans.
 _TRACER_NAME = "weave.conversation"
+_ERROR_TYPE_ATTRIBUTE = "error.type"
 
 logger = logging.getLogger(__name__)
+
+
+def _sanitize_custom_attributes(
+    attributes: dict[str, Any], operation: str
+) -> dict[str, Any]:
+    if _ERROR_TYPE_ATTRIBUTE not in attributes:
+        return attributes
+    sanitized = dict(attributes)
+    del sanitized[_ERROR_TYPE_ATTRIBUTE]
+    logger.warning(
+        "%s ignored %r: managed by record_error() and context-manager errors.",
+        operation,
+        _ERROR_TYPE_ATTRIBUTE,
+    )
+    return sanitized
 
 
 def _capture_info_attrs() -> dict[str, str]:
@@ -202,6 +218,9 @@ class _SpanBase(BaseModel):
         # span too, which starts in a fresh OTel Context to force a new trace.
         conversation = get_current_conversation()
         if conversation is not None and conversation.attributes:
+            conversation.attributes = _sanitize_custom_attributes(
+                conversation.attributes, "Conversation.attributes"
+            )
             self._otel_span.set_attributes(conversation.attributes)
 
     def _end_otel_span(
@@ -266,7 +285,7 @@ class _SpanBase(BaseModel):
             error_type = error_class.__qualname__
             if error_class.__module__ != "builtins":
                 error_type = f"{error_class.__module__}.{error_type}"
-            span.set_attribute("error.type", error_type)
+            span.set_attribute(_ERROR_TYPE_ATTRIBUTE, error_type)
             span.set_status(StatusCode.ERROR, str(error))
             span.record_exception(error)
         return self
@@ -278,13 +297,16 @@ class _SpanBase(BaseModel):
         use ``span.set_attributes({"weave.tag": "value"})``. Mirrors OTel's
         ``Span.set_attributes``.
 
-        Must be called between span start and span end — i.e. inside a
+        ``error.type`` is SDK-managed and ignored here. Must be called between
+        span start and span end — i.e. inside a
         ``with`` block. Outside that window the call is a no-op and logs
         a warning. For batch ingest, populate the object's declared fields
         directly and pass it to ``log_turn`` / ``log_conversation``.
         """
         if span := self._recording_span("set_attributes", list(attributes)):
-            span.set_attributes(attributes)
+            span.set_attributes(
+                _sanitize_custom_attributes(attributes, "set_attributes")
+            )
         return self
 
     @deprecated(_ADD_EVENT_DEPRECATION_MESSAGE)
@@ -1323,6 +1345,9 @@ class Conversation(BaseModel):
     def model_post_init(self, context: Any, /) -> None:
         if not self.conversation_id:
             self.conversation_id = str(uuid.uuid4())
+        self.attributes = _sanitize_custom_attributes(
+            self.attributes, "Conversation.attributes"
+        )
 
     def start_turn(
         self,
@@ -1768,6 +1793,10 @@ def log_turn(
     if not _OTEL_AVAILABLE or should_disable_weave():
         return LogResult(conversation_id=conversation_id)
 
+    safe_attributes = _sanitize_custom_attributes(
+        dict(attributes or {}), "log_turn attributes"
+    )
+
     resolved_spans = spans or []
     # Resolve timestamps before constructing the Turn so model_post_init
     # doesn't override a missing started_at with now() ahead of the
@@ -1796,7 +1825,7 @@ def log_turn(
         conversation_id=conversation_id,
         conversation_name=conversation_name,
         include_content=include_content,
-        attributes=attributes,
+        attributes=safe_attributes,
     )
 
 
@@ -1831,6 +1860,10 @@ def log_conversation(
     if not _OTEL_AVAILABLE or should_disable_weave():
         return LogResult(conversation_id=sid)
 
+    safe_attributes = _sanitize_custom_attributes(
+        dict(attributes or {}), "log_conversation attributes"
+    )
+
     trace_ids: list[str] = []
     root_span_ids: list[str] = []
     span_count = 0
@@ -1852,7 +1885,7 @@ def log_conversation(
             conversation_id=sid,
             conversation_name=conversation_name,
             include_content=include_content,
-            attributes=attributes,
+            attributes=safe_attributes,
         )
         trace_ids.extend(result.trace_ids)
         root_span_ids.extend(result.root_span_ids)


### PR DESCRIPTION
## Summary

- keep OTel `error.type` SDK-managed and derived from exceptions
- ignore attempts to set it through live, inherited, or batch custom attributes
- preserve application-specific classifications under custom keys

Follow-up to #7744; matches the TypeScript contract in #7738.

## Testing

- 249 focused tests
- Ruff, Ty, and Pyright