### PR TITLE
feat(weave): add cluster action item storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,13 @@ for backward compatibility. When neither is configured, it uses
 links use an account-key SAS for explicit credentials and a user-delegation SAS
 for workload identity.
 
+### Insights Action Items
+
+`cluster_action_items` stores user-editable issues for one concrete signature
+cluster. Writers reuse the same item UUID for retries and edits, append complete
+row versions, and keep actionability outside the stored model. The table stores
+workflow status separately from `SEVERE`, `MAJOR`, or `MINOR` severity.
+
 ## Generated Files — Do Not Hand-Edit
 
 `weave/trace_server/model_providers/model_providers.json` and `weave/trace_server/costs/cost_checkpoint.json` are generated. Never edit them by hand — regenerate with `make update_model_providers` / `make update_costs` (see `weave/Makefile`).

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -1018,6 +1018,9 @@ def test_create_distributed_table_sql_id_sharded():
         ("agent_versions", "sipHash64(project_id, agent_name)"),
         ("intent_signatures", "sipHash64(project_id)"),
         ("failure_signatures", "sipHash64(project_id)"),
+        ("signature_cluster_runs", "sipHash64(project_id)"),
+        ("signature_clusters", "sipHash64(project_id)"),
+        ("signature_cluster_assignments", "sipHash64(project_id)"),
     ],
 )
 def test_create_distributed_table_sql_agent_tables_sharded(table_name, expected_expr):

--- a/tests/trace_server/test_insights_config.py
+++ b/tests/trace_server/test_insights_config.py
@@ -36,12 +36,22 @@ def test_clustering_config_is_typed_and_content_addressed(config_dir):
         "metric": "euclidean",
         "cluster_selection_method": "eom",
         "allow_single_cluster": False,
+        "umap": {"n_neighbors": 15, "min_dist": 0.0, "random_state": 0},
     }
 
     before = config.config_sha(clustering)
     with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
         raw["min_cluster_size"] = 5
-    assert config.config_sha(config.load_clustering_config()) != before
+    after_flat_edit = config.config_sha(config.load_clustering_config())
+    assert after_flat_edit != before
+
+    # A nested knob reaches the digest too, so reprojecting declares a new run.
+    with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
+        raw["umap"]["random_state"] = 7
+    assert config.config_sha(config.load_clustering_config()) not in {
+        before,
+        after_flat_edit,
+    }
 
     with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
         raw["untracked_parameter"] = True

--- a/tests/trace_server/test_insights_config.py
+++ b/tests/trace_server/test_insights_config.py
@@ -26,6 +26,35 @@ def test_signature_types_have_distinct_digests():
     assert _digest("intent") != _digest("failure")
 
 
