### PR TITLE
fix(weave): support minimum server version

### DIFF
--- a/.github/workflows/client-server-compatibility.yaml
+++ b/.github/workflows/client-server-compatibility.yaml
@@ -1,0 +1,116 @@
+name: Client-server compatibility
+
+on:
+  schedule:
+    - cron: "30 8 * * *"
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  python-client:
+    name: Python client against minimum server
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.11.19"
+      - name: Extract minimum-server request models
+        run: |
+          set -euo pipefail
+          server_commit=$(python3 -c 'import json; print(json.load(open("client_server_compatibility.json"))["server_weave_commit"])')
+          git fetch --depth 1 origin "$server_commit"
+          server_source="$RUNNER_TEMP/minimum-server"
+          rm -rf "$server_source"
+          mkdir -p "$server_source"
+          git archive "$server_commit" weave | tar -x -C "$server_source"
+          echo "WEAVE_MIN_SERVER_SOURCE=$server_source" >> "$GITHUB_ENV"
+          echo "WEAVE_MIN_SERVER_URL=http://127.0.0.1:9876" >> "$GITHUB_ENV"
+      - name: Start minimum-server HTTP boundary
+        run: |
+          set -euo pipefail
+          uv run --no-project --python 3.12 \
+            --with "fastapi>=0.110" \
+            --with "pydantic>=2" \
+            --with typing-extensions \
+            --with uvicorn \
+            uvicorn --app-dir tests/client_server_compatibility min_server:app \
+            --host 127.0.0.1 --port 9876 > "$RUNNER_TEMP/minimum-server.log" 2>&1 &
+          for _attempt in {1..30}; do
+            if (echo > /dev/tcp/127.0.0.1/9876) 2>/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat "$RUNNER_TEMP/minimum-server.log"
+          exit 1
+      - name: Run minimum-server compatibility test
+        run: >-
+          uv run --python 3.12 --group test python -m pytest
+          tests/trace/test_trace_server_version.py
+          tests/trace_server_bindings/test_http_behavior_remote.py
+          -k minimum_supported_server
+
+  typescript-client:
+    name: TypeScript client against minimum server
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.8.1
+          run_install: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: sdks/node/pnpm-lock.yaml
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.11.19"
+      - name: Extract minimum-server request models
+        run: |
+          set -euo pipefail
+          server_commit=$(python3 -c 'import json; print(json.load(open("client_server_compatibility.json"))["server_weave_commit"])')
+          git fetch --depth 1 origin "$server_commit"
+          server_source="$RUNNER_TEMP/minimum-server"
+          rm -rf "$server_source"
+          mkdir -p "$server_source"
+          git archive "$server_commit" weave | tar -x -C "$server_source"
+          echo "WEAVE_MIN_SERVER_SOURCE=$server_source" >> "$GITHUB_ENV"
+          echo "WEAVE_MIN_SERVER_URL=http://127.0.0.1:9876" >> "$GITHUB_ENV"
+      - name: Start minimum-server HTTP boundary
+        run: |
+          set -euo pipefail
+          uv run --no-project --python 3.12 \
+            --with "fastapi>=0.110" \
+            --with "pydantic>=2" \
+            --with typing-extensions \
+            --with uvicorn \
+            uvicorn --app-dir tests/client_server_compatibility min_server:app \
+            --host 127.0.0.1 --port 9876 > "$RUNNER_TEMP/minimum-server.log" 2>&1 &
+          for _attempt in {1..30}; do
+            if (echo > /dev/tcp/127.0.0.1/9876) 2>/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat "$RUNNER_TEMP/minimum-server.log"
+          exit 1
+      - name: Install dependencies
+        working-directory: sdks/node
+        run: pnpm install --frozen-lockfile
+      - name: Run minimum-server compatibility test
+        working-directory: sdks/node
+        run: >-
+          pnpm exec jest --silent --runTestsByPath
+          src/__tests__/generatedTraceServerApi.test.ts
+          --testNamePattern "minimum supported server"

--- a/.github/workflows/publish_ts_sdk_npm.yaml
+++ b/.github/workflows/publish_ts_sdk_npm.yaml
@@ -16,8 +16,12 @@ on:
         default: latest
 
 jobs:
