### PR TITLE
chore(weave): refresh generated model data

### DIFF
--- a/weave/trace_server/costs/cost_checkpoint.json
+++ b/weave/trace_server/costs/cost_checkpoint.json
@@ -29472,5 +29472,345 @@
       "cache_creation_input": 0.0,
       "created_at": "2026-08-12 22:36:42"
     }
+  ],
+  "azure_ai/FW-DeepSeek-V3.2": [
+    {
+      "provider": "azure_ai",
+      "input": 6.2e-07,
+      "output": 1.85e-06,
+      "cache_read_input": 3.1e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-DeepSeek-V4-Pro": [
+    {
+      "provider": "azure_ai",
+      "input": 1.925e-06,
+      "output": 3.828e-06,
+      "cache_read_input": 1.65e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-GLM-5": [
+    {
+      "provider": "azure_ai",
+      "input": 1.1e-06,
+      "output": 3.52e-06,
+      "cache_read_input": 2.2e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-GLM-5.1": [
+    {
+      "provider": "azure_ai",
+      "input": 1.54e-06,
+      "output": 4.84e-06,
+      "cache_read_input": 2.86e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-GLM-5.2": [
+    {
+      "provider": "azure_ai",
+      "input": 1.54e-06,
+      "output": 4.84e-06,
+      "cache_read_input": 1.5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-GLM-5.2-Fast": [
+    {
+      "provider": "azure_ai",
+      "input": 2.1e-06,
+      "output": 6.6e-06,
+      "cache_read_input": 2.1e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-Inkling": [
+    {
+      "provider": "azure_ai",
+      "input": 1e-06,
+      "output": 4.05e-06,
+      "cache_read_input": 1.7e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-Kimi-K2.5": [
+    {
+      "provider": "azure_ai",
+      "input": 6.6e-07,
+      "output": 3.3e-06,
+      "cache_read_input": 1.1e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-Kimi-K2.6": [
+    {
+      "provider": "azure_ai",
+      "input": 1.045e-06,
+      "output": 4.4e-06,
+      "cache_read_input": 1.76e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-Kimi-K2.7-Code": [
+    {
+      "provider": "azure_ai",
+      "input": 1.05e-06,
+      "output": 4.4e-06,
+      "cache_read_input": 2.1e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-Kimi-K3": [
+    {
+      "provider": "azure_ai",
+      "input": 3.3e-06,
+      "output": 1.65e-05,
+      "cache_read_input": 3.3e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-MiniMax-M2.5": [
+    {
+      "provider": "azure_ai",
+      "input": 3.3e-07,
+      "output": 1.32e-06,
+      "cache_read_input": 3.3e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-MiniMax-M3": [
+    {
+      "provider": "azure_ai",
+      "input": 3.3e-07,
+      "output": 1.32e-06,
+      "cache_read_input": 6.6e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/FW-Nemotron-3-Ultra-NVFP4": [
+    {
+      "provider": "azure_ai",
+      "input": 6e-07,
+      "output": 2.4e-06,
+      "cache_read_input": 1.19e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "azure_ai/grok-4.3": [
+    {
+      "provider": "azure_ai",
+      "input": 1.25e-06,
+      "output": 2.5e-06,
+      "cache_read_input": 2e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "dashscope/deepseek-v4-flash": [
+    {
+      "provider": "dashscope",
+      "input": 2e-07,
+      "output": 4e-07,
+      "cache_read_input": 4e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "dashscope/deepseek-v4-flash-0731": [
+    {
+      "provider": "dashscope",
+      "input": 2e-07,
+      "output": 4e-07,
+      "cache_read_input": 4e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "dashscope/deepseek-v4-pro": [
+    {
+      "provider": "dashscope",
+      "input": 2.4e-06,
+      "output": 4.8e-06,
+      "cache_read_input": 2e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "dashscope/glm-5.1": [
+    {
+      "provider": "dashscope",
+      "input": 1.4e-06,
+      "output": 4.4e-06,
+      "cache_read_input": 2.6e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "dashscope/glm-5.2": [
+    {
+      "provider": "dashscope",
+      "input": 1.4e-06,
+      "output": 4.4e-06,
+      "cache_read_input": 2.8e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "dashscope/kimi-k2.7-code": [
+    {
+      "provider": "dashscope",
+      "input": 9.5e-07,
+      "output": 4e-06,
+      "cache_read_input": 1.9e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "dashscope/qwen3.8-max": [
+    {
+      "provider": "dashscope",
+      "input": 2e-06,
+      "output": 6e-06,
+      "cache_read_input": 2.5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "deepinfra/nvidia/NVIDIA-Nemotron-3.5-Lightning": [
+    {
+      "provider": "deepinfra",
+      "input": 5e-08,
+      "output": 2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "vertex_ai/gemini-3.7-flash": [
+    {
+      "provider": "vertex_ai",
+      "input": 7.5e-07,
+      "output": 3.75e-06,
+      "cache_read_input": 7.5e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "gemini/gemini-3.7-flash": [
+    {
+      "provider": "gemini",
+      "input": 7.5e-07,
+      "output": 3.75e-06,
+      "cache_read_input": 7.5e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "gemini-3.7-flash": [
+    {
+      "provider": "vertex_ai-language-models",
+      "input": 7.5e-07,
+      "output": 3.75e-06,
+      "cache_read_input": 7.5e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "groq/meta-llama/llama-prompt-guard-2-22m": [
+    {
+      "provider": "groq",
+      "input": 3e-08,
+      "output": 3e-08,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "groq/meta-llama/llama-prompt-guard-2-86m": [
+    {
+      "provider": "groq",
+      "input": 4e-08,
+      "output": 4e-08,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "groq/qwen/qwen3.6-27b": [
+    {
+      "provider": "groq",
+      "input": 6e-07,
+      "output": 3e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "meta/muse-spark-1.2": [
+    {
+      "provider": "meta",
+      "input": 1.25e-06,
+      "output": 4.25e-06,
+      "cache_read_input": 1.5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "meta/muse-spark-1.2-contributor": [
+    {
+      "provider": "meta",
+      "input": 1e-07,
+      "output": 2e-07,
+      "cache_read_input": 2e-09,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "openrouter/nvidia/nemotron-3.5-lightning": [
+    {
+      "provider": "openrouter",
+      "input": 5e-08,
+      "output": 2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "xai/grok-4.6": [
+    {
+      "provider": "xai",
+      "input": 2e-06,
+      "output": 6e-06,
+      "cache_read_input": 5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
+  ],
+  "gemini/gemini-3.1-flash-tts-preview": [
+    {
+      "provider": "gemini",
+      "input": 1e-06,
+      "output": 2e-05,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-08-18 17:54:20"
+    }
   ]
 }

--- a/weave/trace_server/model_providers/model_providers.json
+++ b/weave/trace_server/model_providers/model_providers.json
@@ -19,6 +19,10 @@
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
   },
+  "MiniMaxAI/MiniMax-M3": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
   "MiniMaxAI/MiniMax-M2.5": {
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
@@ -36,6 +40,10 @@
     "api_key_name": "WANDB_API_KEY"
   },
   "zai-org/GLM-4.5": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B": {
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
   },
@@ -87,6 +95,10 @@
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
   },
+  "moonshotai/Kimi-K3": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
   "moonshotai/Kimi-K2.7-Code": {
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
@@ -112,6 +124,10 @@
     "api_key_name": "WANDB_API_KEY"
   },
   "meta-llama/Llama-3.1-8B-Instruct": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "deepseek-ai/DeepSeek-V4-Flash-0731": {
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
   },
@@ -455,6 +471,30 @@
     "litellm_provider": "bedrock_converse",
     "api_key_name": "BEDROCK_API_KEY"
   },
+  "anthropic.claude-opus-5": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "global.anthropic.claude-opus-5": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "us.anthropic.claude-opus-5": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "eu.anthropic.claude-opus-5": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "au.anthropic.claude-opus-5": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "jp.anthropic.claude-opus-5": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
   "anthropic.claude-opus-4-8": {
     "litellm_provider": "bedrock_converse",
     "api_key_name": "BEDROCK_API_KEY"
@@ -472,6 +512,10 @@
     "api_key_name": "BEDROCK_API_KEY"
   },
   "au.anthropic.claude-opus-4-8": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "jp.anthropic.claude-opus-4-8": {
     "litellm_provider": "bedrock_converse",
     "api_key_name": "BEDROCK_API_KEY"
   },
@@ -612,6 +656,10 @@
     "api_key_name": "AZURE_API_KEY"
   },
   "azure_ai/claude-fable-5": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/claude-opus-5": {
     "litellm_provider": "azure_ai",
     "api_key_name": "AZURE_API_KEY"
   },
@@ -1119,6 +1167,54 @@
     "litellm_provider": "azure",
     "api_key_name": "AZURE_API_KEY"
   },
+  "azure/gpt-5.6": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/gpt-5.6-sol": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/gpt-5.6-terra": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/gpt-5.6-luna": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/us/gpt-5.6": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/us/gpt-5.6-sol": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/us/gpt-5.6-terra": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/us/gpt-5.6-luna": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/eu/gpt-5.6": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/eu/gpt-5.6-sol": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/eu/gpt-5.6-terra": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/eu/gpt-5.6-luna": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
   "azure/gpt-5.5": {
     "litellm_provider": "azure",
     "api_key_name": "AZURE_API_KEY"
@@ -1503,6 +1599,62 @@
     "litellm_provider": "azure_ai",
     "api_key_name": "AZURE_API_KEY"
   },
+  "azure_ai/FW-DeepSeek-V3.2": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-DeepSeek-V4-Pro": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-GLM-5": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-GLM-5.1": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-GLM-5.2": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-GLM-5.2-Fast": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-Inkling": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-Kimi-K2.5": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-Kimi-K2.6": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-Kimi-K2.7-Code": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-Kimi-K3": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-MiniMax-M2.5": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-MiniMax-M3": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/FW-Nemotron-3-Ultra-NVFP4": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
   "azure_ai/MAI-Image-2.5": {
     "litellm_provider": "azure_ai",
     "api_key_name": "AZURE_API_KEY"
@@ -1704,6 +1856,10 @@
     "api_key_name": "AZURE_API_KEY"
   },
   "azure_ai/grok-4": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/grok-4.3": {
     "litellm_provider": "azure_ai",
     "api_key_name": "AZURE_API_KEY"
   },
@@ -2478,6 +2634,10 @@
     "litellm_provider": "anthropic",
     "api_key_name": "ANTHROPIC_API_KEY"
   },
+  "claude-opus-5": {
+    "litellm_provider": "anthropic",
+    "api_key_name": "ANTHROPIC_API_KEY"
+  },
   "claude-opus-4-8": {
     "litellm_provider": "anthropic",
     "api_key_name": "ANTHROPIC_API_KEY"
@@ -2998,6 +3158,10 @@
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },
+  "gemini-3.5-flash-lite": {
+    "litellm_provider": "vertex_ai-language-models",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
   "deep-research-pro-preview-12-2025": {
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
@@ -3057,6 +3221,14 @@
     "litellm_provider": "vertex_ai",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },
+  "vertex_ai/gemini-3.6-flash": {
+    "litellm_provider": "vertex_ai",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
+  "vertex_ai/gemini-3.7-flash": {
+    "litellm_provider": "vertex_ai",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
   "vertex_ai/gemini-3.1-pro-preview": {
     "litellm_provider": "vertex_ai",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
@@ -3079,6 +3251,14 @@
     "deprecated": true,
     "deprecated_reason": "'NoneType' object is not subscriptable",
     "deprecated_date": "2026-01-29T21:44:57.321191"
+  },
+  "gemini/gemini-robotics-er-2-preview": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/gemini-robotics-er-1.6-preview": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
   },
   "gemini-2.5-computer-use-preview-10-2025": {
     "litellm_provider": "vertex_ai-language-models",
@@ -3221,11 +3401,27 @@
     "litellm_provider": "gemini",
     "api_key_name": "GEMINI_API_KEY"
   },
+  "gemini/gemini-3.5-flash-lite": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
   "gemini/gemini-3-flash-preview": {
     "litellm_provider": "gemini",
     "api_key_name": "GEMINI_API_KEY"
   },
   "gemini/gemini-3.5-flash": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/gemini-3.6-flash": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/gemini-3.7-flash": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/gemini-omni-flash-preview": {
     "litellm_provider": "gemini",
     "api_key_name": "GEMINI_API_KEY"
   },
@@ -3241,7 +3437,19 @@
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },
+  "gemini-omni-flash-preview": {
+    "litellm_provider": "vertex_ai-language-models",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
   "gemini-3.5-flash": {
+    "litellm_provider": "vertex_ai-language-models",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
+  "gemini-3.6-flash": {
+    "litellm_provider": "vertex_ai-language-models",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
+  "gemini-3.7-flash": {
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },
@@ -3938,6 +4146,14 @@
     "litellm_provider": "groq",
     "api_key_name": "GROQ_API_KEY"
   },
+  "groq/meta-llama/llama-prompt-guard-2-22m": {
+    "litellm_provider": "groq",
+    "api_key_name": "GROQ_API_KEY"
+  },
+  "groq/meta-llama/llama-prompt-guard-2-86m": {
+    "litellm_provider": "groq",
+    "api_key_name": "GROQ_API_KEY"
+  },
   "groq/meta-llama/llama-guard-4-12b": {
     "litellm_provider": "groq",
     "api_key_name": "GROQ_API_KEY"
@@ -3966,7 +4182,19 @@
     "litellm_provider": "groq",
     "api_key_name": "GROQ_API_KEY"
   },
+  "groq/canopylabs/orpheus-v1-english": {
+    "litellm_provider": "groq",
+    "api_key_name": "GROQ_API_KEY"
+  },
+  "groq/canopylabs/orpheus-arabic-saudi": {
+    "litellm_provider": "groq",
+    "api_key_name": "GROQ_API_KEY"
+  },
   "groq/playai-tts": {
+    "litellm_provider": "groq",
+    "api_key_name": "GROQ_API_KEY"
+  },
+  "groq/qwen/qwen3.6-27b": {
     "litellm_provider": "groq",
     "api_key_name": "GROQ_API_KEY"
   },
@@ -4970,6 +5198,10 @@
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },
+  "vertex_ai/gemini-3.5-flash-lite": {
+    "litellm_provider": "vertex_ai-language-models",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
   "vertex_ai/deep-research-pro-preview-12-2025": {
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
@@ -5148,6 +5380,10 @@
     "api_key_name": "XAI_API_KEY"
   },
   "xai/grok-4.5-latest": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-4.6": {
     "litellm_provider": "xai",
     "api_key_name": "XAI_API_KEY"
   },
@@ -6241,6 +6477,10 @@
     "litellm_provider": "gemini",
     "api_key_name": "GEMINI_API_KEY"
   },
+  "gemini/gemini-3.1-flash-tts-preview": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
   "gemini-2.5-flash-preview-tts": {
     "litellm_provider": "gemini",
     "api_key_name": "GEMINI_API_KEY"
@@ -6296,5 +6536,65 @@
   "deepseek/deepseek-v4-pro": {
     "litellm_provider": "deepseek",
     "api_key_name": "DEEPSEEK_API_KEY"
+  },
+  "xai/grok-4.20-0309-non-reasoning": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-4.20-multi-agent-0309": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-build-0.1": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "gpt-transcribe": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-live-transcribe": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-realtime-translate": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "claude-mythos-5": {
+    "litellm_provider": "anthropic",
+    "api_key_name": "ANTHROPIC_API_KEY"
+  },
+  "claude-mythos-preview": {
+    "litellm_provider": "anthropic",
+    "api_key_name": "ANTHROPIC_API_KEY"
+  },
+  "gemini/gemini-robotics-er-2-streaming-preview": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "mistral/mistral-small-2603": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/labs-leanstral-1-5": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-moderation-2603": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/voxtral-mini-2602": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/voxtral-mini-transcribe-realtime-2602": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/voxtral-mini-tts-2603": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
   }
 }


### PR DESCRIPTION
## Description

Refresh the generated model-provider routing and token-cost checkpoints from the current upstream sources. This is the repository's periodic generated-data sync and does not add manual routing or pricing logic.

The refresh adds 75 routing keys and 34 cost keys, including Gemini 3.7 Flash routing for Gemini and Vertex AI and its introductory $0.75/M input and $3.75/M output pricing. All 34 added prices match the current LiteLLM source data exactly.

The generated routing changes are backend lookup data, not an advertised model catalog. This PR does not change the Core Playground registry, the W&B-hosted model catalog, or SDK model discovery, so newly recognized Inkling, DeepSeek, GPT, audio, or other upstream IDs do not automatically appear for customers. An API/SDK caller that already submits an exact added ID may now reach its provider route when the required provider secret is configured.

The existing Gemini 3.6 Flash checkpoint remains at the price currently published by LiteLLM. Google's temporary promotional repricing for 3.6 is not overridden here because LiteLLM is the authoritative source in the existing generator. This can affect Weave's displayed trace-cost estimate for Gemini 3.6, but not the external provider's billing.

## Testing

- Re-ran `make update_model_providers` and `make update_costs`; output hashes were unchanged and the cost generator reported zero additional changes.
- 26 focused cost update/insertion tests passed.
- Parsed both generated JSON files and asserted the exact Gemini 3.5 Flash-Lite and 3.7 Flash routing and prices.
- Compared the full generated outputs with the current upstream registry: no current recognized provider route or priced model is missing, and no current price differs.

## Rollout

Related Core Playground PR: https://github.com/wandb/core/pull/51097.

The PRs are not stacked and can be reviewed independently. This generated routing data must be deployed before the Core UI refresh so newly selectable Gemini IDs resolve to the intended provider and secret.