+def test_clustering_config_is_typed_and_content_addressed(config_dir):
+    clustering = config.load_clustering_config()
+    assert clustering.model_dump() == {
+        "config_schema_version": 1,
+        "algorithm": "hdbscan",
+        "min_cluster_size": 3,
+        "min_samples": 3,
+        "metric": "euclidean",
+        "cluster_selection_method": "eom",
+        "allow_single_cluster": False,
+    }
+
+    before = config.config_sha(clustering)
+    with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
+        raw["min_cluster_size"] = 5
+    assert config.config_sha(config.load_clustering_config()) != before
+
+    with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
+        raw["untracked_parameter"] = True
+    with pytest.raises(ValidationError, match="untracked_parameter"):
+        config.load_clustering_config()
+
+    with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
+        raw.pop("untracked_parameter")
+        raw["min_cluster_size"] = 1
+    with pytest.raises(ValidationError, match="min_cluster_size"):
+        config.load_clustering_config()
+
+
 @pytest.mark.parametrize("signature_type", config.SIGNATURE_TYPES)
 def test_prompt_renders_every_declared_label_and_its_definition(signature_type):
     """Every token resolves, and the taxonomy supplies both halves of a label.

--- a/tests/trace_server_bindings/test_action_item_routes.py
+++ b/tests/trace_server_bindings/test_action_item_routes.py
@@ -1,0 +1,114 @@
+import datetime
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from weave.trace_server.insights import action_items
+from weave.trace_server_bindings.remote_http_trace_server import (
+    RemoteHTTPTraceServer,
+)
+
+BASE_URL = "http://example.com"
+NOW = datetime.datetime(2026, 6, 20, tzinfo=datetime.timezone.utc)
+
+
+@pytest.fixture
+def server():
+    return RemoteHTTPTraceServer(BASE_URL, should_batch=False)
+
+
+def _item() -> action_items.ActionItem:
+    return action_items.ActionItem(
+        project_id="entity/project",
+        cluster_run_id="019ff4bc-2ae1-744d-ae3a-285998a90519",
+        cluster_id="019ff4bc-2ae1-744d-ae3a-285998a9051a",
+        run_window_end=NOW,
+        signature_type="failure",
+        id="019ff4bc-2ae1-744d-ae3a-285998a9051c",
+        action_item_config_sha="cfg-a",
+        title="Honor the requested output path",
+        description="The agent ignored an explicit output path.",
+        evidence_trace_ids=["trace-4"],
+        status=action_items.ActionItemStatus.OPEN,
+        severity=action_items.ActionItemSeverity.SEVERE,
+        inserted_at=NOW,
+        expire_at=datetime.datetime(2100, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+
+
+@pytest.mark.parametrize(
+    ("method_name", "req", "expected_url", "res_type", "res_json"),
+    [
+        pytest.param(
+            "action_items_batch_upsert",
+            action_items.ActionItemsBatchUpsertReq(items=[_item()]),
+            "/insights/action-items/batch-upsert",
+            action_items.ActionItemsBatchUpsertRes,
+            {"ids": [_item().id]},
+            id="batch-upsert",
+        ),
+        pytest.param(
+            "action_items_query",
+            action_items.ActionItemsQueryReq(
+                project_id="entity/project",
+                cluster_run_id=_item().cluster_run_id,
+                cluster_id=_item().cluster_id,
+                statuses=[action_items.ActionItemStatus.OPEN],
+                severities=[action_items.ActionItemSeverity.SEVERE],
+            ),
+            "/insights/action-items/query",
+            action_items.ActionItemsQueryRes,
+            {"items": [_item().model_dump(mode="json")]},
+            id="query",
+        ),
+        pytest.param(
+            "action_item_update",
+            action_items.ActionItemUpdateReq(
+                project_id="entity/project",
+                cluster_run_id=_item().cluster_run_id,
+                cluster_id=_item().cluster_id,
+                id=_item().id,
+                status=action_items.ActionItemStatus.COMPLETED,
+                severity=action_items.ActionItemSeverity.MAJOR,
+            ),
+            "/insights/action-items/update",
+            action_items.ActionItemUpdateRes,
+            {"item": _item().model_dump(mode="json")},
+            id="update",
+        ),
+    ],
+)
+def test_action_item_route_posts_complete_request_and_parses_response(
+    server: RemoteHTTPTraceServer,
+    method_name: str,
+    req: BaseModel,
+    expected_url: str,
+    res_type: type[BaseModel],
+    res_json: dict,
+) -> None:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 200
+    response.json.return_value = res_json
+
+    with patch.object(server, "post", return_value=response) as mock_post:
+        result = getattr(server, method_name)(req)
+
+    mock_post.assert_called_once()
+    assert mock_post.call_args[0][0] == expected_url
+    assert json.loads(mock_post.call_args[1]["data"]) == json.loads(
+        req.model_dump_json(by_alias=True)
+    )
+    assert isinstance(result, res_type)
+
+
+def test_action_item_update_requires_an_edit() -> None:
+    with pytest.raises(ValueError, match="status or severity is required"):
+        action_items.ActionItemUpdateReq(
+            project_id="entity/project",
+            cluster_run_id=_item().cluster_run_id,
+            cluster_id=_item().cluster_id,
+            id=_item().id,
+        )

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -700,6 +700,8 @@ _SIGNATURE_KEY = "project_id, toDate(trace_started_at), id"
 _INTENT_ID = "019ff277-bba3-7232-aeb3-0632fd183e1e"
 _FAILURE_ID_1 = "019ff277-bba3-7232-aeb3-0632fd183e2f"
 _FAILURE_ID_2 = "019ff288-c1d4-7333-bfc4-1743fe294f3a"
+_CLUSTER_ID = "019ff4bc-2ae1-744d-ae3a-285998a9051a"
+_NIL_UUID = "00000000-0000-0000-0000-000000000000"
 
 
 def _insert_intent(ch_client, target_db: str, category: str, cost: float) -> None:
@@ -922,7 +924,7 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
                 ("project_id", "String"),
                 ("cluster_run_id", "UUID"),
                 ("signature_record_id", "UUID"),
-                ("cluster_id", "Int32"),
+                ("cluster_id", "UUID"),
                 ("cluster_distance", "Float32"),
                 ("umap_x", "Float32"),
                 ("umap_y", "Float32"),
@@ -945,17 +947,17 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
                 ("window_end", "DateTime64(6, 'UTC')"),
                 ("status", "Enum8('running' = 1, 'completed' = 2, 'failed' = 3)"),
                 ("started_at", "DateTime64(6, 'UTC')"),
-                ("completed_at", "Nullable(DateTime64(6, 'UTC'))"),
+                ("completed_at", "DateTime64(6, 'UTC')"),
                 ("inserted_at", "DateTime64(6, 'UTC')"),
                 ("expire_at", "DateTime"),
             ],
         ),
         "signature_clusters": (
-            "project_id, cluster_run_id, cluster_id",
+            "project_id, cluster_run_id, id",
             [
                 ("project_id", "String"),
                 ("cluster_run_id", "UUID"),
-                ("cluster_id", "Int32"),
+                ("id", "UUID"),
                 ("label", "String"),
                 ("occurrence_count", "UInt64"),
                 ("inserted_at", "DateTime64(6, 'UTC')"),
@@ -1001,7 +1003,7 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
     _insert_intent(ch_client, target_db, "action_request", 0.21)
     run_id = "019ff4bc-2ae1-744d-ae3a-285998a90519"
     for inserted_at, status, completed_at in [
-        ("2026-06-20 15:00:00", "running", "NULL"),
+        ("2026-06-20 15:00:00", "running", "toDateTime64(0, 6, 'UTC')"),
         (
             "2026-06-20 15:05:00",
             "completed",
@@ -1021,13 +1023,13 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         )
 
     for inserted_at, label, count, cluster_id, distance, umap in [
-        ("2026-06-20 15:00:00", "draft", 1, -1, 0.0, (0.0, 0.0)),
-        ("2026-06-20 15:05:00", "checkout", 2, 7, 0.875, (-1.5, 3.25)),
+        ("2026-06-20 15:00:00", "draft", 1, _NIL_UUID, 0.0, (0.0, 0.0)),
+        ("2026-06-20 15:05:00", "checkout", 2, _CLUSTER_ID, 0.875, (-1.5, 3.25)),
     ]:
         ch_client.command(
             f"INSERT INTO {target_db}.signature_clusters "
-            "(project_id, cluster_run_id, cluster_id, label, occurrence_count, inserted_at) "
-            f"VALUES ('project-1', '{run_id}', 7, '{label}', {count}, "
+            "(project_id, cluster_run_id, id, label, occurrence_count, inserted_at) "
+            f"VALUES ('project-1', '{run_id}', '{_CLUSTER_ID}', '{label}', {count}, "
             f"toDateTime64('{inserted_at}', 6, 'UTC'))"
         )
         ch_client.command(
@@ -1035,7 +1037,7 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
             "(project_id, cluster_run_id, signature_record_id, cluster_id, "
             "cluster_distance, umap_x, umap_y, trace_id, turn_duration_ms, "
             "turn_cost_usd, inserted_at) "
-            f"VALUES ('project-1', '{run_id}', '{_INTENT_ID}', {cluster_id}, "
+            f"VALUES ('project-1', '{run_id}', '{_INTENT_ID}', '{cluster_id}', "
             f"toFloat32({distance}), toFloat32({umap[0]}), toFloat32({umap[1]}), "
             "'trace-4', 9000, 0.21, "
             f"toDateTime64('{inserted_at}', 6, 'UTC'))"
@@ -1045,17 +1047,26 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         "SELECT argMax(status, inserted_at), argMax(signature_type, inserted_at), "
         "argMax(signature_config_sha, inserted_at), "
         "argMax(cluster_config_sha, inserted_at), "
-        "isNull(argMax(completed_at, inserted_at)) "
+        "toString(argMax(completed_at, inserted_at)), toString(min(completed_at)) "
         f"FROM {target_db}.signature_cluster_runs "
         "WHERE project_id = 'project-1' GROUP BY project_id, id"
-    ).result_rows == [("completed", "intent", "signature-cfg-a", "cluster-cfg-a", 0)]
+    ).result_rows == [
+        (
+            "completed",
+            "intent",
+            "signature-cfg-a",
+            "cluster-cfg-a",
+            "2026-06-20 15:04:00.000000",
+            "1970-01-01 00:00:00.000000",
+        )
+    ]
     assert ch_client.query(
         "SELECT argMax(label, inserted_at), argMax(occurrence_count, inserted_at) "
         f"FROM {target_db}.signature_clusters "
-        "WHERE project_id = 'project-1' GROUP BY project_id, cluster_run_id, cluster_id"
+        "WHERE project_id = 'project-1' GROUP BY project_id, cluster_run_id, id"
     ).result_rows == [("checkout", 2)]
     assert ch_client.query(
-        "SELECT argMax(cluster_id, inserted_at), "
+        "SELECT toString(argMax(cluster_id, inserted_at)), "
         "round(toFloat64(argMax(cluster_distance, inserted_at)), 3), "
         "toFloat64(argMax(umap_x, inserted_at)), "
         "toFloat64(argMax(umap_y, inserted_at)), "
@@ -1064,7 +1075,7 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         f"FROM {target_db}.signature_cluster_assignments "
         "WHERE project_id = 'project-1' "
         "GROUP BY project_id, cluster_run_id, signature_record_id"
-    ).result_rows == [(7, 0.875, -1.5, 3.25, "trace-4", 9000, 0.21)]
+    ).result_rows == [(_CLUSTER_ID, 0.875, -1.5, 3.25, "trace-4", 9000, 0.21)]
 
     # The assignment references the upstream signature row UUID directly, and the
     # denormalized turn columns carry the same values that join would have hydrated.

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -701,6 +701,8 @@ _INTENT_ID = "019ff277-bba3-7232-aeb3-0632fd183e1e"
 _FAILURE_ID_1 = "019ff277-bba3-7232-aeb3-0632fd183e2f"
 _FAILURE_ID_2 = "019ff288-c1d4-7333-bfc4-1743fe294f3a"
 _CLUSTER_ID = "019ff4bc-2ae1-744d-ae3a-285998a9051a"
+# Stable across runs, unlike `_CLUSTER_ID`, which a run re-mints.
+_TOPIC_ID = "019ff4bc-2ae1-744d-ae3a-285998a9051b"
 _NIL_UUID = "00000000-0000-0000-0000-000000000000"
 
 
@@ -919,12 +921,15 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
 
     expected_tables = {
         "signature_cluster_assignments": (
-            "project_id, cluster_run_id, signature_record_id",
+            "project_id, cluster_run_id, cluster_id, signature_record_id",
+            "toYYYYMM(run_window_end)",
             [
                 ("project_id", "String"),
                 ("cluster_run_id", "UUID"),
                 ("signature_record_id", "UUID"),
+                ("run_window_end", "DateTime64(6, 'UTC')"),
                 ("cluster_id", "UUID"),
+                ("signature_type", "Enum8('intent' = 1, 'failure' = 2)"),
                 ("cluster_distance", "Float32"),
                 ("umap_x", "Float32"),
                 ("umap_y", "Float32"),
@@ -937,15 +942,20 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         ),
         "signature_cluster_runs": (
             "project_id, signature_type, window_end, id",
+            "",
             [
                 ("project_id", "String"),
                 ("id", "UUID"),
                 ("signature_type", "Enum8('intent' = 1, 'failure' = 2)"),
                 ("signature_config_sha", "LowCardinality(String)"),
                 ("cluster_config_sha", "LowCardinality(String)"),
+                ("naming_config_sha", "LowCardinality(String)"),
                 ("window_start", "DateTime64(6, 'UTC')"),
                 ("window_end", "DateTime64(6, 'UTC')"),
-                ("status", "Enum8('running' = 1, 'completed' = 2, 'failed' = 3)"),
+                (
+                    "status",
+                    "Enum8('unset' = 1, 'running' = 2, 'completed' = 3, 'failed' = 4)",
+                ),
                 ("started_at", "DateTime64(6, 'UTC')"),
                 ("completed_at", "DateTime64(6, 'UTC')"),
                 ("inserted_at", "DateTime64(6, 'UTC')"),
@@ -954,11 +964,16 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         ),
         "signature_clusters": (
             "project_id, cluster_run_id, id",
+            "toYYYYMM(run_window_end)",
             [
                 ("project_id", "String"),
                 ("cluster_run_id", "UUID"),
                 ("id", "UUID"),
+                ("run_window_end", "DateTime64(6, 'UTC')"),
+                ("topic_id", "UUID"),
+                ("centroid", "Array(Float32)"),
                 ("label", "String"),
+                ("description", "String"),
                 ("occurrence_count", "UInt64"),
                 ("inserted_at", "DateTime64(6, 'UTC')"),
                 ("expire_at", "DateTime"),
@@ -966,15 +981,15 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         ),
     }
     assert ch_client.query(
-        "SELECT name, engine, sorting_key "
+        "SELECT name, engine, sorting_key, partition_key "
         "FROM system.tables "
         f"WHERE database = '{target_db}' AND name LIKE 'signature_cluster%' "
         "ORDER BY name"
     ).result_rows == [
-        (name, "ReplacingMergeTree", sorting_key)
-        for name, (sorting_key, _) in expected_tables.items()
+        (name, "ReplacingMergeTree", sorting_key, partition_key)
+        for name, (sorting_key, partition_key, _) in expected_tables.items()
     ]
-    for table_name, (_, expected_columns) in expected_tables.items():
+    for table_name, (_, _, expected_columns) in expected_tables.items():
         assert (
             ch_client.query(
                 "SELECT name, type FROM system.columns "
@@ -984,7 +999,8 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
             == expected_columns
         )
 
-    # No speculative read model or index ships with the base storage contract.
+    # No read model or projection ships with the base storage contract. The three
+    # bloom filters are the whole index surface, one per reverse lookup the UI needs.
     assert (
         ch_client.query(
             "SELECT name FROM system.tables "
@@ -999,6 +1015,25 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         ).result_rows
         == []
     )
+    assert ch_client.query(
+        "SELECT table, name, expr, type_full FROM system.data_skipping_indices "
+        f"WHERE database = '{target_db}' AND table LIKE 'signature_cluster%' "
+        "ORDER BY table, name"
+    ).result_rows == [
+        (
+            "signature_cluster_assignments",
+            "idx_signature_record_id",
+            "signature_record_id",
+            "bloom_filter(0.01)",
+        ),
+        (
+            "signature_cluster_assignments",
+            "idx_trace_id",
+            "trace_id",
+            "bloom_filter(0.01)",
+        ),
+        ("signature_clusters", "idx_topic_id", "topic_id", "bloom_filter(0.01)"),
+    ]
 
     _insert_intent(ch_client, target_db, "action_request", 0.21)
     run_id = "019ff4bc-2ae1-744d-ae3a-285998a90519"
@@ -1013,31 +1048,37 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         ch_client.command(
             f"INSERT INTO {target_db}.signature_cluster_runs "
             "(project_id, id, signature_type, signature_config_sha, "
-            "cluster_config_sha, window_start, window_end, status, started_at, "
-            "completed_at, inserted_at) VALUES "
+            "cluster_config_sha, naming_config_sha, window_start, window_end, "
+            "status, started_at, completed_at, inserted_at) VALUES "
             f"('project-1', '{run_id}', 'intent', 'signature-cfg-a', "
-            "'cluster-cfg-a', toDateTime64('2026-05-01', 6, 'UTC'), "
+            "'cluster-cfg-a', 'naming-cfg-a', toDateTime64('2026-05-01', 6, 'UTC'), "
             "toDateTime64('2026-06-01', 6, 'UTC'), "
             f"'{status}', toDateTime64('2026-06-20 14:59:00', 6, 'UTC'), "
             f"{completed_at}, toDateTime64('{inserted_at}', 6, 'UTC'))"
         )
 
-    for inserted_at, label, count, cluster_id, distance, umap in [
-        ("2026-06-20 15:00:00", "draft", 1, _NIL_UUID, 0.0, (0.0, 0.0)),
-        ("2026-06-20 15:05:00", "checkout", 2, _CLUSTER_ID, 0.875, (-1.5, 3.25)),
+    # `cluster_id` sits in the assignment sorting key, so a retry collapses only when it
+    # re-sends the same cluster. Both writes here keep the signature in one cluster.
+    for inserted_at, label, count, distance, umap in [
+        ("2026-06-20 15:00:00", "draft", 1, 0.0, (0.0, 0.0)),
+        ("2026-06-20 15:05:00", "checkout", 2, 0.875, (-1.5, 3.25)),
     ]:
         ch_client.command(
             f"INSERT INTO {target_db}.signature_clusters "
-            "(project_id, cluster_run_id, id, label, occurrence_count, inserted_at) "
-            f"VALUES ('project-1', '{run_id}', '{_CLUSTER_ID}', '{label}', {count}, "
+            "(project_id, cluster_run_id, id, run_window_end, topic_id, centroid, "
+            "label, description, occurrence_count, inserted_at) "
+            f"VALUES ('project-1', '{run_id}', '{_CLUSTER_ID}', "
+            f"toDateTime64('2026-06-01', 6, 'UTC'), '{_TOPIC_ID}', [0.5, -0.25], "
+            f"'{label}', '{label} intents', {count}, "
             f"toDateTime64('{inserted_at}', 6, 'UTC'))"
         )
         ch_client.command(
             f"INSERT INTO {target_db}.signature_cluster_assignments "
-            "(project_id, cluster_run_id, signature_record_id, cluster_id, "
-            "cluster_distance, umap_x, umap_y, trace_id, turn_duration_ms, "
-            "turn_cost_usd, inserted_at) "
-            f"VALUES ('project-1', '{run_id}', '{_INTENT_ID}', '{cluster_id}', "
+            "(project_id, cluster_run_id, signature_record_id, run_window_end, "
+            "cluster_id, signature_type, cluster_distance, umap_x, umap_y, trace_id, "
+            "turn_duration_ms, turn_cost_usd, inserted_at) "
+            f"VALUES ('project-1', '{run_id}', '{_INTENT_ID}', "
+            f"toDateTime64('2026-06-01', 6, 'UTC'), '{_CLUSTER_ID}', 'intent', "
             f"toFloat32({distance}), toFloat32({umap[0]}), toFloat32({umap[1]}), "
             "'trace-4', 9000, 0.21, "
             f"toDateTime64('{inserted_at}', 6, 'UTC'))"
@@ -1047,6 +1088,7 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         "SELECT argMax(status, inserted_at), argMax(signature_type, inserted_at), "
         "argMax(signature_config_sha, inserted_at), "
         "argMax(cluster_config_sha, inserted_at), "
+        "argMax(naming_config_sha, inserted_at), "
         "toString(argMax(completed_at, inserted_at)), toString(min(completed_at)) "
         f"FROM {target_db}.signature_cluster_runs "
         "WHERE project_id = 'project-1' GROUP BY project_id, id"
@@ -1056,6 +1098,7 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
             "intent",
             "signature-cfg-a",
             "cluster-cfg-a",
+            "naming-cfg-a",
             "2026-06-20 15:04:00.000000",
             "1970-01-01 00:00:00.000000",
         )
@@ -1096,6 +1139,36 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         f"WHERE database = '{target_db}' AND active "
         "AND table LIKE 'signature_cluster%'"
     ).result_rows == [(3,)]
+
+    # Both children partition on the run window, so a run's rows land in one partition
+    # named for it rather than for their write time.
+    assert ch_client.query(
+        "SELECT table, partition FROM system.parts "
+        f"WHERE database = '{target_db}' AND active "
+        "AND table IN ('signature_clusters', 'signature_cluster_assignments') "
+        "ORDER BY table"
+    ).result_rows == [
+        ("signature_cluster_assignments", "202606"),
+        ("signature_clusters", "202606"),
+    ]
+
+    # Moving the signature to another cluster inside the same run is a new row, not a
+    # collapse, because `cluster_id` is part of the key. Readers resolve with argMax.
+    ch_client.command(
+        f"INSERT INTO {target_db}.signature_cluster_assignments "
+        "(project_id, cluster_run_id, signature_record_id, run_window_end, "
+        "cluster_id, signature_type, trace_id, inserted_at) "
+        f"VALUES ('project-1', '{run_id}', '{_INTENT_ID}', "
+        f"toDateTime64('2026-06-01', 6, 'UTC'), '{_NIL_UUID}', 'intent', 'trace-4', "
+        "toDateTime64('2026-06-20 15:10:00', 6, 'UTC'))"
+    )
+    ch_client.command(f"OPTIMIZE TABLE {target_db}.signature_cluster_assignments FINAL")
+    assert ch_client.query(
+        "SELECT count(), uniqExact(cluster_id), "
+        "toString(argMax(cluster_id, inserted_at)) "
+        f"FROM {target_db}.signature_cluster_assignments "
+        f"WHERE project_id = 'project-1' AND signature_record_id = '{_INTENT_ID}'"
+    ).result_rows == [(2, 2, _NIL_UUID)]
 
 
 def test_migration_client_timeout_outlasts_replicated_ddl(ch_keeper_server):

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -911,6 +911,167 @@ def test_failure_turn_attribution(ch_client):
     ).result_rows == [(0,)]
 
 
+def test_signature_cluster_tables_schema_and_retry(ch_client):
+    """Cluster storage follows signature-row identity and collapses writer retries."""
+    target_db = _migrate_signatures_db(ch_client, "signature_clusters")
+
+    expected_tables = {
+        "signature_cluster_assignments": (
+            "project_id, cluster_run_id, signature_record_id",
+            [
+                ("project_id", "String"),
+                ("cluster_run_id", "UUID"),
+                ("signature_record_id", "UUID"),
+                ("cluster_id", "Int32"),
+                ("cluster_confidence", "Float32"),
+                ("inserted_at", "DateTime64(6, 'UTC')"),
+                ("expire_at", "DateTime"),
+            ],
+        ),
+        "signature_cluster_runs": (
+            "project_id, id",
+            [
+                ("project_id", "String"),
+                ("id", "UUID"),
+                ("signature_type", "LowCardinality(String)"),
+                ("signature_config_sha", "LowCardinality(String)"),
+                ("cluster_config_sha", "LowCardinality(String)"),
+                ("window_start", "DateTime64(6, 'UTC')"),
+                ("window_end", "DateTime64(6, 'UTC')"),
+                ("status", "LowCardinality(String)"),
+                ("started_at", "DateTime64(6, 'UTC')"),
+                ("completed_at", "Nullable(DateTime64(6, 'UTC'))"),
+                ("inserted_at", "DateTime64(6, 'UTC')"),
+                ("expire_at", "DateTime"),
+            ],
+        ),
+        "signature_clusters": (
+            "project_id, cluster_run_id, cluster_id",
+            [
+                ("project_id", "String"),
+                ("cluster_run_id", "UUID"),
+                ("cluster_id", "Int32"),
+                ("label", "String"),
+                ("occurrence_count", "UInt64"),
+                ("inserted_at", "DateTime64(6, 'UTC')"),
+                ("expire_at", "DateTime"),
+            ],
+        ),
+    }
+    assert ch_client.query(
+        "SELECT name, engine, sorting_key "
+        "FROM system.tables "
+        f"WHERE database = '{target_db}' AND name LIKE 'signature_cluster%' "
+        "ORDER BY name"
+    ).result_rows == [
+        (name, "ReplacingMergeTree", sorting_key)
+        for name, (sorting_key, _) in expected_tables.items()
+    ]
+    for table_name, (_, expected_columns) in expected_tables.items():
+        assert (
+            ch_client.query(
+                "SELECT name, type FROM system.columns "
+                f"WHERE database = '{target_db}' AND table = '{table_name}' "
+                "ORDER BY position"
+            ).result_rows
+            == expected_columns
+        )
+
+    # No speculative read model or index ships with the base storage contract.
+    assert (
+        ch_client.query(
+            "SELECT name FROM system.tables "
+            f"WHERE database = '{target_db}' AND name = 'signature_cluster_daily'"
+        ).result_rows
+        == []
+    )
+    assert (
+        ch_client.query(
+            "SELECT name FROM system.projections "
+            f"WHERE database = '{target_db}' AND table LIKE 'signature_cluster%'"
+        ).result_rows
+        == []
+    )
+
+    _insert_intent(ch_client, target_db, "action_request", 0.21)
+    run_id = "019ff4bc-2ae1-744d-ae3a-285998a90519"
+    for inserted_at, status, completed_at in [
+        ("2026-06-20 15:00:00", "running", "NULL"),
+        (
+            "2026-06-20 15:05:00",
+            "complete",
+            "toDateTime64('2026-06-20 15:04:00', 6, 'UTC')",
+        ),
+    ]:
+        ch_client.command(
+            f"INSERT INTO {target_db}.signature_cluster_runs "
+            "(project_id, id, signature_type, signature_config_sha, "
+            "cluster_config_sha, window_start, window_end, status, started_at, "
+            "completed_at, inserted_at) VALUES "
+            f"('project-1', '{run_id}', 'intent', 'signature-cfg-a', "
+            "'cluster-cfg-a', toDateTime64('2026-05-01', 6, 'UTC'), "
+            "toDateTime64('2026-06-01', 6, 'UTC'), "
+            f"'{status}', toDateTime64('2026-06-20 14:59:00', 6, 'UTC'), "
+            f"{completed_at}, toDateTime64('{inserted_at}', 6, 'UTC'))"
+        )
+
+    for inserted_at, label, count, cluster_id, confidence in [
+        ("2026-06-20 15:00:00", "draft", 1, -1, 0.0),
+        ("2026-06-20 15:05:00", "checkout", 2, 7, 0.875),
+    ]:
+        ch_client.command(
+            f"INSERT INTO {target_db}.signature_clusters "
+            "(project_id, cluster_run_id, cluster_id, label, occurrence_count, inserted_at) "
+            f"VALUES ('project-1', '{run_id}', 7, '{label}', {count}, "
+            f"toDateTime64('{inserted_at}', 6, 'UTC'))"
+        )
+        ch_client.command(
+            f"INSERT INTO {target_db}.signature_cluster_assignments "
+            "(project_id, cluster_run_id, signature_record_id, cluster_id, "
+            "cluster_confidence, inserted_at) "
+            f"VALUES ('project-1', '{run_id}', '{_INTENT_ID}', {cluster_id}, "
+            f"toFloat32({confidence}), toDateTime64('{inserted_at}', 6, 'UTC'))"
+        )
+
+    assert ch_client.query(
+        "SELECT argMax(status, inserted_at), argMax(signature_type, inserted_at), "
+        "argMax(signature_config_sha, inserted_at), "
+        "argMax(cluster_config_sha, inserted_at), "
+        "isNull(argMax(completed_at, inserted_at)) "
+        f"FROM {target_db}.signature_cluster_runs "
+        "WHERE project_id = 'project-1' GROUP BY project_id, id"
+    ).result_rows == [("complete", "intent", "signature-cfg-a", "cluster-cfg-a", 0)]
+    assert ch_client.query(
+        "SELECT argMax(label, inserted_at), argMax(occurrence_count, inserted_at) "
+        f"FROM {target_db}.signature_clusters "
+        "WHERE project_id = 'project-1' GROUP BY project_id, cluster_run_id, cluster_id"
+    ).result_rows == [("checkout", 2)]
+    assert ch_client.query(
+        "SELECT argMax(cluster_id, inserted_at), "
+        "round(toFloat64(argMax(cluster_confidence, inserted_at)), 3) "
+        f"FROM {target_db}.signature_cluster_assignments "
+        "WHERE project_id = 'project-1' "
+        "GROUP BY project_id, cluster_run_id, signature_record_id"
+    ).result_rows == [(7, 0.875)]
+
+    # The assignment references the upstream signature row UUID directly.
+    assert ch_client.query(
+        "SELECT count() "
+        f"FROM {target_db}.signature_cluster_assignments AS a "
+        f"INNER JOIN {target_db}.intent_signatures AS s "
+        "ON a.project_id = s.project_id AND a.signature_record_id = s.id "
+        f"WHERE a.cluster_run_id = toUUID('{run_id}')"
+    ).result_rows == [(2,)]
+
+    for table_name in expected_tables:
+        ch_client.command(f"OPTIMIZE TABLE {target_db}.{table_name} FINAL")
+    assert ch_client.query(
+        "SELECT sum(rows) FROM system.parts "
+        f"WHERE database = '{target_db}' AND active "
+        "AND table LIKE 'signature_cluster%'"
+    ).result_rows == [(3,)]
+
+
 def test_migration_client_timeout_outlasts_replicated_ddl(ch_keeper_server):
     """A client minted with the production migration timeout runs a full
     replicated migration and carries the incident-fixing HTTP read timeout.

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -923,7 +923,9 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
                 ("cluster_run_id", "UUID"),
                 ("signature_record_id", "UUID"),
                 ("cluster_id", "Int32"),
