### PR TITLE
fix(weave): keep an evaluation's derived name off its dataset's object_id

### DIFF
--- a/tests/trace/conftest.py
+++ b/tests/trace/conftest.py
@@ -13,6 +13,7 @@ from google.api_core import exceptions as gcp_exceptions
 from google.auth.credentials import AnonymousCredentials
 
 from tests.trace.test_utils import FailingSaveType, failing_load, failing_save
+from weave.trace import util as trace_util
 from weave.trace.serialization import serializer
 from weave.trace_server.file_storage import reset_stored_key_cache
 
@@ -27,6 +28,14 @@ def reset_bucket_dedup_cache():
     reset_stored_key_cache()
     yield
     reset_stored_key_cache()
+
+
+@pytest.fixture(autouse=True)
+def reset_logged_once_messages():
+    """The memo of what log_once already said would silence later tests."""
+    trace_util.logged_messages.clear()
+    yield
+    trace_util.logged_messages.clear()
 
 
 @pytest.fixture

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -54,7 +54,12 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.clickhouse_trace_server_settings import ENTITY_TOO_LARGE_PAYLOAD
 from weave.trace_server.common_interface import SortBy
-from weave.trace_server.errors import InsertTooLarge, InvalidFieldError, InvalidRequest
+from weave.trace_server.errors import (
+    InsertTooLarge,
+    InvalidFieldError,
+    InvalidRequest,
+    ObjectNameTypeCollision,
+)
 from weave.trace_server.ids import generate_id
 from weave.trace_server.token_costs import COST_OBJECT_NAME
 from weave.trace_server.validation_util import CHValidationError
@@ -3559,6 +3564,10 @@ def test_object_with_char_over_limit(client):
         client.server.obj_create(create_req)
 
 
