### PR TITLE
fix(weave): keep eval rows that produced no score in the summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,11 @@ without a marker filter so both tracing paths contribute coverage.
 Calls-based tests must include the integration's intentional text and thinking
 child calls in exact operation-set assertions.
 
+Every other shard, `flow` included, is run by CI with `-m "trace_server"`, and
+that filter comes from the workflow rather than from `noxfile.py`. A test that
+uses no server fixture therefore never runs in CI unless it carries
+`@pytest.mark.trace_server` itself.
+
 ### Running Tests
 
 **IMPORTANT**: Any test depending on the `client` fixture runs against ClickHouse, the only trace-server backend. Locally, the test fixtures auto-start a ClickHouse Docker container if one isn't already running, so Docker must be available. Pass `--clickhouse-process=true` to use a local `clickhouse-server` binary instead of Docker.

--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -1365,3 +1365,26 @@ def test_scores_are_traced_by_default(client):
 
     assert len(by_op["correctness"]) == 1
     assert by_op["correctness"][0].output == 1.0
+
+
+def test_prediction_without_scores_counts_in_the_summary(client):
+    """A prediction logged with no scores records `{}`, so it stays in the denominator."""
+    ev = EvaluationLogger()
+
+    pred = ev.log_prediction(inputs={"a": 1}, output=2)
+    pred.log_score(scorer="is_even", score=True)
+    pred.finish()
+
+    ev.log_prediction(inputs={"a": 2}, output=3).finish()
+
+    ev.log_summary()
+    client.flush()
+
+    by_op: dict[str, list] = defaultdict(list)
+    for c in client.get_calls():
+        by_op[op_name_from_call(c)].append(c)
+
+    assert by_op["Evaluation.evaluate"][0].output == {
+        "is_even": {"true_count": 1, "true_fraction": 0.5},
+        "output": {},
+    }

--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -1367,8 +1367,10 @@ def test_scores_are_traced_by_default(client):
     assert by_op["correctness"][0].output == 1.0
 
 
-def test_prediction_without_scores_counts_in_the_summary(client):
-    """A prediction logged with no scores records `{}`, so it stays in the denominator."""
+def test_prediction_without_scores_is_not_counted(client):
+    """Here an empty score dict means nothing was logged, so it must stay out of the
+    denominator: a prediction whose scoring failed logs None instead.
+    """
     ev = EvaluationLogger()
 
     pred = ev.log_prediction(inputs={"a": 1}, output=2)
@@ -1385,6 +1387,6 @@ def test_prediction_without_scores_counts_in_the_summary(client):
         by_op[op_name_from_call(c)].append(c)
 
     assert by_op["Evaluation.evaluate"][0].output == {
-        "is_even": {"true_count": 1, "true_fraction": 0.5},
+        "is_even": {"true_count": 1, "true_fraction": 1.0},
         "output": {},
     }

--- a/tests/flow/test_scorer.py
+++ b/tests/flow/test_scorer.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import BaseModel
 
-from weave.flow.scorer import Scorer, _import_numpy, auto_summarize
+from weave.flow.scorer import Scorer, auto_summarize
 from weave.trace.object_record import ObjectRecord
 from weave.trace.vals import WeaveDict, WeaveObject
 
@@ -110,12 +110,8 @@ def test_auto_summarize_mixed_basemodel_and_weave_dict():
     assert abs(result["confidence"]["mean"] - (0.9 + 0.4 + 0.7) / 3) < 1e-9
 
 
-# An evaluation records a row whose model or scorer raised as an empty dict:
-# Evaluation.get_eval_results backfills `{}` for every scorer that produced no
-# result. auto_summarize used to read that empty dict as "no value here", so the
-# row fell out of the boolean denominator, crashed the numeric branch, and chose
-# the branch for the whole column when it came first. A nested empty dict is an
-# ordinary value and must keep aggregating exactly as before.
+# A row whose model or scorer raised is recorded as an empty dict, which
+# auto_summarize used to read as "no value here" rather than "this row failed".
 
 
 class _Passed(BaseModel):
@@ -123,34 +119,49 @@ class _Passed(BaseModel):
 
 
 @pytest.mark.trace_server
-def test_auto_summarize_unscored_rows_stay_in_the_denominator():
-    """Two of four rows produced no score, so the fraction is 2/4, not 2/2."""
-    data = [{"correct": True}, {"correct": True}, {}, {}]
-    assert auto_summarize(data) == {"correct": {"true_count": 2, "true_fraction": 0.5}}
-
-
-@pytest.mark.trace_server
-def test_auto_summarize_unscored_rows_with_basemodel_scores():
-    """A BaseModel score reaches the dict branch via model_dump and needs the same count."""
-    data = [_Passed(passed=True), _Passed(passed=True), {}, {}]
-    assert auto_summarize(data) == {"passed": {"true_count": 2, "true_fraction": 0.5}}
-
-
-@pytest.mark.trace_server
 @pytest.mark.parametrize(
     ("data", "expected"),
     [
-        ([{}, {"correct": True}], {"correct": {"true_count": 1, "true_fraction": 0.5}}),
         (
-            [{}, _Passed(passed=True)],
-            {"passed": {"true_count": 1, "true_fraction": 0.5}},
+            [{"correct": True}, {"correct": True}, {}, {}],
+            {"correct": {"true_count": 2, "true_fraction": 0.5}},
         ),
-        ([{}, True], {"true_count": 1, "true_fraction": 0.5}),
-        ([{}, 1.0], {"mean": 1.0}),
+        (
+            [{}, {}, {"correct": True}, {"correct": True}],
+            {"correct": {"true_count": 2, "true_fraction": 0.5}},
+        ),
+        (
+            [_Passed(passed=True), _Passed(passed=True), {}, {}],
+            {"passed": {"true_count": 2, "true_fraction": 0.5}},
+        ),
+        (
+            [{}, {}, _Passed(passed=True), _Passed(passed=True)],
+            {"passed": {"true_count": 2, "true_fraction": 0.5}},
+        ),
+        ([True, True, {}, {}], {"true_count": 2, "true_fraction": 0.5}),
+        ([{}, {}, True, True], {"true_count": 2, "true_fraction": 0.5}),
+        (
+            [{"a": {"b": True}}, {}],
+            {"a": {"b": {"true_count": 1, "true_fraction": 0.5}}},
+        ),
+        (
+            [{}, {"a": {"b": True}}],
+            {"a": {"b": {"true_count": 1, "true_fraction": 0.5}}},
+        ),
+    ],
+    ids=[
+        "dict-last",
+        "dict-first",
+        "basemodel-last",
+        "basemodel-first",
+        "bool-last",
+        "bool-first",
+        "nested-last",
+        "nested-first",
     ],
 )
-def test_auto_summarize_unscored_first_row_does_not_choose_the_branch(data, expected):
-    """The branch follows the first row that has a score, so the metric survives."""
+def test_auto_summarize_counts_unscored_rows(data, expected):
+    """An unscored row stays in the denominator and never picks the branch, at any position."""
     assert auto_summarize(data) == expected
 
 