-                ("cluster_confidence", "Float32"),
+                ("cluster_distance", "Float32"),
+                ("umap_x", "Float32"),
+                ("umap_y", "Float32"),
                 ("inserted_at", "DateTime64(6, 'UTC')"),
                 ("expire_at", "DateTime"),
             ],
@@ -1015,9 +1017,9 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
             f"{completed_at}, toDateTime64('{inserted_at}', 6, 'UTC'))"
         )
 
-    for inserted_at, label, count, cluster_id, confidence in [
-        ("2026-06-20 15:00:00", "draft", 1, -1, 0.0),
-        ("2026-06-20 15:05:00", "checkout", 2, 7, 0.875),
+    for inserted_at, label, count, cluster_id, distance, umap in [
+        ("2026-06-20 15:00:00", "draft", 1, -1, 0.0, (0.0, 0.0)),
+        ("2026-06-20 15:05:00", "checkout", 2, 7, 0.875, (-1.5, 3.25)),
     ]:
         ch_client.command(
             f"INSERT INTO {target_db}.signature_clusters "
@@ -1028,9 +1030,10 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         ch_client.command(
             f"INSERT INTO {target_db}.signature_cluster_assignments "
             "(project_id, cluster_run_id, signature_record_id, cluster_id, "
-            "cluster_confidence, inserted_at) "
+            "cluster_distance, umap_x, umap_y, inserted_at) "
             f"VALUES ('project-1', '{run_id}', '{_INTENT_ID}', {cluster_id}, "
-            f"toFloat32({confidence}), toDateTime64('{inserted_at}', 6, 'UTC'))"
+            f"toFloat32({distance}), toFloat32({umap[0]}), toFloat32({umap[1]}), "
+            f"toDateTime64('{inserted_at}', 6, 'UTC'))"
         )
 
     assert ch_client.query(
@@ -1048,11 +1051,13 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
     ).result_rows == [("checkout", 2)]
     assert ch_client.query(
         "SELECT argMax(cluster_id, inserted_at), "
-        "round(toFloat64(argMax(cluster_confidence, inserted_at)), 3) "
+        "round(toFloat64(argMax(cluster_distance, inserted_at)), 3), "
+        "toFloat64(argMax(umap_x, inserted_at)), "
+        "toFloat64(argMax(umap_y, inserted_at)) "
         f"FROM {target_db}.signature_cluster_assignments "
         "WHERE project_id = 'project-1' "
         "GROUP BY project_id, cluster_run_id, signature_record_id"
-    ).result_rows == [(7, 0.875)]
+    ).result_rows == [(7, 0.875, -1.5, 3.25)]
 
     # The assignment references the upstream signature row UUID directly.
     assert ch_client.query(

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -926,21 +926,24 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
                 ("cluster_distance", "Float32"),
                 ("umap_x", "Float32"),
                 ("umap_y", "Float32"),
+                ("trace_id", "String"),
+                ("turn_duration_ms", "UInt32"),
+                ("turn_cost_usd", "Float64"),
                 ("inserted_at", "DateTime64(6, 'UTC')"),
                 ("expire_at", "DateTime"),
             ],
         ),
         "signature_cluster_runs": (
-            "project_id, id",
+            "project_id, signature_type, window_end, id",
             [
                 ("project_id", "String"),
                 ("id", "UUID"),
-                ("signature_type", "LowCardinality(String)"),
+                ("signature_type", "Enum8('intent' = 1, 'failure' = 2)"),
                 ("signature_config_sha", "LowCardinality(String)"),
                 ("cluster_config_sha", "LowCardinality(String)"),
                 ("window_start", "DateTime64(6, 'UTC')"),
                 ("window_end", "DateTime64(6, 'UTC')"),
-                ("status", "LowCardinality(String)"),
+                ("status", "Enum8('running' = 1, 'completed' = 2, 'failed' = 3)"),
                 ("started_at", "DateTime64(6, 'UTC')"),
                 ("completed_at", "Nullable(DateTime64(6, 'UTC'))"),
                 ("inserted_at", "DateTime64(6, 'UTC')"),
@@ -1001,7 +1004,7 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         ("2026-06-20 15:00:00", "running", "NULL"),
         (
             "2026-06-20 15:05:00",
-            "complete",
+            "completed",
             "toDateTime64('2026-06-20 15:04:00', 6, 'UTC')",
         ),
     ]:
@@ -1030,9 +1033,11 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         ch_client.command(
             f"INSERT INTO {target_db}.signature_cluster_assignments "
             "(project_id, cluster_run_id, signature_record_id, cluster_id, "
-            "cluster_distance, umap_x, umap_y, inserted_at) "
+            "cluster_distance, umap_x, umap_y, trace_id, turn_duration_ms, "
+            "turn_cost_usd, inserted_at) "
             f"VALUES ('project-1', '{run_id}', '{_INTENT_ID}', {cluster_id}, "
             f"toFloat32({distance}), toFloat32({umap[0]}), toFloat32({umap[1]}), "
+            "'trace-4', 9000, 0.21, "
             f"toDateTime64('{inserted_at}', 6, 'UTC'))"
         )
 
@@ -1043,7 +1048,7 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         "isNull(argMax(completed_at, inserted_at)) "
         f"FROM {target_db}.signature_cluster_runs "
         "WHERE project_id = 'project-1' GROUP BY project_id, id"
-    ).result_rows == [("complete", "intent", "signature-cfg-a", "cluster-cfg-a", 0)]
+    ).result_rows == [("completed", "intent", "signature-cfg-a", "cluster-cfg-a", 0)]
     assert ch_client.query(
         "SELECT argMax(label, inserted_at), argMax(occurrence_count, inserted_at) "
         f"FROM {target_db}.signature_clusters "
@@ -1053,20 +1058,25 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         "SELECT argMax(cluster_id, inserted_at), "
         "round(toFloat64(argMax(cluster_distance, inserted_at)), 3), "
         "toFloat64(argMax(umap_x, inserted_at)), "
-        "toFloat64(argMax(umap_y, inserted_at)) "
+        "toFloat64(argMax(umap_y, inserted_at)), "
+        "argMax(trace_id, inserted_at), argMax(turn_duration_ms, inserted_at), "
+        "round(argMax(turn_cost_usd, inserted_at), 3) "
         f"FROM {target_db}.signature_cluster_assignments "
         "WHERE project_id = 'project-1' "
         "GROUP BY project_id, cluster_run_id, signature_record_id"
-    ).result_rows == [(7, 0.875, -1.5, 3.25)]
+    ).result_rows == [(7, 0.875, -1.5, 3.25, "trace-4", 9000, 0.21)]
 