+  minimum-server-compatibility:
+    uses: ./.github/workflows/client-server-compatibility.yaml
+
   publish-typescript-sdk:
     name: Publish TypeScript SDK to npm
+    needs: [minimum-server-compatibility]
     runs-on: ubuntu-8core
     timeout-minutes: 15
     environment:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,12 @@ on:
         default: true
 
 jobs:
+  minimum-server-compatibility:
+    uses: ./.github/workflows/client-server-compatibility.yaml
+
   build-release:
     name: Build and publish to pypi
+    needs: [minimum-server-compatibility]
     runs-on: ubuntu-8core
     timeout-minutes: 10
     environment:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,16 @@ enough to validate the Core Metadata version emitted by current Hatchling; for
 example, Hatchling 1.32 emits Metadata 2.5, which requires the action's Twine 7
 and Packaging 26 stack rather than Twine 6.1 and Packaging 25.
 
+### Client-server compatibility
+
+- `client_server_compatibility.json` is the source of truth for the minimum
+  supported W&B server release, trace protocol, immutable image, and contract
+  snapshot exercised by client CI.
+- Advancing the minimum server requires an explicit pull request that updates
+  the compatibility contract and `MIN_TRACE_SERVER_VERSION` together.
+- Python and TypeScript client releases must pass
+  `.github/workflows/client-server-compatibility.yaml` before publication.
+
 ### Codex Development (nox)
 
 - Your machine should be setup for you automatically via `bin/codex_setup.sh`

