### PR TITLE
perf(weave): bound eval_results calls_merged scan to the eval run window

### DIFF
--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -667,6 +667,19 @@ def test_full_query_calls_merged() -> None:
                         WHERE roots.id IN {pb_5:Array(String)}
                     ),
                     toDateTime64(0, 3))
+                AND calls_merged.sortable_datetime <= coalesce(
+                    (SELECT CASE
+                        WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
+                        ELSE max(root_ended_at) + toIntervalSecond(300)
+                    END
+                    FROM (
+                        SELECT max(roots.ended_at) AS root_ended_at
+                        FROM calls_merged AS roots
+                        PREWHERE roots.project_id = {pb_4:String}
+                        WHERE roots.id IN {pb_5:Array(String)}
+                        GROUP BY roots.id
+                    )),
+                    toDateTime64('2100-01-01 00:00:00', 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
             )
         SELECT

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -45,18 +45,41 @@ def test_cte_chain_calls_merged() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
-                    OR calls_merged.parent_id IS NULL)
-                    AND calls_merged.id NOT IN {pb_1:Array(String)}
-                    AND (multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
-                        OR calls_merged.op_name IS NULL)
-                    AND calls_merged.sortable_datetime >= coalesce(
-                        (SELECT min(roots.started_at) - toIntervalSecond(300)
-                            FROM calls_merged AS roots
-                            PREWHERE roots.project_id = {pb_0:String}
-                            WHERE roots.id IN {pb_1:Array(String)}
-                        ),
-                        toDateTime64(0, 3))
+                WHERE calls_merged.id IN (
+                    SELECT calls_merged.id
+                    FROM calls_merged
+                    PREWHERE calls_merged.project_id = {pb_0:String}
+                    WHERE calls_merged.parent_id IN {pb_1:Array(String)}
+                        AND calls_merged.id NOT IN {pb_1:Array(String)}
+                        AND multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
+                        AND calls_merged.sortable_datetime >= coalesce(
+                            (SELECT min(roots.started_at) - toIntervalSecond(300)
+                                FROM calls_merged AS roots
+                                PREWHERE roots.project_id = {pb_0:String}
+                                WHERE roots.id IN {pb_1:Array(String)}
+                            ),
+                            toDateTime64(0, 3))
+                        AND calls_merged.sortable_datetime <= coalesce(
+                            (SELECT CASE
+                                WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
+                                ELSE max(root_ended_at) + toIntervalSecond(300)
+                            END
+                            FROM (
+                                SELECT max(roots.ended_at) AS root_ended_at
+                                FROM calls_merged AS roots
+                                PREWHERE roots.project_id = {pb_0:String}
+                                WHERE roots.id IN {pb_1:Array(String)}
+                                GROUP BY roots.id
+                            )),
+                            toDateTime64('2100-01-01 00:00:00', 3))
+                )
+                AND calls_merged.sortable_datetime >= coalesce(
+                    (SELECT min(roots.started_at) - toIntervalSecond(300)
+                        FROM calls_merged AS roots
+                        PREWHERE roots.project_id = {pb_0:String}
+                        WHERE roots.id IN {pb_1:Array(String)}
+                    ),
+                    toDateTime64(0, 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
                     AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
@@ -410,18 +433,41 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
-                    OR calls_merged.parent_id IS NULL)
-                    AND calls_merged.id NOT IN {pb_1:Array(String)}
-                    AND (multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
-                        OR calls_merged.op_name IS NULL)
-                    AND calls_merged.sortable_datetime >= coalesce(
-                        (SELECT min(roots.started_at) - toIntervalSecond(300)
-                            FROM calls_merged AS roots
-                            PREWHERE roots.project_id = {pb_0:String}
-                            WHERE roots.id IN {pb_1:Array(String)}
-                        ),
-                        toDateTime64(0, 3))
+                WHERE calls_merged.id IN (
+                    SELECT calls_merged.id
+                    FROM calls_merged
+                    PREWHERE calls_merged.project_id = {pb_0:String}
+                    WHERE calls_merged.parent_id IN {pb_1:Array(String)}
+                        AND calls_merged.id NOT IN {pb_1:Array(String)}
+                        AND multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
+                        AND calls_merged.sortable_datetime >= coalesce(
+                            (SELECT min(roots.started_at) - toIntervalSecond(300)
+                                FROM calls_merged AS roots
+                                PREWHERE roots.project_id = {pb_0:String}
+                                WHERE roots.id IN {pb_1:Array(String)}
+                            ),
+                            toDateTime64(0, 3))
+                        AND calls_merged.sortable_datetime <= coalesce(
+                            (SELECT CASE
+                                WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
+                                ELSE max(root_ended_at) + toIntervalSecond(300)
+                            END
+                            FROM (
+                                SELECT max(roots.ended_at) AS root_ended_at
+                                FROM calls_merged AS roots
+                                PREWHERE roots.project_id = {pb_0:String}
+                                WHERE roots.id IN {pb_1:Array(String)}
+                                GROUP BY roots.id
+                            )),
+                            toDateTime64('2100-01-01 00:00:00', 3))
+                )
+                AND calls_merged.sortable_datetime >= coalesce(
+                    (SELECT min(roots.started_at) - toIntervalSecond(300)
+                        FROM calls_merged AS roots
+                        PREWHERE roots.project_id = {pb_0:String}
+                        WHERE roots.id IN {pb_1:Array(String)}
+                    ),
+                    toDateTime64(0, 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
                     AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
@@ -515,18 +561,41 @@ def test_full_query_calls_merged() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
-                    OR calls_merged.parent_id IS NULL)
-                    AND calls_merged.id NOT IN {pb_1:Array(String)}
-                    AND (multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
-                        OR calls_merged.op_name IS NULL)
-                    AND calls_merged.sortable_datetime >= coalesce(
-                        (SELECT min(roots.started_at) - toIntervalSecond(300)
-                            FROM calls_merged AS roots
-                            PREWHERE roots.project_id = {pb_0:String}
-                            WHERE roots.id IN {pb_1:Array(String)}
-                        ),
-                        toDateTime64(0, 3))
+                WHERE calls_merged.id IN (
+                    SELECT calls_merged.id
+                    FROM calls_merged
+                    PREWHERE calls_merged.project_id = {pb_0:String}
+                    WHERE calls_merged.parent_id IN {pb_1:Array(String)}
+                        AND calls_merged.id NOT IN {pb_1:Array(String)}
+                        AND multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
+                        AND calls_merged.sortable_datetime >= coalesce(
+                            (SELECT min(roots.started_at) - toIntervalSecond(300)
+                                FROM calls_merged AS roots
+                                PREWHERE roots.project_id = {pb_0:String}
+                                WHERE roots.id IN {pb_1:Array(String)}
+                            ),
+                            toDateTime64(0, 3))
+                        AND calls_merged.sortable_datetime <= coalesce(
+                            (SELECT CASE
+                                WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
+                                ELSE max(root_ended_at) + toIntervalSecond(300)
+                            END
+                            FROM (
+                                SELECT max(roots.ended_at) AS root_ended_at
+                                FROM calls_merged AS roots
+                                PREWHERE roots.project_id = {pb_0:String}
+                                WHERE roots.id IN {pb_1:Array(String)}
+                                GROUP BY roots.id
+                            )),
+                            toDateTime64('2100-01-01 00:00:00', 3))
+                )
+                AND calls_merged.sortable_datetime >= coalesce(
+                    (SELECT min(roots.started_at) - toIntervalSecond(300)
+                        FROM calls_merged AS roots
+                        PREWHERE roots.project_id = {pb_0:String}
+                        WHERE roots.id IN {pb_1:Array(String)}
+                    ),
+                    toDateTime64(0, 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
                     AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
@@ -591,6 +660,13 @@ def test_full_query_calls_merged() -> None:
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_4:String}
                 WHERE calls_merged.id IN (SELECT call_id FROM page_rows)
+                AND calls_merged.sortable_datetime >= coalesce(
+                    (SELECT min(roots.started_at) - toIntervalSecond(300)
+                        FROM calls_merged AS roots
+                        PREWHERE roots.project_id = {pb_4:String}
+                        WHERE roots.id IN {pb_5:Array(String)}
+                    ),
+                    toDateTime64(0, 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
             )
         SELECT
@@ -620,6 +696,7 @@ def test_full_query_calls_merged() -> None:
             "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
             "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
             "pb_4": "proj-1",
+            "pb_5": ["eval-1"],
         },
     )
 

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -45,7 +45,7 @@ def test_cte_chain_calls_merged() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE calls_merged.id IN (
+                AND calls_merged.id IN (
                     SELECT calls_merged.id
                     FROM calls_merged
                     PREWHERE calls_merged.project_id = {pb_0:String}
@@ -73,7 +73,7 @@ def test_cte_chain_calls_merged() -> None:
                             )),
                             toDateTime64('2100-01-01 00:00:00', 3))
                 )