-    # The assignment references the upstream signature row UUID directly.
+    # The assignment references the upstream signature row UUID directly, and the
+    # denormalized turn columns carry the same values that join would have hydrated.
     assert ch_client.query(
-        "SELECT count() "
+        "SELECT count(), countIf(a.trace_id = s.trace_id "
+        "AND a.turn_duration_ms = s.turn_duration_ms "
+        "AND round(a.turn_cost_usd, 3) = round(s.turn_cost_usd, 3)) "
         f"FROM {target_db}.signature_cluster_assignments AS a "
         f"INNER JOIN {target_db}.intent_signatures AS s "
         "ON a.project_id = s.project_id AND a.signature_record_id = s.id "
         f"WHERE a.cluster_run_id = toUUID('{run_id}')"
-    ).result_rows == [(2,)]
+    ).result_rows == [(2, 2)]
 
     for table_name in expected_tables:
         ch_client.command(f"OPTIMIZE TABLE {target_db}.{table_name} FINAL")

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -725,6 +725,7 @@ _FAILURE_ID_2 = "019ff288-c1d4-7333-bfc4-1743fe294f3a"
 _CLUSTER_ID = "019ff4bc-2ae1-744d-ae3a-285998a9051a"
 # Stable across runs, unlike `_CLUSTER_ID`, which a run re-mints.
 _TOPIC_ID = "019ff4bc-2ae1-744d-ae3a-285998a9051b"
+_ACTION_ITEM_ID = "019ff4bc-2ae1-744d-ae3a-285998a9051c"
 _NIL_UUID = "00000000-0000-0000-0000-000000000000"
 
 
@@ -1207,6 +1208,109 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         f"FROM {target_db}.signature_cluster_assignments "
         f"WHERE project_id = 'project-1' AND signature_record_id = '{_INTENT_ID}'"
     ).result_rows == [(2, 2, _NIL_UUID)]