+class OtherCustom(weave.Object):
+    val: dict
+
+
 def _expected_truncation_warning(name: str) -> str:
     return (
         f"Object name '{name}' is longer than {CHAR_LIMIT} characters and is published "
@@ -3617,6 +3626,29 @@ def test_object_name_over_limit_warns_after_the_log_level_is_raised(client, capl
         weave.publish(Custom(name=name, val={"1": 2}))
 
     assert caplog.messages == [_expected_truncation_warning(name)]
+
+
+@pytest.mark.disable_logging_error_check
+def test_names_truncated_to_one_id_are_rejected_with_the_name_that_was_sent(client):
+    """Two types cannot share an id (WB-30574). When the id is a truncation, the
+    rejection quotes the name that produced it, which is the only part the caller
+    recognizes.
+    """
+    object_id = "p" * CHAR_LIMIT
+    other_name = object_id + "-and-more"
+
+    weave.publish(Custom(name=object_id, val={"1": 1}))
+
+    with pytest.raises(ObjectNameTypeCollision) as excinfo:
+        weave.publish(OtherCustom(name=other_name, val={"1": 2}))
+
+    assert excinfo.value.object_id == object_id
+    assert excinfo.value.object_name == other_name
+    assert str(excinfo.value) == (
+        f"Cannot publish '{object_id}' as a OtherCustom: that name is already used "
+        f"by a Custom in this project. The object is named '{other_name}'. Object "
+        "versions cannot share types, publish this object under a different name."
+    )
 
 
 chars = "+_(){}|\"'<>!@$^&*#:,.[]-=;~`"

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -47,6 +47,7 @@ from weave.trace.context.weave_client_context import (
     set_weave_client_global,
 )
 from weave.trace.refs import TableRef
+from weave.trace.util import LOG_ONCE_MESSAGE_SUFFIX, logged_messages
 from weave.trace.vals import MissingSelfInstanceError
 from weave.trace.weave_client import sanitize_object_name
 from weave.trace_server import trace_server_interface as tsi
@@ -3556,6 +3557,66 @@ def test_object_with_char_over_limit(client):
     )
     with pytest.raises(CHValidationError):
         client.server.obj_create(create_req)
+
+
+def _expected_truncation_warning(name: str) -> str:
+    return (
+        f"Object name '{name}' is longer than {CHAR_LIMIT} characters and is published "
+        f"as '{name[:CHAR_LIMIT]}'. Names whose sanitized forms only differ past that "
+        f"limit become one object." + LOG_ONCE_MESSAGE_SUFFIX
+    )
+
+
+def test_object_name_over_limit_warns_once(client, caplog):
+    """Truncation is silent today, so a caller cannot tell that the id they published
+    under is not the name they asked for.
+    """
+    name = "w" * (CHAR_LIMIT + 1)
+    logger_name = "weave.trace.weave_client"
+
+    with caplog.at_level("WARNING", logger=logger_name):
+        first = weave.publish(Custom(name=name, val={"1": 1}))
+        second = weave.publish(Custom(name=name, val={"1": 2}))
+
+    assert first.name == name[:CHAR_LIMIT]
+    assert second.name == name[:CHAR_LIMIT]
+    assert caplog.messages == [_expected_truncation_warning(name)]
+
+
+@pytest.mark.parametrize(
+    ("name", "object_id"),
+    [
+        ("y" * CHAR_LIMIT, "y" * CHAR_LIMIT),
+        ("z" + "." * 200 + "z", "z-z"),
+    ],
+    ids=["at_the_limit", "sanitized_under_the_limit"],
+)
+def test_object_name_that_fits_its_id_does_not_warn(client, caplog, name, object_id):
+    """Only a name the limit cut is worth reporting. A name of exactly the limit is
+    published whole, and one that sanitizing shortens never reached the limit.
+    """
+    with caplog.at_level("WARNING", logger="weave.trace.weave_client"):
+        ref = weave.publish(Custom(name=name, val={"1": 1}))
+
+    assert ref.name == object_id
+    assert caplog.messages == []
+
+
+def test_object_name_over_limit_warns_after_the_log_level_is_raised(client, caplog):
+    """A warning nobody could see is not remembered, so turning warnings back on
+    still reports it.
+    """
+    name = "m" * (CHAR_LIMIT + 1)
+    logger_name = "weave.trace.weave_client"
+
+    with caplog.at_level("ERROR", logger=logger_name):
+        weave.publish(Custom(name=name, val={"1": 1}))
+    assert not logged_messages
+
+    with caplog.at_level("WARNING", logger=logger_name):
+        weave.publish(Custom(name=name, val={"1": 2}))
+
+    assert caplog.messages == [_expected_truncation_warning(name)]
 
 
 chars = "+_(){}|\"'<>!@$^&*#:,.[]-=;~`"

--- a/tests/trace/test_evaluate.py
+++ b/tests/trace/test_evaluate.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 import weave
 from tests.conftest import LATENCY_TOL
 from weave import Dataset, Evaluation, Model
+from weave.trace_server.constants import MAX_OBJECT_NAME_LENGTH
 
 dataset_rows = [{"input": "1 + 2", "target": 3}, {"input": "2**4", "target": 15}]
 dataset = Dataset(rows=dataset_rows)
@@ -278,6 +279,90 @@ async def test_basic_evaluation_with_scorer_styles(
         "scores": {scorer_results[s]: True for s in scorers},
     }
     assert all(o == expected_output for o in outputs)
+
+
+@pytest.mark.parametrize(
+    "dataset_name",
+    [
+        "my-dataset",
+        "!!!",
+        "d" * (MAX_OBJECT_NAME_LENGTH - len("-evaluation")),
+        "d" * 120,
+    ],
+)
+def test_evaluation_name_is_derived_unchanged_while_it_has_a_distinct_id(dataset_name):
+    """Only a name that lands on the dataset's own id is rewritten, so anything short of
+    that -- including names the id limit still truncates -- derives as it always did.
+    """
+    evaluation = Evaluation(dataset=Dataset(name=dataset_name, rows=dataset_rows))
+
+    assert evaluation.name == f"{dataset_name}-evaluation"
+
+
+def test_evaluation_name_is_rewritten_when_it_lands_on_the_dataset_id():
+    """The suffix is what tells the two objects apart, so when truncation would cut it
+    off the name carries a digest instead, one character under the limit.
+    """
+    evaluation = Evaluation(
+        dataset=Dataset(name="d" * MAX_OBJECT_NAME_LENGTH, rows=dataset_rows)
+    )
+
+    assert evaluation.name == "d" * 60 + "_5b10_" + "d" * 61
+
+
+def test_evaluation_name_is_rewritten_off_a_dataset_named_after_an_evaluation():
+    """A dataset whose own name already ends in the suffix is the case that reserving
+    room for the suffix would have left colliding.
+    """
+    evaluation = Evaluation(
+        dataset=Dataset(name="x" * 117 + "-evaluation", rows=dataset_rows)
+    )
+
+    assert evaluation.name == "x" * 60 + "_4978_" + "x" * 50 + "-evaluation"
+
+
+def test_evaluation_name_is_rewritten_off_a_dataset_id_the_digest_reproduces():
+    """A digest is not a guarantee: this dataset name is one the truncation maps to
+    itself. Staying a character under the limit is what separates the ids.
+    """
+    dataset_name = (
+        "1" + "a" * 60 + "_f1c7_uation-evaluation-evaluation-evaluation"
+        "-evaluation-evaluation"
+    )
+
+    evaluation = Evaluation(dataset=Dataset(name=dataset_name, rows=dataset_rows))
+
+    assert evaluation.name == (
+        "1" + "a" * 59 + "_43a2_uation-evaluation-evaluation-evaluation"
+        "-evaluation-evaluation"
+    )
+
+
+def test_evaluation_name_is_derived_from_a_name_utf8_cannot_encode():
+    """A name can carry a lone surrogate, which sanitizing drops, so rewriting one must
+    not raise where publishing it did not.
+    """
+    evaluation = Evaluation(
+        dataset=Dataset(name="\ud800" + "d" * MAX_OBJECT_NAME_LENGTH, rows=dataset_rows)
+    )
+
+    assert evaluation.name == "d" * 60 + "_5b10_" + "d" * 61
+
+
+def test_evaluation_derived_name_does_not_collide_with_its_dataset(client):
+    """Object names are truncated to the id limit, so a dataset name that already
+    reaches it used to swallow the derived suffix and both objects landed on one id,
+    which the server rejects (WB-30574).
+    """
+    dataset_name = "d" * MAX_OBJECT_NAME_LENGTH
+    dataset = Dataset(name=dataset_name, rows=dataset_rows)
+    evaluation = Evaluation(dataset=dataset)
+
+    dataset_ref = weave.publish(dataset)
+    evaluation_ref = weave.publish(evaluation)
+
+    assert dataset_ref.name == dataset_name
+    assert evaluation_ref.name == "d" * 60 + "_5b10_" + "d" * 61
 
 
 @pytest.mark.parametrize(

--- a/tests/trace_server/test_errors.py
+++ b/tests/trace_server/test_errors.py
@@ -227,3 +227,59 @@ def test_object_name_type_collision_maps_to_400() -> None:
             "cannot share types, publish this object under a different name."
         )
     }