@@ -159,12 +170,13 @@ def test_auto_summarize_unscored_first_row_does_not_choose_the_branch(data, expe
     ("data", "expected"),
     [
         ([1.0, 1.0, {}, {}], {"mean": 1.0}),
+        ([{}, {}, 1.0, 1.0], {"mean": 1.0}),
         ([{"distance": 2.0}, {}, {}], {"distance": {"mean": 2.0}}),
-        ([{"distance": 1.0}, {"distance": None}, {}, {}], {"distance": {"mean": 1.0}}),
     ],
+    ids=["bare-last", "bare-first", "nested"],
 )
 def test_auto_summarize_numeric_scores_with_unscored_rows(data, expected):
-    """A numeric column mixed with unscored rows averages the numbers instead of raising."""
+    """A numeric column with unscored rows averages the scored values instead of raising."""
     assert auto_summarize(data) == expected
 
 
@@ -198,18 +210,8 @@ def test_auto_summarize_keeps_nested_empty_dicts():
         ([None, None], None),
         ([], {}),
     ],
+    ids=["bool", "none-leaf", "all-unscored", "all-none", "empty"],
 )
 def test_auto_summarize_results_unchanged(data, expected):
     """Values the current implementation already returns; the unscored count must not move them."""
     assert auto_summarize(data) == expected
-
-
-@pytest.mark.trace_server
-def test_auto_summarize_float_mean_matches_the_numpy_path():
-    """Filtering the numeric column must not change which mean is computed: numpy and
-    pure Python disagree in the last bit, so both must keep averaging the same values.
-    """
-    data = [0.1, 0.2, 0.3]
-    np = _import_numpy()
-    expected = np.mean(data).item() if np else sum(data) / len(data)
-    assert auto_summarize(data) == {"mean": expected}

--- a/tests/flow/test_scorer.py
+++ b/tests/flow/test_scorer.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import BaseModel
 
-from weave.flow.scorer import Scorer, auto_summarize
+from weave.flow.scorer import Scorer, _import_numpy, auto_summarize
 from weave.trace.object_record import ObjectRecord
 from weave.trace.vals import WeaveDict, WeaveObject
 
@@ -108,3 +108,108 @@ def test_auto_summarize_mixed_basemodel_and_weave_dict():
     result = auto_summarize(data)
     assert result["correct"] == {"true_count": 2, "true_fraction": 2 / 3}
     assert abs(result["confidence"]["mean"] - (0.9 + 0.4 + 0.7) / 3) < 1e-9
+
+
+# An evaluation records a row whose model or scorer raised as an empty dict:
+# Evaluation.get_eval_results backfills `{}` for every scorer that produced no
+# result. auto_summarize used to read that empty dict as "no value here", so the
+# row fell out of the boolean denominator, crashed the numeric branch, and chose
+# the branch for the whole column when it came first. A nested empty dict is an
+# ordinary value and must keep aggregating exactly as before.
+
+
+class _Passed(BaseModel):
+    passed: bool
+
+
+@pytest.mark.trace_server
+def test_auto_summarize_unscored_rows_stay_in_the_denominator():
+    """Two of four rows produced no score, so the fraction is 2/4, not 2/2."""
+    data = [{"correct": True}, {"correct": True}, {}, {}]
+    assert auto_summarize(data) == {"correct": {"true_count": 2, "true_fraction": 0.5}}
+
+
+@pytest.mark.trace_server
+def test_auto_summarize_unscored_rows_with_basemodel_scores():
+    """A BaseModel score reaches the dict branch via model_dump and needs the same count."""
+    data = [_Passed(passed=True), _Passed(passed=True), {}, {}]
+    assert auto_summarize(data) == {"passed": {"true_count": 2, "true_fraction": 0.5}}
+
+
+@pytest.mark.trace_server
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ([{}, {"correct": True}], {"correct": {"true_count": 1, "true_fraction": 0.5}}),
+        (
+            [{}, _Passed(passed=True)],
+            {"passed": {"true_count": 1, "true_fraction": 0.5}},
+        ),
+        ([{}, True], {"true_count": 1, "true_fraction": 0.5}),
+        ([{}, 1.0], {"mean": 1.0}),
+    ],
+)
+def test_auto_summarize_unscored_first_row_does_not_choose_the_branch(data, expected):
+    """The branch follows the first row that has a score, so the metric survives."""
+    assert auto_summarize(data) == expected
+
+
+@pytest.mark.trace_server
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ([1.0, 1.0, {}, {}], {"mean": 1.0}),
+        ([{"distance": 2.0}, {}, {}], {"distance": {"mean": 2.0}}),
+        ([{"distance": 1.0}, {"distance": None}, {}, {}], {"distance": {"mean": 1.0}}),
+    ],
+)
+def test_auto_summarize_numeric_scores_with_unscored_rows(data, expected):
+    """A numeric column mixed with unscored rows averages the numbers instead of raising."""
+    assert auto_summarize(data) == expected
+
+
+@pytest.mark.trace_server
+def test_auto_summarize_keeps_nested_empty_dicts():
+    """Only a top-level empty dict is an unscored row; a nested one is a real value."""
+    data = [
+        {"metadata": {"usage": {}}},
+        {"metadata": {"usage": {"input_tokens": 10, "ok": True}}},
+    ]
+    assert auto_summarize(data) == {
+        "metadata": {
+            "usage": {
+                "input_tokens": {"mean": 10.0},
+                "ok": {"true_count": 1, "true_fraction": 1.0},
+            }
+        }
+    }
+
+
+@pytest.mark.trace_server
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ([True, False], {"true_count": 1, "true_fraction": 0.5}),
+        (
+            [{"correct": True}, {"correct": None}],
+            {"correct": {"true_count": 1, "true_fraction": 1.0}},
+        ),
+        ([{}, {}], None),
+        ([None, None], None),
+        ([], {}),
+    ],
+)
+def test_auto_summarize_results_unchanged(data, expected):
+    """Values the current implementation already returns; the unscored count must not move them."""
+    assert auto_summarize(data) == expected
+
+
+@pytest.mark.trace_server
+def test_auto_summarize_float_mean_matches_the_numpy_path():
+    """Filtering the numeric column must not change which mean is computed: numpy and
+    pure Python disagree in the last bit, so both must keep averaging the same values.
+    """
+    data = [0.1, 0.2, 0.3]
+    np = _import_numpy()
+    expected = np.mean(data).item() if np else sum(data) / len(data)
+    assert auto_summarize(data) == {"mean": expected}

--- a/tests/flow/test_scorer.py
+++ b/tests/flow/test_scorer.py
@@ -110,8 +110,7 @@ def test_auto_summarize_mixed_basemodel_and_weave_dict():
     assert abs(result["confidence"]["mean"] - (0.9 + 0.4 + 0.7) / 3) < 1e-9
 
 
-# A row whose model or scorer raised is recorded as an empty dict, which
-# auto_summarize used to read as "no value here" rather than "this row failed".
+# A row whose model or scorer raised is recorded as an empty dict.
 
 
 class _Passed(BaseModel):