+
+
+def test_cluster_action_items_schema_and_retry(ch_client):
+    """Action Items are cluster-scoped and user edits append complete versions."""
+    target_db = _migrate_signatures_db(ch_client, "cluster_action_items")
+
+    assert ch_client.query(
+        "SELECT engine, partition_key, sorting_key, primary_key, "
+        "extract(create_table_query, 'TTL (.+) SETTINGS') "
+        f"FROM system.tables WHERE database = '{target_db}' "
+        "AND name = 'cluster_action_items'"
+    ).result_rows == [
+        (
+            "ReplacingMergeTree",
+            "toYYYYMM(run_window_end)",
+            "project_id, cluster_run_id, cluster_id, id",
+            "project_id, cluster_run_id, cluster_id, id",
+            "expire_at",
+        )
+    ]
+    assert ch_client.query(
+        "SELECT name, type, default_kind, default_expression "
+        "FROM system.columns "
+        f"WHERE database = '{target_db}' AND table = 'cluster_action_items' "
+        "ORDER BY position"
+    ).result_rows == [
+        ("project_id", "String", "", ""),
+        ("cluster_run_id", "UUID", "", ""),
+        ("cluster_id", "UUID", "", ""),
+        ("run_window_end", "DateTime64(6, 'UTC')", "", ""),
+        ("signature_type", "Enum8('intent' = 1, 'failure' = 2)", "", ""),
+        ("id", "UUID", "", ""),
+        ("action_item_config_sha", "LowCardinality(String)", "", ""),
+        ("title", "String", "", ""),
+        ("description", "String", "DEFAULT", "''"),
+        ("evidence_trace_ids", "Array(String)", "DEFAULT", "[]"),
+        (
+            "status",
+            "Enum8('OPEN' = 1, 'IN_PROGRESS' = 2, 'COMPLETED' = 3, 'DISMISSED' = 4)",
+            "DEFAULT",
+            "'OPEN'",
+        ),
+        (
+            "severity",
+            "Enum8('SEVERE' = 1, 'MAJOR' = 2, 'MINOR' = 3)",
+            "DEFAULT",
+            "'MINOR'",
+        ),
+        ("inserted_at", "DateTime64(6, 'UTC')", "DEFAULT", "now64(6)"),
+        ("expire_at", "DateTime", "DEFAULT", "'2100-01-01 00:00:00'"),
+    ]
+
+    run_id = "019ff4bc-2ae1-744d-ae3a-285998a90519"
+    for inserted_at, title, status, severity in [
+        ("2026-06-20 15:00:00", "Draft issue", "OPEN", "MINOR"),
+        ("2026-06-20 15:05:00", "Honor output path", "IN_PROGRESS", "SEVERE"),
+    ]:
+        ch_client.command(
+            f"INSERT INTO {target_db}.cluster_action_items "
+            "(project_id, cluster_run_id, cluster_id, run_window_end, "
+            "signature_type, id, action_item_config_sha, title, description, "
+            "evidence_trace_ids, status, severity, inserted_at) VALUES "
+            f"('project-1', '{run_id}', '{_CLUSTER_ID}', "
+            "toDateTime64('2026-06-01', 6, 'UTC'), 'failure', "
+            f"'{_ACTION_ITEM_ID}', 'action-cfg-a', '{title}', 'Details', "
+            f"['trace-4'], '{status}', '{severity}', "
+            f"toDateTime64('{inserted_at}', 6, 'UTC'))"
+        )
+
+    assert ch_client.query(
+        "SELECT argMax(title, inserted_at), argMax(status, inserted_at), "
+        "argMax(severity, inserted_at), argMax(evidence_trace_ids, inserted_at) "
+        f"FROM {target_db}.cluster_action_items WHERE project_id = 'project-1' "
+        "GROUP BY project_id, cluster_run_id, cluster_id, id"
+    ).result_rows == [("Honor output path", "IN_PROGRESS", "SEVERE", ["trace-4"])]
+    assert ch_client.query(
+        "SELECT DISTINCT partition FROM system.parts "
+        f"WHERE database = '{target_db}' AND table = 'cluster_action_items' "
+        "AND active"
+    ).result_rows == [("202606",)]
+
+    second_item_id = "019ff4bc-2ae1-744d-ae3a-285998a9051d"
+    ch_client.command(
+        f"INSERT INTO {target_db}.cluster_action_items "
+        "(project_id, cluster_run_id, cluster_id, run_window_end, "
+        "signature_type, id, action_item_config_sha, title) VALUES "
+        f"('project-1', '{run_id}', '{_CLUSTER_ID}', "
+        "toDateTime64('2026-06-01', 6, 'UTC'), 'failure', "
+        f"'{second_item_id}', 'action-cfg-a', 'Second issue')"
+    )
+    assert ch_client.query(
+        "SELECT countDistinct(id) FROM "
+        f"{target_db}.cluster_action_items WHERE project_id = 'project-1' "
+        f"AND cluster_run_id = toUUID('{run_id}') "
+        f"AND cluster_id = toUUID('{_CLUSTER_ID}')"
+    ).result_rows == [(2,)]
+
+    # A forced merge is test-only proof that the version key physically collapses.
+    ch_client.command(f"OPTIMIZE TABLE {target_db}.cluster_action_items FINAL")
+    assert ch_client.query(
+        f"SELECT count() FROM {target_db}.cluster_action_items "
+        "WHERE project_id = 'project-1'"
+    ).result_rows == [(2,)]
 
 
 def test_migration_client_timeout_outlasts_replicated_ddl(ch_keeper_server):

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -611,6 +611,11 @@ _INTENT_COLUMNS = [
     ("agent_name", "String"),
     ("turn_duration_ms", "UInt32"),
     ("turn_cost_usd", "Float64"),
+    ("turn_input_tokens", "UInt64"),
+    ("turn_output_tokens", "UInt64"),
+    ("turn_reasoning_tokens", "UInt64"),
+    ("turn_cache_creation_input_tokens", "UInt64"),
+    ("turn_cache_read_input_tokens", "UInt64"),
     ("trace_started_at", "DateTime64(6, 'UTC')"),
     ("extracted_at", "DateTime64(6, 'UTC')"),
     ("inserted_at", "DateTime64(6, 'UTC')"),
@@ -634,6 +639,11 @@ _FAILURE_COLUMNS = [
     ("agent_name", "String"),
     ("turn_duration_ms", "UInt32"),
     ("turn_cost_usd", "Float64"),
+    ("turn_input_tokens", "UInt64"),
+    ("turn_output_tokens", "UInt64"),
+    ("turn_reasoning_tokens", "UInt64"),
+    ("turn_cache_creation_input_tokens", "UInt64"),
+    ("turn_cache_read_input_tokens", "UInt64"),
     ("trace_started_at", "DateTime64(6, 'UTC')"),
     ("extracted_at", "DateTime64(6, 'UTC')"),
     ("inserted_at", "DateTime64(6, 'UTC')"),
@@ -644,7 +654,7 @@ _FAILURE_COLUMNS = [
 # from a shared block: the assert is ORDER BY position, and shared columns
 # interleave with grain-specific ones differently in each table. Growing this
 # count is a decision, not a side effect.
-_EXPECTED_SHARED_COLUMNS = 15
+_EXPECTED_SHARED_COLUMNS = 20
 
 _SIGNATURE_TABLES = [
     (
@@ -691,6 +701,18 @@ _TRACE_STARTED_AT = "toDateTime64('2026-05-30 09:15:00', 6, 'UTC')"
 _EXTRACTED_AT = "toDateTime64('2026-06-20 14:32:00', 6, 'UTC')"
 _UNIT_VECTOR = "arrayResize([toFloat32(1)], 1024, toFloat32(0))"
 
+# Every value distinct, so a pair transposed on the way in fails the assert. Written
+# in schema order, which is what lets one dict drive both the insert and the read.
+_TURN_TOKENS = {
+    "turn_input_tokens": 12000,
+    "turn_output_tokens": 800,
+    "turn_reasoning_tokens": 320,
+    "turn_cache_creation_input_tokens": 4096,
+    "turn_cache_read_input_tokens": 65536,
+}
+_TOKEN_COLUMNS = ", ".join(_TURN_TOKENS)
+_TOKEN_VALUES = ", ".join(str(count) for count in _TURN_TOKENS.values())
+
 # The sorting key, and therefore the dedup key: a read that collapses a retry
 # groups by all three terms, because no read here uses FINAL.
 _SIGNATURE_KEY = "project_id, toDate(trace_started_at), id"
@@ -712,10 +734,12 @@ def _insert_intent(ch_client, target_db: str, category: str, cost: float) -> Non
         f"INSERT INTO {target_db}.intent_signatures "
         "(project_id, id, config_sha, signature, category, language, "
         "sentiment, vector, conversation_id, trace_id, user_id, agent_name, "
-        "turn_duration_ms, turn_cost_usd, trace_started_at, extracted_at) VALUES "
+        f"turn_duration_ms, turn_cost_usd, {_TOKEN_COLUMNS}, "
+        "trace_started_at, extracted_at) VALUES "
         f"('project-1', '{_INTENT_ID}', 'cfg-a', 'add stripe checkout', "
         f"'{category}', 'es', 'frustrated', {_UNIT_VECTOR}, "
         f"'conversation-1', 'trace-4', 'user-1', 'checkout-agent', 9000, {cost}, "
+        f"{_TOKEN_VALUES}, "
         f"{_TRACE_STARTED_AT}, {_EXTRACTED_AT})"
     )
 
@@ -728,11 +752,13 @@ def _insert_failure(
         f"INSERT INTO {target_db}.failure_signatures "
         "(project_id, id, config_sha, signature, failure_reason, category, "
         "severity, vector, conversation_id, current_trace_id, affected_trace_ids, "
-        "user_id, agent_name, turn_duration_ms, turn_cost_usd, trace_started_at, "
-        f"extracted_at) VALUES ('project-1', '{row_id}', 'cfg-a', "
+        f"user_id, agent_name, turn_duration_ms, turn_cost_usd, {_TOKEN_COLUMNS}, "
+        "trace_started_at, extracted_at) VALUES "
+        f"('project-1', '{row_id}', 'cfg-a', "
         "'ignored the stated output path', 'The user specified /tmp/out.json.', "
         f"'requirement_violation', 'major', {_UNIT_VECTOR}, 'conversation-1', "
         f"'{current}', {affected}, 'user-1', 'checkout-agent', 16000, {cost}, "
+        f"{_TOKEN_VALUES}, "
         f"{_TRACE_STARTED_AT}, {_EXTRACTED_AT})"
     )
 
@@ -936,6 +962,11 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
                 ("trace_id", "String"),
                 ("turn_duration_ms", "UInt32"),
                 ("turn_cost_usd", "Float64"),
+                ("turn_input_tokens", "UInt64"),
+                ("turn_output_tokens", "UInt64"),
+                ("turn_reasoning_tokens", "UInt64"),
+                ("turn_cache_creation_input_tokens", "UInt64"),
+                ("turn_cache_read_input_tokens", "UInt64"),
                 ("inserted_at", "DateTime64(6, 'UTC')"),
                 ("expire_at", "DateTime"),
             ],
@@ -954,7 +985,8 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
                 ("window_end", "DateTime64(6, 'UTC')"),
                 (
                     "status",
-                    "Enum8('unset' = 1, 'running' = 2, 'completed' = 3, 'failed' = 4)",
+                    "Enum8('pending' = 1, 'running' = 2, 'succeeded' = 3, "
+                    "'failed' = 4, 'canceled' = 5)",
                 ),
                 ("started_at", "DateTime64(6, 'UTC')"),
                 ("completed_at", "DateTime64(6, 'UTC')"),
@@ -1041,7 +1073,7 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         ("2026-06-20 15:00:00", "running", "toDateTime64(0, 6, 'UTC')"),
         (
             "2026-06-20 15:05:00",
-            "completed",
+            "succeeded",
             "toDateTime64('2026-06-20 15:04:00', 6, 'UTC')",
         ),
     ]:
@@ -1076,11 +1108,12 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
             f"INSERT INTO {target_db}.signature_cluster_assignments "
             "(project_id, cluster_run_id, signature_record_id, run_window_end, "
             "cluster_id, signature_type, cluster_distance, umap_x, umap_y, trace_id, "
-            "turn_duration_ms, turn_cost_usd, inserted_at) "
+            f"turn_duration_ms, turn_cost_usd, {_TOKEN_COLUMNS}, "
+            "inserted_at) "
             f"VALUES ('project-1', '{run_id}', '{_INTENT_ID}', "
             f"toDateTime64('2026-06-01', 6, 'UTC'), '{_CLUSTER_ID}', 'intent', "
             f"toFloat32({distance}), toFloat32({umap[0]}), toFloat32({umap[1]}), "
-            "'trace-4', 9000, 0.21, "
+            f"'trace-4', 9000, 0.21, {_TOKEN_VALUES}, "
             f"toDateTime64('{inserted_at}', 6, 'UTC'))"
         )
 
@@ -1094,7 +1127,7 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         "WHERE project_id = 'project-1' GROUP BY project_id, id"
     ).result_rows == [
         (
-            "completed",
+            "succeeded",
             "intent",
             "signature-cfg-a",
             "cluster-cfg-a",
@@ -1114,18 +1147,23 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
         "toFloat64(argMax(umap_x, inserted_at)), "
         "toFloat64(argMax(umap_y, inserted_at)), "
         "argMax(trace_id, inserted_at), argMax(turn_duration_ms, inserted_at), "
-        "round(argMax(turn_cost_usd, inserted_at), 3) "
-        f"FROM {target_db}.signature_cluster_assignments "
+        "round(argMax(turn_cost_usd, inserted_at), 3), "
+        + ", ".join(f"argMax({column}, inserted_at)" for column in _TURN_TOKENS)
+        + f" FROM {target_db}.signature_cluster_assignments "
         "WHERE project_id = 'project-1' "
         "GROUP BY project_id, cluster_run_id, signature_record_id"
-    ).result_rows == [(_CLUSTER_ID, 0.875, -1.5, 3.25, "trace-4", 9000, 0.21)]
+    ).result_rows == [
+        (_CLUSTER_ID, 0.875, -1.5, 3.25, "trace-4", 9000, 0.21, *_TURN_TOKENS.values())
+    ]
 
     # The assignment references the upstream signature row UUID directly, and the
     # denormalized turn columns carry the same values that join would have hydrated.
     assert ch_client.query(
         "SELECT count(), countIf(a.trace_id = s.trace_id "
         "AND a.turn_duration_ms = s.turn_duration_ms "
-        "AND round(a.turn_cost_usd, 3) = round(s.turn_cost_usd, 3)) "
+        "AND round(a.turn_cost_usd, 3) = round(s.turn_cost_usd, 3) "
+        + "".join(f"AND a.{column} = s.{column} " for column in _TURN_TOKENS)
+        + ") "
         f"FROM {target_db}.signature_cluster_assignments AS a "
         f"INNER JOIN {target_db}.intent_signatures AS s "
         "ON a.project_id = s.project_id AND a.signature_record_id = s.id "

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -191,6 +191,9 @@ ID_SHARDED_TABLES: dict[str, str] = {
     # nearest-neighbor search and clustering do not fan out across shards.
     "intent_signatures": "project_id",
     "failure_signatures": "project_id",
+    "signature_cluster_runs": "project_id",
+    "signature_clusters": "project_id",
+    "signature_cluster_assignments": "project_id",
     # Keep each agent aggregate on one shard. Shard versions by the same key so
     # "versions for agent" queries have the same locality as the agent row.
     "agents": "project_id, agent_name",

--- a/weave/trace_server/insights/action_items.py
+++ b/weave/trace_server/insights/action_items.py
@@ -1,0 +1,77 @@
+import datetime
+from enum import Enum
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from weave.trace_server.common_interface import BaseModelStrict
+
+
+class ActionItemStatus(str, Enum):
+    OPEN = "OPEN"
+    IN_PROGRESS = "IN_PROGRESS"
+    COMPLETED = "COMPLETED"
+    DISMISSED = "DISMISSED"
+
+
+class ActionItemSeverity(str, Enum):
+    SEVERE = "SEVERE"
+    MAJOR = "MAJOR"
+    MINOR = "MINOR"
+
+
+class ActionItem(BaseModelStrict):
+    project_id: str
+    cluster_run_id: str
+    cluster_id: str
+    run_window_end: datetime.datetime
+    signature_type: Literal["intent", "failure"]
+    id: str
+    action_item_config_sha: str
+    title: str
+    description: str = ""
+    evidence_trace_ids: list[str] = Field(default_factory=list)
+    status: ActionItemStatus = ActionItemStatus.OPEN
+    severity: ActionItemSeverity = ActionItemSeverity.MINOR
+    inserted_at: datetime.datetime | None = None
+    expire_at: datetime.datetime | None = None
+
+
+class ActionItemsBatchUpsertReq(BaseModelStrict):
+    items: list[ActionItem]
+
+
+class ActionItemsBatchUpsertRes(BaseModelStrict):
+    ids: list[str]
+
+
+class ActionItemsQueryReq(BaseModelStrict):
+    project_id: str
+    cluster_run_id: str | None = None
+    cluster_id: str | None = None
+    statuses: list[ActionItemStatus] | None = None
+    severities: list[ActionItemSeverity] | None = None
+    limit: int = Field(default=100, ge=1, le=1000)
+
+
+class ActionItemsQueryRes(BaseModelStrict):
+    items: list[ActionItem]
+
+
+class ActionItemUpdateReq(BaseModelStrict):
+    project_id: str
+    cluster_run_id: str
+    cluster_id: str
+    id: str
+    status: ActionItemStatus | None = None
+    severity: ActionItemSeverity | None = None
+
+    @model_validator(mode="after")
+    def require_change(self) -> "ActionItemUpdateReq":
+        if self.status is None and self.severity is None:
+            raise ValueError("status or severity is required")
+        return self
+
+
+class ActionItemUpdateRes(BaseModelStrict):
+    item: ActionItem

--- a/weave/trace_server/insights/config.py
+++ b/weave/trace_server/insights/config.py
@@ -1,4 +1,4 @@
-"""Insights extraction config: the thing `config_sha` on the signature tables names.
+"""Content-addressed configuration for insights extraction and clustering.
 
 Every knob that changes what gets written into `intent_signatures` or
 `failure_signatures` lives in one checked-in config file per signature type, so the whole
@@ -10,10 +10,10 @@ digest without anyone touching the config.
 import hashlib
 import json
 import os
-from typing import Generic, Literal, TypeVar
+from typing import Annotated, Generic, Literal, TypeVar
 
 import yaml
-from pydantic import BaseModel, ConfigDict, model_serializer
+from pydantic import BaseModel, ConfigDict, Field, model_serializer
 
 CONFIG_DIR = os.path.join(os.path.dirname(__file__), "configs")
 
@@ -114,6 +114,18 @@ class Embedding(_Strict):
     output_normalization: str
 
 
+class ClusteringConfig(_Strict):
+    """Every parameter that changes a clustering run's output."""
+
+    config_schema_version: Literal[1]
+    algorithm: Literal["hdbscan"]
+    min_cluster_size: Annotated[int, Field(ge=2)]
+    min_samples: Annotated[int, Field(ge=1)]
+    metric: Literal["euclidean"]
+    cluster_selection_method: Literal["eom"]
+    allow_single_cluster: bool
+
+
 _E = TypeVar("_E", bound=Extraction)
 
 
@@ -157,7 +169,14 @@ def load_config(signature_type: str) -> SignatureConfig:
         return _CONFIG_MODELS[signature_type].model_validate(yaml.safe_load(handle))
 
 
-def config_sha(config: SignatureConfig) -> str:
+def load_clustering_config() -> ClusteringConfig:
+    """Load and validate the checked-in clustering config."""
+    path = os.path.join(CONFIG_DIR, "clustering.yaml")
+    with open(path, encoding="utf-8") as handle:
+        return ClusteringConfig.model_validate(yaml.safe_load(handle))
+
+
+def config_sha(config: _Strict) -> str:
     """Digest the config with every file reference resolved to its own sha256.
 
     Keys are sorted, so reordering a config file leaves the digest alone while

--- a/weave/trace_server/insights/config.py
+++ b/weave/trace_server/insights/config.py
@@ -114,6 +114,18 @@ class Embedding(_Strict):
     output_normalization: str
 
 
+class UmapProjection(_Strict):
+    """Knobs for the 2-D projection persisted on every cluster assignment.
+
+    It carries no metric of its own: on l2-normalized vectors cosine and euclidean
+    rank neighbors identically, so the clustering `metric` describes both.
+    """
+
+    n_neighbors: Annotated[int, Field(ge=2)]
+    min_dist: Annotated[float, Field(ge=0, lt=1)]
+    random_state: int
+
+
 class ClusteringConfig(_Strict):
     """Every parameter that changes a clustering run's output."""
 
@@ -124,6 +136,7 @@ class ClusteringConfig(_Strict):
     metric: Literal["euclidean"]
     cluster_selection_method: Literal["eom"]
     allow_single_cluster: bool
+    umap: UmapProjection
 
 
 _E = TypeVar("_E", bound=Extraction)

--- a/weave/trace_server/insights/configs/clustering.yaml
+++ b/weave/trace_server/insights/configs/clustering.yaml
@@ -6,3 +6,10 @@ min_samples: 3
 metric: euclidean
 cluster_selection_method: eom
 allow_single_cluster: false
+
+# Projection persisted per assignment, so a finished run's scatter plot redraws
+# without reprojecting. Fixed at two components by umap_x and umap_y.
+umap:
+  n_neighbors: 15
+  min_dist: 0.0
+  random_state: 0

--- a/weave/trace_server/insights/configs/clustering.yaml
+++ b/weave/trace_server/insights/configs/clustering.yaml
@@ -1,0 +1,8 @@
+config_schema_version: 1
+algorithm: hdbscan
+
+min_cluster_size: 3
+min_samples: 3
+metric: euclidean
+cluster_selection_method: eom
+allow_single_cluster: false

--- a/weave/trace_server/migrations/042_add_signature_cluster_tables.down.sql
+++ b/weave/trace_server/migrations/042_add_signature_cluster_tables.down.sql
@@ -1,3 +1,17 @@
+ALTER TABLE failure_signatures
+    DROP COLUMN IF EXISTS turn_cache_read_input_tokens,
+    DROP COLUMN IF EXISTS turn_cache_creation_input_tokens,
+    DROP COLUMN IF EXISTS turn_reasoning_tokens,
+    DROP COLUMN IF EXISTS turn_output_tokens,
+    DROP COLUMN IF EXISTS turn_input_tokens;
+
+ALTER TABLE intent_signatures
+    DROP COLUMN IF EXISTS turn_cache_read_input_tokens,
+    DROP COLUMN IF EXISTS turn_cache_creation_input_tokens,
+    DROP COLUMN IF EXISTS turn_reasoning_tokens,
+    DROP COLUMN IF EXISTS turn_output_tokens,
+    DROP COLUMN IF EXISTS turn_input_tokens;
+
 DROP TABLE IF EXISTS signature_cluster_assignments;
 
 DROP TABLE IF EXISTS signature_clusters;

--- a/weave/trace_server/migrations/042_add_signature_cluster_tables.down.sql
+++ b/weave/trace_server/migrations/042_add_signature_cluster_tables.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS signature_cluster_assignments;
+
+DROP TABLE IF EXISTS signature_clusters;
+
+DROP TABLE IF EXISTS signature_cluster_runs;

--- a/weave/trace_server/migrations/042_add_signature_cluster_tables.up.sql
+++ b/weave/trace_server/migrations/042_add_signature_cluster_tables.up.sql
@@ -42,7 +42,11 @@ CREATE TABLE IF NOT EXISTS signature_cluster_assignments
     cluster_run_id UUID,
     signature_record_id UUID,
     cluster_id Int32 DEFAULT -1,
-    cluster_confidence Float32 DEFAULT 0,
+    -- Distance from the signature vector to its cluster centroid, 0 for noise rows.
+    cluster_distance Float32 DEFAULT 0,
+    -- UMAP 2-D projection of the signature vector, reprojected by every run.
+    umap_x Float32 DEFAULT 0,
+    umap_y Float32 DEFAULT 0,
     inserted_at DateTime64(6, 'UTC') DEFAULT now(),
     expire_at DateTime DEFAULT '2100-01-01 00:00:00'
 )

--- a/weave/trace_server/migrations/042_add_signature_cluster_tables.up.sql
+++ b/weave/trace_server/migrations/042_add_signature_cluster_tables.up.sql
@@ -3,19 +3,22 @@ CREATE TABLE IF NOT EXISTS signature_cluster_runs
 (
     project_id String,
     id UUID DEFAULT generateUUIDv7(),
-    signature_type LowCardinality(String),
+    signature_type Enum8('intent' = 1, 'failure' = 2),
     signature_config_sha LowCardinality(String),
     cluster_config_sha LowCardinality(String),
     window_start DateTime64(6, 'UTC'),
     window_end DateTime64(6, 'UTC'),
-    status LowCardinality(String) DEFAULT 'running',
+    status Enum8('running' = 1, 'completed' = 2, 'failed' = 3) DEFAULT 'running',
     started_at DateTime64(6, 'UTC'),
+    -- NULL until the run terminates. `inserted_at` is the merge version, not a finish time.
     completed_at Nullable(DateTime64(6, 'UTC')) DEFAULT NULL,
-    inserted_at DateTime64(6, 'UTC') DEFAULT now(),
+    inserted_at DateTime64(6, 'UTC') DEFAULT now64(6),
     expire_at DateTime DEFAULT '2100-01-01 00:00:00'
 )
 ENGINE = ReplacingMergeTree(inserted_at)
-ORDER BY (project_id, id)
+-- Every key column is fixed at run creation, so the terminal rewrite of `status` collapses
+-- onto the running row instead of landing beside it.
+ORDER BY (project_id, signature_type, window_end, id)
 TTL expire_at DELETE
 SETTINGS min_bytes_for_wide_part = 0;
 
@@ -24,13 +27,17 @@ CREATE TABLE IF NOT EXISTS signature_clusters
 (
     project_id String,
     cluster_run_id UUID,
+    -- The clusterer's own label, dense from 0 and unique only within `cluster_run_id`. A run
+    -- relabels from scratch, so this never identifies the same cluster across two runs.
     cluster_id Int32,
-    label String DEFAULT '',
+    label String,
     occurrence_count UInt64 DEFAULT 0,
-    inserted_at DateTime64(6, 'UTC') DEFAULT now(),
+    inserted_at DateTime64(6, 'UTC') DEFAULT now64(6),
     expire_at DateTime DEFAULT '2100-01-01 00:00:00'
 )
 ENGINE = ReplacingMergeTree(inserted_at)
+-- `(cluster_run_id, cluster_id)` is the natural key, so a retried run collapses rather than
+-- double-counting `occurrence_count`.
 ORDER BY (project_id, cluster_run_id, cluster_id)
 TTL expire_at DELETE
 SETTINGS min_bytes_for_wide_part = 0;
@@ -41,13 +48,24 @@ CREATE TABLE IF NOT EXISTS signature_cluster_assignments
     project_id String,
     cluster_run_id UUID,
     signature_record_id UUID,
+    -- -1 is noise, which has no `signature_clusters` row.
     cluster_id Int32 DEFAULT -1,
     -- Distance from the signature vector to its cluster centroid, 0 for noise rows.
     cluster_distance Float32 DEFAULT 0,
     -- UMAP 2-D projection of the signature vector, reprojected by every run.
     umap_x Float32 DEFAULT 0,
     umap_y Float32 DEFAULT 0,
-    inserted_at DateTime64(6, 'UTC') DEFAULT now(),
+
+    -- Denormalized from the signature row so cluster aggregates need no join.
+    -- The turn the signature was extracted from, `failure_signatures.current_trace_id` for
+    -- failures. Join to hydrate `affected_trace_ids`, which is not copied.
+    trace_id String,
+    -- Whole-turn values copied onto every fan-out row, so summing them across a cluster
+    -- without first deduplicating on `trace_id` overcounts.
+    turn_duration_ms UInt32 DEFAULT 0,
+    turn_cost_usd Float64 DEFAULT 0,
+
+    inserted_at DateTime64(6, 'UTC') DEFAULT now64(6),
     expire_at DateTime DEFAULT '2100-01-01 00:00:00'
 )
 ENGINE = ReplacingMergeTree(inserted_at)

