### PR TITLE
feat(weave_ts): record the agent span that invoked a call

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,14 @@ our backend. Spans opened by `trace_server.tracing` are the one exclusion, and
 they are recognised through `WEAVE_SERVER_SPAN_KEY` on the context rather than
 off the span object, which under the OTel→DD bridge is not an SDK span.
 
+`WeaveClient.createCall` in the Node SDK writes the same key with the same
+meaning, but sees fewer spans. That SDK registers no OTel context manager and
+gives every span it starts an explicit parent, so its own spans never become
+current and `getActiveSpan` returns only instrumentation the user installed
+themselves. Linking the `execute_tool` spans the `openai-agents` and
+`google_adk` integrations emit has to read their own state instead, and is a
+separate step.
+
 If `sdks/node/node_modules` is missing, run `pnpm install --frozen-lockfile` in `sdks/node` first. Do not use `npm install`; this SDK is pinned to pnpm.
 
 ## Python Testing Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,11 +140,12 @@ off the span object, which under the OTel→DD bridge is not an SDK span.
 
 `WeaveClient.createCall` in the Node SDK writes the same key with the same
 meaning, but sees fewer spans. That SDK registers no OTel context manager and
-gives every span it starts an explicit parent, so its own spans never become
-current and `getActiveSpan` returns only instrumentation the user installed
-themselves. Linking the `execute_tool` spans the `openai-agents` and
-`google_adk` integrations emit has to read their own state instead, and is a
-separate step.
+never calls `startActiveSpan`, so its own spans never become current and
+`getActiveSpan` returns only instrumentation the user installed themselves.
+Linking the `execute_tool` spans the `openai-agents` and `google_adk`
+integrations emit has to read those integrations' own state instead — the
+agents SDK keeps its current span in its own AsyncLocalStorage, and the ADK
+plugin keeps a map of open tool spans.
 
 If `sdks/node/node_modules` is missing, run `pnpm install --frozen-lockfile` in `sdks/node` first. Do not use `npm install`; this SDK is pinned to pnpm.
 

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -698,6 +698,43 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     );
   });
 
+  test('a weave.op tool records no invoking span', async () => {
+    const getWeather = weave.op(
+      async ({city}: {city: string}) => `${city}: Sunny, 22°C`,
+      {name: 'get_weather'}
+    );
+    const agent = new Agent({
+      name: 'Assistant',
+      tools: [
+        tool({
+          name: 'get_weather',
+          description: 'Get the current weather for a given city.',
+          parameters: z.object({city: z.string()}),
+          execute: getWeather,
+        }),
+      ],
+      model: new MockAgent([
+        toolCall('get_weather', {city: 'Tokyo'}, 'call-tokyo'),
+        assistantMessage('Tokyo is sunny.', 'msg-final'),
+      ]),
+    });
+
+    await run(agent, 'What is the weather in Tokyo?');
+
+    // `weave.invoking_span` reads the ambient OTel context, and the
+    // `execute_tool` span wrapping this call is emitted with an explicit parent
+    // and never made current, so the link cannot see it. Reaching it needs this
+    // integration's own span map, which is the next step; until then the call
+    // and the span stay unrelated. Both sides are asserted so the absence is
+    // about the link rather than about a missing span or a missing call.
+    const spans = await emittedSpans();
+    expect(spans.map(s => s.name)).toContain('execute_tool get_weather');
+
+    const calls = await inMemoryTraceServer.getCalls(testProjectName);
+    const weatherCall = calls.find(c => c.op_name.includes('get_weather'))!;
+    expect(weatherCall.attributes.weave).not.toHaveProperty('invoking_span');
+  });
+
   test('OpenAI SDK calls inside an agent context are not double-traced', async () => {
     // Under OTel V2 the agents OTel processor already emits a `chat` span
     // for every model call (with messages + usage). The OpenAI integration's

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -698,7 +698,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     );
   });
 
