### PR TITLE
fix(weave): stop duplicating custom summaries in log_summary

### DIFF
--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -537,7 +537,7 @@ def test_evaluation_no_auto_summarize(client):
     calls = client.get_calls()
     # assert len(calls) == 1
     summarize_call = calls[4]
-    assert summarize_call.output == {"output": {}}
+    assert summarize_call.output == {}
 
 
 def test_evaluation_fail_with_exception(client):
@@ -566,11 +566,7 @@ def test_evaluation_no_auto_summarize_with_custom_dict(client):
     calls = client.get_calls()
     # assert len(calls) == 1
     summarize_call = calls[4]
-    assert summarize_call.output == {
-        "something": 1,
-        "else": 2,
-        "output": {"something": 1, "else": 2},
-    }
+    assert summarize_call.output == {"something": 1, "else": 2}
 
 
 def test_evaluation_logger_model_inference_method_handling(weave_active):

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -1083,7 +1083,7 @@ class EvaluationLogger:
         final_summary = {}
         if summary_data:
             final_summary = summary_data
-        if summary is not None:
+        if summary is not None and auto_summarize:
             final_summary = {**final_summary, "output": summary}
 
         # Call the summarize op


### PR DESCRIPTION
## Problem

With `auto_summarize=False`, `EvaluationLogger.log_summary(summary=...)` set `summary_data` to the caller's dict and then nested that same dict again under an `"output"` key. Every custom key appeared twice in the logged summary and in the child `Evaluation.summarize` call output.

Fixes #7741.

## Fix

The caller-supplied summary is only nested under `"output"` when an auto-computed summary was merged alongside it (`auto_summarize=True`), which is the distinct-object case the nesting exists for. With `auto_summarize=False` the logged summary is exactly the caller's dict.

## Test

Updated `test_evaluation_no_auto_summarize` (expects `{}` instead of `{"output": {}}`) and `test_evaluation_no_auto_summarize_with_custom_dict` (expects the custom dict without the duplicated nested copy) in `tests/flow/test_evaluation_imperative.py`.