+
+
+def test_object_name_type_collision_quotes_an_over_long_name() -> None:
+    """object_id is cut from the object's name, so a caller who ran past the length
+    limit is quoted an id they never wrote. Quote the name they did write too.
+    """
+    object_id = "d" * 128
+    exc = ObjectNameTypeCollision(
+        object_id=object_id,
+        kind="object",
+        new_base_object_class="Evaluation",
+        existing_base_object_classes=["Dataset"],
+        object_name=f"{object_id}-evaluation",
+    )
+    result = handle_server_exception(exc)
+    assert result.status_code == 400
+    assert result.message == {
+        "reason": (
+            f"Cannot publish '{object_id}' as a Evaluation: that name is already "
+            f"used by a Dataset in this project. The object is named "
+            f"'{object_id}-evaluation'. Object versions cannot share types, "
+            "publish this object under a different name."
+        )
+    }
+
+
+@pytest.mark.parametrize(
+    ("object_id", "object_name"),
+    [
+        ("Custom-1", "Custom(1)"),
+        ("d" * 128, "d" * 128),
+    ],
+    ids=["sanitized_not_truncated", "name_is_the_id"],
+)
+def test_object_name_type_collision_omits_a_name_that_fits(
+    object_id: str, object_name: str
+) -> None:
+    """A name is only worth quoting when the limit cut it. Sanitizing shortens names
+    the limit never touched, and a name already at the limit says nothing new.
+    """
+    exc = ObjectNameTypeCollision(
+        object_id=object_id,
+        kind="object",
+        new_base_object_class="Prompt",
+        existing_base_object_classes=[None],
+        object_name=object_name,
+    )
+    result = handle_server_exception(exc)
+    assert result.status_code == 400
+    assert result.message == {
+        "reason": (
+            f"Cannot publish '{object_id}' as a Prompt: that name is already used "
+            "by a generic (untyped) object in this project. Object versions "
+            "cannot share types, publish this object under a different name."
+        )
+    }