-  test('a weave.op tool records no invoking span', async () => {
+  test('a weave.op tool is not yet linked to its execute_tool span', async () => {
     const getWeather = weave.op(
       async ({city}: {city: string}) => `${city}: Sunny, 22°C`,
       {name: 'get_weather'}
@@ -721,12 +721,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
 
     await run(agent, 'What is the weather in Tokyo?');
 
-    // `weave.invoking_span` reads the ambient OTel context, and the
-    // `execute_tool` span wrapping this call is emitted with an explicit parent
-    // and never made current, so the link cannot see it. Reaching it needs this
-    // integration's own span map, which is the next step; until then the call
-    // and the span stay unrelated. Both sides are asserted so the absence is
-    // about the link rather than about a missing span or a missing call.
+    // Ambient-only for now; the integration's own span map is the follow-up.
+    // Both sides are asserted so the absence is about the link rather than
+    // about a missing span or a missing call.
     const spans = await emittedSpans();
     expect(spans.map(s => s.name)).toContain('execute_tool get_weather');
 

--- a/sdks/node/src/__tests__/invokingSpan.test.ts
+++ b/sdks/node/src/__tests__/invokingSpan.test.ts
@@ -222,9 +222,9 @@ describe('invoking span', () => {
       trace_id: traceId,
       span_id: spanId,
     });
-    expect(await weaveAttributes('outside')).not.toHaveProperty(
-      INVOKING_SPAN_ATTR_KEY
-    );
+    // Empty, not `WITHOUT_LINK`: the supplied object replaced ours, and all it
+    // held was the key we drop.
+    expect(await weaveAttributes('outside')).toEqual({});
   });
 
   test('keeps the other keys of a caller-supplied weave object', async () => {

--- a/sdks/node/src/__tests__/invokingSpan.test.ts
+++ b/sdks/node/src/__tests__/invokingSpan.test.ts
@@ -13,11 +13,13 @@ import {
   SamplingDecision,
 } from '@opentelemetry/sdk-trace-base';
 
+import {requireGlobalClient} from '../clientApi';
 import {INVOKING_SPAN_ATTR_KEY} from '../constants';
 import {op} from '../op';
 import {packageVersion} from '../utils/packageVersion';
 import {initWithCustomTraceServer} from './clientMock';
-import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
+import {TEST_PROJECT} from './genai/common';
+import {type Call, InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 
 /**
  * The ambient source answers only while a context manager is registered, and
@@ -66,23 +68,24 @@ const zeroIdGenerator: IdGenerator = {
   generateSpanId: () => '0'.repeat(16),
 };
 
-const PROJECT_ID = 'test-project';
+/** Everything a call carries under `weave` when no link was recorded. */
+const WITHOUT_LINK = {client_version: packageVersion, source: 'js-sdk'};
 
 // Every test goes through the public path — run an op, read the stored call —
-// because the span has to be read at a point `createCall` reaches before it
-// awaits, which a direct call to the resolver cannot show.
+// because the span has to be read before `createCall` awaits, which a direct
+// call to the resolver cannot show.
 describe('invoking span', () => {
   let traceServer: InMemoryTraceServer;
 
   beforeEach(() => {
     traceServer = new InMemoryTraceServer();
-    initWithCustomTraceServer(PROJECT_ID, traceServer);
+    initWithCustomTraceServer(TEST_PROJECT, traceServer);
     context.setGlobalContextManager(new TestContextManager());
   });
 
   afterEach(() => {
-    // Jest runs the files in one process, so a registration left behind here
-    // would make the ambient source answer in every later file.
+    // setGlobalContextManager refuses to overwrite an existing registration, so
+    // every test after the first would silently keep this one.
     context.disable();
   });
 
@@ -98,8 +101,14 @@ describe('invoking span', () => {
 
   /** The `weave` attributes of the stored call named `opName`. */
   async function weaveAttributes(opName: string): Promise<Record<string, any>> {
-    const calls = await traceServer.getCalls(PROJECT_ID);
-    const call = calls.find(c => c.op_name.includes(opName));
+    // Query directly once the client has drained: getCalls() waits for the call
+    // count to move, so after a flush it burns its full 1500ms timeout and logs
+    // a warning.
+    await requireGlobalClient().flush();
+    const {calls} = await traceServer.calls.callsStreamQueryPost({
+      project_id: TEST_PROJECT,
+    });
+    const call = calls.find((c: Call) => c.op_name.includes(opName));
     if (!call) {
       throw new Error(`no stored call for op ${opName}`);
     }
@@ -120,19 +129,19 @@ describe('invoking span', () => {
       }
     );
 
+    // Spelled out, not via the constant: Python matches on this string, so a
+    // rename has to fail here rather than pass every test that imports it.
     expect(await weaveAttributes('lookup')).toEqual({
       client_version: packageVersion,
       source: 'js-sdk',
-      [INVOKING_SPAN_ATTR_KEY]: {trace_id: traceId, span_id: spanId},
+      invoking_span: {trace_id: traceId, span_id: spanId},
     });
   });
 
   test('records nothing outside a span', async () => {
     await tracedOp('lookup')();
 
-    expect(await weaveAttributes('lookup')).not.toHaveProperty(
-      INVOKING_SPAN_ATTR_KEY
-    );
+    expect(await weaveAttributes('lookup')).toEqual(WITHOUT_LINK);
   });
 
   test('records nothing for a span that will not be exported', async () => {
@@ -142,9 +151,7 @@ describe('invoking span', () => {
       span.end();
     });
 
-    expect(await weaveAttributes('lookup')).not.toHaveProperty(
-      INVOKING_SPAN_ATTR_KEY
-    );
+    expect(await weaveAttributes('lookup')).toEqual(WITHOUT_LINK);
   });
 
   test('records nothing for a span that has already ended', async () => {
@@ -153,9 +160,7 @@ describe('invoking span', () => {
       await tracedOp('lookup')();
     });
 
-    expect(await weaveAttributes('lookup')).not.toHaveProperty(
-      INVOKING_SPAN_ATTR_KEY
-    );
+    expect(await weaveAttributes('lookup')).toEqual(WITHOUT_LINK);
   });
 
   test('records nothing for an all-zero span identity', async () => {
@@ -165,9 +170,7 @@ describe('invoking span', () => {
       span.end();
     });
 
-    expect(await weaveAttributes('lookup')).not.toHaveProperty(
-      INVOKING_SPAN_ATTR_KEY
-    );
+    expect(await weaveAttributes('lookup')).toEqual(WITHOUT_LINK);
   });
 
   test('records the span on every call started inside it, not just the first', async () => {
@@ -188,14 +191,15 @@ describe('invoking span', () => {
     );
   });
 
-  test('records the span across an await inside it', async () => {
+  test('records a span the op body ends while the call start is in flight', async () => {
+    // `createCall` suspends on its first await and hands control back, so the
+    // op body runs — and ends the span — before it reaches the attributes. Read
+    // the span there instead of on entry and this is the case that goes silent.
     await userTracer().startActiveSpan('user_work', async span => {
-      await new Promise(resolve => setTimeout(resolve, 0));
-      await tracedOp('lookup')();
-      span.end();
+      await op(async () => span.end(), {name: 'ends_span'})();
     });
 
-    expect(await weaveAttributes('lookup')).toHaveProperty(
+    expect(await weaveAttributes('ends_span')).toHaveProperty(
       INVOKING_SPAN_ATTR_KEY
     );
   });
@@ -233,8 +237,8 @@ describe('invoking span', () => {
       }
     );
 
-    // A caller's `weave` object replaces ours instead of merging with it, so
-    // `client_version` and `source` are gone here. That predates this link.
+    // A caller's `weave` object replaces ours instead of merging, so
+    // `client_version` and `source` are gone here — that predates this link.
     expect(await weaveAttributes('lookup')).toEqual({
       tenant: 'acme',
       [INVOKING_SPAN_ATTR_KEY]: {trace_id: traceId, span_id: spanId},

--- a/sdks/node/src/__tests__/invokingSpan.test.ts
+++ b/sdks/node/src/__tests__/invokingSpan.test.ts
@@ -1,0 +1,243 @@
+import {AsyncLocalStorage} from 'async_hooks';
+import {
+  context,
+  type Context,
+  type ContextManager,
+  ROOT_CONTEXT,
+  type Tracer,
+} from '@opentelemetry/api';
+import {
+  BasicTracerProvider,
+  type IdGenerator,
+  type Sampler,
+  SamplingDecision,
+} from '@opentelemetry/sdk-trace-base';
+
+import {INVOKING_SPAN_ATTR_KEY} from '../constants';
+import {op} from '../op';
+import {packageVersion} from '../utils/packageVersion';
+import {initWithCustomTraceServer} from './clientMock';
+import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
+
+/**
+ * The ambient source answers only while a context manager is registered, and
+ * `@opentelemetry/context-async-hooks` is not a dependency of this SDK. This is
+ * the part of it these tests need — what a user running the OTel Node SDK has.
+ */
+class TestContextManager implements ContextManager {
+  private readonly storage = new AsyncLocalStorage<Context>();
+
+  active(): Context {
+    return this.storage.getStore() ?? ROOT_CONTEXT;
+  }
+
+  with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
+    ctx: Context,
+    fn: F,
+    thisArg?: ThisParameterType<F>,
+    ...args: A
+  ): ReturnType<F> {
+    return this.storage.run(ctx, () => fn.call(thisArg, ...args));
+  }
+
+  bind<T>(_ctx: Context, target: T): T {
+    return target;
+  }
+
+  enable(): this {
+    return this;
+  }
+
+  disable(): this {
+    this.storage.disable();
+    return this;
+  }
+}
+
+/** Alive but never exported — the decision Weave records nothing for. */
+const recordOnlySampler: Sampler = {
+  shouldSample: () => ({decision: SamplingDecision.RECORD}),
+  toString: () => 'RecordOnlySampler',
+};
+
+/** The all-zero identity a custom generator can produce. */
+const zeroIdGenerator: IdGenerator = {
+  generateTraceId: () => '0'.repeat(32),
+  generateSpanId: () => '0'.repeat(16),
+};
+
+const PROJECT_ID = 'test-project';
+
+// Every test goes through the public path — run an op, read the stored call —
+// because the span has to be read at a point `createCall` reaches before it
+// awaits, which a direct call to the resolver cannot show.
+describe('invoking span', () => {
+  let traceServer: InMemoryTraceServer;
+
+  beforeEach(() => {
+    traceServer = new InMemoryTraceServer();
+    initWithCustomTraceServer(PROJECT_ID, traceServer);
+    context.setGlobalContextManager(new TestContextManager());
+  });
+
+  afterEach(() => {
+    // Jest runs the files in one process, so a registration left behind here
+    // would make the ambient source answer in every later file.
+    context.disable();
+  });
+
+  /** A tracer from a provider the user owns, the way BYO-OTel reaches us. */
+  function userTracer(
+    config: {
+      sampler?: Sampler;
+      idGenerator?: IdGenerator;
+    } = {}
+  ): Tracer {
+    return new BasicTracerProvider(config).getTracer('user');
+  }
+
+  /** The `weave` attributes of the stored call named `opName`. */
+  async function weaveAttributes(opName: string): Promise<Record<string, any>> {
+    const calls = await traceServer.getCalls(PROJECT_ID);
+    const call = calls.find(c => c.op_name.includes(opName));
+    if (!call) {
+      throw new Error(`no stored call for op ${opName}`);
+    }
+    return call.attributes.weave;
+  }
+
+  function tracedOp(name: string, attributes?: Record<string, any>) {
+    return op(async () => 'done', {name, attributes});
+  }
+
+  test('records the span a call started inside', async () => {
+    const {traceId, spanId} = await userTracer().startActiveSpan(
+      'user_work',
+      async span => {
+        await tracedOp('lookup')();
+        span.end();
+        return span.spanContext();
+      }
+    );
+
+    expect(await weaveAttributes('lookup')).toEqual({
+      client_version: packageVersion,
+      source: 'js-sdk',
+      [INVOKING_SPAN_ATTR_KEY]: {trace_id: traceId, span_id: spanId},
+    });
+  });
+
+  test('records nothing outside a span', async () => {
+    await tracedOp('lookup')();
+
+    expect(await weaveAttributes('lookup')).not.toHaveProperty(
+      INVOKING_SPAN_ATTR_KEY
+    );
+  });
+
+  test('records nothing for a span that will not be exported', async () => {
+    const tracer = userTracer({sampler: recordOnlySampler});
+    await tracer.startActiveSpan('user_work', async span => {
+      await tracedOp('lookup')();
+      span.end();
+    });
+
+    expect(await weaveAttributes('lookup')).not.toHaveProperty(
+      INVOKING_SPAN_ATTR_KEY
+    );
+  });
+
+  test('records nothing for a span that has already ended', async () => {
+    await userTracer().startActiveSpan('user_work', async span => {
+      span.end();
+      await tracedOp('lookup')();
+    });
+
+    expect(await weaveAttributes('lookup')).not.toHaveProperty(
+      INVOKING_SPAN_ATTR_KEY
+    );
+  });
+
+  test('records nothing for an all-zero span identity', async () => {
+    const tracer = userTracer({idGenerator: zeroIdGenerator});
+    await tracer.startActiveSpan('user_work', async span => {
+      await tracedOp('lookup')();
+      span.end();
+    });
+
+    expect(await weaveAttributes('lookup')).not.toHaveProperty(
+      INVOKING_SPAN_ATTR_KEY
+    );
+  });
+
+  test('records the span on every call started inside it, not just the first', async () => {
+    const inner = tracedOp('inner');
+    const outer = op(async () => inner(), {name: 'outer'});
+    await userTracer().startActiveSpan('user_work', async span => {
+      await outer();
+      span.end();
+    });
+
+    const expected = (await weaveAttributes('outer'))[INVOKING_SPAN_ATTR_KEY];
+    expect(expected).toEqual({
+      trace_id: expect.any(String),
+      span_id: expect.any(String),
+    });
+    expect((await weaveAttributes('inner'))[INVOKING_SPAN_ATTR_KEY]).toEqual(
+      expected
+    );
+  });
+
+  test('records the span across an await inside it', async () => {
+    await userTracer().startActiveSpan('user_work', async span => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await tracedOp('lookup')();
+      span.end();
+    });
+
+    expect(await weaveAttributes('lookup')).toHaveProperty(
+      INVOKING_SPAN_ATTR_KEY
+    );
+  });
+
+  test('overwrites a value a caller supplied under the key', async () => {
+    const supplied = {
+      weave: {[INVOKING_SPAN_ATTR_KEY]: {trace_id: 'ff', span_id: 'ff'}},
+    };
+    const {traceId, spanId} = await userTracer().startActiveSpan(
+      'user_work',
+      async span => {
+        await tracedOp('inside', supplied)();
+        span.end();
+        return span.spanContext();
+      }
+    );
+    await tracedOp('outside', supplied)();
+
+    expect((await weaveAttributes('inside'))[INVOKING_SPAN_ATTR_KEY]).toEqual({
+      trace_id: traceId,
+      span_id: spanId,
+    });
+    expect(await weaveAttributes('outside')).not.toHaveProperty(
+      INVOKING_SPAN_ATTR_KEY
+    );
+  });
+
+  test('keeps the other keys of a caller-supplied weave object', async () => {
+    const {traceId, spanId} = await userTracer().startActiveSpan(
+      'user_work',
+      async span => {
+        await tracedOp('lookup', {weave: {tenant: 'acme'}})();
+        span.end();
+        return span.spanContext();
+      }
+    );
+
+    // A caller's `weave` object replaces ours instead of merging with it, so
+    // `client_version` and `source` are gone here. That predates this link.
+    expect(await weaveAttributes('lookup')).toEqual({
+      tenant: 'acme',
+      [INVOKING_SPAN_ATTR_KEY]: {trace_id: traceId, span_id: spanId},
+    });
+  });
+});

--- a/sdks/node/src/constants.ts
+++ b/sdks/node/src/constants.ts
@@ -36,6 +36,14 @@ export const PARENT_CALL_ID_SPAN_ATTR = 'weave.parent_call.id';
 export const PARENT_CALL_TRACE_ID_SPAN_ATTR = 'weave.parent_call.trace_id';
 
 /**
+ * Call-attribute key, under the reserved `weave` namespace, holding the OTel
+ * span that was current when the call started as `{trace_id, span_id}` hex.
+ * Spelled the same as `weave/trace_server/constants.py`: the two SDKs write one
+ * field and a mismatch shows up as an empty filter result, not as an error.
+ */
+export const INVOKING_SPAN_ATTR_KEY = 'invoking_span';
+
+/**
  * Request header advertising the sampling-relevant capabilities this SDK build
  * guarantees, so a future server-side ingest sampler can tell a sampling-safe
  * client from an older one and leave unsupported traffic unsampled. Sent on

--- a/sdks/node/src/invokingSpan.ts
+++ b/sdks/node/src/invokingSpan.ts
@@ -3,21 +3,16 @@ import {isSpanContextValid, trace, TraceFlags} from '@opentelemetry/api';
 /**
  * Identity of the OTel span a call starting now was invoked from, or null.
  *
- * Recorded on the call so a reader can walk from an agent's `execute_tool` span
- * to the op call it invoked. The pair means "this span was current", not "this
- * span called exactly this call", so one span maps to every call started inside
- * it. Nothing is recorded for a span a reader could not use: `isRecording()`
- * says the span is alive, the sampled flag says it will be exported, which a
- * RECORD_ONLY sampling decision withholds, and `isSpanContextValid` rejects the
- * all-zero identity a custom `IdGenerator` can produce.
+ * The pair means "this span was current", not "this span called exactly this
+ * call", so one span maps to every call started inside it. Nothing is recorded
+ * for a span a reader could not use: not alive, held out of the export path by
+ * a RECORD_ONLY sampling decision, or carrying the all-zero identity a custom
+ * `IdGenerator` can produce.
  *
- * Only instrumentation the user installed themselves is visible here. Weave's
- * own spans never become current — this SDK registers no OTel context manager
- * and passes every parent as an explicit `Context` — so the integrations that
- * emit them have to answer from their own state instead. Who installed the
- * tracer provider is deliberately not checked: that is process state while the
- * question is about one span. A missing key and a pair that matches no span are
- * therefore both normal.
+ * Only instrumentation the user installed themselves is visible: this SDK
+ * registers no OTel context manager and never calls `startActiveSpan`, so its
+ * own spans never become current. A missing key and a pair that matches no span
+ * are both normal.
  */
 export function invokingSpanAttr(): {
   trace_id: string;

--- a/sdks/node/src/invokingSpan.ts
+++ b/sdks/node/src/invokingSpan.ts
@@ -1,0 +1,38 @@
+import {isSpanContextValid, trace, TraceFlags} from '@opentelemetry/api';
+
+/**
+ * Identity of the OTel span a call starting now was invoked from, or null.
+ *
+ * Recorded on the call so a reader can walk from an agent's `execute_tool` span
+ * to the op call it invoked. The pair means "this span was current", not "this
+ * span called exactly this call", so one span maps to every call started inside
+ * it. Nothing is recorded for a span a reader could not use: `isRecording()`
+ * says the span is alive, the sampled flag says it will be exported, which a
+ * RECORD_ONLY sampling decision withholds, and `isSpanContextValid` rejects the
+ * all-zero identity a custom `IdGenerator` can produce.
+ *
+ * Only instrumentation the user installed themselves is visible here. Weave's
+ * own spans never become current — this SDK registers no OTel context manager
+ * and passes every parent as an explicit `Context` — so the integrations that
+ * emit them have to answer from their own state instead. Who installed the
+ * tracer provider is deliberately not checked: that is process state while the
+ * question is about one span. A missing key and a pair that matches no span are
+ * therefore both normal.
+ */
+export function invokingSpanAttr(): {
+  trace_id: string;
+  span_id: string;
+} | null {
+  const span = trace.getActiveSpan();
+  if (!span || !span.isRecording()) {
+    return null;
+  }
+  const spanContext = span.spanContext();
+  if (
+    !isSpanContextValid(spanContext) ||
+    !(spanContext.traceFlags & TraceFlags.SAMPLED)
+  ) {
+    return null;
+  }
+  return {trace_id: spanContext.traceId, span_id: spanContext.spanId};
+}

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -2023,9 +2023,8 @@ export class WeaveClient {
       ...combinedAttributes,
     };
 
-    // Written after the merge because a caller's own `weave` object replaces
-    // ours wholesale, and dropped first because this key is ours to write and
-    // never a caller's to supply.
+    // After the merge: a caller's own `weave` object replaces ours wholesale.
+    // Dropped first: this key is ours to write, never a caller's to supply.
     const weaveAttributes: Record<string, any> = {...mergedAttributes.weave};
     delete weaveAttributes[INVOKING_SPAN_ATTR_KEY];
     if (invokingSpan !== null) {

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -5,6 +5,7 @@ import {uuidv7} from 'uuidv7';
 import {
   EVAL_META_KEY,
   EVALUATION_RUN_OP_NAME,
+  INVOKING_SPAN_ATTR_KEY,
   MAX_OBJECT_NAME_LENGTH,
 } from './constants';
 import {computeDigest} from './digest';
@@ -32,6 +33,7 @@ import type {
   AgentSpanStatsColumn,
   AgentCustomAttrSchemaItem,
 } from './generated/traceServerApi';
+import {invokingSpanAttr} from './invokingSpan';
 import {
   type AudioType,
   DEFAULT_AUDIO_TYPE,
@@ -1984,6 +1986,11 @@ export class WeaveClient {
     attributes?: Record<string, any>,
     eagerCallStart: boolean = false
   ) {
+    // Read before the awaits below, because the link says which span was
+    // current when the call started and a span alive then may have closed by
+    // the time the attributes are assembled.
+    const invokingSpan = invokingSpanAttr();
+
     // EvalLinkSpanProcessor runs from OTel callbacks and only has access to
     // the in-memory call stack. Store the short op name for stack lookup
     // because the persisted `opName` below is a full ref URI; store the
@@ -2016,6 +2023,15 @@ export class WeaveClient {
       ...combinedAttributes,
     };
 
+    // Written after the merge because a caller's own `weave` object replaces
+    // ours wholesale, and dropped first because this key is ours to write and
+    // never a caller's to supply.
+    const weaveAttributes: Record<string, any> = {...mergedAttributes.weave};
+    delete weaveAttributes[INVOKING_SPAN_ATTR_KEY];
+    if (invokingSpan !== null) {
+      weaveAttributes[INVOKING_SPAN_ATTR_KEY] = invokingSpan;
+    }
+
     const startReq = {
       project_id: this.projectId,
       id: currentCall.callId,
@@ -2024,7 +2040,7 @@ export class WeaveClient {
       parent_id: parentCall?.callId,
       started_at: startTime.toISOString(),
       display_name: displayName,
-      attributes: mergedAttributes,
+      attributes: {...mergedAttributes, weave: weaveAttributes},
       inputs,
     };
     internalCall.updateWithCallSchemaData(startReq);


### PR DESCRIPTION
## JIRA Issue(s)

[WB-38655](https://coreweave.atlassian.net/browse/WB-38655)

## Description

Today if you wrap a tool in `weave.op` and give it to an agent, the tool's call lands in one table and the agent's spans land in another. Nothing links them. The call has no weave parent, so it opens a trace of its own, and the UI shows it as an orphan next to the agent trace.

#7739 added that link in Python. When a call starts, `create_call` reads the OTel span that is open at that moment and saves its id on the call. This PR does the same in the Node SDK, under the same key and in the same form:

```json
{"weave": {"invoking_span": {"trace_id": "41512b73...", "span_id": "31b3c094..."}}}
```

The ids are lowercase hex, the same form `spans.trace_id` and `spans.span_id` already use, so a reader compares strings and nothing more. To find the calls a span made, filter `/calls/stream_query` on the pair. No new endpoint, no server change.

## Why this approach

I expected a port. Python does it in about 18 lines, so I sat down to write the same 18 lines here.

Then I checked what `trace.getActiveSpan()` actually returns in this SDK. It never returns a span weave emitted, for two reasons and either one is enough: we register no OTel context manager, and we start every span with `startSpan` and an explicit parent, never `startActiveSpan`. A weave span is never the current one.

So the port would have compiled, passed its tests, and never fired once for the case it was written for. That is why this is not a port.

It covers users who set up OpenTelemetry themselves, because their spans really are current. It does not cover tools running under our `openai-agents` and `google_adk` integrations. Those keep the span in their own state, and reaching it from `createCall` is a bigger change, so it is separate.

Doing this half now puts the key on the wire under the name Python already picked, so a second name cannot appear later. A test pins the gap so nobody has to remember it.

## Testing

Nine tests run an op and read the stored call back: the recorded pair, the four cases that record nothing, the moment the span is read, nested calls, and caller-supplied attributes. One test in `openaiAgent.test.ts` runs an agent with a `weave.op` tool and checks the gap above is still there, so it flips to a positive check when the integrations land.



## Screenshots

This is not a UI PR. Nothing here touches the frontend, and there is no new button to look at. I ran it end to end anyway, because an attribute like this can pass every test and still write nothing real.

I built the SDK from this branch, linked it into a scratch project, and called a `weave.op` tool inside a span from my own OpenTelemetry setup. Then I filtered `/calls/stream_query` on the pair, which returned that one call.

The call, with the ids of the span it started under:

<img width="1728" height="911" alt="call attributes showing weave.invoking_span" src="https://github.com/user-attachments/assets/8d8d4cf7-ec31-4dc8-a3d8-c7b3e362b179" />

The span those ids point at, same trace id `6ba1d4813819157fd3bc...`, so the reference resolves and is not dangling:

<img width="1728" height="911" alt="agent spans list showing the execute_tool span" src="https://github.com/user-attachments/assets/a4603da4-71ba-43f6-9f7d-84a954778636" />

[WB-38655]: https://coreweave.atlassian.net/browse/WB-38655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