--- a/CLIENT_SERVER_COMPATIBILITY.md
+++ b/CLIENT_SERVER_COMPATIBILITY.md
@@ -1,0 +1,21 @@
+# Client-server compatibility
+
+Every Python and TypeScript client release is tested against the minimum
+supported W&B server recorded in
+[`client_server_compatibility.json`](client_server_compatibility.json).
+
+The minimum is an explicit release boundary. CI does not calculate or advance
+it from the current date. Advancing it requires a pull request that updates the
+server release, trace protocol version, immutable server image, source commit,
+and contract snapshot together. The default support window is 90 days.
+
+Client changes that require a newer trace-server protocol must update
+`MIN_TRACE_SERVER_VERSION` and the compatibility contract in the same pull
+request. Ordinary additive request fields should remain compatible with the
+minimum server by staying off the wire when they are unset or equal to their
+defaults.
+
+The compatibility smoke tests cross a real HTTP boundary and exercise
+`/feedback/batch/create`, the endpoint involved in the strict-model rollback.
+The Python test also sends the unfiltered request as a negative control and
+requires the minimum-server contract to reject it with `extra_forbidden`.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Our goal is to bring rigor, best-practices, and composability to the inherently 
 
 Our documentation site can be found [here](https://wandb.me/weave).
 
+See [Client-server compatibility](CLIENT_SERVER_COMPATIBILITY.md) for the
+minimum supported W&B server release and the client release policy.
+
 ## Prerequisites
 
 - Python 3.10 or higher
@@ -123,4 +126,3 @@ We're in the process of 🧹 cleaning up 🧹. This codebase contains a large am
 The Weave Tracing code is mostly in: `weave/trace` and `weave/trace_server`.
 
 The Weave Evaluations code is mostly in `weave/flow`.
-

--- a/client_server_compatibility.json
+++ b/client_server_compatibility.json
@@ -1,0 +1,24 @@
+{
+  "minimum_server_version": "0.81.0",
+  "minimum_trace_server_version": "0.1.0",
+  "server_image": "wandb/weave-trace@sha256:4e5e6eee23bf3b6ead02dba12b167e8f6db28365d8ef42b93983b6402402364b",
+  "server_weave_commit": "b7773bee4f8f9ee537ecd2f6632e20e4c270f22e",
+  "support_window_days": 90,
+  "feedback_create_batch": {
+    "path": "/feedback/batch/create",
+    "request_fields": [
+      "annotation_ref",
+      "call_ref",
+      "creator",
+      "feedback_type",
+      "id",
+      "payload",
+      "project_id",
+      "queue_id",
+      "runnable_ref",
+      "trigger_ref",
+      "wb_user_id",
+      "weave_ref"
+    ]
+  }
+}

--- a/sdks/node/src/__tests__/generatedTraceServerApi.test.ts
+++ b/sdks/node/src/__tests__/generatedTraceServerApi.test.ts
@@ -1,3 +1,7 @@
+import {readFileSync} from 'node:fs';
+import {createServer} from 'node:http';
+import {resolve} from 'node:path';
+
 import {Api as TraceServerApi} from '../generated/traceServerApi';
 
 test('encodes custom runtime names in request paths', async () => {
@@ -26,4 +30,80 @@ test('encodes custom runtime names in request paths', async () => {
   expect(requestedUrl).toBe(
     'https://trace.example/v2/entity/project/runtimes/support%2Fagent%3Fcanary'
   );
+});
+
+test('sends feedback accepted by the minimum supported server', async () => {
+  const compatibility = JSON.parse(
+    readFileSync(
+      resolve(__dirname, '../../../../client_server_compatibility.json'),
+      'utf8'
+    )
+  );
+  const contract = compatibility.feedback_create_batch;
+  let server: ReturnType<typeof createServer> | undefined;
+  let baseUrl = process.env.WEAVE_MIN_SERVER_URL;
+
+  if (baseUrl == null) {
+    const allowedFields = new Set(contract.request_fields);
+    server = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on('data', chunk => chunks.push(chunk));
+      request.on('end', () => {
+        const payload = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+        const extraFields = payload.batch.flatMap(
+          (item: Record<string, unknown>) =>
+            Object.keys(item).filter(field => !allowedFields.has(field))
+        );
+        const accepted =
+          request.url === contract.path && extraFields.length === 0;
+        response.writeHead(accepted ? 200 : 422, {
+          'Content-Type': 'application/json',
+        });
+        response.end(
+          JSON.stringify(
+            accepted
+              ? {res: []}
+              : {
+                  detail: extraFields.map((field: string) => ({
+                    type: 'extra_forbidden',
+                    field,
+                  })),
+                }
+          )
+        );
+      });
+    });
+    await new Promise<void>(resolveListen =>
+      server?.listen(0, '127.0.0.1', resolveListen)
+    );
+    const address = server.address();
+    if (address == null || typeof address === 'string') {
+      throw new Error('Compatibility server did not bind to a TCP port');
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  }
+
+  try {
+    const api = new TraceServerApi({baseUrl});
+    const response =
+      await api.feedback.feedbackCreateBatchFeedbackBatchCreatePost({
+        batch: [
+          {
+            project_id: 'entity/project',
+            weave_ref: 'weave:///entity/project/call/call-id',
+            feedback_type: 'custom',
+            payload: {value: 1},
+          },
+        ],
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({res: []});
+  } finally {
+    if (server != null) {
+      await new Promise<void>((resolveClose, reject) =>
+        server?.close(error => (error ? reject(error) : resolveClose()))
+      );
+    }
+  }
 });

--- a/tests/client_server_compatibility/min_server.py
+++ b/tests/client_server_compatibility/min_server.py
@@ -1,0 +1,25 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from fastapi import FastAPI
+
+source_root = Path(os.environ["WEAVE_MIN_SERVER_SOURCE"])
+weave_package = ModuleType("weave")
+weave_package.__path__ = [str(source_root / "weave")]
+sys.modules["weave"] = weave_package
+tsi = importlib.import_module("weave.trace_server.trace_server_interface")
+
+app = FastAPI()
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/feedback/batch/create")
+def feedback_create_batch(req: tsi.FeedbackCreateBatchReq) -> dict[str, list]:
+    return {"res": []}

--- a/tests/trace/test_trace_server_version.py
+++ b/tests/trace/test_trace_server_version.py
@@ -1,8 +1,23 @@
 """Tests for trace server version checking."""
 
+import json
+from pathlib import Path
+
 from weave.trace.init_message import check_min_trace_server_version
+from weave.trace_server_version import (
+    MIN_SUPPORTED_SERVER_VERSION,
+    MIN_TRACE_SERVER_VERSION,
+)
 
 TEST_SERVER_URL = "https://test.trace.server"
+
+
+def test_minimum_supported_server_protocol_matches_runtime() -> None:
+    contract_path = Path(__file__).parents[2] / "client_server_compatibility.json"
+    contract = json.loads(contract_path.read_text())
+
+    assert contract["minimum_server_version"] == MIN_SUPPORTED_SERVER_VERSION
+    assert contract["minimum_trace_server_version"] == MIN_TRACE_SERVER_VERSION
 
 
 class TestCheckMinTraceServerVersion:

--- a/tests/trace_server_bindings/test_http_behavior_remote.py
+++ b/tests/trace_server_bindings/test_http_behavior_remote.py
@@ -9,6 +9,12 @@ from __future__ import annotations
 import datetime
 import json
 import logging
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
 from types import MethodType
 from unittest.mock import MagicMock, patch
 
@@ -59,10 +65,107 @@ def _request_headers(mock_call) -> dict:
     return mock_call.kwargs.get("headers", {})
 
 
+def _minimum_server_contract() -> dict:
+    contract_path = Path(__file__).parents[2] / "client_server_compatibility.json"
+    return json.loads(contract_path.read_text())
+
+
+@contextmanager
+def _minimum_server_feedback_endpoint() -> Iterator[str]:
+    if external_server := os.environ.get("WEAVE_MIN_SERVER_URL"):
+        yield external_server
+        return
+
+    contract = _minimum_server_contract()["feedback_create_batch"]
+    allowed_fields = set(contract["request_fields"])
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            content_length = int(self.headers["Content-Length"])
+            payload = json.loads(self.rfile.read(content_length))
+            extra_fields = sorted(
+                {
+                    field
+                    for item in payload["batch"]
+                    for field in item
+                    if field not in allowed_fields
+                }
+            )
+            if self.path != contract["path"]:
+                self.send_response(404)
+                response = {"detail": "not found"}
+            elif extra_fields:
+                self.send_response(422)
+                response = {
+                    "detail": [
+                        {"type": "extra_forbidden", "field": field}
+                        for field in extra_fields
+                    ]
+                }
+            else:
+                self.send_response(200)
+                response = {"res": []}
+            body = json.dumps(response).encode("utf-8")
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
 @pytest.fixture
 def unbatched_server():
     """Create a RemoteHTTPTraceServer instance without batching for testing."""
     return RemoteHTTPTraceServer("http://example.com")
+
+
+def test_feedback_batch_compatible_with_minimum_supported_server() -> None:
+    request = tsi.FeedbackCreateBatchReq(
+        batch=[
+            tsi.FeedbackCreateReq(
+                project_id="entity/project",
+                weave_ref="weave:///entity/project/call/call-id",
+                feedback_type="custom",
+                payload={"value": 1},
+            )
+        ]
+    )
+    contract = _minimum_server_contract()["feedback_create_batch"]
+
+    with _minimum_server_feedback_endpoint() as base_url:
+        incompatible_response = httpx.post(
+            base_url + contract["path"],
+            json=request.model_dump(mode="json"),
+        )
+        assert incompatible_response.status_code == 422
+        assert {
+            detail["type"] for detail in incompatible_response.json()["detail"]
+        } == {"extra_forbidden"}
+
+        client = RemoteHTTPTraceServer(base_url, should_batch=True)
+        try:
+            response = client.feedback_create_batch(request)
+            client._flush_feedback(request.batch)
+        finally:
+            if client.call_processor:
+                client.call_processor.stop_accepting_new_work_and_flush_queue()
+            if client.feedback_processor:
+                client.feedback_processor.stop_accepting_new_work_and_flush_queue()
+
+    assert response.res == []
 
 
 @patch("weave.utils.http_requests.post")

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -445,7 +445,9 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
 
         def encode_batch(batch: list[tsi.FeedbackCreateReq]) -> bytes:
             batch_req = tsi.FeedbackCreateBatchReq(batch=batch)
-            data = batch_req.model_dump_json()
+            data = batch_req.model_dump_json(
+                by_alias=True, exclude_defaults=True, exclude_none=True
+            )
             return data.encode("utf-8")
 
         def send_feedback_batch(encoded_data: bytes) -> None:
@@ -513,13 +515,17 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         stream: bool = False,
         trace_id: str | None = None,
     ) -> httpx.Response:
+        # `by_alias` preserves Mongo-style query properties that start with `$`.
+        if isinstance(req, (tsi.FeedbackCreateReq, tsi.FeedbackCreateBatchReq)):
+            # Keep additive defaults off the wire for the minimum supported server.
+            data = req.model_dump_json(
+                by_alias=True, exclude_defaults=True, exclude_none=True
+            )
+        else:
+            data = req.model_dump_json(by_alias=True)
         r = self.post(
             url,
-            # `by_alias` is required since we have Mongo-style properties in the
-            # query models that are aliased to conform to start with `$`. Without
-            # this, the model_dump will use the internal property names which are
-            # not valid for the `model_validate` step.
-            data=req.model_dump_json(by_alias=True).encode("utf-8"),
+            data=data.encode("utf-8"),
             stream=stream,
             trace_id=trace_id,
         )

--- a/weave/trace_server_version.py
+++ b/weave/trace_server_version.py
@@ -29,4 +29,6 @@
 #
 # Use semantic versioning: "MAJOR.MINOR.PATCH" (e.g., "0.1.0", "1.0.0")
 # =============================================================================
-MIN_TRACE_SERVER_VERSION: str | None = None
+# GA W&B server release exercised by client release and nightly compatibility tests.
+MIN_SUPPORTED_SERVER_VERSION = "0.81.0"
+MIN_TRACE_SERVER_VERSION: str | None = "0.1.0"


### PR DESCRIPTION
## What

- Define W&B server `0.81.0` and trace protocol `0.1.0` as the minimum supported client/server boundary.
- Test Python and TypeScript clients against that historical request model nightly and before either client is published.
- Keep unset/default additive feedback fields off the Python client's wire payload.

[WB-38398](https://coreweave.atlassian.net/browse/WB-38398)

## Why

New feedback fields were serialized by a newer SDK and rejected by older servers using `extra="forbid"`. The rejection dropped the entire feedback batch. Same-revision client and server tests cannot detect this schema skew.

## How

`client_server_compatibility.json` pins the supported server release, trace protocol, immutable image digest, and corresponding Weave source commit. Moving the floor requires an explicit PR.

The compatibility workflow fetches the pinned source commit and exposes its real `FeedbackCreateBatchReq` model through a small FastAPI endpoint. The Python test first sends the old unfiltered payload and requires a `422 extra_forbidden` response, then both candidate clients must receive `200` responses.

Python feedback serialization now excludes fields that are `None` or equal to their defaults in direct and asynchronous batch paths. Non-default fields remain on the wire.

The test intentionally stops at HTTP request validation. It does not start the historical ClickHouse and Gorilla stack because those systems are downstream of the incident's failure boundary.

## Testing

- `uv run --python 3.12 --group test python -m pytest tests/trace/test_trace_server_version.py tests/trace_server_bindings/test_http_behavior_remote.py` — 33 passed.
- `pnpm exec jest --silent --runTestsByPath src/__tests__/generatedTraceServerApi.test.ts` — 2 passed.
- Live pinned `0.81.0` model — unfiltered negative control returned 422; direct Python, asynchronous Python, and TypeScript requests returned 200.
- `uvx ruff check . && uvx ruff format --check .` — passed across 887 Python files.
- `pnpm run prettier-check && pnpm run lint && pnpm run typecheck:cjs && pnpm run typecheck:esm` — passed.
- Changed workflows passed actionlint; the command ignored only the repository's existing `ubuntu-8core` custom-runner-label diagnostic.

## Anything Else

This changes the runtime handshake from no client-side server requirement to trace protocol `0.1.0`. Server `0.81.0` reports that protocol; older servers that do not report a version are outside the documented support floor and will now fail during initialization.

Please verify that W&B server `0.81.0` is the intended current support floor for the 90-day policy.


[WB-38398]: https://coreweave.atlassian.net/browse/WB-38398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