-                AND calls_merged.sortable_datetime >= coalesce(
+                WHERE calls_merged.sortable_datetime >= coalesce(
                     (SELECT min(roots.started_at) - toIntervalSecond(300)
                         FROM calls_merged AS roots
                         PREWHERE roots.project_id = {pb_0:String}
@@ -433,7 +433,7 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE calls_merged.id IN (
+                AND calls_merged.id IN (
                     SELECT calls_merged.id
                     FROM calls_merged
                     PREWHERE calls_merged.project_id = {pb_0:String}
@@ -461,7 +461,7 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                             )),
                             toDateTime64('2100-01-01 00:00:00', 3))
                 )
-                AND calls_merged.sortable_datetime >= coalesce(
+                WHERE calls_merged.sortable_datetime >= coalesce(
                     (SELECT min(roots.started_at) - toIntervalSecond(300)
                         FROM calls_merged AS roots
                         PREWHERE roots.project_id = {pb_0:String}
@@ -561,7 +561,7 @@ def test_full_query_calls_merged() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE calls_merged.id IN (
+                AND calls_merged.id IN (
                     SELECT calls_merged.id
                     FROM calls_merged
                     PREWHERE calls_merged.project_id = {pb_0:String}
@@ -589,7 +589,7 @@ def test_full_query_calls_merged() -> None:
                             )),
                             toDateTime64('2100-01-01 00:00:00', 3))
                 )
-                AND calls_merged.sortable_datetime >= coalesce(
+                WHERE calls_merged.sortable_datetime >= coalesce(
                     (SELECT min(roots.started_at) - toIntervalSecond(300)
                         FROM calls_merged AS roots
                         PREWHERE roots.project_id = {pb_0:String}

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -11,8 +11,10 @@ from weave.trace_server.interface.query import Query
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.eval_results_query_builder import (
     build_eval_results_cte_chain,
-    build_eval_results_query,
+    build_eval_results_hydration_query,
+    build_eval_results_page_query,
     build_sort_expression,
+    build_table_rows_resolution_query,
 )
 
 
@@ -112,23 +114,13 @@ def test_cte_chain_calls_merged() -> None:
                 OFFSET 0
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -201,23 +193,13 @@ def test_cte_chain_calls_complete() -> None:
                 OFFSET 10
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -337,23 +319,13 @@ def test_cte_chain_sort_and_multi_eval_filters() -> None:
                 OFFSET 50
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -500,23 +472,13 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                 OFFSET 0
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -532,10 +494,10 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
     )
 
 
-def test_full_query_calls_merged() -> None:
-    """Full SQL: lean CTEs + outer SELECT hydrates from calls_merged."""
+def test_page_query_calls_merged() -> None:
+    """Page query: lean CTE chain + page_rows projection, no hydration columns."""
     pb = ParamBuilder("pb")
-    sql = build_eval_results_query(
+    sql = build_eval_results_page_query(
         project_id="proj-1",
         eval_root_ids=["eval-1"],
         sort_by=None,
@@ -546,171 +508,64 @@ def test_full_query_calls_merged() -> None:
         pb=pb,
         read_table="calls_merged",
     )
+    pb_chain = ParamBuilder("pb")
+    chain = build_eval_results_cte_chain(
+        project_id="proj-1",
+        eval_root_ids=["eval-1"],
+        sort_by=None,
+        filters=None,
+        require_intersection=False,
+        limit=10,
+        offset=0,
+        pb=pb_chain,
+        read_table="calls_merged",
+    )
     assert_raw_sql(
         sql,
-        """
-        WITH predict_and_score_calls AS (
-                SELECT calls_merged.id AS call_id,
-                    any(calls_merged.parent_id) AS eval_call_id,
-                    any(calls_merged.inputs_dump) AS inputs_dump,
-                    any(calls_merged.output_dump) AS output_dump,
-                    CASE
-                        WHEN position(JSON_VALUE(any(calls_merged.inputs_dump), '$.example'), '/attr/rows/id/') > 0
-                            THEN regexpExtract(JSON_VALUE(any(calls_merged.inputs_dump), '$.example'), '/attr/rows/id/([^/]+)$', 1)
-                        ELSE hex(SHA256(JSONExtractRaw(any(calls_merged.inputs_dump), 'example')))
-                    END AS row_digest
-                FROM calls_merged
-                PREWHERE calls_merged.project_id = {pb_0:String}
-                AND calls_merged.id IN (
-                    SELECT calls_merged.id
-                    FROM calls_merged
-                    PREWHERE calls_merged.project_id = {pb_0:String}
-                    WHERE calls_merged.parent_id IN {pb_1:Array(String)}
-                        AND calls_merged.id NOT IN {pb_1:Array(String)}
-                        AND multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
-                        AND calls_merged.sortable_datetime >= coalesce(
-                            (SELECT min(roots.started_at) - toIntervalSecond(300)
-                                FROM calls_merged AS roots
-                                PREWHERE roots.project_id = {pb_0:String}
-                                WHERE roots.id IN {pb_1:Array(String)}
-                            ),
-                            toDateTime64(0, 3))
-                        AND calls_merged.sortable_datetime <= coalesce(
-                            (SELECT CASE
-                                WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
-                                ELSE max(root_ended_at) + toIntervalSecond(300)
-                            END
-                            FROM (
-                                SELECT max(roots.ended_at) AS root_ended_at
-                                FROM calls_merged AS roots
-                                PREWHERE roots.project_id = {pb_0:String}
-                                WHERE roots.id IN {pb_1:Array(String)}
-                                GROUP BY roots.id
-                            )),
-                            toDateTime64('2100-01-01 00:00:00', 3))
-                )
-                WHERE calls_merged.sortable_datetime >= coalesce(
-                    (SELECT min(roots.started_at) - toIntervalSecond(300)
-                        FROM calls_merged AS roots
-                        PREWHERE roots.project_id = {pb_0:String}
-                        WHERE roots.id IN {pb_1:Array(String)}
-                    ),
-                    toDateTime64(0, 3))
-                GROUP BY (calls_merged.project_id, calls_merged.id)
-                HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
-                    AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
-                    AND any(calls_merged.deleted_at) IS NULL
-                    AND any(calls_merged.started_at) IS NOT NULL
-            ),
-
-            predict_and_score_calls_resolved AS (
-                SELECT * FROM predict_and_score_calls
-            ),
-
-            ranked_digests AS (
-                SELECT row_digest,
-                    ROW_NUMBER() OVER(ORDER BY row_digest ASC) AS row_order
-                FROM predict_and_score_calls_resolved
-                GROUP BY row_digest
-                HAVING 1=1
-            ),
-
-            ranked_digest_count AS (
-                SELECT count(*) AS total_rows FROM ranked_digests
-            ),
-
-            page_digests AS (
-                SELECT row_digest, row_order
-                FROM ranked_digests
-                ORDER BY row_order
-                LIMIT 10
-                OFFSET 0
-            ),
-
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
-            page_rows AS (
-                SELECT predict_and_score_calls_resolved.call_id AS call_id,
-                    predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
-                    predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
-                FROM predict_and_score_calls_resolved
-                INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
-            ),
-
-            page_calls AS (
-                SELECT calls_merged.id AS call_id,
-                    any(calls_merged.project_id) AS project_id,
-                    any(calls_merged.trace_id) AS trace_id,
-                    any(calls_merged.op_name) AS op_name,
-                    any(calls_merged.started_at) AS started_at,
-                    any(calls_merged.ended_at) AS ended_at,
-                    any(calls_merged.attributes_dump) AS attributes_dump,
-                    any(calls_merged.inputs_dump) AS inputs_dump,
-                    any(calls_merged.output_dump) AS output_dump,
-                    any(calls_merged.summary_dump) AS summary_dump
-                FROM calls_merged
-                PREWHERE calls_merged.project_id = {pb_4:String}
-                WHERE calls_merged.id IN (SELECT call_id FROM page_rows)
-                AND calls_merged.sortable_datetime >= coalesce(
-                    (SELECT min(roots.started_at) - toIntervalSecond(300)
-                        FROM calls_merged AS roots
-                        PREWHERE roots.project_id = {pb_4:String}
-                        WHERE roots.id IN {pb_5:Array(String)}
-                    ),
-                    toDateTime64(0, 3))
-                AND calls_merged.sortable_datetime <= coalesce(
-                    (SELECT CASE
-                        WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
-                        ELSE max(root_ended_at) + toIntervalSecond(300)
-                    END
-                    FROM (
-                        SELECT max(roots.ended_at) AS root_ended_at
-                        FROM calls_merged AS roots
-                        PREWHERE roots.project_id = {pb_4:String}
-                        WHERE roots.id IN {pb_5:Array(String)}
-                        GROUP BY roots.id
-                    )),
-                    toDateTime64('2100-01-01 00:00:00', 3))
-                GROUP BY (calls_merged.project_id, calls_merged.id)
-            )
+        f"""
+        WITH {chain}
         SELECT
-            page_rows.call_id AS id,
-            page_rows.eval_call_id AS parent_id,
-            page_calls.project_id,
-            page_calls.trace_id,
-            page_calls.op_name,
-            page_calls.started_at,
-            page_calls.ended_at,
-            page_calls.attributes_dump,
-            page_calls.inputs_dump,
-            page_calls.output_dump,
-            page_calls.summary_dump,
-            page_rows.row_digest AS __row_digest,
-            page_rows.row_order AS __row_order,
-            page_rows.resolved_inputs AS __resolved_inputs,
-            (SELECT total_rows FROM ranked_digest_count) AS __total_rows
+            page_rows.call_id AS call_id,
+            page_rows.eval_call_id AS eval_call_id,
+            page_rows.row_digest AS row_digest,
+            page_rows.row_order AS row_order,
+            (SELECT total_rows FROM ranked_digest_count) AS total_rows
         FROM page_rows
-        LEFT JOIN page_calls ON page_calls.call_id = page_rows.call_id
         ORDER BY page_rows.row_order ASC
         """,
         pb.get_params(),
-        {
-            "pb_0": "proj-1",
-            "pb_1": ["eval-1"],
-            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
-            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
-            "pb_4": "proj-1",
-            "pb_5": ["eval-1"],
-        },
+        pb_chain.get_params(),
+    )
+
+
+def test_hydration_query_calls_merged() -> None:
+    """Hydration query: literal id set in PREWHERE so dump reads are row-level."""
+    pb = ParamBuilder("pb")
+    sql = build_eval_results_hydration_query(
+        project_id="proj-1",
+        call_ids=["call-1", "call-2"],
+        pb=pb,
+        read_table="calls_merged",
+    )
+    assert_raw_sql(
+        sql,
+        """SELECT
+    calls_merged.id AS id,
+    any(calls_merged.project_id) AS project_id,
+    any(calls_merged.trace_id) AS trace_id,
+    any(calls_merged.op_name) AS op_name,
+    any(calls_merged.started_at) AS started_at,
+    any(calls_merged.ended_at) AS ended_at,
+    any(calls_merged.attributes_dump) AS attributes_dump,
+    any(calls_merged.inputs_dump) AS inputs_dump,
+    any(calls_merged.output_dump) AS output_dump,
+    any(calls_merged.summary_dump) AS summary_dump
+FROM calls_merged
+PREWHERE calls_merged.project_id = {pb_0:String}
+AND calls_merged.id IN {pb_1:Array(String)}
+GROUP BY (calls_merged.project_id, calls_merged.id)""",
+        pb.get_params(),
+        {"pb_0": "proj-1", "pb_1": ["call-1", "call-2"]},
     )
 
 
@@ -870,23 +725,13 @@ def test_filter_logic_operator_or_produces_match_any() -> None:
                 OFFSET 0
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -1000,23 +845,13 @@ def test_filter_logic_operator_and_produces_match_all() -> None:
                 OFFSET 0
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -1127,23 +962,13 @@ def test_filter_logic_operator_or_same_eval_multiple_conditions() -> None:
                 OFFSET 0
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -1161,10 +986,10 @@ def test_filter_logic_operator_or_same_eval_multiple_conditions() -> None:
     )
 
 
-def test_full_query_calls_complete() -> None:
-    """Full SQL: lean CTEs + page_calls hydration on calls_complete (no GROUP BY)."""
+def test_page_query_calls_complete() -> None:
+    """Page query on calls_complete: same lean projection over its CTE chain."""
     pb = ParamBuilder("pb")
-    sql = build_eval_results_query(
+    sql = build_eval_results_page_query(
         project_id="proj-1",
         eval_root_ids=["eval-1"],
         sort_by=None,
@@ -1175,114 +1000,83 @@ def test_full_query_calls_complete() -> None:
         pb=pb,
         read_table="calls_complete",
     )
+    pb_chain = ParamBuilder("pb")
+    chain = build_eval_results_cte_chain(
+        project_id="proj-1",
+        eval_root_ids=["eval-1"],
+        sort_by=None,
+        filters=None,
+        require_intersection=False,
+        limit=10,
+        offset=0,
+        pb=pb_chain,
+        read_table="calls_complete",
+    )
     assert_raw_sql(
         sql,
-        """
-        WITH predict_and_score_calls AS (
-                SELECT calls_complete.id AS call_id,
-                    calls_complete.parent_id AS eval_call_id,
-                    calls_complete.inputs_dump,
-                    calls_complete.output_dump,
-                    CASE
-                        WHEN position(JSON_VALUE(calls_complete.inputs_dump, '$.example'), '/attr/rows/id/') > 0
-                            THEN regexpExtract(JSON_VALUE(calls_complete.inputs_dump, '$.example'), '/attr/rows/id/([^/]+)$', 1)
-                        ELSE hex(SHA256(JSONExtractRaw(calls_complete.inputs_dump, 'example')))
-                    END AS row_digest
-                FROM calls_complete
-                PREWHERE calls_complete.project_id = {pb_0:String}
-                WHERE calls_complete.parent_id IN {pb_1:Array(String)}
-                    AND calls_complete.id NOT IN {pb_1:Array(String)}
-                    AND (multiSearchAny(calls_complete.op_name, [{pb_2:String}, {pb_3:String}]))
-                    AND calls_complete.deleted_at = {pb_4:DateTime64(3)}
-            ),
-
-            predict_and_score_calls_resolved AS (
-                SELECT * FROM predict_and_score_calls
-            ),
-
-            ranked_digests AS (
-                SELECT row_digest,
-                    ROW_NUMBER() OVER(ORDER BY row_digest ASC) AS row_order
-                FROM predict_and_score_calls_resolved
-                GROUP BY row_digest
-                HAVING 1=1
-            ),
-
-            ranked_digest_count AS (
-                SELECT count(*) AS total_rows FROM ranked_digests
-            ),
-
-            page_digests AS (
-                SELECT row_digest, row_order
-                FROM ranked_digests
-                ORDER BY row_order
-                LIMIT 10
-                OFFSET 0
-            ),
-
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
-            page_rows AS (
-                SELECT predict_and_score_calls_resolved.call_id AS call_id,
-                    predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
-                    predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
-                FROM predict_and_score_calls_resolved
-                INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
-            ),
-
-            page_calls AS (
-                SELECT calls_complete.id AS call_id,
-                    calls_complete.project_id,
-                    calls_complete.trace_id,
-                    calls_complete.op_name,
-                    calls_complete.started_at,
-                    calls_complete.ended_at,
-                    calls_complete.attributes_dump,
-                    calls_complete.inputs_dump,
-                    calls_complete.output_dump,
-                    calls_complete.summary_dump
-                FROM calls_complete
-                WHERE calls_complete.project_id = {pb_5:String}
-                    AND calls_complete.id IN (SELECT call_id FROM page_rows)
-            )
+        f"""
+        WITH {chain}
         SELECT
-            page_rows.call_id AS id,
-            page_rows.eval_call_id AS parent_id,
-            page_calls.project_id,
-            page_calls.trace_id,
-            page_calls.op_name,
-            page_calls.started_at,
-            page_calls.ended_at,
-            page_calls.attributes_dump,
-            page_calls.inputs_dump,
-            page_calls.output_dump,
-            page_calls.summary_dump,
-            page_rows.row_digest AS __row_digest,
-            page_rows.row_order AS __row_order,
-            page_rows.resolved_inputs AS __resolved_inputs,
-            (SELECT total_rows FROM ranked_digest_count) AS __total_rows
+            page_rows.call_id AS call_id,
+            page_rows.eval_call_id AS eval_call_id,
+            page_rows.row_digest AS row_digest,
+            page_rows.row_order AS row_order,
+            (SELECT total_rows FROM ranked_digest_count) AS total_rows
         FROM page_rows
-        LEFT JOIN page_calls ON page_calls.call_id = page_rows.call_id
         ORDER BY page_rows.row_order ASC
         """,
         pb.get_params(),
-        {
-            "pb_0": "proj-1",
-            "pb_1": ["eval-1"],
-            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
-            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
-            "pb_4": SENTINEL_EPOCH,
-            "pb_5": "proj-1",
-        },
+        pb_chain.get_params(),
+    )
+
+
+def test_hydration_query_calls_complete() -> None:
+    """Hydration on calls_complete: literal id set in PREWHERE, no GROUP BY."""
+    pb = ParamBuilder("pb")
+    sql = build_eval_results_hydration_query(
+        project_id="proj-1",
+        call_ids=["call-1"],
+        pb=pb,
+        read_table="calls_complete",
+    )
+    assert_raw_sql(
+        sql,
+        """SELECT
+    calls_complete.id AS id,
+    calls_complete.project_id,
+    calls_complete.trace_id,
+    calls_complete.op_name,
+    calls_complete.started_at,
+    calls_complete.ended_at,
+    calls_complete.attributes_dump,
+    calls_complete.inputs_dump,
+    calls_complete.output_dump,
+    calls_complete.summary_dump
+FROM calls_complete
+PREWHERE calls_complete.project_id = {pb_0:String}
+AND calls_complete.id IN {pb_1:Array(String)}""",
+        pb.get_params(),
+        {"pb_0": "proj-1", "pb_1": ["call-1"]},
+    )
+
+
+def test_table_rows_resolution_query() -> None:
+    """Dataset-row resolution uses a literal digest set in PREWHERE."""
+    pb = ParamBuilder("pb")
+    sql = build_table_rows_resolution_query(
+        project_id="proj-1",
+        digests=["digest-1", "digest-2"],
+        pb=pb,
+    )
+    assert_raw_sql(
+        sql,
+        """SELECT digest, any(val_dump) AS val_dump
+FROM table_rows
+PREWHERE project_id = {pb_0:String}
+AND digest IN {pb_1:Array(String)}
+GROUP BY digest""",
+        pb.get_params(),
+        {"pb_0": "proj-1", "pb_1": ["digest-1", "digest-2"]},
     )
 
 

--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -2117,3 +2117,199 @@ def test_eval_results_summary_with_filter(client):
         s for s in eval_summary.scorer_stats if s.scorer_key == "accuracy"
     )
     assert accuracy_stat.numeric_mean == pytest.approx(0.75, abs=0.01)
+
+
+def _create_raw_eval(client, n_rows, started_at, ended_at=None):
+    """Helper: create an eval root + predict-and-score calls at explicit times.
+
+    Timestamp control matters for the calls_merged scan-window tests below:
+    the query bounds its scan by the root's started_at/ended_at (+5min buffer).
+    ended_at=None leaves the root running. Returns (eval_call_id, [pas_ids]).
+    """
+    project_id = client.project_id
+    eval_id = generate_id()
+    client.server.call_start(
+        CallStartReq(
+            start=StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=eval_id,
+                trace_id=eval_id,
+                op_name="Evaluation.evaluate",
+                started_at=started_at,
+                attributes={},
+                inputs={"self": "eval://raw", "model": "model://raw"},
+            )
+        )
+    )
+    pas_ids = []
+    for i in range(n_rows):
+        pas_id = generate_id()
+        pas_ids.append(pas_id)
+        client.server.call_start(
+            CallStartReq(
+                start=StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=pas_id,
+                    trace_id=eval_id,
+                    parent_id=eval_id,
+                    op_name="Evaluation.predict_and_score",
+                    started_at=started_at + datetime.timedelta(seconds=i + 1),
+                    attributes={},
+                    inputs={"example": {"idx": i}, "model": "model://raw"},
+                )
+            )
+        )
+        client.server.call_end(
+            CallEndReq(
+                end=EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=pas_id,
+                    ended_at=started_at + datetime.timedelta(seconds=i + 2),
+                    output={"output": i, "scores": {"accuracy": i / 10}},
+                    summary={},
+                )
+            )
+        )
+    if ended_at is not None:
+        client.server.call_end(
+            CallEndReq(
+                end=EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=eval_id,
+                    ended_at=ended_at,
+                    output={"summary": {}},
+                    summary={},
+                )
+            )
+        )
+    return eval_id, pas_ids
+
+
+def test_eval_results_ignores_post_eval_traffic(client):
+    """Calls written to the project after the eval ended must not change results.
+
+    Exercises the scan-window bounds: the calls_merged path prefilters on
+    [eval start - buffer, eval end + buffer], so unrelated post-eval project
+    traffic stays out of the scan without affecting the rows returned.
+    """
+    hour_ago = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(
+        hours=1
+    )
+    eval_id, _ = _create_raw_eval(
+        client, 3, hour_ago, ended_at=hour_ago + datetime.timedelta(minutes=5)
+    )
+    req = EvalResultsQueryReq(
+        project_id=client.project_id, evaluation_call_ids=[eval_id]
+    )
+    before = client.server.eval_results_query(req)
+    assert before.total_rows == 3
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    for i in range(20):
+        noise_id = generate_id()
+        client.server.call_start(
+            CallStartReq(
+                start=StartedCallSchemaForInsert(
+                    project_id=client.project_id,
+                    id=noise_id,
+                    trace_id=noise_id,
+                    op_name="unrelated_op",
+                    started_at=now,
+                    attributes={},
+                    inputs={"i": i},
+                )
+            )
+        )
+        client.server.call_end(
+            CallEndReq(
+                end=EndedCallSchemaForInsert(
+                    project_id=client.project_id,
+                    id=noise_id,
+                    ended_at=now,
+                    output="x" * 100,
+                    summary={},
+                )
+            )
+        )
+
+    after = client.server.eval_results_query(req)
+    assert after.total_rows == 3
+    assert [r.row_digest for r in after.rows] == [r.row_digest for r in before.rows]
+    assert [
+        [t.scores for e in r.evaluations for t in e.trials] for r in after.rows
+    ] == [[t.scores for e in r.evaluations for t in e.trials] for r in before.rows]
+
+
+def test_eval_results_excludes_calls_deleted_after_eval_window(client):
+    """A predict call deleted long after the eval ended must stay excluded.
+
+    The delete marker's row lands at deletion time — outside the eval's scan
+    window — so this pins the design constraint that the outer aggregation
+    keeps only the lower time bound (a two-sided bound would miss the marker
+    and resurrect the deleted call).
+    """
+    two_hours_ago = datetime.datetime.now(
+        tz=datetime.timezone.utc
+    ) - datetime.timedelta(hours=2)
+    eval_id, pas_ids = _create_raw_eval(
+        client, 3, two_hours_ago, ended_at=two_hours_ago + datetime.timedelta(minutes=5)
+    )
+    req = EvalResultsQueryReq(
+        project_id=client.project_id, evaluation_call_ids=[eval_id]
+    )
+    assert client.server.eval_results_query(req).total_rows == 3
+
+    # Deletion happens "now" — ~2 hours past the eval window and its buffer.
+    client.server.calls_delete(
+        CallsDeleteReq(project_id=client.project_id, call_ids=[pas_ids[0]])
+    )
+    res = client.server.eval_results_query(req)
+    assert res.total_rows == 2
+    returned_pas_ids = {
+        t.predict_and_score_call_id
+        for r in res.rows
+        for e in r.evaluations
+        for t in e.trials
+    }
+    assert pas_ids[0] not in returned_pas_ids
+
+
+def test_eval_results_running_eval_returns_rows(client):
+    """An eval whose root has not ended must still return its rows.
+
+    Exercises the upper-bound fallback: with a NULL root ended_at the scan
+    ceiling falls back to no limit instead of cutting off in-flight results.
+    """
+    hour_ago = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(
+        hours=1
+    )
+    eval_id, _ = _create_raw_eval(client, 2, hour_ago, ended_at=None)
+    res = client.server.eval_results_query(
+        EvalResultsQueryReq(project_id=client.project_id, evaluation_call_ids=[eval_id])
+    )
+    assert res.total_rows == 2
+
+
+def test_eval_results_evaluations_follow_request_order(client):
+    """Each row's evaluations list is ordered by the requested eval ids."""
+    hour_ago = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(
+        hours=1
+    )
+    eval_a, _ = _create_raw_eval(
+        client, 2, hour_ago, ended_at=hour_ago + datetime.timedelta(minutes=5)
+    )
+    eval_b, _ = _create_raw_eval(
+        client,
+        2,
+        hour_ago + datetime.timedelta(minutes=10),
+        ended_at=hour_ago + datetime.timedelta(minutes=15),
+    )
+    for requested in ([eval_a, eval_b], [eval_b, eval_a]):
+        res = client.server.eval_results_query(
+            EvalResultsQueryReq(
+                project_id=client.project_id, evaluation_call_ids=requested
+            )
+        )
+        assert res.total_rows == 2
+        for row in res.rows:
+            assert [e.evaluation_call_id for e in row.evaluations] == requested

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5938,7 +5938,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         pb = ParamBuilder()
 
