### PR TITLE
fix(weave): prevent negative agent span costs

### DIFF
--- a/tests/trace_server/test_genai_agent_costs.py
+++ b/tests/trace_server/test_genai_agent_costs.py
@@ -134,40 +134,66 @@ def test_spans_query_includes_costs(ch_server):
     )
 
 
-def test_spans_query_cost_subtracts_cache_tokens(ch_server):
-    """Cached input tokens are billed at the cache rate, not the input rate."""
+def test_spans_query_costs_cached_tokens(ch_server):
+    """Cached tokens use their own rate across supported input conventions."""
     project_id = _make_project_id("span-costs-cache")
     model = f"test-cost-model-{uuid.uuid4().hex}"
     _insert_project_price(ch_server.ch_client, project_id, model)
+    inclusive_span = _make_span(
+        project_id,
+        request_model=model,
+        input_tokens=1000,
+        output_tokens=500,
+        cache_read_input_tokens=200,
+        cache_creation_input_tokens=100,
+    )
+    exclusive_span = _make_span(
+        project_id,
+        request_model=model,
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_input_tokens=200,
+        cache_creation_input_tokens=50,
+    )
     _insert_spans(
         ch_server.ch_client,
-        [
-            _make_span(
-                project_id,
-                request_model=model,
-                input_tokens=1000,
-                output_tokens=500,
-                cache_read_input_tokens=200,
-                cache_creation_input_tokens=100,
-            )
-        ],
+        [inclusive_span, exclusive_span],
     )
 
     res = ch_server.agent_spans_query(
         AgentSpansQueryReq(project_id=project_id, include_costs=True)
     )
-    span = res.spans[0]
-    expected_input = (1000 - 200 - 100) * _PROMPT_COST
-    expected_total = (
-        expected_input
+    by_id = {span.span_id: span for span in res.spans}
+
+    # Canonical OTel input includes cached tokens.
+    inclusive = by_id[inclusive_span.span_id]
+    inclusive_input_cost = (1000 - 200 - 100) * _PROMPT_COST
+    inclusive_total_cost = (
+        inclusive_input_cost
         + 500 * _COMPLETION_COST
         + 200 * _CACHE_READ_COST
         + 100 * _CACHE_CREATION_COST
     )
-    assert span.input_cost_usd == pytest.approx(expected_input)
-    assert span.cache_read_cost_usd == pytest.approx(200 * _CACHE_READ_COST)
-    assert span.cache_creation_cost_usd == pytest.approx(100 * _CACHE_CREATION_COST)
-    assert span.total_cost_usd == pytest.approx(expected_total)
+    assert inclusive.input_cost_usd == pytest.approx(inclusive_input_cost)
+    assert inclusive.cache_read_cost_usd == pytest.approx(200 * _CACHE_READ_COST)
+    assert inclusive.cache_creation_cost_usd == pytest.approx(
+        100 * _CACHE_CREATION_COST
+    )
+    assert inclusive.total_cost_usd == pytest.approx(inclusive_total_cost)
+
+    # Nonconforming input excludes cached tokens and remains billable input.
+    exclusive = by_id[exclusive_span.span_id]
+    exclusive_input_cost = 100 * _PROMPT_COST
+    exclusive_total_cost = (
+        exclusive_input_cost
+        + 50 * _COMPLETION_COST
+        + 200 * _CACHE_READ_COST
+        + 50 * _CACHE_CREATION_COST
+    )
+    assert exclusive.input_cost_usd == pytest.approx(exclusive_input_cost)
+    assert exclusive.cache_read_cost_usd == pytest.approx(200 * _CACHE_READ_COST)
+    assert exclusive.cache_creation_cost_usd == pytest.approx(50 * _CACHE_CREATION_COST)
+    assert exclusive.total_cost_usd == pytest.approx(exclusive_total_cost)
 
 
 def test_spans_query_unpriced_model_has_none_cost(ch_server):

--- a/weave/trace_server/agents/span_costs.py
+++ b/weave/trace_server/agents/span_costs.py
@@ -161,17 +161,25 @@ def cost_select_exprs(
 
     Cost formulas mirror the calls path (`token_costs._build_cost_summary_dump_snippet`):
     cached input tokens are billed at the cache rate, so they are subtracted
-    from the regular input-token cost. Reasoning tokens are not priced
-    separately — providers fold them into `output_tokens` — matching the
-    calls behavior. When no price matched, every cost column is NULL.
+    from the regular input-token cost. Some producers report uncached input
+    separately even though the OTel convention requires an inclusive total.
+    When the cache count exceeds the reported input count, treat input as the
+    uncached count so malformed historical spans cannot produce negative costs.
+    Reasoning tokens are not priced separately — providers fold them into
+    `output_tokens` — matching the calls behavior. When no price matched, every
+    cost column is NULL.
     """
     matched = f"{price_alias}.{_PRICE_MATCHED} = 1"
     s = span_alias
     p = price_alias
-    input_cost_usd = (
-        f"({s}.input_tokens - {s}.cache_read_input_tokens "
-        f"- {s}.cache_creation_input_tokens) * {p}.prompt_token_cost"
+    cache_input_tokens = (
+        f"({s}.cache_read_input_tokens + {s}.cache_creation_input_tokens)"
     )
+    uncached_input_tokens = (
+        f"if({s}.input_tokens >= {cache_input_tokens}, "
+        f"{s}.input_tokens - {cache_input_tokens}, {s}.input_tokens)"
+    )
+    input_cost_usd = f"({uncached_input_tokens}) * {p}.prompt_token_cost"
     output_cost_usd = f"{s}.output_tokens * {p}.completion_token_cost"
     cache_read_cost_usd = (
         f"{s}.cache_read_input_tokens * {p}.cache_read_input_token_cost"


### PR DESCRIPTION
## Summary
- Agent span costs now support canonical OTel input totals and producer payloads where input excludes cached tokens, preventing negative fresh-input and total costs across span, grouped, chat, and stats queries.
- Conforming spans are unchanged; the fallback applies only when cache tokens exceed reported input tokens.
- Historical spans are corrected at query time. No migration, API, or configuration change.

## Testing
Focused ClickHouse cost suite (7 passed); focused Ruff and Pyright.