### PR TITLE
chore(weave): add the canonical clustering recipe config

### DIFF
--- a/tests/trace_server/test_insights_config.py
+++ b/tests/trace_server/test_insights_config.py
@@ -32,26 +32,35 @@ def test_clustering_config_is_typed_and_content_addressed(config_dir):
         "config_schema_version": 1,
         "algorithm": "hdbscan",
         "scope": "global",
-        "min_cluster_size": 3,
-        "min_samples": 3,
-        "metric": "euclidean",
-        "cluster_selection_method": "eom",
-        "allow_single_cluster": False,
-        "umap": {"n_neighbors": 15, "min_dist": 0.0, "random_state": 0},
+        "reduction": {
+            "dimensions": 15,
+            "neighbors": 15,
+            "min_dist": 0.0,
+            "metric": "cosine",
+            "random_state": 0,
+            "minimum_rows": 50,
+        },
+        "density": {
+            "min_cluster_size": 3,
+            "min_samples": 3,
+            "metric": "euclidean",
+            "cluster_selection_method": "eom",
+            "allow_single_cluster": False,
+        },
+        "projection": {"neighbors": 15, "min_dist": 0.0, "random_state": 0},
     }
 
     before = config.config_sha(clustering)
     with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
-        raw["min_cluster_size"] = 5
-    after_flat_edit = config.config_sha(config.load_clustering_config())
-    assert after_flat_edit != before
+        raw["density"]["min_cluster_size"] = 5
+    after_density_edit = config.config_sha(config.load_clustering_config())
+    assert after_density_edit != before
 
-    # A nested knob reaches the digest too, so reprojecting declares a new run.
     with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
-        raw["umap"]["random_state"] = 7
+        raw["reduction"]["random_state"] = 7
     assert config.config_sha(config.load_clustering_config()) not in {
         before,
-        after_flat_edit,
+        after_density_edit,
     }
 
     with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
@@ -61,7 +70,7 @@ def test_clustering_config_is_typed_and_content_addressed(config_dir):
 
     with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
         raw.pop("untracked_parameter")
-        raw["min_cluster_size"] = 1
+        raw["density"]["min_cluster_size"] = 1
     with pytest.raises(ValidationError, match="min_cluster_size"):
         config.load_clustering_config()
 
@@ -158,6 +167,57 @@ def test_unloadable_configs_are_rejected_by_field(config_dir, edit, match):
 def test_an_unknown_signature_type_is_rejected():
     with pytest.raises(ValueError, match="unknown insights signature type"):
         config.load_config("sentiment")