--- a/weave/evaluation/eval.py
+++ b/weave/evaluation/eval.py
@@ -30,6 +30,7 @@ from weave.flow.scorer import (
     get_scorer_attributes,
 )
 from weave.flow.util import make_memorable_name, transpose
+from weave.integrations.integration_utilities import _uniquely_truncate_str
 from weave.object.obj import Object
 from weave.trace.api import attributes
 from weave.trace.call import Call, CallsIter
@@ -42,7 +43,7 @@ from weave.trace.op_protocol import CallDisplayNameFunc, Op
 from weave.trace.refs import ObjectRef
 from weave.trace.table import Table
 from weave.trace.vals import WeaveObject
-from weave.trace.weave_client import get_ref
+from weave.trace.weave_client import get_ref, sanitize_object_name
 from weave.trace_server import constants
 from weave.trace_server.trace_server_interface import CallsFilter
 from weave.utils.project_id import from_project_id
@@ -261,7 +262,17 @@ class Evaluation(Object):
             eval_op.call_display_name = self.evaluation_name
 
         if self.name is None and self.dataset.name is not None:
-            self.name = self.dataset.name + "-evaluation"  # type: ignore
+            derived_name = f"{self.dataset.name}-evaluation"
+            derived_id = sanitize_object_name(derived_name)
+            # An id at the limit may be the dataset's own, which the server rejects
+            # (WB-30574); one character under the limit cannot be.
+            if len(derived_id) == constants.MAX_OBJECT_NAME_LENGTH and derived_id == (
+                sanitize_object_name(self.dataset.name)
+            ):
+                derived_name = _uniquely_truncate_str(
+                    derived_id, constants.MAX_OBJECT_NAME_LENGTH - 1
+                )
+            self.name = derived_name
 
     @op
     async def predict_and_score(self, model: Op | Model, example: dict) -> dict:

--- a/weave/shared/object_class_util.py
+++ b/weave/shared/object_class_util.py
@@ -42,6 +42,14 @@ def get_object_classes(val: Any) -> GetObjectClassesResult | None:
     )
 
 
+def get_object_name(val: Any) -> str | None:
+    """The ``name`` a serialized weave object declares, if it has one."""
+    if get_object_classes(val) is None:
+        return None
+    name = val.get("name")
+    return name if isinstance(name, str) else None
+
+
 class ProcessIncomingObjectResult(TypedDict):
     val: Any
     base_object_class: str | None

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -2867,7 +2867,9 @@ class WeaveClient:
         if name is None:
             raise ValueError("Name must be provided for object saving")
 
+        original_name = name
         name = sanitize_object_name(name)
+        _warn_if_object_name_truncated(original_name, name)
 
         compute_digests = self._should_compute_client_digests()
 
@@ -3674,6 +3676,23 @@ def sanitize_object_name(name: str) -> str:
     if len(res) > MAX_OBJECT_NAME_LENGTH:
         res = res[:MAX_OBJECT_NAME_LENGTH]
     return res
+
+
+def _warn_if_object_name_truncated(name: str, object_id: str) -> None:
+    """Report a name that did not fit the id it is published under."""
+    if len(name) <= MAX_OBJECT_NAME_LENGTH or len(object_id) < MAX_OBJECT_NAME_LENGTH:
+        return
+
+    # Do not remember what the level suppressed; raising it later must still report.
+    if not logger.isEnabledFor(logging.WARNING):
+        return
+
+    log_once(
+        logger.warning,
+        f"Object name {name!r} is longer than {MAX_OBJECT_NAME_LENGTH} characters and is "
+        f"published as {object_id!r}. Names whose sanitized forms only differ past that "
+        f"limit become one object.",
+    )
 
 
 def _get_call_processor(server: Any) -> Any:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -37,6 +37,7 @@ from weave.shared.digest import (
     compute_row_digest,
     compute_table_digest,
 )