--- a/weave/trace_server/migrations/042_add_signature_cluster_tables.up.sql
+++ b/weave/trace_server/migrations/042_add_signature_cluster_tables.up.sql
@@ -14,7 +14,8 @@ CREATE TABLE IF NOT EXISTS signature_cluster_runs
     window_start DateTime64(6, 'UTC'),
     window_end DateTime64(6, 'UTC'),
 
-    status Enum8('unset' = 1, 'running' = 2, 'completed' = 3, 'failed' = 4) DEFAULT 'unset',
+    status Enum8('pending' = 1, 'running' = 2, 'succeeded' = 3, 'failed' = 4, 'canceled' = 5)
+        DEFAULT 'pending',
 
     started_at DateTime64(6, 'UTC'),
     completed_at DateTime64(6, 'UTC'),
@@ -37,8 +38,8 @@ CREATE TABLE IF NOT EXISTS signature_clusters
     -- Copied from the run. Fixed at run creation, so it is partition-safe.
     run_window_end DateTime64(6, 'UTC'),
 
-    -- Stable across runs. The writer matches each cluster to the previous run's
-    -- clusters by centroid similarity. Nil means no match, so this topic is new.
+    -- Not an FK: a topic identity carried forward by centroid match across runs, so it
+    -- outlives the per-run `id`. Nil until the writer links a run to its predecessor.
     topic_id UUID,
     -- Mean signature vector. Enables assigning a new signature to an existing cluster.
     centroid Array(Float32),