@@ -124,10 +123,6 @@ class _Passed(BaseModel):
     [
         (
             [{"correct": True}, {"correct": True}, {}, {}],
-            {"correct": {"true_count": 2, "true_fraction": 0.5}},
-        ),
-        (
-            [{}, {}, {"correct": True}, {"correct": True}],
             {"correct": {"true_count": 2, "true_fraction": 0.5}},
         ),
         (
@@ -144,20 +139,14 @@ class _Passed(BaseModel):
             [{"a": {"b": True}}, {}],
             {"a": {"b": {"true_count": 1, "true_fraction": 0.5}}},
         ),
-        (
-            [{}, {"a": {"b": True}}],
-            {"a": {"b": {"true_count": 1, "true_fraction": 0.5}}},
-        ),
     ],
     ids=[
-        "dict-last",
-        "dict-first",
+        "dict",
         "basemodel-last",
         "basemodel-first",
         "bool-last",
         "bool-first",
-        "nested-last",
-        "nested-first",
+        "nested",
     ],
 )
 def test_auto_summarize_counts_unscored_rows(data, expected):
@@ -172,8 +161,9 @@ def test_auto_summarize_counts_unscored_rows(data, expected):
         ([1.0, 1.0, {}, {}], {"mean": 1.0}),
         ([{}, {}, 1.0, 1.0], {"mean": 1.0}),
         ([{"distance": 2.0}, {}, {}], {"distance": {"mean": 2.0}}),
+        ([{"distance": 1.0}, {"distance": None}, {}, {}], {"distance": {"mean": 1.0}}),
     ],
-    ids=["bare-last", "bare-first", "nested"],
+    ids=["bare-last", "bare-first", "nested", "nested-none-leaf"],
 )
 def test_auto_summarize_numeric_scores_with_unscored_rows(data, expected):
     """A numeric column with unscored rows averages the scored values instead of raising."""
@@ -198,10 +188,24 @@ def test_auto_summarize_keeps_nested_empty_dicts():
 
 
 @pytest.mark.trace_server