+from weave.shared.object_class_util import get_object_name
 from weave.shared.trace_server_interface_util import (
     assert_non_null_wb_user_id,
     extract_refs_from_values,
@@ -1271,13 +1272,20 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             by_project.setdefault(obj.project_id, []).append(obj)
 
         for project_id, project_objs in by_project.items():
-            checks: list[tuple[str, str, str | None]] = []
+            checks: list[tuple[str, str, str | None, str | None]] = []
             for obj in project_objs:
                 digest_result = compute_object_digest_result(
                     obj.val, obj.builtin_object_class
                 )
                 kind = get_kind(digest_result.processed_val)
-                checks.append((obj.object_id, kind, digest_result.base_object_class))
+                checks.append(
+                    (
+                        obj.object_id,
+                        kind,
+                        digest_result.base_object_class,
+                        get_object_name(digest_result.processed_val),
+                    )
+                )
             collisions = self._find_obj_name_type_collisions(project_id, checks)
             for collision in collisions:
                 logger.warning(
@@ -2317,6 +2325,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             object_id=req.obj.object_id,
             kind=kind,
             new_base_object_class=digest_result.base_object_class,
+            object_name=get_object_name(processed_val),
         )
 
         ch_obj = ObjCHInsertable(
@@ -2357,6 +2366,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         object_id: str,
         kind: str,
         new_base_object_class: str | None,
+        object_name: str | None,
     ) -> None:
         """Reject obj_create when (project_id, object_id) already exists with a
         different base_object_class. Names are bound to one type per project
@@ -2364,7 +2374,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         different-type would make refs ambiguous.
         """
         collisions = self._find_obj_name_type_collisions(
-            project_id, [(object_id, kind, new_base_object_class)]
+            project_id, [(object_id, kind, new_base_object_class, object_name)]
         )
         if collisions:
             raise collisions[0]
@@ -2372,20 +2382,24 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def _find_obj_name_type_collisions(
         self,
         project_id: str,
-        checks: list[tuple[str, str, str | None]],
+        checks: list[tuple[str, str, str | None, str | None]],
     ) -> list[ObjectNameTypeCollision]:
         """WB-30574 collision check: one query per distinct kind, returning
         one ObjectNameTypeCollision per object_id bound to more than one
         base_object_class, by committed rows or by conflicting entries
         within ``checks`` itself. Callers decide whether to raise.
 
-        ``checks`` is a list of (object_id, kind, new_base_object_class).
+        ``checks`` is a list of (object_id, kind, new_base_object_class, object_name),
+        where object_name is the name the serialized object declares, so a caller whose
+        name did not fit the id can be told so.
         """
         by_kind: dict[str, dict[str, set[str | None]]] = {}
-        for object_id, kind, new_base_object_class in checks:
+        names: dict[tuple[str, str, str | None], str | None] = {}
+        for object_id, kind, new_base_object_class, object_name in checks:
             by_kind.setdefault(kind, {}).setdefault(object_id, set()).add(
                 new_base_object_class
             )
+            names[kind, object_id, new_base_object_class] = object_name
 
         collisions: list[ObjectNameTypeCollision] = []
         for kind, object_id_to_classes in by_kind.items():
@@ -2413,6 +2427,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                             existing_base_object_classes=sorted(
                                 (c for c in bound if c != new_class), key=str
                             ),
+                            object_name=names[kind, object_id, new_class],
                         )
                     )
         return collisions

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -7,6 +7,7 @@ from typing import Any
 import httpx
 from gql.transport.exceptions import TransportQueryError, TransportServerError
 
+from weave.trace_server.constants import MAX_OBJECT_NAME_LENGTH
 from weave.trace_server.validation_util import CHValidationError
 
 # =============================================================================