@@ -78,8 +79,16 @@ CREATE TABLE IF NOT EXISTS signature_cluster_assignments
 
     -- `failure_signatures.current_trace_id` or `intent_signatures.trace_id`
     trace_id String,
+    -- Whole-turn values copied onto every fan-out row, so summing them overcounts a
+    -- cluster that holds more than one signature from the same turn.
     turn_duration_ms UInt32 DEFAULT 0,
     turn_cost_usd Float64 DEFAULT 0,
+    -- Same vocabulary as the agent spans table, so no translation on the way in.
+    turn_input_tokens UInt64 DEFAULT 0,
+    turn_output_tokens UInt64 DEFAULT 0,
+    turn_reasoning_tokens UInt64 DEFAULT 0,
+    turn_cache_creation_input_tokens UInt64 DEFAULT 0,
+    turn_cache_read_input_tokens UInt64 DEFAULT 0,
 
     inserted_at DateTime64(6, 'UTC') DEFAULT now64(6),
     expire_at DateTime DEFAULT '2100-01-01 00:00:00',
@@ -92,3 +101,23 @@ PARTITION BY toYYYYMM(run_window_end)
 ORDER BY (project_id, cluster_run_id, cluster_id, signature_record_id)
 TTL expire_at DELETE
 SETTINGS min_bytes_for_wide_part = 0;
+
+-- Tokens for the turn each signature came from, added here because 041 has shipped.
+-- One column per category, not a map, so a rollup can sum them with SimpleAggregateFunction.
+ALTER TABLE intent_signatures
+    ADD COLUMN IF NOT EXISTS turn_input_tokens UInt64 DEFAULT 0 AFTER turn_cost_usd,
+    ADD COLUMN IF NOT EXISTS turn_output_tokens UInt64 DEFAULT 0 AFTER turn_input_tokens,
+    ADD COLUMN IF NOT EXISTS turn_reasoning_tokens UInt64 DEFAULT 0 AFTER turn_output_tokens,
+    ADD COLUMN IF NOT EXISTS turn_cache_creation_input_tokens UInt64 DEFAULT 0
+        AFTER turn_reasoning_tokens,
+    ADD COLUMN IF NOT EXISTS turn_cache_read_input_tokens UInt64 DEFAULT 0
+        AFTER turn_cache_creation_input_tokens;
+
+ALTER TABLE failure_signatures
+    ADD COLUMN IF NOT EXISTS turn_input_tokens UInt64 DEFAULT 0 AFTER turn_cost_usd,
+    ADD COLUMN IF NOT EXISTS turn_output_tokens UInt64 DEFAULT 0 AFTER turn_input_tokens,
+    ADD COLUMN IF NOT EXISTS turn_reasoning_tokens UInt64 DEFAULT 0 AFTER turn_output_tokens,
+    ADD COLUMN IF NOT EXISTS turn_cache_creation_input_tokens UInt64 DEFAULT 0
+        AFTER turn_reasoning_tokens,
+    ADD COLUMN IF NOT EXISTS turn_cache_read_input_tokens UInt64 DEFAULT 0
+        AFTER turn_cache_creation_input_tokens;

--- a/weave/trace_server/migrations/042_add_signature_cluster_tables.up.sql
+++ b/weave/trace_server/migrations/042_add_signature_cluster_tables.up.sql
@@ -10,8 +10,8 @@ CREATE TABLE IF NOT EXISTS signature_cluster_runs
     window_end DateTime64(6, 'UTC'),
     status Enum8('running' = 1, 'completed' = 2, 'failed' = 3) DEFAULT 'running',
     started_at DateTime64(6, 'UTC'),
-    -- NULL until the run terminates. `inserted_at` is the merge version, not a finish time.
-    completed_at Nullable(DateTime64(6, 'UTC')) DEFAULT NULL,
+    -- Epoch zero until the run terminates. `inserted_at` is the merge version, not a finish time.
+    completed_at DateTime64(6, 'UTC') DEFAULT toDateTime64(0, 6, 'UTC'),
     inserted_at DateTime64(6, 'UTC') DEFAULT now64(6),
     expire_at DateTime DEFAULT '2100-01-01 00:00:00'
 )
@@ -27,18 +27,16 @@ CREATE TABLE IF NOT EXISTS signature_clusters
 (
     project_id String,
     cluster_run_id UUID,
-    -- The clusterer's own label, dense from 0 and unique only within `cluster_run_id`. A run
-    -- relabels from scratch, so this never identifies the same cluster across two runs.
-    cluster_id Int32,
+    -- Writer-minted uuidv7, so only a retry reusing this id collapses in the merge. A run
+    -- relabels from scratch, so an id never identifies the same cluster across two runs.
+    id UUID DEFAULT generateUUIDv7(),
     label String,
     occurrence_count UInt64 DEFAULT 0,
     inserted_at DateTime64(6, 'UTC') DEFAULT now64(6),
     expire_at DateTime DEFAULT '2100-01-01 00:00:00'
 )
 ENGINE = ReplacingMergeTree(inserted_at)
--- `(cluster_run_id, cluster_id)` is the natural key, so a retried run collapses rather than
--- double-counting `occurrence_count`.
-ORDER BY (project_id, cluster_run_id, cluster_id)
+ORDER BY (project_id, cluster_run_id, id)
 TTL expire_at DELETE
 SETTINGS min_bytes_for_wide_part = 0;
 
@@ -48,8 +46,8 @@ CREATE TABLE IF NOT EXISTS signature_cluster_assignments
     project_id String,
     cluster_run_id UUID,
     signature_record_id UUID,
-    -- -1 is noise, which has no `signature_clusters` row.
-    cluster_id Int32 DEFAULT -1,
+    -- References `signature_clusters.id`. The nil uuid is noise, which has no cluster row.
+    cluster_id UUID DEFAULT toUUID('00000000-0000-0000-0000-000000000000'),
     -- Distance from the signature vector to its cluster centroid, 0 for noise rows.
     cluster_distance Float32 DEFAULT 0,
     -- UMAP 2-D projection of the signature vector, reprojected by every run.

--- a/weave/trace_server/migrations/042_add_signature_cluster_tables.up.sql
+++ b/weave/trace_server/migrations/042_add_signature_cluster_tables.up.sql
@@ -1,0 +1,52 @@
+-- A cluster run groups one signature type and exact extraction and clustering configs.
+CREATE TABLE IF NOT EXISTS signature_cluster_runs
+(
+    project_id String,
+    id UUID DEFAULT generateUUIDv7(),
+    signature_type LowCardinality(String),
+    signature_config_sha LowCardinality(String),
+    cluster_config_sha LowCardinality(String),
+    window_start DateTime64(6, 'UTC'),
+    window_end DateTime64(6, 'UTC'),
+    status LowCardinality(String) DEFAULT 'running',
+    started_at DateTime64(6, 'UTC'),
+    completed_at Nullable(DateTime64(6, 'UTC')) DEFAULT NULL,
+    inserted_at DateTime64(6, 'UTC') DEFAULT now(),
+    expire_at DateTime DEFAULT '2100-01-01 00:00:00'
+)
+ENGINE = ReplacingMergeTree(inserted_at)
+ORDER BY (project_id, id)
+TTL expire_at DELETE
+SETTINGS min_bytes_for_wide_part = 0;
+
+-- One generated label and occurrence count per cluster in a run.
+CREATE TABLE IF NOT EXISTS signature_clusters
+(
+    project_id String,
+    cluster_run_id UUID,
+    cluster_id Int32,
+    label String DEFAULT '',
+    occurrence_count UInt64 DEFAULT 0,
+    inserted_at DateTime64(6, 'UTC') DEFAULT now(),
+    expire_at DateTime DEFAULT '2100-01-01 00:00:00'
+)
+ENGINE = ReplacingMergeTree(inserted_at)
+ORDER BY (project_id, cluster_run_id, cluster_id)
+TTL expire_at DELETE
+SETTINGS min_bytes_for_wide_part = 0;
+
+-- One assignment per signature-table row in a run.
+CREATE TABLE IF NOT EXISTS signature_cluster_assignments
+(
+    project_id String,
+    cluster_run_id UUID,
+    signature_record_id UUID,
+    cluster_id Int32 DEFAULT -1,
+    cluster_confidence Float32 DEFAULT 0,
+    inserted_at DateTime64(6, 'UTC') DEFAULT now(),
+    expire_at DateTime DEFAULT '2100-01-01 00:00:00'
+)
+ENGINE = ReplacingMergeTree(inserted_at)
+ORDER BY (project_id, cluster_run_id, signature_record_id)
+TTL expire_at DELETE
+SETTINGS min_bytes_for_wide_part = 0;