+
+
+def test_the_clustering_recipe_is_a_separate_digest_from_the_signature_configs():
+    """A partition can be refit without re-extracting, so the two digests answer different
+    questions and a reader must never see one standing in for the other.
+    """
+    clustering = config.load_clustering_config()
+    digest = config.config_sha(clustering)
+
+    assert digest not in {_digest("intent"), _digest("failure")}
+    assert clustering.algorithm == "hdbscan"
+    assert clustering.scope == "global"
+    # The reduced space is what gets clustered; the projection is drawn. Separate knobs,
+    # because reading the projection's neighbor count as the partition's is a real mistake.
+    assert clustering.reduction.dimensions == 15
+    assert clustering.reduction.neighbors == 15
+    assert clustering.reduction.metric == "cosine"
+    assert clustering.reduction.random_state == 0
+    assert clustering.reduction.minimum_rows == 50
+    assert clustering.density.min_cluster_size == clustering.density.min_samples == 3
+    assert clustering.density.metric == "euclidean"
+
+
+@pytest.mark.parametrize(
+    ("edit", "match"),
+    [
+        (lambda raw: raw.update(algorithm="kmeans"), "algorithm"),
+        (lambda raw: raw["reduction"].update(spectral_init=True), "spectral_init"),
+        (lambda raw: raw["reduction"].pop("random_state"), "random_state"),
+        (lambda raw: raw.update(config_schema_version=2), "config_schema_version"),
+    ],
+    ids=["unimplemented_algorithm", "undeclared_knob", "missing_seed", "wrong_version"],
+)
+def test_an_unloadable_clustering_recipe_is_rejected_by_field(config_dir, edit, match):
+    with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
+        edit(raw)
+
+    with pytest.raises(ValidationError, match=match):
+        config.load_clustering_config()
+
+
+def test_unpinning_the_reduction_seed_moves_the_clustering_digest(config_dir):
+    """An unpinned refit is a different pipeline generation, so rows must not claim the old one."""
+    before = config.config_sha(config.load_clustering_config())
+
+    with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
+        raw["reduction"]["random_state"] = None
+    unpinned = config.load_clustering_config()
+
+    assert unpinned.reduction.random_state is None
+    assert config.config_sha(unpinned) != before
 
 
 @pytest.mark.parametrize(

--- a/weave/trace_server/insights/config.py
+++ b/weave/trace_server/insights/config.py
@@ -1,10 +1,13 @@
-"""Content-addressed configuration for insights extraction and clustering.
+"""Insights configs: the things `config_sha` names on the signature and cluster tables.
 
 Every knob that changes what gets written into `intent_signatures` or
 `failure_signatures` lives in one checked-in config file per signature type, so the whole
 pipeline state is one column and none of it is in the sorting key. A reference
 serializes as its own content hash, so editing a taxonomy or a prompt moves the
 digest without anyone touching the config.
+
+The clustering recipe is a separate file with its own digest, because a partition can be
+refit without re-extracting anything and the two digests answer different questions.
 """
 
 import hashlib
@@ -114,31 +117,56 @@ class Embedding(_Strict):
     output_normalization: str
 
 
-class UmapProjection(_Strict):
-    """Knobs for the 2-D projection persisted on every cluster assignment.
+class Reduction(_Strict):
+    """The space HDBSCAN clusters in, which is not the 2-D layout the UI draws.
 
-    It carries no metric of its own: on l2-normalized vectors cosine and euclidean
-    rank neighbors identically, so the clustering `metric` describes both.
+    Every field moves the partition, so every field is in the digest. `random_state`
+    included: a run that unpins the seed is a different pipeline generation, not the
+    same one with jitter.
     """
 
-    n_neighbors: Annotated[int, Field(ge=2)]
+    dimensions: Annotated[int, Field(ge=2)]
+    neighbors: Annotated[int, Field(ge=2)]
     min_dist: Annotated[float, Field(ge=0, lt=1)]
-    random_state: int
+    metric: str
+    random_state: int | None
+    minimum_rows: Annotated[int, Field(ge=2)]
+
+
+class Density(_Strict):
+    """The density clusterer's own knobs, applied to the reduced space."""
+
+    min_cluster_size: Annotated[int, Field(ge=2)]
+    min_samples: Annotated[int, Field(ge=1)]
+    metric: str
+    cluster_selection_method: str
+    allow_single_cluster: bool
+
+
+class Projection(_Strict):
+    """The stored 2-D coordinates. Display only, so it never decides a label."""
+
+    neighbors: Annotated[int, Field(ge=2)]
+    min_dist: Annotated[float, Field(ge=0, lt=1)]
+    random_state: int | None
 
 
 class ClusteringConfig(_Strict):
-    """Every parameter that changes a clustering run's output."""
+    """The recipe behind one partition, named by `cluster_config_sha` on a cluster run.
+
+    Separate from the signature configs because a partition can be refit without
+    re-extracting anything, and the two digests answer different questions.
+    """
 
     config_schema_version: Literal[1]
+    # A one-value Literal on purpose: a config naming an algorithm nothing implements
+    # fails to load rather than being silently ignored.
     algorithm: Literal["hdbscan"]
     # What one fit covers: the whole signature type, or each category on its own.
     scope: Literal["global", "category"]
-    min_cluster_size: Annotated[int, Field(ge=2)]
-    min_samples: Annotated[int, Field(ge=1)]
-    metric: Literal["euclidean"]
-    cluster_selection_method: Literal["eom"]
-    allow_single_cluster: bool
-    umap: UmapProjection
+    reduction: Reduction
+    density: Density
+    projection: Projection
 
 
 _E = TypeVar("_E", bound=Extraction)
@@ -165,6 +193,7 @@ class FailureConfig(_SignatureConfig[FailureExtraction]):
 
 SignatureConfig = IntentConfig | FailureConfig
 
+
 _CONFIG_MODELS: dict[str, type[SignatureConfig]] = {
     "intent": IntentConfig,
     "failure": FailureConfig,
@@ -185,7 +214,7 @@ def load_config(signature_type: str) -> SignatureConfig:
 
 
 def load_clustering_config() -> ClusteringConfig:
-    """Load and validate the checked-in clustering config."""
+    """Load and validate the checked-in clustering recipe."""
     path = os.path.join(CONFIG_DIR, "clustering.yaml")
     with open(path, encoding="utf-8") as handle:
         return ClusteringConfig.model_validate(yaml.safe_load(handle))

--- a/weave/trace_server/insights/configs/clustering.yaml
+++ b/weave/trace_server/insights/configs/clustering.yaml
@@ -5,15 +5,31 @@ algorithm: hdbscan
 # category, which resolves finer topics inside a category that dominates the space.
 scope: global
 
-min_cluster_size: 3
-min_samples: 3
-metric: euclidean
-cluster_selection_method: eom
-allow_single_cluster: false
+# What HDBSCAN actually clusters. Reducing first was chosen against a measurement rather than
+# taken as a default: on the reference corpus, reducing with UMAP or not reducing at all both
+# beat reducing with PCA, so these are the measured parameters and not tunables.
+reduction:
+  dimensions: 15
+  neighbors: 15
+  min_dist: 0.0
+  metric: cosine
+  # Pinned, so a refit on identical input returns an identical partition. Unpinning it is a
+  # different pipeline generation, which is why the digest covers this field.
+  random_state: 0
+  # Below this many distinct signatures the reducer's own degenerate paths cost more than the
+  # curse of dimensionality it exists to fix, and the raw vectors cluster well already.
+  minimum_rows: 50
 
-# Projection persisted per assignment, so a finished run's scatter plot redraws
-# without reprojecting. Fixed at two components by umap_x and umap_y.
-umap:
-  n_neighbors: 15
+density:
+  min_cluster_size: 3
+  min_samples: 3
+  metric: euclidean
+  cluster_selection_method: eom
+  allow_single_cluster: false
+
+# The 2-D coordinates stored per assignment, for drawing only. Nothing here decides a label,
+# so it is separate from `reduction` and its neighbor count is a different knob.
+projection:
+  neighbors: 15
   min_dist: 0.0
   random_state: 0


### PR DESCRIPTION
## Summary
- `cluster_config_sha` on a cluster run had nothing canonical to name: the signature configs cover extraction, and the recipe behind the partition lived in whatever the caller passed in. `clustering.yaml` gives it a checked-in home with its own digest, separate because a partition can be refit without re-extracting anything and the two digests answer different questions.
- Three groups rather than one flat set of knobs, because two of them were confusable. `reduction` is the space HDBSCAN clusters in; `density` is the clusterer applied to that space; `projection` is the stored 2-D layout, which is drawn and never decides a label. Reading the projection's neighbor count as the partition's is a real mistake and the shape now prevents it.
- `reduction.random_state` is a config field rather than a hardcoded constant, so an unpinned refit is a different pipeline generation instead of the same one with jitter, and rows cannot carry a digest that does not describe them. Same for `reduction.minimum_rows`, which decides whether reduction happens at all on a small project.
- `algorithm` is a one-value `Literal`, so a config naming something nothing implements fails to load rather than being silently ignored.
- The values are the measured ones: on the reference corpus, reducing with UMAP at 15 dimensions and 15 neighbors, or not reducing at all, both beat reducing with PCA. These are not tunables.

## Testing
Parameterized rejection cases assert each failure names the field that is wrong: an unimplemented algorithm, an undeclared knob, a missing seed, a wrong schema version. One test asserts unpinning the reduction seed moves the digest, and one asserts the clustering digest is distinct from both signature digests, which is what a reader joining on `config_sha` depends on.