@@ -60,18 +61,21 @@ class ObjectNameTypeCollision(InvalidRequest):
         kind: str,
         new_base_object_class: str | None,
         existing_base_object_classes: list[str | None],
+        object_name: str | None = None,
     ):
         self.object_id = object_id
         self.kind = kind
         self.new_base_object_class = new_base_object_class
         self.existing_base_object_classes = existing_base_object_classes
+        self.object_name = object_name
         existing_labels = [
             _describe_object_class(c) for c in existing_base_object_classes
         ]
         existing_desc = " or ".join(dict.fromkeys(existing_labels))
         super().__init__(
             f"Cannot publish {object_id!r} as {_describe_object_class(new_base_object_class)}: "
-            f"that name is already used by {existing_desc} in this project. "
+            f"that name is already used by {existing_desc} in this project."
+            f"{_describe_object_name(object_id, object_name)} "
             f"Object versions cannot share types, publish this object under a different name."
         )
 
@@ -528,6 +532,17 @@ def _describe_object_class(base_object_class: str | None) -> str:
     if base_object_class is None:
         return "a generic (untyped) object"
     return f"a {base_object_class}"
+
+
+def _describe_object_name(object_id: str, object_name: str | None) -> str:
+    """Quote the object's own name when the id is at the limit and the name overran it."""
+    if (
+        object_name is None
+        or len(object_id) < MAX_OBJECT_NAME_LENGTH
+        or len(object_name) <= len(object_id)
+    ):
+        return ""
+    return f" The object is named {object_name!r}."
 
 
 def _format_missing_llm_api_key(exc: Exception) -> dict[str, Any]:

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -39,6 +39,7 @@ from weave.shared.digest import (
     compute_row_digest,
     compute_table_digest,
 )
+from weave.shared.object_class_util import get_object_name
 from weave.shared.trace_server_interface_util import (
     WILDCARD_ARTIFACT_VERSION_AND_PATH,
     assert_non_null_wb_user_id,
@@ -2870,6 +2871,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                 object_id=object_id,
                 kind=kind,
                 new_base_object_class=digest_result.base_object_class,
+                object_name=get_object_name(processed_val),
             )
 
             self._mark_existing_objects_as_not_latest(project_id, object_id)
@@ -2933,6 +2935,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
         object_id: str,
         kind: str,
         new_base_object_class: str | None,
+        object_name: str | None,
     ) -> None:
         existing_classes = {
             rec.base_object_class
@@ -2946,6 +2949,7 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                 kind=kind,
                 new_base_object_class=new_base_object_class,
                 existing_base_object_classes=mismatched,
+                object_name=object_name,
             )
 
     def _mark_existing_objects_as_not_latest(


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-38822

## Description

If you don't name an `Evaluation`, we name it: the dataset's name plus `-evaluation`. Names are cut at 128 characters, so if the dataset's name already fills that, the suffix goes with it and both objects share one `object_id`. The server rejects the second one (WB-30574, #6804) with an id you never typed. Through `EvaluationLogger` it doesn't even raise, it just never saves.

207 of these in the last seven days ([datadog](https://us5.datadoghq.com/apm/traces?query=env%3Aprod%20service%3Aweave-trace%20resource_name%3A%22POST%20%2Fobj%2Fcreate%22%20%40http.status_code%3A400)), up from one or two a day before 7 August. It is not spread out, though: of 200 I sampled, 179 are this bug and every one of them is a single internal project retrying. No customer hit it in that window. Any dataset whose name reaches the limit will do the same, which is why it is worth fixing now rather than when it lands on someone else.

Leaving room for the suffix doesn't work: a dataset named `<117 chars>-evaluation` collides anyway. So compare the two ids, rewrite the name only if they match, and cut to 127 characters with a hash in the middle. A colliding dataset's id is always exactly 128, so a shorter one can't be it.

Long dataset names stop breaking unnamed evaluations, and only already-broken ids move. The general two-name collision stays, but now it is visible: the client warns on a cut name, and the server's error names the object.

## Testing

Ran the trace, eval and `trace_server` suites locally, plus ruff, mypy, pyright, ty and import-linter. Green, apart from two flakes that pass when run on their own and six `tests/flow/` failures that are the same on master.