+def test_auto_summarize_separates_unscored_rows_from_nested_empty_dicts():
+    """One column, both kinds of empty dict: only the top-level one moves a denominator."""
+    data = [
+        {"usage": {}, "ok": True},
+        {"usage": {"tokens": 10}, "ok": True},
+        {},
+    ]
+    assert auto_summarize(data) == {
+        "usage": {"tokens": {"mean": 10.0}},
+        "ok": {"true_count": 2, "true_fraction": 2 / 3},
+    }
+
+
+@pytest.mark.trace_server
 @pytest.mark.parametrize(
     ("data", "expected"),
     [
-        ([True, False], {"true_count": 1, "true_fraction": 0.5}),
+        ([0.0, 1.0], {"mean": 0.5}),
         (
             [{"correct": True}, {"correct": None}],
             {"correct": {"true_count": 1, "true_fraction": 1.0}},
@@ -210,8 +214,11 @@ def test_auto_summarize_keeps_nested_empty_dicts():
         ([None, None], None),
         ([], {}),
     ],
-    ids=["bool", "none-leaf", "all-unscored", "all-none", "empty"],
+    ids=["falsy-number", "none-leaf", "all-unscored", "all-none", "empty"],
 )
 def test_auto_summarize_results_unchanged(data, expected):
-    """Values the current implementation already returns; the unscored count must not move them."""
+    """Values the current implementation already returns; the unscored count must not move them.
+
+    A falsy number and a None leaf are real values, not unscored rows.
+    """
     assert auto_summarize(data) == expected

--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -121,7 +121,7 @@ library_cases = [
             "description": None,
             "dataset": "weave:///shawn/test-project/object/Dataset:YLYVrBqCtlMOa770T1oPssqYnf9rgqdnY5hVCwRcrm8",
             "scorers": [
-                "weave:///shawn/test-project/object/MyScorer:xGNFtpWKgn1TyYA0YzLMrKVxJkg3Mf8NyHzFc1R2sLg",
+                "weave:///shawn/test-project/object/MyScorer:8v25dGChke4FIp8qcRWvrQp72FNJkLSxByuG2uE3Rck",
                 f"weave:///shawn/test-project/object/LLMAsAJudgeScorer:{llm_as_a_judge_scorer_digest}",
             ],
             "preprocess_model_input": None,
@@ -168,14 +168,14 @@ library_cases = [
             },
             {
                 "object_id": "MyScorer",
-                "digest": "xGNFtpWKgn1TyYA0YzLMrKVxJkg3Mf8NyHzFc1R2sLg",
+                "digest": "8v25dGChke4FIp8qcRWvrQp72FNJkLSxByuG2uE3Rck",
                 "exp_val": {
                     "_type": "MyScorer",
                     "name": None,
                     "description": None,
                     "column_map": None,
                     "score": "weave:///shawn/test-project/op/MyScorer.score:lwLZn8tYQ025uYUv8SPwa1TlVfWSbzVSyw4aDynz1yQ",
-                    "summarize": "weave:///shawn/test-project/op/Scorer.summarize:bxtFn6x27RJmJ1fzbdfY76Y1XgYfSemEXU2XBqcFCnI",
+                    "summarize": "weave:///shawn/test-project/op/Scorer.summarize:kXItGo03ynxVl7CJCp6AGrtpOQe02L5QqsVGyFYXnWo",
                     "_class_name": "MyScorer",
                     "_bases": ["Scorer", "Object", "BaseModel"],
                 },
@@ -259,11 +259,11 @@ library_cases = [
             },
             {
                 "object_id": "Scorer.summarize",
-                "digest": "bxtFn6x27RJmJ1fzbdfY76Y1XgYfSemEXU2XBqcFCnI",
+                "digest": "kXItGo03ynxVl7CJCp6AGrtpOQe02L5QqsVGyFYXnWo",
                 "exp_val": {
                     "_type": "CustomWeaveType",
                     "weave_type": {"type": "Op"},
-                    "files": {"obj.py": "VOiN2jQwOlcTREFr5xoJhZbRsyKaRkiNMGk9O5XeCxo"},
+                    "files": {"obj.py": "LFL8Nn0Psr2gWeobJolUjjIsOZUO2vq4lRwTV8twu7Y"},
                 },
             },
         ],
@@ -277,8 +277,8 @@ library_cases = [
                 "exp_content": b"import weave\n\n@weave.op\ndef score(self, user_input: str, output: str) -> str:\n    return user_input in output\n",
             },
             {
-                "digest": "VOiN2jQwOlcTREFr5xoJhZbRsyKaRkiNMGk9O5XeCxo",
-                "exp_content": b'import weave\nfrom typing import Any\nfrom numbers import Number\nfrom pydantic.main import BaseModel\nfrom weave.trace.op import op\n\ndef _row_produced_a_score(x: Any) -> bool:\n    """A row that produced no score is recorded as an empty dict."""\n    return not isinstance(x, dict) or bool(x)\n\ndef _import_numpy() -> Any | None:\n    try:\n        import numpy\n    except ImportError:\n        return None\n    return numpy\n\ndef _summarize(data: list, *, unscored: int) -> dict[str, Any] | None:\n    """Summarize one column, given how many of its rows produced no score."""\n    data = [x for x in data if x is not None]\n\n    if not data:\n        return None\n\n    val = data[0]\n\n    if isinstance(val, bool):\n        return {\n            "true_count": (true_count := sum(1 for x in data if x)),\n            "true_fraction": true_count / (len(data) + unscored),\n        }\n    elif isinstance(val, Number):\n        if np := _import_numpy():\n            return {"mean": np.mean(data).item()}\n        else:\n            return {"mean": sum(data) / len(data)}\n    elif isinstance(val, dict):\n        result = {}\n        all_keys = list(\n            dict.fromkeys([k for d in data if isinstance(d, dict) for k in d.keys()])\n        )\n        for k in all_keys:\n            if (\n                summary := _summarize(\n                    [x.get(k) for x in data if isinstance(x, dict)],\n                    unscored=unscored,\n                )\n            ) is not None:\n                if k in summary:\n                    result.update(summary)\n                else:\n                    result[k] = summary\n        if not result:\n            return None\n        return result\n    elif isinstance(val, BaseModel):\n        return _summarize(\n            [x.model_dump() if isinstance(x, BaseModel) else x for x in data],\n            unscored=unscored,\n        )\n    return None\n\ndef auto_summarize(data: list) -> dict[str, Any] | None:\n    """Automatically summarize a list of (potentially nested) dicts.\n\n    Computes:\n        - avg for numeric cols\n        - count and fraction for boolean cols\n        - other col types are ignored\n\n    If col is all None, result is None\n\n    A top-level empty dict marks a row that produced no score, because its model or\n    one of its scorers raised. Such a row does not pick the aggregation branch and\n    stays in the denominator of a boolean fraction. Numeric means still divide by\n    the rows that produced a value. A nested empty dict is an ordinary value.\n\n    Returns:\n      dict of summary stats, with structure matching input dict structure.\n    """\n    if not data:\n        return {}\n    scored = [x for x in data if _row_produced_a_score(x)]\n    return _summarize(scored, unscored=len(data) - len(scored))\n\n@weave.op\n@op\ndef summarize(self, score_rows: list) -> dict | None:\n    return auto_summarize(score_rows)\n',
+                "digest": "LFL8Nn0Psr2gWeobJolUjjIsOZUO2vq4lRwTV8twu7Y",
+                "exp_content": b'import weave\nfrom typing import Any\nfrom numbers import Number\nfrom pydantic.main import BaseModel\nfrom weave.trace.op import op\n\ndef _row_has_score(x: Any) -> bool:\n    """Return False for the empty dict that marks a row with no score."""\n    return not isinstance(x, dict) or bool(x)\n\ndef _import_numpy() -> Any | None:\n    try:\n        import numpy\n    except ImportError:\n        return None\n    return numpy\n\ndef _auto_summarize(data: list, *, unscored: int) -> dict[str, Any] | None:\n    """Summarize one column, given how many of its rows produced no score."""\n    data = [x for x in data if x is not None]\n\n    if not data:\n        return None\n\n    val = data[0]\n\n    if isinstance(val, bool):\n        return {\n            "true_count": (true_count := sum(1 for x in data if x)),\n            "true_fraction": true_count / (len(data) + unscored),\n        }\n    elif isinstance(val, Number):\n        if np := _import_numpy():\n            return {"mean": np.mean(data).item()}\n        else:\n            return {"mean": sum(data) / len(data)}\n    elif isinstance(val, dict):\n        result = {}\n        all_keys = list(\n            dict.fromkeys([k for d in data if isinstance(d, dict) for k in d.keys()])\n        )\n        for k in all_keys:\n            if (\n                summary := _auto_summarize(\n                    [x.get(k) for x in data if isinstance(x, dict)],\n                    unscored=unscored,\n                )\n            ) is not None:\n                if k in summary:\n                    result.update(summary)\n                else:\n                    result[k] = summary\n        if not result:\n            return None\n        return result\n    elif isinstance(val, BaseModel):\n        return _auto_summarize(\n            [x.model_dump() if isinstance(x, BaseModel) else x for x in data],\n            unscored=unscored,\n        )\n    return None\n\ndef auto_summarize(data: list) -> dict[str, Any] | None:\n    """Automatically summarize a list of (potentially nested) dicts.\n\n    Computes:\n        - avg for numeric cols\n        - count and fraction for boolean cols\n        - other col types are ignored\n\n    If col is all None, result is None\n\n    A top-level empty dict marks a row that produced no score. Such a row does not\n    pick the aggregation branch and stays in the denominator of a boolean fraction.\n    Numeric means still divide by the rows that produced a value. A nested empty\n    dict is an ordinary value.\n\n    Returns:\n      dict of summary stats, with structure matching input dict structure.\n    """\n    if not data:\n        return {}\n    scored = [x for x in data if _row_has_score(x)]\n    return _auto_summarize(scored, unscored=len(data) - len(scored))\n\n@weave.op\n@op\ndef summarize(self, score_rows: list) -> dict | None:\n    return auto_summarize(score_rows)\n',
             },
             {
                 "digest": "ZHD4K7uUDPT93NdVQO3I6F9Xah9AEceWYBSQXg1bZPM",

--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -121,7 +121,7 @@ library_cases = [
             "description": None,
             "dataset": "weave:///shawn/test-project/object/Dataset:YLYVrBqCtlMOa770T1oPssqYnf9rgqdnY5hVCwRcrm8",
             "scorers": [
-                "weave:///shawn/test-project/object/MyScorer:ARQ9tSLVgUkjk68rO1ZvO6PnykD4QzxSECDB3qxruwQ",
+                "weave:///shawn/test-project/object/MyScorer:xGNFtpWKgn1TyYA0YzLMrKVxJkg3Mf8NyHzFc1R2sLg",
                 f"weave:///shawn/test-project/object/LLMAsAJudgeScorer:{llm_as_a_judge_scorer_digest}",
             ],
             "preprocess_model_input": None,
@@ -168,14 +168,14 @@ library_cases = [
             },
             {
                 "object_id": "MyScorer",
-                "digest": "ARQ9tSLVgUkjk68rO1ZvO6PnykD4QzxSECDB3qxruwQ",
+                "digest": "xGNFtpWKgn1TyYA0YzLMrKVxJkg3Mf8NyHzFc1R2sLg",
                 "exp_val": {
                     "_type": "MyScorer",
                     "name": None,
                     "description": None,
                     "column_map": None,
                     "score": "weave:///shawn/test-project/op/MyScorer.score:lwLZn8tYQ025uYUv8SPwa1TlVfWSbzVSyw4aDynz1yQ",
-                    "summarize": "weave:///shawn/test-project/op/Scorer.summarize:7q8tACYJKKemTUH29iLOsMku4IQHNJB3NNs3LT43YfA",
+                    "summarize": "weave:///shawn/test-project/op/Scorer.summarize:bxtFn6x27RJmJ1fzbdfY76Y1XgYfSemEXU2XBqcFCnI",
                     "_class_name": "MyScorer",
                     "_bases": ["Scorer", "Object", "BaseModel"],
                 },
@@ -259,11 +259,11 @@ library_cases = [
             },
             {
                 "object_id": "Scorer.summarize",
-                "digest": "7q8tACYJKKemTUH29iLOsMku4IQHNJB3NNs3LT43YfA",
+                "digest": "bxtFn6x27RJmJ1fzbdfY76Y1XgYfSemEXU2XBqcFCnI",
                 "exp_val": {
                     "_type": "CustomWeaveType",
                     "weave_type": {"type": "Op"},
-                    "files": {"obj.py": "CW3p0ODOmukWyXxfflPEHB9vFjO9hHuc2TD6jIY7rdU"},
+                    "files": {"obj.py": "VOiN2jQwOlcTREFr5xoJhZbRsyKaRkiNMGk9O5XeCxo"},
                 },
             },
         ],
@@ -277,8 +277,8 @@ library_cases = [
                 "exp_content": b"import weave\n\n@weave.op\ndef score(self, user_input: str, output: str) -> str:\n    return user_input in output\n",
             },
             {
-                "digest": "CW3p0ODOmukWyXxfflPEHB9vFjO9hHuc2TD6jIY7rdU",
-                "exp_content": b'import weave\nfrom typing import Any\nfrom numbers import Number\nfrom pydantic.main import BaseModel\nfrom weave.trace.op import op\n\ndef _row_has_no_score(x: Any) -> bool:\n    """True for the empty dict an evaluation records for a row that produced no score."""\n    return isinstance(x, dict) and not x\n\ndef _import_numpy() -> Any | None:\n    try:\n        import numpy\n    except ImportError:\n        return None\n    return numpy\n\ndef _summarize(data: list, *, unscored: int) -> dict[str, Any] | None:\n    """Summarize one column, given how many of its rows produced no score."""\n    data = [x for x in data if x is not None]\n\n    if not data:\n        return None\n\n    val = data[0]\n\n    if isinstance(val, bool):\n        return {\n            "true_count": (true_count := sum(1 for x in data if x)),\n            "true_fraction": true_count / (len(data) + unscored),\n        }\n    elif isinstance(val, Number):\n        nums: list[Any] = [x for x in data if isinstance(x, Number)]\n        if np := _import_numpy():\n            return {"mean": np.mean(nums).item()}\n        else:\n            return {"mean": sum(nums) / len(nums)}\n    elif isinstance(val, dict):\n        result = {}\n        all_keys = list(\n            dict.fromkeys([k for d in data if isinstance(d, dict) for k in d.keys()])\n        )\n        for k in all_keys:\n            if (\n                summary := _summarize(\n                    [x.get(k) for x in data if isinstance(x, dict)],\n                    unscored=unscored,\n                )\n            ) is not None:\n                if k in summary:\n                    result.update(summary)\n                else:\n                    result[k] = summary\n        if not result:\n            return None\n        return result\n    elif isinstance(val, BaseModel):\n        return _summarize(\n            [x.model_dump() if isinstance(x, BaseModel) else x for x in data],\n            unscored=unscored,\n        )\n    return None\n\ndef auto_summarize(data: list) -> dict[str, Any] | None:\n    """Automatically summarize a list of (potentially nested) dicts.\n\n    Computes:\n        - avg for numeric cols\n        - count and fraction for boolean cols\n        - other col types are ignored\n\n    If col is all None, result is None\n\n    A top-level empty dict marks a row whose model or scorer raised. Such rows do\n    not pick the aggregation branch, and they stay in the denominator of a boolean\n    fraction. Numeric means are computed over the values that exist. Nested empty\n    dicts are ordinary values and are left alone.\n\n    Returns:\n      dict of summary stats, with structure matching input dict structure.\n    """\n    if not data:\n        return {}\n    scored = [x for x in data if not _row_has_no_score(x)]\n    return _summarize(scored, unscored=len(data) - len(scored))\n\n@weave.op\n@op\ndef summarize(self, score_rows: list) -> dict | None:\n    return auto_summarize(score_rows)\n',
+                "digest": "VOiN2jQwOlcTREFr5xoJhZbRsyKaRkiNMGk9O5XeCxo",
+                "exp_content": b'import weave\nfrom typing import Any\nfrom numbers import Number\nfrom pydantic.main import BaseModel\nfrom weave.trace.op import op\n\ndef _row_produced_a_score(x: Any) -> bool:\n    """A row that produced no score is recorded as an empty dict."""\n    return not isinstance(x, dict) or bool(x)\n\ndef _import_numpy() -> Any | None:\n    try:\n        import numpy\n    except ImportError:\n        return None\n    return numpy\n\ndef _summarize(data: list, *, unscored: int) -> dict[str, Any] | None:\n    """Summarize one column, given how many of its rows produced no score."""\n    data = [x for x in data if x is not None]\n\n    if not data:\n        return None\n\n    val = data[0]\n\n    if isinstance(val, bool):\n        return {\n            "true_count": (true_count := sum(1 for x in data if x)),\n            "true_fraction": true_count / (len(data) + unscored),\n        }\n    elif isinstance(val, Number):\n        if np := _import_numpy():\n            return {"mean": np.mean(data).item()}\n        else:\n            return {"mean": sum(data) / len(data)}\n    elif isinstance(val, dict):\n        result = {}\n        all_keys = list(\n            dict.fromkeys([k for d in data if isinstance(d, dict) for k in d.keys()])\n        )\n        for k in all_keys:\n            if (\n                summary := _summarize(\n                    [x.get(k) for x in data if isinstance(x, dict)],\n                    unscored=unscored,\n                )\n            ) is not None:\n                if k in summary:\n                    result.update(summary)\n                else:\n                    result[k] = summary\n        if not result:\n            return None\n        return result\n    elif isinstance(val, BaseModel):\n        return _summarize(\n            [x.model_dump() if isinstance(x, BaseModel) else x for x in data],\n            unscored=unscored,\n        )\n    return None\n\ndef auto_summarize(data: list) -> dict[str, Any] | None:\n    """Automatically summarize a list of (potentially nested) dicts.\n\n    Computes:\n        - avg for numeric cols\n        - count and fraction for boolean cols\n        - other col types are ignored\n\n    If col is all None, result is None\n\n    A top-level empty dict marks a row that produced no score, because its model or\n    one of its scorers raised. Such a row does not pick the aggregation branch and\n    stays in the denominator of a boolean fraction. Numeric means still divide by\n    the rows that produced a value. A nested empty dict is an ordinary value.\n\n    Returns:\n      dict of summary stats, with structure matching input dict structure.\n    """\n    if not data:\n        return {}\n    scored = [x for x in data if _row_produced_a_score(x)]\n    return _summarize(scored, unscored=len(data) - len(scored))\n\n@weave.op\n@op\ndef summarize(self, score_rows: list) -> dict | None:\n    return auto_summarize(score_rows)\n',
             },
             {
                 "digest": "ZHD4K7uUDPT93NdVQO3I6F9Xah9AEceWYBSQXg1bZPM",

--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -121,7 +121,7 @@ library_cases = [
             "description": None,
             "dataset": "weave:///shawn/test-project/object/Dataset:YLYVrBqCtlMOa770T1oPssqYnf9rgqdnY5hVCwRcrm8",
             "scorers": [
-                "weave:///shawn/test-project/object/MyScorer:erh2OhYuvmiYF5MAHd2iNbtJkiAfvkHYn5l78CV6XrU",
+                "weave:///shawn/test-project/object/MyScorer:ARQ9tSLVgUkjk68rO1ZvO6PnykD4QzxSECDB3qxruwQ",
                 f"weave:///shawn/test-project/object/LLMAsAJudgeScorer:{llm_as_a_judge_scorer_digest}",
             ],
             "preprocess_model_input": None,
@@ -168,14 +168,14 @@ library_cases = [
             },
             {
                 "object_id": "MyScorer",
-                "digest": "erh2OhYuvmiYF5MAHd2iNbtJkiAfvkHYn5l78CV6XrU",
+                "digest": "ARQ9tSLVgUkjk68rO1ZvO6PnykD4QzxSECDB3qxruwQ",
                 "exp_val": {
                     "_type": "MyScorer",
                     "name": None,
                     "description": None,
                     "column_map": None,
                     "score": "weave:///shawn/test-project/op/MyScorer.score:lwLZn8tYQ025uYUv8SPwa1TlVfWSbzVSyw4aDynz1yQ",
-                    "summarize": "weave:///shawn/test-project/op/Scorer.summarize:R9dPVXqD4IgSlmmGS5RA8uQPehMlvQ0CHRJMEMf1AMQ",
+                    "summarize": "weave:///shawn/test-project/op/Scorer.summarize:7q8tACYJKKemTUH29iLOsMku4IQHNJB3NNs3LT43YfA",
                     "_class_name": "MyScorer",
                     "_bases": ["Scorer", "Object", "BaseModel"],
                 },
@@ -259,11 +259,11 @@ library_cases = [
             },
             {
                 "object_id": "Scorer.summarize",
-                "digest": "R9dPVXqD4IgSlmmGS5RA8uQPehMlvQ0CHRJMEMf1AMQ",
+                "digest": "7q8tACYJKKemTUH29iLOsMku4IQHNJB3NNs3LT43YfA",
                 "exp_val": {
                     "_type": "CustomWeaveType",
                     "weave_type": {"type": "Op"},
-                    "files": {"obj.py": "kxYDFAafHpBRX2O9hujrELhbFm3pGR6sAhzTfE1JdwA"},
+                    "files": {"obj.py": "CW3p0ODOmukWyXxfflPEHB9vFjO9hHuc2TD6jIY7rdU"},
                 },
             },
         ],
@@ -277,8 +277,8 @@ library_cases = [
                 "exp_content": b"import weave\n\n@weave.op\ndef score(self, user_input: str, output: str) -> str:\n    return user_input in output\n",
             },
             {
-                "digest": "kxYDFAafHpBRX2O9hujrELhbFm3pGR6sAhzTfE1JdwA",
-                "exp_content": b'import weave\nfrom numbers import Number\nfrom typing import Any\nfrom pydantic.main import BaseModel\nfrom weave.trace.op import op\n\ndef _import_numpy() -> Any | None:\n    try:\n        import numpy\n    except ImportError:\n        return None\n    return numpy\n\ndef auto_summarize(data: list) -> dict[str, Any] | None:\n    """Automatically summarize a list of (potentially nested) dicts.\n\n    Computes:\n        - avg for numeric cols\n        - count and fraction for boolean cols\n        - other col types are ignored\n\n    If col is all None, result is None\n\n    Returns:\n      dict of summary stats, with structure matching input dict structure.\n    """\n    if not data:\n        return {}\n    data = [x for x in data if x is not None]\n\n    if not data:\n        return None\n\n    val = data[0]\n\n    if isinstance(val, bool):\n        return {\n            "true_count": (true_count := sum(1 for x in data if x)),\n            "true_fraction": true_count / len(data),\n        }\n    elif isinstance(val, Number):\n        if np := _import_numpy():\n            return {"mean": np.mean(data).item()}\n        else:\n            return {"mean": sum(data) / len(data)}\n    elif isinstance(val, dict):\n        result = {}\n        all_keys = list(\n            dict.fromkeys([k for d in data if isinstance(d, dict) for k in d.keys()])\n        )\n        for k in all_keys:\n            if (\n                summary := auto_summarize(\n                    [x.get(k) for x in data if isinstance(x, dict)]\n                )\n            ) is not None:\n                if k in summary:\n                    result.update(summary)\n                else:\n                    result[k] = summary\n        if not result:\n            return None\n        return result\n    elif isinstance(val, BaseModel):\n        return auto_summarize(\n            [x.model_dump() if isinstance(x, BaseModel) else x for x in data]\n        )\n    return None\n\n@weave.op\n@op\ndef summarize(self, score_rows: list) -> dict | None:\n    return auto_summarize(score_rows)\n',
+                "digest": "CW3p0ODOmukWyXxfflPEHB9vFjO9hHuc2TD6jIY7rdU",
+                "exp_content": b'import weave\nfrom typing import Any\nfrom numbers import Number\nfrom pydantic.main import BaseModel\nfrom weave.trace.op import op\n\ndef _row_has_no_score(x: Any) -> bool:\n    """True for the empty dict an evaluation records for a row that produced no score."""\n    return isinstance(x, dict) and not x\n\ndef _import_numpy() -> Any | None:\n    try:\n        import numpy\n    except ImportError:\n        return None\n    return numpy\n\ndef _summarize(data: list, *, unscored: int) -> dict[str, Any] | None:\n    """Summarize one column, given how many of its rows produced no score."""\n    data = [x for x in data if x is not None]\n\n    if not data:\n        return None\n\n    val = data[0]\n\n    if isinstance(val, bool):\n        return {\n            "true_count": (true_count := sum(1 for x in data if x)),\n            "true_fraction": true_count / (len(data) + unscored),\n        }\n    elif isinstance(val, Number):\n        nums: list[Any] = [x for x in data if isinstance(x, Number)]\n        if np := _import_numpy():\n            return {"mean": np.mean(nums).item()}\n        else:\n            return {"mean": sum(nums) / len(nums)}\n    elif isinstance(val, dict):\n        result = {}\n        all_keys = list(\n            dict.fromkeys([k for d in data if isinstance(d, dict) for k in d.keys()])\n        )\n        for k in all_keys:\n            if (\n                summary := _summarize(\n                    [x.get(k) for x in data if isinstance(x, dict)],\n                    unscored=unscored,\n                )\n            ) is not None:\n                if k in summary:\n                    result.update(summary)\n                else:\n                    result[k] = summary\n        if not result:\n            return None\n        return result\n    elif isinstance(val, BaseModel):\n        return _summarize(\n            [x.model_dump() if isinstance(x, BaseModel) else x for x in data],\n            unscored=unscored,\n        )\n    return None\n\ndef auto_summarize(data: list) -> dict[str, Any] | None:\n    """Automatically summarize a list of (potentially nested) dicts.\n\n    Computes:\n        - avg for numeric cols\n        - count and fraction for boolean cols\n        - other col types are ignored\n\n    If col is all None, result is None\n\n    A top-level empty dict marks a row whose model or scorer raised. Such rows do\n    not pick the aggregation branch, and they stay in the denominator of a boolean\n    fraction. Numeric means are computed over the values that exist. Nested empty\n    dicts are ordinary values and are left alone.\n\n    Returns:\n      dict of summary stats, with structure matching input dict structure.\n    """\n    if not data:\n        return {}\n    scored = [x for x in data if not _row_has_no_score(x)]\n    return _summarize(scored, unscored=len(data) - len(scored))\n\n@weave.op\n@op\ndef summarize(self, score_rows: list) -> dict | None:\n    return auto_summarize(score_rows)\n',
             },
             {
                 "digest": "ZHD4K7uUDPT93NdVQO3I6F9Xah9AEceWYBSQXg1bZPM",

--- a/tests/trace/test_evaluate.py
+++ b/tests/trace/test_evaluate.py
@@ -527,3 +527,28 @@ async def test_evaluate_with_pydantic_summary(weave_active):
     model = EvalModel()
     result = await evaluation.evaluate(model)
     assert result["MyScorer"].awesome == 3
+
+
+@pytest.mark.asyncio
+async def test_summary_counts_rows_the_model_failed_on(weave_active):
+    """A row whose model raised reaches the aggregation as an empty dict, and counts."""
+
+    @weave.op
+    def sometimes_raises(input):
+        if input == "boom":
+            raise ValueError("boom")
+        return 1
+
+    @weave.op
+    def dict_score(output):
+        return {"correct": output == 1}
+
+    evaluation = Evaluation(
+        dataset=[{"input": "ok"}, {"input": "boom"}], scorers=[dict_score]
+    )
+    result = await evaluation.evaluate(sometimes_raises)
+    assert result == {
+        "output": {"mean": 1.0},
+        "dict_score": {"correct": {"true_count": 1, "true_fraction": 0.5}},
+        "model_latency": {"mean": pytest.approx(0, abs=LATENCY_TOL)},
+    }

--- a/tests/trace/test_evaluate_oldstyle.py
+++ b/tests/trace/test_evaluate_oldstyle.py
@@ -209,8 +209,7 @@ async def test_multiclass_f1_score(weave_active):
     }
 
 
-@pytest.mark.asyncio
-async def test_multiclass_f1_score_with_unscored_rows(weave_active):
+def test_multiclass_f1_score_with_unscored_rows(weave_active):
     """Every row produced no score, so transpose yields no class columns at all."""
     scorer = MultiTaskBinaryClassificationF1(class_names=["a"])
     assert scorer.summarize([{}, {}]) == {"a": {"f1": 0, "precision": 0, "recall": 0}}

--- a/tests/trace/test_evaluate_oldstyle.py
+++ b/tests/trace/test_evaluate_oldstyle.py
@@ -207,3 +207,10 @@ async def test_multiclass_f1_score(weave_active):
             "mean": pytest.approx(0, abs=LATENCY_TOL),
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_multiclass_f1_score_with_unscored_rows(weave_active):
+    """Every row produced no score, so transpose yields no class columns at all."""
+    scorer = MultiTaskBinaryClassificationF1(class_names=["a"])
+    assert scorer.summarize([{}, {}]) == {"a": {"f1": 0, "precision": 0, "recall": 0}}

--- a/tests/trace/test_evaluate_oldstyle.py
+++ b/tests/trace/test_evaluate_oldstyle.py
@@ -213,3 +213,6 @@ def test_multiclass_f1_score_with_unscored_rows(weave_active):
     """Every row produced no score, so transpose yields no class columns at all."""
     scorer = MultiTaskBinaryClassificationF1(class_names=["a"])
     assert scorer.summarize([{}, {}]) == {"a": {"f1": 0, "precision": 0, "recall": 0}}
+    # A class the scorer never produced is a configuration error, and still raises.
+    with pytest.raises(KeyError):
+        scorer.summarize([{"b": {"correct": True, "negative": False}}])

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -28,7 +28,7 @@ from weave.evaluation.eval import (
 from weave.evaluation.eval_meta import EVAL_META_KEY
 from weave.flow.model import MissingInferenceMethodError, Model
 from weave.flow.scorer import Scorer
-from weave.flow.scorer import auto_summarize as auto_summarize_fn
+from weave.flow.scorer import _auto_summarize as auto_summarize_fn
 from weave.flow.util import make_memorable_name
 from weave.object.obj import Object
 from weave.shared.digest import compute_row_digest
@@ -1132,7 +1132,9 @@ class EvaluationLogger:
             data_to_summarize = [
                 pred._captured_scores for pred in self._accumulated_predictions
             ]
-            summary_data = auto_summarize_fn(data_to_summarize)
+            # Here an empty dict means no score was logged, not that scoring failed:
+            # a failed score is logged as None.
+            summary_data = auto_summarize_fn(data_to_summarize, unscored=0)
         else:
             summary_data = summary
 

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -140,6 +140,11 @@ def stderr(data: Sequence[int | float]) -> float:
         return float(math.sqrt(sample_variance / len(data)))  # type: ignore
 
 
+def _row_has_no_score(x: Any) -> bool:
+    """True for the empty dict an evaluation records for a row that produced no score."""
+    return isinstance(x, dict) and not x
+
+
 def auto_summarize(data: list) -> dict[str, Any] | None:
     """Automatically summarize a list of (potentially nested) dicts.
 
@@ -150,11 +155,22 @@ def auto_summarize(data: list) -> dict[str, Any] | None:
 
     If col is all None, result is None
 
+    A top-level empty dict marks a row whose model or scorer raised. Such rows do
+    not pick the aggregation branch, and they stay in the denominator of a boolean
+    fraction. Numeric means are computed over the values that exist. Nested empty
+    dicts are ordinary values and are left alone.
+
     Returns:
       dict of summary stats, with structure matching input dict structure.
     """
     if not data:
         return {}
+    scored = [x for x in data if not _row_has_no_score(x)]
+    return _summarize(scored, unscored=len(data) - len(scored))
+
+
+def _summarize(data: list, *, unscored: int) -> dict[str, Any] | None:
+    """Summarize one column, given how many of its rows produced no score."""
     data = [x for x in data if x is not None]
 
     if not data:
@@ -165,13 +181,14 @@ def auto_summarize(data: list) -> dict[str, Any] | None:
     if isinstance(val, bool):
         return {
             "true_count": (true_count := sum(1 for x in data if x)),
-            "true_fraction": true_count / len(data),
+            "true_fraction": true_count / (len(data) + unscored),
         }
     elif isinstance(val, Number):
+        nums: list[Any] = [x for x in data if isinstance(x, Number)]
         if np := _import_numpy():
-            return {"mean": np.mean(data).item()}
+            return {"mean": np.mean(nums).item()}
         else:
-            return {"mean": sum(data) / len(data)}
+            return {"mean": sum(nums) / len(nums)}
     elif isinstance(val, dict):
         result = {}
         all_keys = list(
@@ -179,8 +196,9 @@ def auto_summarize(data: list) -> dict[str, Any] | None:
         )
         for k in all_keys:
             if (
-                summary := auto_summarize(
-                    [x.get(k) for x in data if isinstance(x, dict)]
+                summary := _summarize(
+                    [x.get(k) for x in data if isinstance(x, dict)],
+                    unscored=unscored,
                 )
             ) is not None:
                 if k in summary:
@@ -191,8 +209,9 @@ def auto_summarize(data: list) -> dict[str, Any] | None:
             return None
         return result
     elif isinstance(val, BaseModel):
-        return auto_summarize(
-            [x.model_dump() if isinstance(x, BaseModel) else x for x in data]
+        return _summarize(
+            [x.model_dump() if isinstance(x, BaseModel) else x for x in data],
+            unscored=unscored,
         )
     return None
 

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -140,11 +140,6 @@ def stderr(data: Sequence[int | float]) -> float:
         return float(math.sqrt(sample_variance / len(data)))  # type: ignore
 
 
-def _row_has_no_score(x: Any) -> bool:
-    """True for the empty dict an evaluation records for a row that produced no score."""
-    return isinstance(x, dict) and not x
-
-
 def auto_summarize(data: list) -> dict[str, Any] | None:
     """Automatically summarize a list of (potentially nested) dicts.
 
@@ -155,18 +150,23 @@ def auto_summarize(data: list) -> dict[str, Any] | None:
 
     If col is all None, result is None
 
-    A top-level empty dict marks a row whose model or scorer raised. Such rows do
-    not pick the aggregation branch, and they stay in the denominator of a boolean
-    fraction. Numeric means are computed over the values that exist. Nested empty
-    dicts are ordinary values and are left alone.
+    A top-level empty dict marks a row that produced no score, because its model or
+    one of its scorers raised. Such a row does not pick the aggregation branch and
+    stays in the denominator of a boolean fraction. Numeric means still divide by
+    the rows that produced a value. A nested empty dict is an ordinary value.
 
     Returns:
       dict of summary stats, with structure matching input dict structure.
     """
     if not data:
         return {}
-    scored = [x for x in data if not _row_has_no_score(x)]
+    scored = [x for x in data if _row_produced_a_score(x)]
     return _summarize(scored, unscored=len(data) - len(scored))
+
+
+def _row_produced_a_score(x: Any) -> bool:
+    """A row that produced no score is recorded as an empty dict."""
+    return not isinstance(x, dict) or bool(x)
 
 
 def _summarize(data: list, *, unscored: int) -> dict[str, Any] | None:
@@ -184,11 +184,10 @@ def _summarize(data: list, *, unscored: int) -> dict[str, Any] | None:
             "true_fraction": true_count / (len(data) + unscored),
         }
     elif isinstance(val, Number):
-        nums: list[Any] = [x for x in data if isinstance(x, Number)]
         if np := _import_numpy():
-            return {"mean": np.mean(nums).item()}
+            return {"mean": np.mean(data).item()}
         else:
-            return {"mean": sum(nums) / len(nums)}
+            return {"mean": sum(data) / len(data)}
     elif isinstance(val, dict):
         result = {}
         all_keys = list(

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -150,26 +150,26 @@ def auto_summarize(data: list) -> dict[str, Any] | None:
 
     If col is all None, result is None
 
-    A top-level empty dict marks a row that produced no score, because its model or
-    one of its scorers raised. Such a row does not pick the aggregation branch and
-    stays in the denominator of a boolean fraction. Numeric means still divide by
-    the rows that produced a value. A nested empty dict is an ordinary value.
+    A top-level empty dict marks a row that produced no score. Such a row does not
+    pick the aggregation branch and stays in the denominator of a boolean fraction.
+    Numeric means still divide by the rows that produced a value. A nested empty
+    dict is an ordinary value.
 
     Returns:
       dict of summary stats, with structure matching input dict structure.
     """
     if not data:
         return {}
-    scored = [x for x in data if _row_produced_a_score(x)]
-    return _summarize(scored, unscored=len(data) - len(scored))
+    scored = [x for x in data if _row_has_score(x)]
+    return _auto_summarize(scored, unscored=len(data) - len(scored))
 
 
-def _row_produced_a_score(x: Any) -> bool:
-    """A row that produced no score is recorded as an empty dict."""
+def _row_has_score(x: Any) -> bool:
+    """Return False for the empty dict that marks a row with no score."""
     return not isinstance(x, dict) or bool(x)
 
 
-def _summarize(data: list, *, unscored: int) -> dict[str, Any] | None:
+def _auto_summarize(data: list, *, unscored: int) -> dict[str, Any] | None:
     """Summarize one column, given how many of its rows produced no score."""
     data = [x for x in data if x is not None]
 
@@ -195,7 +195,7 @@ def _summarize(data: list, *, unscored: int) -> dict[str, Any] | None:
         )
         for k in all_keys:
             if (
-                summary := _summarize(
+                summary := _auto_summarize(
                     [x.get(k) for x in data if isinstance(x, dict)],
                     unscored=unscored,
                 )
@@ -208,7 +208,7 @@ def _summarize(data: list, *, unscored: int) -> dict[str, Any] | None:
             return None
         return result
     elif isinstance(val, BaseModel):
-        return _summarize(
+        return _auto_summarize(
             [x.model_dump() if isinstance(x, BaseModel) else x for x in data],
             unscored=unscored,
         )

--- a/weave/scorers/classification_scorer.py
+++ b/weave/scorers/classification_scorer.py
@@ -63,6 +63,8 @@ class MultiTaskBinaryClassificationF1(weave.Scorer):
         cols = transpose(score_rows)
 
         for class_name in self.class_names:
+            # transpose adds no keys for a row with no score, so cols is empty when
+            # every row failed.
             col = cols[class_name] if cols else []
             tp = sum(r["correct"] and not r["negative"] for r in col)
             fp = sum(not r["correct"] and not r["negative"] for r in col)

--- a/weave/scorers/classification_scorer.py
+++ b/weave/scorers/classification_scorer.py
@@ -63,7 +63,7 @@ class MultiTaskBinaryClassificationF1(weave.Scorer):
         cols = transpose(score_rows)
 
         for class_name in self.class_names:
-            col = cols.get(class_name, [])
+            col = cols[class_name] if cols else []
             tp = sum(r["correct"] and not r["negative"] for r in col)
             fp = sum(not r["correct"] and not r["negative"] for r in col)
             fn = sum(not r["correct"] and r["negative"] for r in col)

--- a/weave/scorers/classification_scorer.py
+++ b/weave/scorers/classification_scorer.py
@@ -63,7 +63,7 @@ class MultiTaskBinaryClassificationF1(weave.Scorer):
         cols = transpose(score_rows)
 
         for class_name in self.class_names:
-            col = cols[class_name]
+            col = cols.get(class_name, [])
             tp = sum(r["correct"] and not r["negative"] for r in col)
             fp = sum(not r["correct"] and not r["negative"] for r in col)
             fn = sum(not r["correct"] and r["negative"] for r in col)


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-18523

## Description

When a scorer or model raises on a row, the eval keeps the row and stores an empty `scores` dict. `auto_summarize` read that as "no value here" instead of "this row failed", so the row left the math. A model that crashed on half its rows reported `true_fraction: 1.0` — a perfect score for failing. A plain-number scorer was worse: `TypeError`, whole run dead, after the inference was paid for. A failed *first* row made the metric vanish.

Now an empty dict means one thing: no score for this row. It stays in the denominator and never picks the branch. Top level only — a nested `{}` is a real value. `MultiTaskBinaryClassificationF1` also raised `KeyError` when every row failed; one-line guard.

## Why this approach

No new summary key: the frontend types a metric by counting them. So numeric averages and partial-failure F1 are still too high — separate tickets. The imperative logger is excluded; there `{}` means nobody logged a score, and a failure is `None`.

## Backward compatibility

Runs with failures report new numbers. `Scorer.summarize` inlines `auto_summarize`, so `Scorer`-subclass evals get a new digest and old leaderboard columns stop matching. Hence the `library_cases.py` churn. The `output` column shares the helper, so a literal `{}` output counts too — a failed model stores `None`.

## Testing

Unit cases for every score shape and both empty-dict kinds, plus F1 all-unscored, one end-to-end eval whose model raises, and one imperative case.