--- a/weave/trace_server/migrations/042_add_signature_cluster_tables.up.sql
+++ b/weave/trace_server/migrations/042_add_signature_cluster_tables.up.sql
@@ -2,16 +2,22 @@
 CREATE TABLE IF NOT EXISTS signature_cluster_runs
 (
     project_id String,
-    id UUID DEFAULT generateUUIDv7(),
+    -- Intentionally omit UUID default, tracking in-progress runs requires re-inserting 
+    -- with the same PK, consumers should generate uuidv7 before insert
+    id UUID, -- UUIDv7
+
     signature_type Enum8('intent' = 1, 'failure' = 2),
     signature_config_sha LowCardinality(String),
     cluster_config_sha LowCardinality(String),
+    naming_config_sha LowCardinality(String),
+
     window_start DateTime64(6, 'UTC'),
     window_end DateTime64(6, 'UTC'),
-    status Enum8('running' = 1, 'completed' = 2, 'failed' = 3) DEFAULT 'running',
+
+    status Enum8('unset' = 1, 'running' = 2, 'completed' = 3, 'failed' = 4) DEFAULT 'unset',
+
     started_at DateTime64(6, 'UTC'),
-    -- Epoch zero until the run terminates. `inserted_at` is the merge version, not a finish time.
-    completed_at DateTime64(6, 'UTC') DEFAULT toDateTime64(0, 6, 'UTC'),
+    completed_at DateTime64(6, 'UTC'),
     inserted_at DateTime64(6, 'UTC') DEFAULT now64(6),
     expire_at DateTime DEFAULT '2100-01-01 00:00:00'
 )
@@ -27,15 +33,26 @@ CREATE TABLE IF NOT EXISTS signature_clusters
 (
     project_id String,
     cluster_run_id UUID,
-    -- Writer-minted uuidv7, so only a retry reusing this id collapses in the merge. A run
-    -- relabels from scratch, so an id never identifies the same cluster across two runs.
-    id UUID DEFAULT generateUUIDv7(),
+    id UUID,
+    -- Copied from the run. Fixed at run creation, so it is partition-safe.
+    run_window_end DateTime64(6, 'UTC'),
+
+    -- Stable across runs. The writer matches each cluster to the previous run's
+    -- clusters by centroid similarity. Nil means no match, so this topic is new.
+    topic_id UUID,
+    -- Mean signature vector. Enables assigning a new signature to an existing cluster.
+    centroid Array(Float32),
+
     label String,
+    description String DEFAULT '',
     occurrence_count UInt64 DEFAULT 0,
     inserted_at DateTime64(6, 'UTC') DEFAULT now64(6),
-    expire_at DateTime DEFAULT '2100-01-01 00:00:00'
+    expire_at DateTime DEFAULT '2100-01-01 00:00:00',
+
+    INDEX idx_topic_id topic_id TYPE bloom_filter(0.01) GRANULARITY 1
 )
 ENGINE = ReplacingMergeTree(inserted_at)
+PARTITION BY toYYYYMM(run_window_end)
 ORDER BY (project_id, cluster_run_id, id)
 TTL expire_at DELETE
 SETTINGS min_bytes_for_wide_part = 0;
@@ -46,27 +63,32 @@ CREATE TABLE IF NOT EXISTS signature_cluster_assignments
     project_id String,
     cluster_run_id UUID,
     signature_record_id UUID,
-    -- References `signature_clusters.id`. The nil uuid is noise, which has no cluster row.
-    cluster_id UUID DEFAULT toUUID('00000000-0000-0000-0000-000000000000'),
-    -- Distance from the signature vector to its cluster centroid, 0 for noise rows.
+    -- FK to `signature_cluster_runs.window_end`.
+    run_window_end DateTime64(6, 'UTC'),
+    -- FK to `signature_clusters.id`. The nil uuid is noise, which has no cluster row,
+    -- so a run's noise rows are one contiguous range of the sorting key.
+    cluster_id UUID,
+    signature_type Enum8('intent' = 1, 'failure' = 2),
+
+    -- Distance from the signature vector to its cluster centroid.
     cluster_distance Float32 DEFAULT 0,
-    -- UMAP 2-D projection of the signature vector, reprojected by every run.
+    -- UMAP 2-D projection of the signature vector.
     umap_x Float32 DEFAULT 0,
     umap_y Float32 DEFAULT 0,
 
-    -- Denormalized from the signature row so cluster aggregates need no join.
-    -- The turn the signature was extracted from, `failure_signatures.current_trace_id` for
-    -- failures. Join to hydrate `affected_trace_ids`, which is not copied.
+    -- `failure_signatures.current_trace_id` or `intent_signatures.trace_id`
     trace_id String,
-    -- Whole-turn values copied onto every fan-out row, so summing them across a cluster
-    -- without first deduplicating on `trace_id` overcounts.
     turn_duration_ms UInt32 DEFAULT 0,
     turn_cost_usd Float64 DEFAULT 0,
 
     inserted_at DateTime64(6, 'UTC') DEFAULT now64(6),
-    expire_at DateTime DEFAULT '2100-01-01 00:00:00'
+    expire_at DateTime DEFAULT '2100-01-01 00:00:00',
+
+    INDEX idx_signature_record_id signature_record_id TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1
 )
 ENGINE = ReplacingMergeTree(inserted_at)
-ORDER BY (project_id, cluster_run_id, signature_record_id)
+PARTITION BY toYYYYMM(run_window_end)
+ORDER BY (project_id, cluster_run_id, cluster_id, signature_record_id)
 TTL expire_at DELETE
 SETTINGS min_bytes_for_wide_part = 0;

--- a/weave/trace_server/migrations/043_add_cluster_action_items.down.sql
+++ b/weave/trace_server/migrations/043_add_cluster_action_items.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS cluster_action_items;

--- a/weave/trace_server/migrations/043_add_cluster_action_items.up.sql
+++ b/weave/trace_server/migrations/043_add_cluster_action_items.up.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS cluster_action_items
+(
+    project_id String,
+    cluster_run_id UUID,
+    cluster_id UUID,
+    -- Copied from the cluster run so Action Items share its lifecycle partition.
+    run_window_end DateTime64(6, 'UTC'),
+    signature_type Enum8('intent' = 1, 'failure' = 2),
+
+    -- The writer reuses this UUID for retries and later user edits.
+    id UUID,
+    action_item_config_sha LowCardinality(String),
+
+    title String,
+    description String DEFAULT '',
+    evidence_trace_ids Array(String) DEFAULT [],
+    status Enum8('OPEN' = 1, 'IN_PROGRESS' = 2, 'COMPLETED' = 3, 'DISMISSED' = 4)
+        DEFAULT 'OPEN',
+    severity Enum8('SEVERE' = 1, 'MAJOR' = 2, 'MINOR' = 3) DEFAULT 'MINOR',
+
+    inserted_at DateTime64(6, 'UTC') DEFAULT now64(6),
+    expire_at DateTime DEFAULT '2100-01-01 00:00:00'
+)
+ENGINE = ReplacingMergeTree(inserted_at)
+PARTITION BY toYYYYMM(run_window_end)
+ORDER BY (project_id, cluster_run_id, cluster_id, id)
+TTL expire_at DELETE
+SETTINGS min_bytes_for_wide_part = 0;

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -36,11 +36,12 @@ from weave.trace_server.constants import (
     MAX_OBJECT_NAME_LENGTH,
 )
 from weave.trace_server.errors import InvalidRequest
+from weave.trace_server.insights import action_items
 from weave.trace_server.interface.query import Query
 
 # Re-exported from service_interface for backwards compatibility.
 # New code should import from weave.trace_server.service_interface directly.
-from weave.trace_server.service_interface import (  # noqa: F401
+from weave.trace_server.service_interface import (  # ruff: ignore[unused-import]
     EnsureProjectExistsRes,
     ProjectsInfoReq,
     ProjectsInfoRes,
@@ -3639,6 +3640,17 @@ class TraceServerInterface(Protocol):
     def agent_conversation_spans(
         self, req: agent_types.AgentConversationSpansReq
     ) -> agent_types.AgentConversationSpansRes: ...
+
+    # Insights Action Items API
+    def action_items_batch_upsert(
+        self, req: action_items.ActionItemsBatchUpsertReq
+    ) -> action_items.ActionItemsBatchUpsertRes: ...
+    def action_items_query(
+        self, req: action_items.ActionItemsQueryReq
+    ) -> action_items.ActionItemsQueryRes: ...
+    def action_item_update(
+        self, req: action_items.ActionItemUpdateReq
+    ) -> action_items.ActionItemUpdateRes: ...
 
     # Call API
     def call_start(self, req: CallStartReq) -> CallStartRes: ...

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -20,6 +20,7 @@ from weave.trace.settings import (
 from weave.trace_server import http_service_interface as his
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ids import generate_id
+from weave.trace_server.insights import action_items
 from weave.trace_server.service_interface import ServerInfoRes
 from weave.trace_server.trace_server_interface import agent_types
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
@@ -705,6 +706,41 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             req,
             agent_types.AgentCustomAttrsSchemaReq,
             agent_types.AgentCustomAttrsSchemaRes,
+        )
+
+    # === Insights Action Items API ===
+
+    @validate_call
+    def action_items_batch_upsert(
+        self, req: action_items.ActionItemsBatchUpsertReq
+    ) -> action_items.ActionItemsBatchUpsertRes:
+        return self._generic_request(
+            "/insights/action-items/batch-upsert",
+            req,
+            action_items.ActionItemsBatchUpsertReq,
+            action_items.ActionItemsBatchUpsertRes,
+        )
+
+    @validate_call
+    def action_items_query(
+        self, req: action_items.ActionItemsQueryReq
+    ) -> action_items.ActionItemsQueryRes:
+        return self._generic_request(
+            "/insights/action-items/query",
+            req,
+            action_items.ActionItemsQueryReq,
+            action_items.ActionItemsQueryRes,
+        )
+
+    @validate_call
+    def action_item_update(
+        self, req: action_items.ActionItemUpdateReq
+    ) -> action_items.ActionItemUpdateRes:
+        return self._generic_request(
+            "/insights/action-items/update",
+            req,
+            action_items.ActionItemUpdateReq,
+            action_items.ActionItemUpdateRes,
         )
 
     @validate_call


### PR DESCRIPTION
## What

Add migration 043 for cluster-scoped Action Items and typed Python bindings for batch upsert, query, and user updates.

On merge, the Weave migration chain creates `cluster_action_items` after the signature cluster tables. The table stores workflow status and severity, but does not store agent actionability. This PR does not add Action Item generation, curation, HTTP handlers, or UI.

## Why

Agent Insights needs durable issues associated with a concrete signature cluster. Each cluster can have multiple Action Items, and users need to edit an item's workflow status and severity without mutating ClickHouse parts in place.

## How

- Use `ReplacingMergeTree(inserted_at)` with `(project_id, cluster_run_id, cluster_id, id)` as the replacement key. Writers reuse an item UUID for retries and later edits.
- Partition by the cluster run's `run_window_end` month and apply the existing `expire_at` TTL convention.
- Store workflow status as `OPEN`, `IN_PROGRESS`, `COMPLETED`, or `DISMISSED`. Store severity as `SEVERE`, `MAJOR`, or `MINOR`.
- Add strict Pydantic models and `RemoteHTTPTraceServer` bindings for batch upsert, query, and status or severity updates.

## Testing

- `tests/trace_server_migrator/test_migrator_functional.py`: 30 passed against ClickHouse, including migration apply and rollback coverage, exact schema assertions, append-only edits, retry collapse, partitioning, and multiple items per cluster.
- Action Item and existing Agent route binding tests: 13 passed, including endpoint paths, full serialized payloads, enum hydration, and update validation.

## Anything Else

- This is an additive database migration and must follow migration 042.
- The PR is based on `griffin/intent-records-normalized`, which contains migrations 041 and 042. It does not include the separate Insights Reports migration branch.
- The new binding contract names the future HTTP endpoints. Server handlers and curation behavior remain separate work.