-        page_query = eval_results_query_builder.build_eval_results_query(
+        page_query = eval_results_query_builder.build_eval_results_page_query(
             req.project_id,
             eval_root_ids,
             req.sort_by,
@@ -5954,27 +5954,73 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         result = self._query(page_query, pb.get_params())
 
         digest_by_call: dict[str, str] = {}
-        resolved_by_call_id: dict[str, Any] = {}
+        eval_call_id_by_call: dict[str, str | None] = {}
+        ordered_call_ids: list[str] = []
         total_rows = 0
-        page_calls: list[tsi.CallSchema] = []
 
         for row in result.result_rows:
             row_data = dict(zip(result.column_names, row, strict=True))
-            total_rows = int(row_data.get("__total_rows", 0))
-            row_digest = row_data.get("__row_digest")
-            resolved_raw = row_data.get("__resolved_inputs")
-
-            call_id = row_data.get("id")
-            if row_digest and call_id:
+            total_rows = int(row_data.get("total_rows", 0))
+            call_id = row_data.get("call_id")
+            if not call_id:
+                continue
+            ordered_call_ids.append(call_id)
+            eval_call_id_by_call[call_id] = row_data.get("eval_call_id")
+            row_digest = row_data.get("row_digest")
+            if row_digest:
                 digest_by_call[call_id] = row_digest
-            if resolved_raw and call_id and req.resolve_row_refs:
-                parsed = try_parse_json(resolved_raw)
-                if parsed is not None:
-                    resolved_by_call_id[call_id] = parsed
 
+        # Resolve dataset-row payloads by literal digests (PREWHERE); inline
+        # rows have no table_rows entry and keep their inputs.example as-is.
+        resolved_by_call_id: dict[str, Any] = {}
+        if req.resolve_row_refs and digest_by_call:
+            val_by_digest: dict[str, Any] = {}
+            unique_digests = list(dict.fromkeys(digest_by_call.values()))
+            for i in range(0, len(unique_digests), MAX_FILTER_LENGTH):
+                dbatch = unique_digests[i : i + MAX_FILTER_LENGTH]
+                rpb = ParamBuilder()
+                resolution_query = (
+                    eval_results_query_builder.build_table_rows_resolution_query(
+                        req.project_id, dbatch, rpb
+                    )
+                )
+                for digest, val_dump in self._query(
+                    resolution_query, rpb.get_params()
+                ).result_rows:
+                    if val_dump:
+                        parsed = try_parse_json(val_dump)
+                        if parsed is not None:
+                            val_by_digest[digest] = parsed
+            for call_id, digest in digest_by_call.items():
+                if digest in val_by_digest:
+                    resolved_by_call_id[call_id] = val_by_digest[digest]
+
+        # Hydrate heavy call columns in a second statement so the id set is a
+        # literal PREWHERE param (row-level lazy reads); see
+        # build_eval_results_hydration_query for why this can't be one statement.
+        hydrated_by_id: dict[str, dict[str, Any]] = {}
+        for i in range(0, len(ordered_call_ids), MAX_FILTER_LENGTH):
+            batch = ordered_call_ids[i : i + MAX_FILTER_LENGTH]
+            hpb = ParamBuilder()
+            hydration_query = (
+                eval_results_query_builder.build_eval_results_hydration_query(
+                    req.project_id, batch, hpb, read_table
+                )
+            )
+            hydration_result = self._query(hydration_query, hpb.get_params())
+            for hrow in hydration_result.result_rows:
+                hdata = dict(zip(hydration_result.column_names, hrow, strict=True))
+                hydrated_by_id[hdata["id"]] = hdata
+
+        page_calls: list[tsi.CallSchema] = []
+        for call_id in ordered_call_ids:
+            call_data = hydrated_by_id.get(call_id)
+            if call_data is None:
+                continue
+            call_data["parent_id"] = eval_call_id_by_call.get(call_id)
             page_calls.append(
                 tsi.CallSchema.model_validate(
-                    ch_call_dict_to_call_schema_dict(row_data)
+                    ch_call_dict_to_call_schema_dict(call_data)
                 )
             )
 

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -676,9 +676,15 @@ def finalize_rows(
     limit: int | None,
 ) -> tuple[list[tsi.EvalResultsRow], int]:
     """Attach evaluations to rows, apply intersection filter, sort, and paginate."""
+    # Order each row's evaluations by the requested eval ids, not by call scan
+    # order, which varies with the query plan.
+    eval_order = {eval_id: i for i, eval_id in enumerate(eval_root_ids)}
     for row_digest, eval_entries in row_eval_map.items():
         if row_digest in row_map:
-            row_map[row_digest].evaluations = list(eval_entries.values())
+            row_map[row_digest].evaluations = sorted(
+                eval_entries.values(),
+                key=lambda e: eval_order.get(e.evaluation_call_id, len(eval_order)),
+            )
 
     rows = list(row_map.values())
 
@@ -738,9 +744,15 @@ def build_eval_rows(
 
         eval_entry.trials.append(_build_trial(predict_and_score_call, child_by_parent))
 
+    # Order each row's evaluations by the requested eval ids, not by call scan
+    # order, which varies with the query plan.
+    eval_order = {eval_id: i for i, eval_id in enumerate(eval_root_ids)}
     for row_digest, eval_entries in row_eval_map.items():
         if row_digest in row_map:
-            row_map[row_digest].evaluations = list(eval_entries.values())
+            row_map[row_digest].evaluations = sorted(
+                eval_entries.values(),
+                key=lambda e: eval_order.get(e.evaluation_call_id, len(eval_order)),
+            )
 
     return list(row_map.values())
 

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -667,6 +667,24 @@ def build_eval_rows_from_calls(
     return row_map, row_eval_map
 
 
+def _attach_evaluations(
+    row_map: dict[str, tsi.EvalResultsRow],
+    row_eval_map: dict[str, dict[str, tsi.EvalResultsRowEvaluation]],
+    eval_root_ids: list[str],
+) -> None:
+    """Attach each row's evaluations, ordered by the requested eval ids.
+
+    Scan order varies with the query plan, so it is not a stable ordering.
+    """
+    eval_order = {eval_id: i for i, eval_id in enumerate(eval_root_ids)}
+    for row_digest, eval_entries in row_eval_map.items():
+        if row_digest in row_map:
+            row_map[row_digest].evaluations = sorted(
+                eval_entries.values(),
+                key=lambda e: eval_order.get(e.evaluation_call_id, len(eval_order)),
+            )
+
+
 def finalize_rows(
     row_map: dict[str, tsi.EvalResultsRow],
     row_eval_map: dict[str, dict[str, tsi.EvalResultsRowEvaluation]],
@@ -676,15 +694,7 @@ def finalize_rows(
     limit: int | None,
 ) -> tuple[list[tsi.EvalResultsRow], int]:
     """Attach evaluations to rows, apply intersection filter, sort, and paginate."""
-    # Order each row's evaluations by the requested eval ids, not by call scan
-    # order, which varies with the query plan.
-    eval_order = {eval_id: i for i, eval_id in enumerate(eval_root_ids)}
-    for row_digest, eval_entries in row_eval_map.items():
-        if row_digest in row_map:
-            row_map[row_digest].evaluations = sorted(
-                eval_entries.values(),
-                key=lambda e: eval_order.get(e.evaluation_call_id, len(eval_order)),
-            )
+    _attach_evaluations(row_map, row_eval_map, eval_root_ids)
 
     rows = list(row_map.values())
 
@@ -744,15 +754,7 @@ def build_eval_rows(
 
         eval_entry.trials.append(_build_trial(predict_and_score_call, child_by_parent))
 
-    # Order each row's evaluations by the requested eval ids, not by call scan
-    # order, which varies with the query plan.
-    eval_order = {eval_id: i for i, eval_id in enumerate(eval_root_ids)}
-    for row_digest, eval_entries in row_eval_map.items():
-        if row_digest in row_map:
-            row_map[row_digest].evaluations = sorted(
-                eval_entries.values(),
-                key=lambda e: eval_order.get(e.evaluation_call_id, len(eval_order)),
-            )
+    _attach_evaluations(row_map, row_eval_map, eval_root_ids)
 
     return list(row_map.values())
 

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -6,8 +6,11 @@ Generates ClickHouse CTEs for the eval_results CTE chain:
   ranked_digests                   → GROUP BY row_digest, HAVING filters, ROW_NUMBER for sort
   ranked_digest_count              → total matching rows (for pagination metadata)
   page_digests                     → paginated slice of ranked_digests
-  page_resolved_inputs             → table_rows JOIN for the paginated digests only
-  page_rows                        → call IDs + resolved_inputs for the page
+  page_rows                        → call IDs + digests + order for the page
+
+Heavy data (call payload columns, dataset-row val_dump) is fetched by separate
+statements with literal id/digest params in PREWHERE — see
+build_eval_results_hydration_query and build_table_rows_resolution_query.
 """
 
 from functools import partial
@@ -516,98 +519,43 @@ page_digests AS (
 )"""
 
 
-def build_page_resolved_inputs_cte(project_id_param: str) -> str:
-    """Hydrate dataset-row val_dump for just the page's digests."""
-    return f"""page_resolved_inputs AS (
-    SELECT digest, any(val_dump) AS val_dump
-    FROM table_rows
-    PREWHERE project_id = {project_id_param}
-    WHERE digest IN (SELECT row_digest FROM page_digests)
-    GROUP BY digest
-)"""
-
-
 def build_page_rows_cte() -> str:
-    """Build page_rows CTE: joins page digests with the per-page val_dump
-    resolution.
+    """Build page_rows CTE: page digests joined back to their calls.
+
+    Dataset-row resolution deliberately does NOT happen here: a
+    `digest IN (SELECT ... FROM page_digests)` scan of table_rows reads
+    val_dump for every row in the surviving granules (GBs on fat datasets)
+    even though only the page's digests are needed. Callers that want
+    resolved rows fetch them with build_table_rows_resolution_query using
+    the returned digests as a literal PREWHERE param.
     """
     return """page_rows AS (
     SELECT
         predict_and_score_calls_resolved.call_id AS call_id,
         predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
         predict_and_score_calls_resolved.row_digest AS row_digest,
-        page_digests.row_order AS row_order,
-        COALESCE(
-            nullIf(page_resolved_inputs.val_dump, ''),
-            JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')
-        ) AS resolved_inputs
+        page_digests.row_order AS row_order
     FROM predict_and_score_calls_resolved
     INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-    LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
 )"""
 
 
-def _build_page_calls_cte(
-    project_id_param: str,
-    read_table: str,
-    eval_root_ids_param: str | None = None,
+def build_table_rows_resolution_query(
+    project_id: str,
+    digests: list[str],
+    pb: ParamBuilder,
 ) -> str:
-    """Build page_calls CTE: pre-filter and pre-aggregate source table for page rows only.
-
-    page_calls only hydrates display columns for calls already selected by
-    page_rows, and every such call's start/end rows lie inside the eval run
-    window -- so both time bounds apply. The bounds prune granules via the
-    sortable_datetime minmax index from WHERE (the id filter must stay out of
-    PREWHERE: referencing a chained CTE there re-evaluates it pathologically),
-    which keeps the dump-column reads to the window instead of the project.
-    """
-    if read_table == "calls_merged":
-        assert eval_root_ids_param is not None
-        eval_start_lower_bound = _build_eval_start_lower_bound(
-            project_id_param, eval_root_ids_param
-        )
-        eval_end_upper_bound = _build_eval_end_upper_bound(
-            project_id_param, eval_root_ids_param
-        )
-        return f"""page_calls AS (
-    SELECT
-        calls_merged.id AS call_id,
-        any(calls_merged.project_id) AS project_id,
-        any(calls_merged.trace_id) AS trace_id,
-        any(calls_merged.op_name) AS op_name,
-        any(calls_merged.started_at) AS started_at,
-        any(calls_merged.ended_at) AS ended_at,
-        any(calls_merged.attributes_dump) AS attributes_dump,
-        any(calls_merged.inputs_dump) AS inputs_dump,
-        any(calls_merged.output_dump) AS output_dump,
-        any(calls_merged.summary_dump) AS summary_dump
-    FROM calls_merged
-    PREWHERE calls_merged.project_id = {project_id_param}
-    WHERE calls_merged.id IN (SELECT call_id FROM page_rows)
-    AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
-    AND calls_merged.sortable_datetime <= {eval_end_upper_bound}
-    GROUP BY (calls_merged.project_id, calls_merged.id)
-)"""
-    else:
-        return f"""page_calls AS (
-    SELECT
-        calls_complete.id AS call_id,
-        calls_complete.project_id,
-        calls_complete.trace_id,
-        calls_complete.op_name,
-        calls_complete.started_at,
-        calls_complete.ended_at,
-        calls_complete.attributes_dump,
-        calls_complete.inputs_dump,
-        calls_complete.output_dump,
-        calls_complete.summary_dump
-    FROM calls_complete
-    WHERE calls_complete.project_id = {project_id_param}
-      AND calls_complete.id IN (SELECT call_id FROM page_rows)
-)"""
+    """Resolve dataset-row val_dump for a literal digest list (PREWHERE)."""
+    project_id_param = param_slot(pb.add_param(project_id), "String")
+    digests_param = pb.add(digests, None, "Array(String)")
+    return f"""SELECT digest, any(val_dump) AS val_dump
+FROM table_rows
+PREWHERE project_id = {project_id_param}
+AND digest IN {digests_param}
+GROUP BY digest"""
 
 
-def build_eval_results_query(
+def build_eval_results_page_query(
     project_id: str,
     eval_root_ids: list[str],
     sort_by: list[tsi.EvalResultsSortBy] | None,
@@ -619,11 +567,16 @@ def build_eval_results_query(
     read_table: str,
     filter_logic_operator: str = "or",
 ) -> str:
-    """Build the complete eval_results SQL query.
+    """Build the page-selection SQL: which rows to show, on light columns only.
 
-    The CTE chain carries only lightweight columns for sort/filter/pagination.
-    A page_calls CTE pre-filters the source table to just the page's call IDs,
-    then the outer SELECT joins two small tables (page_rows + page_calls).
+    Returns one row per page call with call_id, eval_call_id, row_digest,
+    row_order, resolved_inputs, and the total row count. Heavy call payloads
+    are fetched by a second statement (build_eval_results_hydration_query)
+    with the selected ids as a literal parameter: an in-statement
+    `id IN (SELECT ... FROM page_rows)` cannot sit in PREWHERE (chained-CTE
+    references re-evaluate pathologically), and from WHERE the dump columns
+    are read for every row in the surviving granules -- GBs on fat projects
+    to display 50 rows.
     """
     cte_chain = build_eval_results_cte_chain(
         project_id,
@@ -637,36 +590,63 @@ def build_eval_results_query(
         read_table,
         filter_logic_operator,
     )
-    project_id_param = param_slot(pb.add_param(project_id), "String")
-    page_eval_root_ids_param = None
-    if read_table == "calls_merged":
-        page_eval_root_ids_param = pb.add(eval_root_ids, None, "Array(String)")
-    page_calls_cte = _build_page_calls_cte(
-        project_id_param, read_table, page_eval_root_ids_param
-    )
-
-    return f"""WITH {cte_chain.strip()},
-
-{page_calls_cte}
+    return f"""WITH {cte_chain.strip()}
 SELECT
-    page_rows.call_id AS id,
-    page_rows.eval_call_id AS parent_id,
-    page_calls.project_id,
-    page_calls.trace_id,
-    page_calls.op_name,
-    page_calls.started_at,
-    page_calls.ended_at,
-    page_calls.attributes_dump,
-    page_calls.inputs_dump,
-    page_calls.output_dump,
-    page_calls.summary_dump,
-    page_rows.row_digest AS __row_digest,
-    page_rows.row_order AS __row_order,
-    page_rows.resolved_inputs AS __resolved_inputs,
-    (SELECT total_rows FROM ranked_digest_count) AS __total_rows
+    page_rows.call_id AS call_id,
+    page_rows.eval_call_id AS eval_call_id,
+    page_rows.row_digest AS row_digest,
+    page_rows.row_order AS row_order,
+    (SELECT total_rows FROM ranked_digest_count) AS total_rows
 FROM page_rows
-LEFT JOIN page_calls ON page_calls.call_id = page_rows.call_id
 ORDER BY page_rows.row_order ASC"""
+
+
+def build_eval_results_hydration_query(
+    project_id: str,
+    call_ids: list[str],
+    pb: ParamBuilder,
+    read_table: str,
+) -> str:
+    """Build the hydration SQL: heavy call columns for a literal id list.
+
+    The literal id set sits in PREWHERE, so ClickHouse row-filters on
+    (project_id, id) before reading the dump columns -- reads stay
+    proportional to the page, not to the granules the page's rows live in.
+    """
+    project_id_param = param_slot(pb.add_param(project_id), "String")
+    call_ids_param = pb.add(call_ids, None, "Array(String)")
+
+    if read_table == "calls_merged":
+        return f"""SELECT
+    calls_merged.id AS id,
+    any(calls_merged.project_id) AS project_id,
+    any(calls_merged.trace_id) AS trace_id,
+    any(calls_merged.op_name) AS op_name,
+    any(calls_merged.started_at) AS started_at,
+    any(calls_merged.ended_at) AS ended_at,
+    any(calls_merged.attributes_dump) AS attributes_dump,
+    any(calls_merged.inputs_dump) AS inputs_dump,
+    any(calls_merged.output_dump) AS output_dump,
+    any(calls_merged.summary_dump) AS summary_dump
+FROM calls_merged
+PREWHERE calls_merged.project_id = {project_id_param}
+AND calls_merged.id IN {call_ids_param}
+GROUP BY (calls_merged.project_id, calls_merged.id)"""
+    else:
+        return f"""SELECT
+    calls_complete.id AS id,
+    calls_complete.project_id,
+    calls_complete.trace_id,
+    calls_complete.op_name,
+    calls_complete.started_at,
+    calls_complete.ended_at,
+    calls_complete.attributes_dump,
+    calls_complete.inputs_dump,
+    calls_complete.output_dump,
+    calls_complete.summary_dump
+FROM calls_complete
+PREWHERE calls_complete.project_id = {project_id_param}
+AND calls_complete.id IN {call_ids_param}"""
 
 
 def build_eval_results_cte_chain(
@@ -729,7 +709,6 @@ def build_eval_results_cte_chain(
         pb,
         filter_logic_operator,
     )
-    page_resolved_cte = build_page_resolved_inputs_cte(project_id_param)
     page_rows_cte = build_page_rows_cte()
 
     return f"""{calls_cte},
@@ -737,7 +716,5 @@ def build_eval_results_cte_chain(
 {resolved_cte},
 
 {ranked_cte},
-
-{page_resolved_cte},
 
 {page_rows_cte}"""

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -552,10 +552,21 @@ def _build_page_calls_cte(
     read_table: str,
     eval_root_ids_param: str | None = None,
 ) -> str:
-    """Build page_calls CTE: pre-filter and pre-aggregate source table for page rows only."""
+    """Build page_calls CTE: pre-filter and pre-aggregate source table for page rows only.
+
+    page_calls only hydrates display columns for calls already selected by
+    page_rows, and every such call's start/end rows lie inside the eval run
+    window -- so both time bounds apply. The bounds prune granules via the
+    sortable_datetime minmax index from WHERE (the id filter must stay out of
+    PREWHERE: referencing a chained CTE there re-evaluates it pathologically),
+    which keeps the dump-column reads to the window instead of the project.
+    """
     if read_table == "calls_merged":
         assert eval_root_ids_param is not None
         eval_start_lower_bound = _build_eval_start_lower_bound(
+            project_id_param, eval_root_ids_param
+        )
+        eval_end_upper_bound = _build_eval_end_upper_bound(
             project_id_param, eval_root_ids_param
         )
         return f"""page_calls AS (
@@ -574,6 +585,7 @@ def _build_page_calls_cte(
     PREWHERE calls_merged.project_id = {project_id_param}
     WHERE calls_merged.id IN (SELECT call_id FROM page_rows)
     AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
+    AND calls_merged.sortable_datetime <= {eval_end_upper_bound}
     GROUP BY (calls_merged.project_id, calls_merged.id)
 )"""
     else:

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -152,11 +152,12 @@ def build_predict_and_score_calls_cte(
             project_id_param, eval_root_ids_param
         )
         # The inner id subquery matches on call-start rows only (they carry
-        # parent_id/op_name), reading light columns; the outer aggregation then
-        # touches inputs_dump/output_dump for just those ids instead of every
-        # call in the window. The outer keeps only the lower bound: delete rows
-        # are written at deletion time (after the eval window) and must still
-        # merge in so HAVING can exclude deleted calls.
+        # parent_id/op_name), reading light columns. It lives in PREWHERE (an
+        # explicit PREWHERE disables automatic condition movement) so the outer
+        # aggregation reads inputs_dump/output_dump for just those ids instead
+        # of every call in the window. The outer keeps only the lower time
+        # bound: delete rows are written at deletion time (after the eval
+        # window) and must still merge in so HAVING can exclude deleted calls.
         return f"""predict_and_score_calls AS (
     SELECT
         calls_merged.id AS call_id,
@@ -166,7 +167,7 @@ def build_predict_and_score_calls_cte(
         {row_digest_expr} AS row_digest
     FROM calls_merged
     PREWHERE calls_merged.project_id = {project_id_param}
-    WHERE calls_merged.id IN (
+    AND calls_merged.id IN (
         SELECT calls_merged.id
         FROM calls_merged
         PREWHERE calls_merged.project_id = {project_id_param}
@@ -176,7 +177,7 @@ def build_predict_and_score_calls_cte(
         AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
         AND calls_merged.sortable_datetime <= {eval_end_upper_bound}
     )
-    AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
+    WHERE calls_merged.sortable_datetime >= {eval_start_lower_bound}
     GROUP BY (calls_merged.project_id, calls_merged.id)
     HAVING any(calls_merged.parent_id) IN {eval_root_ids_param}
         AND ({op_match_having})

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -68,6 +68,32 @@ def _build_eval_start_lower_bound(
     )"""
 
 
+def _build_eval_end_upper_bound(project_id_param: str, eval_root_ids_param: str) -> str:
+    """sortable_datetime ceiling for the calls_merged scan, as a scalar subquery.
+
+    Predict-and-score calls finish before their eval root does, so bounding by
+    the roots' latest ended_at (plus a buffer) keeps the scan inside the eval
+    run window instead of eval start -> now. Falls back to a far-future
+    datetime (no ceiling) when any root is still running or has no rows.
+    """
+    return f"""coalesce(
+        (
+            SELECT CASE
+                WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
+                ELSE max(root_ended_at) + toIntervalSecond({DATETIME_BUFFER_TIME_SECONDS})
+            END
+            FROM (
+                SELECT max(roots.ended_at) AS root_ended_at
+                FROM calls_merged AS roots
+                PREWHERE roots.project_id = {project_id_param}
+                WHERE roots.id IN {eval_root_ids_param}
+                GROUP BY roots.id
+            )
+        ),
+        toDateTime64('2100-01-01 00:00:00', 3)
+    )"""
+
+
 def _sort_filter_uses_inputs(
     sort_by: list[tsi.EvalResultsSortBy] | None,
     filters: list[tsi.EvalResultsFilter] | None,
@@ -122,6 +148,15 @@ def build_predict_and_score_calls_cte(
         eval_start_lower_bound = _build_eval_start_lower_bound(
             project_id_param, eval_root_ids_param
         )
+        eval_end_upper_bound = _build_eval_end_upper_bound(
+            project_id_param, eval_root_ids_param
+        )
+        # The inner id subquery matches on call-start rows only (they carry
+        # parent_id/op_name), reading light columns; the outer aggregation then
+        # touches inputs_dump/output_dump for just those ids instead of every
+        # call in the window. The outer keeps only the lower bound: delete rows
+        # are written at deletion time (after the eval window) and must still
+        # merge in so HAVING can exclude deleted calls.
         return f"""predict_and_score_calls AS (
     SELECT
         calls_merged.id AS call_id,
@@ -131,14 +166,15 @@ def build_predict_and_score_calls_cte(
         {row_digest_expr} AS row_digest
     FROM calls_merged
     PREWHERE calls_merged.project_id = {project_id_param}
-    WHERE (
-        calls_merged.parent_id IN {eval_root_ids_param}
-        OR calls_merged.parent_id IS NULL
-    )
-    AND calls_merged.id NOT IN {eval_root_ids_param}
-    AND (
-        {op_match_where}
-        OR calls_merged.op_name IS NULL
+    WHERE calls_merged.id IN (
+        SELECT calls_merged.id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {project_id_param}
+        WHERE calls_merged.parent_id IN {eval_root_ids_param}
+        AND calls_merged.id NOT IN {eval_root_ids_param}
+        AND {op_match_where}
+        AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
+        AND calls_merged.sortable_datetime <= {eval_end_upper_bound}
     )
     AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
     GROUP BY (calls_merged.project_id, calls_merged.id)
@@ -510,9 +546,17 @@ def build_page_rows_cte() -> str:
 )"""
 
 
-def _build_page_calls_cte(project_id_param: str, read_table: str) -> str:
+def _build_page_calls_cte(
+    project_id_param: str,
+    read_table: str,
+    eval_root_ids_param: str | None = None,
+) -> str:
     """Build page_calls CTE: pre-filter and pre-aggregate source table for page rows only."""
     if read_table == "calls_merged":
+        assert eval_root_ids_param is not None
+        eval_start_lower_bound = _build_eval_start_lower_bound(
+            project_id_param, eval_root_ids_param
+        )
         return f"""page_calls AS (
     SELECT
         calls_merged.id AS call_id,
@@ -528,6 +572,7 @@ def _build_page_calls_cte(project_id_param: str, read_table: str) -> str:
     FROM calls_merged
     PREWHERE calls_merged.project_id = {project_id_param}
     WHERE calls_merged.id IN (SELECT call_id FROM page_rows)
+    AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
     GROUP BY (calls_merged.project_id, calls_merged.id)
 )"""
     else:
@@ -580,7 +625,12 @@ def build_eval_results_query(
         filter_logic_operator,
     )
     project_id_param = param_slot(pb.add_param(project_id), "String")
-    page_calls_cte = _build_page_calls_cte(project_id_param, read_table)
+    page_eval_root_ids_param = None
+    if read_table == "calls_merged":
+        page_eval_root_ids_param = pb.add(eval_root_ids, None, "Array(String)")
+    page_calls_cte = _build_page_calls_cte(
+        project_id_param, read_table, page_eval_root_ids_param
+    )
 
     return f"""WITH {cte_chain.strip()},
 


### PR DESCRIPTION
## Description

goal is to speed up the /eval-results query which is a complex query w multiple CTEs.
the query is also different depending on where the project calls data is stored (either calls_merged or calls_complete)
this PR optimizes the `calls_merged` path in two moves: fixes 1-3 change how the eval's rows get *selected* (stop scanning the whole project), fixes 4-5 change how the selected rows get *fetched* (stop reading payloads that aren't the page's). the `calls_complete` path is untouched.

### The fixes

**1. Find the eval's calls before reading payloads.** The end-row of a call has `parent_id = NULL` / `op_name = NULL`, so the old filters admitted every end-row in the project and only `HAVING` (after aggregation) knew which calls actually matched — payload columns were read for all of it.

Before:
```sql
FROM calls_merged
PREWHERE project_id = {proj}
WHERE (parent_id IN {eval_ids} OR parent_id IS NULL)      -- every end-row passes
  AND (multiSearchAny(op_name, [...]) OR op_name IS NULL) -- every end-row passes
  AND sortable_datetime >= {eval_start}
GROUP BY id
HAVING any(parent_id) IN {eval_ids} ...                   -- identity checked after the reads
```

After:
```sql
FROM calls_merged
PREWHERE project_id = {proj}
  AND id IN (SELECT id FROM calls_merged                  -- start-rows only, light columns
             WHERE parent_id IN {eval_ids}
               AND multiSearchAny(op_name, [...])
               AND sortable_datetime >= {eval_start}
               AND sortable_datetime <= {eval_end} + 5min)
WHERE sortable_datetime >= {eval_start}
GROUP BY id
HAVING ... (unchanged)
```
PREWHERE filters rows before the remaining columns are read, so `inputs_dump`/`output_dump` are only decompressed for the eval's own calls.

**2. Cap the scan at the eval's end.** 
Before: the only bound was `sortable_datetime >= {eval_start}` — a window that grows forever as the project keeps writing. 
After: the prefilter also has `sortable_datetime <= max(roots.ended_at) + 5min` (no ceiling if a root is still running). 

this stops the query from getting more expensive with eval age. sample query is above (shown in fix 1)

**3. Bound the page hydration scan.**

Before:
```sql
page_calls AS (
  SELECT ... FROM calls_merged
  PREWHERE project_id = {proj}
  WHERE id IN (SELECT call_id FROM page_rows))            -- scanned the whole project
```

After:
```sql
page_calls AS (
  SELECT ... FROM calls_merged
  PREWHERE project_id = {proj}
  WHERE id IN (SELECT call_id FROM page_rows)   -- must stay in WHERE: a chained-CTE
    AND sortable_datetime >= {eval_start}       --   reference in PREWHERE re-evaluates
    AND sortable_datetime <= {eval_end} + 5min) --   the chain pathologically
```
so the `id IN` only evaluates over the eval's window instead of the whole project. (fix 4 below removes this scan from the statement entirely.)

**4. Fetch page payloads in a separate statement with a literal id list.** Inside one statement, the page's ids only exist as a CTE — and a CTE reference can't go in `PREWHERE` (it re-evaluates the whole chain; this hung a ClickHouse locally). Stuck in `WHERE`, the filter ran *after* the payload columns were read: on the incident project, ~2.2GB decompressed to display 50 rows whose payloads total 27MB.

Before (one statement):
```sql
page_calls AS (
  SELECT id, ..., inputs_dump, output_dump, ...
  FROM calls_merged
  PREWHERE project_id = {proj}
  WHERE id IN (SELECT call_id FROM page_rows))   -- filter runs AFTER payload reads
...
SELECT ... FROM page_rows LEFT JOIN page_calls ...
```

After (two statements):
```sql
-- statement 1: pick the page, light columns only
WITH <cte chain> SELECT call_id, row_digest, row_order, total_rows FROM page_rows ORDER BY row_order

-- statement 2: fetch payloads for exactly those ids
SELECT id, ..., inputs_dump, output_dump, ...
FROM calls_merged
PREWHERE project_id = {proj} AND id IN {ids:Array(String)}  -- literal param: filter BEFORE reads
GROUP BY id
```

**5. Dataset-row resolution becomes opt-in, also literal-key.** The chain always joined `table_rows` to build a `resolved_inputs` field — up to 1.8GB of `val_dump` reads on fat-dataset projects — and the default request (`resolve_row_refs=false`, what the UI sends) throws that field away.

Before (inside the chain, always ran):
```sql
page_resolved_inputs AS (
  SELECT digest, any(val_dump) FROM table_rows
  PREWHERE project_id = {proj}
  WHERE digest IN (SELECT row_digest FROM page_digests))  -- val_dump read granule-wide
```

After (separate statement, only when `resolve_row_refs=true`):
```sql
SELECT digest, any(val_dump) FROM table_rows
PREWHERE project_id = {proj} AND digest IN {digests:Array(String)}
GROUP BY digest
```

server-side, `_eval_results_via_cte` now runs: page query → hydration per id batch (`MAX_FILTER_LENGTH`) → optional resolution → rows reassembled in page order.

### Why the query gets faster — the query planner, before vs after

`EXPLAIN indexes=1` on the incident project, both shapes. First surprise: **the index-level pruning is the same** — the planner was never the problem:

Before (old shape):
```text
ReadFromMergeTree (calls_merged)
  PrimaryKey   Condition: project_id IN [...]              Parts 126/297   Granules 328 / 18,483,588
  Skip index   idx_sortable_datetime (eval lower bound)    Parts  10/126   Granules  35 / 328
```

After (this PR):
```text
ReadFromMergeTree (calls_merged)
  PrimaryKey   Condition: project_id IN [...]              Parts 125/296   Granules 327 / 18,483,587
  Skip index   idx_sortable_datetime (eval window)         Parts   9/125   Granules  34 / 327
```

Both prune 18.5M granules down to ~34. The difference is what happens *inside* those 34 granules (~280K rows), and that shows up in `EXPLAIN PIPELINE`:

```mermaid
flowchart TD
    subgraph B["BEFORE — filter runs AFTER the read"]
        direction TB
        B1["ReadFromMergeTree<br/><i>reads ALL columns — inputs_dump, output_dump —<br/>for every row in the window</i>"]
        B2["FilterTransform<br/><i>parent_id IN roots OR parent_id IS NULL<br/>→ every end-row passes</i>"]
        B3["AggregatingTransform<br/><i>GROUP BY id, payloads in tow</i>"]
        B4["HAVING<br/><i>identity finally checked — ~99% discarded</i>"]
        B1 --> B2 --> B3 --> B4
    end
    subgraph A["AFTER — filter runs BEFORE the read"]
        direction TB
        A1["CreatingSets<br/><i>subquery finds the eval's call ids<br/>(light columns only)</i>"]
        A2["ReadFromMergeTree<br/><i>PREWHERE id IN set —<br/>payload columns skipped for non-matching rows</i>"]
        A3["AggregatingTransform<br/><i>GROUP BY id (unchanged)</i>"]
        A4["HAVING (unchanged)"]
        A1 --> A2 --> A3 --> A4
    end
    classDef heavy fill:#b91c1c,stroke:#7f1d1d,color:#ffffff
    classDef waste fill:#d97706,stroke:#92400e,color:#ffffff
    classDef light fill:#15803d,stroke:#14532d,color:#ffffff
    classDef neutral fill:#374151,stroke:#1f2937,color:#ffffff
    class B1 heavy
    class B2,B3,B4 waste
    class A1,A2 light
    class A3,A4 neutral
```

Same aggregation, same HAVING, same results — the selective filter just moved from after the payload reads (red/orange path) to before them (green). That's the entire mechanism; the benchmark deltas below are this one change measured.

and the second half — one fused mega-plan becomes two (optionally three) trivial ones:

`EXPLAIN PIPELINE` tells it at a glance — one fused mega-plan becomes two (optionally three) trivial ones:

```mermaid
flowchart TD
    subgraph B["BEFORE — one statement: 101 pipeline stages, 8 table scans, 3 joins"]
        direction TB
        B1["selection CTEs<br/><i>which 50 rows to show</i>"]
        B2["page_calls scan<br/><i>id IN (SELECT … FROM page_rows)<br/>filter AFTER payload reads → ~2.2GB decompressed</i>"]
        B3["table_rows scan<br/><i>digest IN (SELECT …)<br/>up to 1.8GB val_dump — for a field the UI discards</i>"]
        B4["3-way JOIN → result"]
        B1 --> B4
        B2 --> B4
        B3 --> B4
    end
    subgraph A["AFTER — separate statements"]
        direction TB
        A1["statement 1 — page selection<br/><i>same CTE machinery, light columns only<br/>returns 50 call ids + digests + order</i>"]
        A2["statement 2 — hydration (14 plan lines)<br/><i>PREWHERE id IN literal 50-id set<br/>Granules 135 / 18,483,593 — only the page's rows decompress</i>"]
        A3["statement 3 — dataset rows (optional)<br/><i>PREWHERE digest IN literal set<br/>runs only when resolve_row_refs=true</i>"]
        A1 -->|"literal ids"| A2
        A1 -.->|"literal digests"| A3
    end
    classDef heavy fill:#b91c1c,stroke:#7f1d1d,color:#ffffff
    classDef waste fill:#d97706,stroke:#92400e,color:#ffffff
    classDef light fill:#15803d,stroke:#14532d,color:#ffffff
    classDef optional fill:#374151,stroke:#1f2937,color:#ffffff
    class B2 heavy
    class B3 waste
    class B1,B4 optional
    class A1,A2 light
    class A3 optional
```

with the ids as a literal `PREWHERE` param, ClickHouse row-filters on the primary key before touching payload columns — inside those 135 granules only the page's ~50 rows get decompressed (red scan → green statement). the resolution statement has the same trivial shape and only runs on request.

### Benchmarks / Testing

9 request shapes over 7 real production projects taken from actual `eval_results/query` traffic (all `calls_merged`-resident), including the original incident repro and real **compare-page** requests with two eval roots. Both variants executed read-only against production ClickHouse with `log_comment` attribution, warmup + timed runs; identical result rows verified per case. Negative % = improvement; ordered by row count. Baseline = master, after = this full PR (wall = page + hydration statements).

| case | wall p50 ms | mem MB | read MB | rows |
| --- | --- | --- | --- | --- |
| project A — single 27K-predict eval | 942 → 542 (**-42%**) | 1384 → 337 (**-76%**) | 22796 → 1471 (**-94%**) | 27359 |
| project A — 2-eval compare (2×25.6K) | 1001 → 620 (**-38%**) | 1476 → 495 (**-66%**) | 27145 → 2650 (**-90%**) | 25604 |
| project B — 2-eval compare (6 wk apart) | 1680 → 487 (**-71%**) | 2086 → 263 (**-87%**) | 13308 → 950 (**-93%**) | 2404 |
| project C — 2-eval compare (1 month apart) | 4892 → 1891 (**-61%**) | 3801 → 2062 (**-46%**) | 95602 → 14503 (**-85%**) | 1400 |
| project D — single eval (the WB-38786 repro) | 2499 → 351 (**-86%**) | 3771 → 125 (**-97%**) | 2617 → 288 (**-89%**) | 981 |
| project D — 2-eval compare | 2940 → 393 (**-87%**) | 3770 → 148 (**-96%**) | 3031 → 454 (**-85%**) | 981 |
| project E — 2-eval compare (2yr-old evals) | 8412 → 2977 (**-65%**) | 3340 → 938 (**-72%**) | 233344 → 14184 (**-94%**) | 716 |
| project F — 2-eval compare (small, high-traffic project) | 537 → 345 (**-36%**) | 294 → 127 (**-57%**) | 496 → 50 (**-90%**) | 100 |
| project G — tiny eval (3 rows, months old) | 921 → 351 (**-62%**) | 550 → 134 (**-76%**) | 1544 → 29 (**-98%**) | 3 |

**every case improves on every metric.** all page ids hydrate 1:1; row-content parity covered by the ClickHouse-backed suites (71 tests).

<details>
<summary><b>Layer attribution</b> — the scan-window fixes (1-3) measured alone, before the statement split (4-5) landed. CPU column included. The small/fresh cases were flat here; fixes 4-5 are what took them negative.</summary>

8 request shapes over 6 real production projects taken from actual `eval_results/query` traffic (all `calls_merged`-resident), including the original incident repro and real **compare-page** requests with two eval roots. Both SQL variants executed serially against production ClickHouse with `log_comment` attribution, 1 warmup + 3-5 timed runs each; identical result rows verified per case (sorted call-id hash). Negative % = improvement; ordered by row count.

| case | wall p50 ms | CPU ms | mem MB | read MB | rows |
| --- | --- | --- | --- | --- | --- |
| project A — single 27K-predict eval | 942→694 (-26%) | 13332→4563 (**-66%**) | 1384→484 (**-65%**) | 22796→3388 (**-85%**) | 27359 |
| project A — 2-eval compare (2×25.6K) | 1001→885 (-12%) | 16229→5961 (**-63%**) | 1476→606 (**-59%**) | 27145→5899 (**-78%**) | 25604 |
| project B — 2-eval compare (6 wk apart) | 1680→1618 (-4%) | 7351→4303 (**-41%**) | 2086→2108 (+1%) | 13308→3542 (**-73%**) | 2404 |
| project C — 2-eval compare (1 month apart) | 4892→2806 (**-43%**) | 109433→38425 (**-65%**) | 3801→2205 (**-42%**) | 95602→33778 (**-65%**) | 1400 |
| project D — single eval (the WB-38786 repro) | 2499→2575 (+3%) | 3906→4431 (+13%) | 3771→3790 (+1%) | 2617→2173 (-17%) | 981 |
| project D — 2-eval compare | 2940→3129 (+6%) | 5441→5609 (+3%) | 3770→3792 (+1%) | 3031→2475 (-18%) | 981 |
| project E — 2-eval compare (evals from 2024, 2yr of later traffic) | 8412→3712 (**-56%**) | 288295→34628 (**-88%**) | 3340→1006 (**-70%**) | 233344→32760 (**-86%**) | 716 |
| project F — 2-eval compare (small, high-traffic project) | 537→456 (-15%) | 847→988 (+17%) | 294→327 (+11%) | 496→146 (**-71%**) | 100 |
| project G — tiny eval (3 rows, months old) | 921→952 (+3%) | 2107→2021 (-4%) | 550→253 (**-54%**) | 1544→197 (**-87%**) | 3 |

Note, that in every scenario the bytes read decrease. The smallest projects may pay a little more in CPU time, but larger projects with more data have a significant drop in latency/bytes read/...
The query is arguably a teeny weeny worse for small projects, but for a massive improvement in larger ones!

</details>

### Tail latency: warm p95 + cold-cache runs (the 30s+ cases)

same protocol as #7761 (warm N=8, cold = `enable_filesystem_cache=0`, N=2-3), baseline vs full stack:

| case | warm p50 ms | warm p95 ms | cold p50 ms | cold max ms | rows |
| --- | --- | --- | --- | --- | --- |
| project A — single 27K-predict eval | 1264 → 523 (**-59%**) | 1592 → 752 (**-53%**) | 4663 → 2126 (**-54%**) | 5287 → 2347 (**-56%**) | 27359 |
| project A — 2-eval compare (2×25.6K) | 1509 → 529 (**-65%**) | 1585 → 620 (**-61%**) | 5290 → 2911 (**-45%**) | 5534 → 2947 (**-47%**) | 25604 |
| project B — 2-eval compare (6 wk apart) | 1819 → 373 (**-80%**) | 2188 → 489 (**-78%**) | 6577 → 2425 (**-63%**) | 9364 → 2745 (**-71%**) | 2404 |
| project C — 2-eval compare (1 month apart) | 4789 → 1327 (**-72%**) | 6838 → 2192 (**-68%**) | 30152 → 11418 (**-62%**) | 33952 → 18301 (**-46%**) | 1400 |
| project D — single eval (the WB-38786 repro) | 3235 → 280 (**-91%**) | 3544 → 307 (**-91%**) | 6210 → 1753 (**-72%**) | 10677 → 3188 (**-70%**) | 981 |
| project D — 2-eval compare | 4225 → 279 (**-93%**) | 4404 → 334 (**-92%**) | 7521 → 1530 (**-80%**) | 8828 → 1845 (**-79%**) | 981 |
| project E — 2-eval compare (2yr-old evals) | 9155 → 1996 (**-78%**) | 9797 → 2547 (**-74%**) | 71663 → 9196 (**-87%**) | 73984 → 10878 (**-85%**) | 716 |
| project F — 2-eval compare (small project) | 615 → 222 (**-64%**) | 831 → 259 (**-69%**) | 1857 → 1878 (+1%) | 2977 → 2201 (-26%) | 100 |
| project G — tiny eval (3 rows, months old) | 921 → 351 (**-62%**) | 1617 → 394 (**-76%**) | 3503 → 3521 (+1%) | 5532 → 5038 (-9%) | 3 |

the worst real-world case (project E cold, 71.7s — matching the 71s p95 in production traffic) drops to 9.2s. note, cold columns are only 2-3 samples each since cold reads are expensive to repeat in prod.

test coverage: `test_eval_results_query_builder.py` rewritten for the split (20 tests), plus the ClickHouse-backed eval suites (51 tests) — all green.
