### PR TITLE
perf(weave): hydrate eval_results page rows with a literal-id PREWHERE query

### DIFF
--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -11,7 +11,8 @@ from weave.trace_server.interface.query import Query
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.eval_results_query_builder import (
     build_eval_results_cte_chain,
-    build_eval_results_query,
+    build_eval_results_hydration_query,
+    build_eval_results_page_query,
     build_sort_expression,
 )
 
@@ -532,10 +533,10 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
     )
 
 
-def test_full_query_calls_merged() -> None:
-    """Full SQL: lean CTEs + outer SELECT hydrates from calls_merged."""
+def test_page_query_calls_merged() -> None:
+    """Page query: lean CTE chain + page_rows projection, no hydration columns."""
     pb = ParamBuilder("pb")
-    sql = build_eval_results_query(
+    sql = build_eval_results_page_query(
         project_id="proj-1",
         eval_root_ids=["eval-1"],
         sort_by=None,
@@ -546,171 +547,65 @@ def test_full_query_calls_merged() -> None:
         pb=pb,
         read_table="calls_merged",
     )
+    pb_chain = ParamBuilder("pb")
+    chain = build_eval_results_cte_chain(
+        project_id="proj-1",
+        eval_root_ids=["eval-1"],
+        sort_by=None,
+        filters=None,
+        require_intersection=False,
+        limit=10,
+        offset=0,
+        pb=pb_chain,
+        read_table="calls_merged",
+    )
     assert_raw_sql(
         sql,
-        """
-        WITH predict_and_score_calls AS (
-                SELECT calls_merged.id AS call_id,
-                    any(calls_merged.parent_id) AS eval_call_id,
-                    any(calls_merged.inputs_dump) AS inputs_dump,
-                    any(calls_merged.output_dump) AS output_dump,
-                    CASE
-                        WHEN position(JSON_VALUE(any(calls_merged.inputs_dump), '$.example'), '/attr/rows/id/') > 0
-                            THEN regexpExtract(JSON_VALUE(any(calls_merged.inputs_dump), '$.example'), '/attr/rows/id/([^/]+)$', 1)
-                        ELSE hex(SHA256(JSONExtractRaw(any(calls_merged.inputs_dump), 'example')))
-                    END AS row_digest
-                FROM calls_merged
-                PREWHERE calls_merged.project_id = {pb_0:String}
-                AND calls_merged.id IN (
-                    SELECT calls_merged.id
-                    FROM calls_merged
-                    PREWHERE calls_merged.project_id = {pb_0:String}
-                    WHERE calls_merged.parent_id IN {pb_1:Array(String)}
-                        AND calls_merged.id NOT IN {pb_1:Array(String)}
-                        AND multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
-                        AND calls_merged.sortable_datetime >= coalesce(
-                            (SELECT min(roots.started_at) - toIntervalSecond(300)
-                                FROM calls_merged AS roots
-                                PREWHERE roots.project_id = {pb_0:String}
-                                WHERE roots.id IN {pb_1:Array(String)}
-                            ),
-                            toDateTime64(0, 3))
-                        AND calls_merged.sortable_datetime <= coalesce(
-                            (SELECT CASE
-                                WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
-                                ELSE max(root_ended_at) + toIntervalSecond(300)
-                            END
-                            FROM (
-                                SELECT max(roots.ended_at) AS root_ended_at
-                                FROM calls_merged AS roots
-                                PREWHERE roots.project_id = {pb_0:String}
-                                WHERE roots.id IN {pb_1:Array(String)}
-                                GROUP BY roots.id
-                            )),
-                            toDateTime64('2100-01-01 00:00:00', 3))
-                )
-                WHERE calls_merged.sortable_datetime >= coalesce(
-                    (SELECT min(roots.started_at) - toIntervalSecond(300)
-                        FROM calls_merged AS roots
-                        PREWHERE roots.project_id = {pb_0:String}
-                        WHERE roots.id IN {pb_1:Array(String)}
-                    ),
-                    toDateTime64(0, 3))
-                GROUP BY (calls_merged.project_id, calls_merged.id)
-                HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
-                    AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
-                    AND any(calls_merged.deleted_at) IS NULL
-                    AND any(calls_merged.started_at) IS NOT NULL
-            ),
-
-            predict_and_score_calls_resolved AS (
-                SELECT * FROM predict_and_score_calls
-            ),
-
-            ranked_digests AS (
-                SELECT row_digest,
-                    ROW_NUMBER() OVER(ORDER BY row_digest ASC) AS row_order
-                FROM predict_and_score_calls_resolved
-                GROUP BY row_digest
-                HAVING 1=1
-            ),
-
-            ranked_digest_count AS (
-                SELECT count(*) AS total_rows FROM ranked_digests
-            ),
-
-            page_digests AS (
-                SELECT row_digest, row_order
-                FROM ranked_digests
-                ORDER BY row_order
-                LIMIT 10
-                OFFSET 0
-            ),
-
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
-            page_rows AS (
-                SELECT predict_and_score_calls_resolved.call_id AS call_id,
-                    predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
-                    predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
-                FROM predict_and_score_calls_resolved
-                INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
-            ),
-
-            page_calls AS (
-                SELECT calls_merged.id AS call_id,
-                    any(calls_merged.project_id) AS project_id,
-                    any(calls_merged.trace_id) AS trace_id,
-                    any(calls_merged.op_name) AS op_name,
-                    any(calls_merged.started_at) AS started_at,
-                    any(calls_merged.ended_at) AS ended_at,
-                    any(calls_merged.attributes_dump) AS attributes_dump,
-                    any(calls_merged.inputs_dump) AS inputs_dump,
-                    any(calls_merged.output_dump) AS output_dump,
-                    any(calls_merged.summary_dump) AS summary_dump
-                FROM calls_merged
-                PREWHERE calls_merged.project_id = {pb_4:String}
-                WHERE calls_merged.id IN (SELECT call_id FROM page_rows)
-                AND calls_merged.sortable_datetime >= coalesce(
-                    (SELECT min(roots.started_at) - toIntervalSecond(300)
-                        FROM calls_merged AS roots
-                        PREWHERE roots.project_id = {pb_4:String}
-                        WHERE roots.id IN {pb_5:Array(String)}
-                    ),
-                    toDateTime64(0, 3))
-                AND calls_merged.sortable_datetime <= coalesce(
-                    (SELECT CASE
-                        WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
-                        ELSE max(root_ended_at) + toIntervalSecond(300)
-                    END
-                    FROM (
-                        SELECT max(roots.ended_at) AS root_ended_at
-                        FROM calls_merged AS roots
-                        PREWHERE roots.project_id = {pb_4:String}
-                        WHERE roots.id IN {pb_5:Array(String)}
-                        GROUP BY roots.id
-                    )),
-                    toDateTime64('2100-01-01 00:00:00', 3))
-                GROUP BY (calls_merged.project_id, calls_merged.id)
-            )
+        f"""
+        WITH {chain}
         SELECT
-            page_rows.call_id AS id,
-            page_rows.eval_call_id AS parent_id,
-            page_calls.project_id,
-            page_calls.trace_id,
-            page_calls.op_name,
-            page_calls.started_at,
-            page_calls.ended_at,
-            page_calls.attributes_dump,
-            page_calls.inputs_dump,
-            page_calls.output_dump,
-            page_calls.summary_dump,
-            page_rows.row_digest AS __row_digest,
-            page_rows.row_order AS __row_order,
-            page_rows.resolved_inputs AS __resolved_inputs,
-            (SELECT total_rows FROM ranked_digest_count) AS __total_rows
+            page_rows.call_id AS call_id,
+            page_rows.eval_call_id AS eval_call_id,
+            page_rows.row_digest AS row_digest,
+            page_rows.row_order AS row_order,
+            page_rows.resolved_inputs AS resolved_inputs,
+            (SELECT total_rows FROM ranked_digest_count) AS total_rows
         FROM page_rows
-        LEFT JOIN page_calls ON page_calls.call_id = page_rows.call_id
         ORDER BY page_rows.row_order ASC
         """,
         pb.get_params(),
-        {
-            "pb_0": "proj-1",
-            "pb_1": ["eval-1"],
-            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
-            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
-            "pb_4": "proj-1",
-            "pb_5": ["eval-1"],
-        },
+        pb_chain.get_params(),
+    )
+
+
+def test_hydration_query_calls_merged() -> None:
+    """Hydration query: literal id set in PREWHERE so dump reads are row-level."""
+    pb = ParamBuilder("pb")
+    sql = build_eval_results_hydration_query(
+        project_id="proj-1",
+        call_ids=["call-1", "call-2"],
+        pb=pb,
+        read_table="calls_merged",
+    )
+    assert_raw_sql(
+        sql,
+        """SELECT
+    calls_merged.id AS id,
+    any(calls_merged.project_id) AS project_id,
+    any(calls_merged.trace_id) AS trace_id,
+    any(calls_merged.op_name) AS op_name,
+    any(calls_merged.started_at) AS started_at,
+    any(calls_merged.ended_at) AS ended_at,
+    any(calls_merged.attributes_dump) AS attributes_dump,
+    any(calls_merged.inputs_dump) AS inputs_dump,
+    any(calls_merged.output_dump) AS output_dump,
+    any(calls_merged.summary_dump) AS summary_dump
+FROM calls_merged
+PREWHERE calls_merged.project_id = {pb_0:String}
+AND calls_merged.id IN {pb_1:Array(String)}
+GROUP BY (calls_merged.project_id, calls_merged.id)""",
+        pb.get_params(),
+        {"pb_0": "proj-1", "pb_1": ["call-1", "call-2"]},
     )
 
 
@@ -1161,10 +1056,10 @@ def test_filter_logic_operator_or_same_eval_multiple_conditions() -> None:
     )
 
 
-def test_full_query_calls_complete() -> None:
-    """Full SQL: lean CTEs + page_calls hydration on calls_complete (no GROUP BY)."""
+def test_page_query_calls_complete() -> None:
+    """Page query on calls_complete: same lean projection over its CTE chain."""
     pb = ParamBuilder("pb")
-    sql = build_eval_results_query(
+    sql = build_eval_results_page_query(
         project_id="proj-1",
         eval_root_ids=["eval-1"],
         sort_by=None,
@@ -1175,114 +1070,64 @@ def test_full_query_calls_complete() -> None:
         pb=pb,
         read_table="calls_complete",
     )
+    pb_chain = ParamBuilder("pb")
+    chain = build_eval_results_cte_chain(
+        project_id="proj-1",
+        eval_root_ids=["eval-1"],
+        sort_by=None,
+        filters=None,
+        require_intersection=False,
+        limit=10,
+        offset=0,
+        pb=pb_chain,
+        read_table="calls_complete",
+    )
     assert_raw_sql(
         sql,
-        """
-        WITH predict_and_score_calls AS (
-                SELECT calls_complete.id AS call_id,
-                    calls_complete.parent_id AS eval_call_id,
-                    calls_complete.inputs_dump,
-                    calls_complete.output_dump,
-                    CASE
-                        WHEN position(JSON_VALUE(calls_complete.inputs_dump, '$.example'), '/attr/rows/id/') > 0
-                            THEN regexpExtract(JSON_VALUE(calls_complete.inputs_dump, '$.example'), '/attr/rows/id/([^/]+)$', 1)
-                        ELSE hex(SHA256(JSONExtractRaw(calls_complete.inputs_dump, 'example')))
-                    END AS row_digest
-                FROM calls_complete
-                PREWHERE calls_complete.project_id = {pb_0:String}
-                WHERE calls_complete.parent_id IN {pb_1:Array(String)}
-                    AND calls_complete.id NOT IN {pb_1:Array(String)}
-                    AND (multiSearchAny(calls_complete.op_name, [{pb_2:String}, {pb_3:String}]))
-                    AND calls_complete.deleted_at = {pb_4:DateTime64(3)}
-            ),
-
-            predict_and_score_calls_resolved AS (
-                SELECT * FROM predict_and_score_calls
-            ),
-
-            ranked_digests AS (
-                SELECT row_digest,
-                    ROW_NUMBER() OVER(ORDER BY row_digest ASC) AS row_order
-                FROM predict_and_score_calls_resolved
-                GROUP BY row_digest
-                HAVING 1=1
-            ),
-
-            ranked_digest_count AS (
-                SELECT count(*) AS total_rows FROM ranked_digests
-            ),
-
-            page_digests AS (
-                SELECT row_digest, row_order
-                FROM ranked_digests
-                ORDER BY row_order
-                LIMIT 10
-                OFFSET 0
-            ),
-
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
-            page_rows AS (
-                SELECT predict_and_score_calls_resolved.call_id AS call_id,
-                    predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
-                    predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
-                FROM predict_and_score_calls_resolved
-                INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
-            ),
-
-            page_calls AS (
-                SELECT calls_complete.id AS call_id,
-                    calls_complete.project_id,
-                    calls_complete.trace_id,
-                    calls_complete.op_name,
-                    calls_complete.started_at,
-                    calls_complete.ended_at,
-                    calls_complete.attributes_dump,
-                    calls_complete.inputs_dump,
-                    calls_complete.output_dump,
-                    calls_complete.summary_dump
-                FROM calls_complete
-                WHERE calls_complete.project_id = {pb_5:String}
-                    AND calls_complete.id IN (SELECT call_id FROM page_rows)
-            )
+        f"""
+        WITH {chain}
         SELECT
-            page_rows.call_id AS id,
-            page_rows.eval_call_id AS parent_id,
-            page_calls.project_id,
-            page_calls.trace_id,
-            page_calls.op_name,
-            page_calls.started_at,
-            page_calls.ended_at,
-            page_calls.attributes_dump,
-            page_calls.inputs_dump,
-            page_calls.output_dump,
-            page_calls.summary_dump,
-            page_rows.row_digest AS __row_digest,
-            page_rows.row_order AS __row_order,
-            page_rows.resolved_inputs AS __resolved_inputs,
-            (SELECT total_rows FROM ranked_digest_count) AS __total_rows
+            page_rows.call_id AS call_id,
+            page_rows.eval_call_id AS eval_call_id,
+            page_rows.row_digest AS row_digest,
+            page_rows.row_order AS row_order,
+            page_rows.resolved_inputs AS resolved_inputs,
+            (SELECT total_rows FROM ranked_digest_count) AS total_rows
         FROM page_rows
-        LEFT JOIN page_calls ON page_calls.call_id = page_rows.call_id
         ORDER BY page_rows.row_order ASC
         """,
         pb.get_params(),
-        {
-            "pb_0": "proj-1",
-            "pb_1": ["eval-1"],
-            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
-            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
-            "pb_4": SENTINEL_EPOCH,
-            "pb_5": "proj-1",
-        },
+        pb_chain.get_params(),
+    )
+
+
+def test_hydration_query_calls_complete() -> None:
+    """Hydration on calls_complete: literal id set in PREWHERE, no GROUP BY."""
+    pb = ParamBuilder("pb")
+    sql = build_eval_results_hydration_query(
+        project_id="proj-1",
+        call_ids=["call-1"],
+        pb=pb,
+        read_table="calls_complete",
+    )
+    assert_raw_sql(
+        sql,
+        """SELECT
+    calls_complete.id AS id,
+    calls_complete.project_id,
+    calls_complete.trace_id,
+    calls_complete.op_name,
+    calls_complete.started_at,
+    calls_complete.ended_at,
+    calls_complete.attributes_dump,
+    calls_complete.inputs_dump,
+    calls_complete.output_dump,
+    calls_complete.summary_dump
+FROM calls_complete
+PREWHERE calls_complete.project_id = {pb_0:String}
+AND calls_complete.id IN {pb_1:Array(String)}""",
+        pb.get_params(),
+        {"pb_0": "proj-1", "pb_1": ["call-1"]},
     )
 
 

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -13,6 +13,7 @@ from weave.trace_server.query_builder.eval_results_query_builder import (
     build_eval_results_cte_chain,
     build_eval_results_hydration_query,
     build_eval_results_page_query,
+    build_table_rows_resolution_query,
     build_sort_expression,
 )
 
@@ -113,23 +114,13 @@ def test_cte_chain_calls_merged() -> None:
                 OFFSET 0
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -202,23 +193,13 @@ def test_cte_chain_calls_complete() -> None:
                 OFFSET 10
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -338,23 +319,13 @@ def test_cte_chain_sort_and_multi_eval_filters() -> None:
                 OFFSET 50
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -501,23 +472,13 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                 OFFSET 0
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -568,7 +529,6 @@ def test_page_query_calls_merged() -> None:
             page_rows.eval_call_id AS eval_call_id,
             page_rows.row_digest AS row_digest,
             page_rows.row_order AS row_order,
-            page_rows.resolved_inputs AS resolved_inputs,
             (SELECT total_rows FROM ranked_digest_count) AS total_rows
         FROM page_rows
         ORDER BY page_rows.row_order ASC
@@ -765,23 +725,13 @@ def test_filter_logic_operator_or_produces_match_any() -> None:
                 OFFSET 0
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -895,23 +845,13 @@ def test_filter_logic_operator_and_produces_match_all() -> None:
                 OFFSET 0
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -1022,23 +962,13 @@ def test_filter_logic_operator_or_same_eval_multiple_conditions() -> None:
                 OFFSET 0
             ),
 
-            page_resolved_inputs AS (
-                SELECT digest, any(val_dump) AS val_dump
-                FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
-                GROUP BY digest
-            ),
-
             page_rows AS (
                 SELECT predict_and_score_calls_resolved.call_id AS call_id,
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
-                    page_digests.row_order AS row_order,
-                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    page_digests.row_order AS row_order
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
         pb.get_params(),
@@ -1091,7 +1021,6 @@ def test_page_query_calls_complete() -> None:
             page_rows.eval_call_id AS eval_call_id,
             page_rows.row_digest AS row_digest,
             page_rows.row_order AS row_order,
-            page_rows.resolved_inputs AS resolved_inputs,
             (SELECT total_rows FROM ranked_digest_count) AS total_rows
         FROM page_rows
         ORDER BY page_rows.row_order ASC
@@ -1128,6 +1057,26 @@ PREWHERE calls_complete.project_id = {pb_0:String}
 AND calls_complete.id IN {pb_1:Array(String)}""",
         pb.get_params(),
         {"pb_0": "proj-1", "pb_1": ["call-1"]},
+    )
+
+
+def test_table_rows_resolution_query() -> None:
+    """Dataset-row resolution uses a literal digest set in PREWHERE."""
+    pb = ParamBuilder("pb")
+    sql = build_table_rows_resolution_query(
+        project_id="proj-1",
+        digests=["digest-1", "digest-2"],
+        pb=pb,
+    )
+    assert_raw_sql(
+        sql,
+        """SELECT digest, any(val_dump) AS val_dump
+FROM table_rows
+PREWHERE project_id = {pb_0:String}
+AND digest IN {pb_1:Array(String)}
+GROUP BY digest""",
+        pb.get_params(),
+        {"pb_0": "proj-1", "pb_1": ["digest-1", "digest-2"]},
     )
 
 

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -13,8 +13,8 @@ from weave.trace_server.query_builder.eval_results_query_builder import (
     build_eval_results_cte_chain,
     build_eval_results_hydration_query,
     build_eval_results_page_query,
-    build_table_rows_resolution_query,
     build_sort_expression,
+    build_table_rows_resolution_query,
 )
 
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5954,7 +5954,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         result = self._query(page_query, pb.get_params())
 
         digest_by_call: dict[str, str] = {}
-        resolved_by_call_id: dict[str, Any] = {}
         eval_call_id_by_call: dict[str, str | None] = {}
         ordered_call_ids: list[str] = []
         total_rows = 0
@@ -5970,11 +5969,31 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             row_digest = row_data.get("row_digest")
             if row_digest:
                 digest_by_call[call_id] = row_digest
-            resolved_raw = row_data.get("resolved_inputs")
-            if resolved_raw and req.resolve_row_refs:
-                parsed = try_parse_json(resolved_raw)
-                if parsed is not None:
-                    resolved_by_call_id[call_id] = parsed
+
+        # Resolve dataset-row payloads by literal digests (PREWHERE); inline
+        # rows have no table_rows entry and keep their inputs.example as-is.
+        resolved_by_call_id: dict[str, Any] = {}
+        if req.resolve_row_refs and digest_by_call:
+            val_by_digest: dict[str, Any] = {}
+            unique_digests = list(dict.fromkeys(digest_by_call.values()))
+            for i in range(0, len(unique_digests), MAX_FILTER_LENGTH):
+                dbatch = unique_digests[i : i + MAX_FILTER_LENGTH]
+                rpb = ParamBuilder()
+                resolution_query = (
+                    eval_results_query_builder.build_table_rows_resolution_query(
+                        req.project_id, dbatch, rpb
+                    )
+                )
+                for digest, val_dump in self._query(
+                    resolution_query, rpb.get_params()
+                ).result_rows:
+                    if val_dump:
+                        parsed = try_parse_json(val_dump)
+                        if parsed is not None:
+                            val_by_digest[digest] = parsed
+            for call_id, digest in digest_by_call.items():
+                if digest in val_by_digest:
+                    resolved_by_call_id[call_id] = val_by_digest[digest]
 
         # Hydrate heavy call columns in a second statement so the id set is a
         # literal PREWHERE param (row-level lazy reads); see

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6014,12 +6014,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         page_calls: list[tsi.CallSchema] = []
         for call_id in ordered_call_ids:
-            hdata = hydrated_by_id.get(call_id)
-            if hdata is None:
+            call_data = hydrated_by_id.get(call_id)
+            if call_data is None:
                 continue
-            hdata["parent_id"] = eval_call_id_by_call.get(call_id)
+            call_data["parent_id"] = eval_call_id_by_call.get(call_id)
             page_calls.append(
-                tsi.CallSchema.model_validate(ch_call_dict_to_call_schema_dict(hdata))
+                tsi.CallSchema.model_validate(
+                    ch_call_dict_to_call_schema_dict(call_data)
+                )
             )
 
         for call in page_calls:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5938,7 +5938,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         pb = ParamBuilder()
 
-        page_query = eval_results_query_builder.build_eval_results_query(
+        page_query = eval_results_query_builder.build_eval_results_page_query(
             req.project_id,
             eval_root_ids,
             req.sort_by,
@@ -5955,27 +5955,52 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         digest_by_call: dict[str, str] = {}
         resolved_by_call_id: dict[str, Any] = {}
+        eval_call_id_by_call: dict[str, str | None] = {}
+        ordered_call_ids: list[str] = []
         total_rows = 0
-        page_calls: list[tsi.CallSchema] = []
 
         for row in result.result_rows:
             row_data = dict(zip(result.column_names, row, strict=True))
-            total_rows = int(row_data.get("__total_rows", 0))
-            row_digest = row_data.get("__row_digest")
-            resolved_raw = row_data.get("__resolved_inputs")
-
-            call_id = row_data.get("id")
-            if row_digest and call_id:
+            total_rows = int(row_data.get("total_rows", 0))
+            call_id = row_data.get("call_id")
+            if not call_id:
+                continue
+            ordered_call_ids.append(call_id)
+            eval_call_id_by_call[call_id] = row_data.get("eval_call_id")
+            row_digest = row_data.get("row_digest")
+            if row_digest:
                 digest_by_call[call_id] = row_digest
-            if resolved_raw and call_id and req.resolve_row_refs:
+            resolved_raw = row_data.get("resolved_inputs")
+            if resolved_raw and req.resolve_row_refs:
                 parsed = try_parse_json(resolved_raw)
                 if parsed is not None:
                     resolved_by_call_id[call_id] = parsed
 
-            page_calls.append(
-                tsi.CallSchema.model_validate(
-                    ch_call_dict_to_call_schema_dict(row_data)
+        # Hydrate heavy call columns in a second statement so the id set is a
+        # literal PREWHERE param (row-level lazy reads); see
+        # build_eval_results_hydration_query for why this can't be one statement.
+        hydrated_by_id: dict[str, dict[str, Any]] = {}
+        for i in range(0, len(ordered_call_ids), MAX_FILTER_LENGTH):
+            batch = ordered_call_ids[i : i + MAX_FILTER_LENGTH]
+            hpb = ParamBuilder()
+            hydration_query = (
+                eval_results_query_builder.build_eval_results_hydration_query(
+                    req.project_id, batch, hpb, read_table
                 )
+            )
+            hydration_result = self._query(hydration_query, hpb.get_params())
+            for hrow in hydration_result.result_rows:
+                hdata = dict(zip(hydration_result.column_names, hrow, strict=True))
+                hydrated_by_id[hdata["id"]] = hdata
+
+        page_calls: list[tsi.CallSchema] = []
+        for call_id in ordered_call_ids:
+            hdata = hydrated_by_id.get(call_id)
+            if hdata is None:
+                continue
+            hdata["parent_id"] = eval_call_id_by_call.get(call_id)
+            page_calls.append(
+                tsi.CallSchema.model_validate(ch_call_dict_to_call_schema_dict(hdata))
             )
 
         for call in page_calls:

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -6,8 +6,11 @@ Generates ClickHouse CTEs for the eval_results CTE chain:
   ranked_digests                   → GROUP BY row_digest, HAVING filters, ROW_NUMBER for sort
   ranked_digest_count              → total matching rows (for pagination metadata)
   page_digests                     → paginated slice of ranked_digests
-  page_resolved_inputs             → table_rows JOIN for the paginated digests only
-  page_rows                        → call IDs + resolved_inputs for the page
+  page_rows                        → call IDs + digests + order for the page
+
+Heavy data (call payload columns, dataset-row val_dump) is fetched by separate
+statements with literal id/digest params in PREWHERE — see
+build_eval_results_hydration_query and build_table_rows_resolution_query.
 """
 
 from functools import partial
@@ -516,35 +519,40 @@ page_digests AS (
 )"""
 
 
-def build_page_resolved_inputs_cte(project_id_param: str) -> str:
-    """Hydrate dataset-row val_dump for just the page's digests."""
-    return f"""page_resolved_inputs AS (
-    SELECT digest, any(val_dump) AS val_dump
-    FROM table_rows
-    PREWHERE project_id = {project_id_param}
-    WHERE digest IN (SELECT row_digest FROM page_digests)
-    GROUP BY digest
-)"""
-
-
 def build_page_rows_cte() -> str:
-    """Build page_rows CTE: joins page digests with the per-page val_dump
-    resolution.
+    """Build page_rows CTE: page digests joined back to their calls.
+
+    Dataset-row resolution deliberately does NOT happen here: a
+    `digest IN (SELECT ... FROM page_digests)` scan of table_rows reads
+    val_dump for every row in the surviving granules (GBs on fat datasets)
+    even though only the page's digests are needed. Callers that want
+    resolved rows fetch them with build_table_rows_resolution_query using
+    the returned digests as a literal PREWHERE param.
     """
     return """page_rows AS (
     SELECT
         predict_and_score_calls_resolved.call_id AS call_id,
         predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
         predict_and_score_calls_resolved.row_digest AS row_digest,
-        page_digests.row_order AS row_order,
-        COALESCE(
-            nullIf(page_resolved_inputs.val_dump, ''),
-            JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')
-        ) AS resolved_inputs
+        page_digests.row_order AS row_order
     FROM predict_and_score_calls_resolved
     INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
-    LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
 )"""
+
+
+def build_table_rows_resolution_query(
+    project_id: str,
+    digests: list[str],
+    pb: ParamBuilder,
+) -> str:
+    """Resolve dataset-row val_dump for a literal digest list (PREWHERE)."""
+    project_id_param = param_slot(pb.add_param(project_id), "String")
+    digests_param = pb.add(digests, None, "Array(String)")
+    return f"""SELECT digest, any(val_dump) AS val_dump
+FROM table_rows
+PREWHERE project_id = {project_id_param}
+AND digest IN {digests_param}
+GROUP BY digest"""
 
 
 def build_eval_results_page_query(
@@ -588,7 +596,6 @@ SELECT
     page_rows.eval_call_id AS eval_call_id,
     page_rows.row_digest AS row_digest,
     page_rows.row_order AS row_order,
-    page_rows.resolved_inputs AS resolved_inputs,
     (SELECT total_rows FROM ranked_digest_count) AS total_rows
 FROM page_rows
 ORDER BY page_rows.row_order ASC"""
@@ -702,7 +709,6 @@ def build_eval_results_cte_chain(
         pb,
         filter_logic_operator,
     )
-    page_resolved_cte = build_page_resolved_inputs_cte(project_id_param)
     page_rows_cte = build_page_rows_cte()
 
     return f"""{calls_cte},
@@ -710,7 +716,5 @@ def build_eval_results_cte_chain(
 {resolved_cte},
 
 {ranked_cte},
-
-{page_resolved_cte},
 
 {page_rows_cte}"""

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -547,67 +547,7 @@ def build_page_rows_cte() -> str:
 )"""
 
 
-def _build_page_calls_cte(
-    project_id_param: str,
-    read_table: str,
-    eval_root_ids_param: str | None = None,
-) -> str:
-    """Build page_calls CTE: pre-filter and pre-aggregate source table for page rows only.
-
-    page_calls only hydrates display columns for calls already selected by
-    page_rows, and every such call's start/end rows lie inside the eval run
-    window -- so both time bounds apply. The bounds prune granules via the
-    sortable_datetime minmax index from WHERE (the id filter must stay out of
-    PREWHERE: referencing a chained CTE there re-evaluates it pathologically),
-    which keeps the dump-column reads to the window instead of the project.
-    """
-    if read_table == "calls_merged":
-        assert eval_root_ids_param is not None
-        eval_start_lower_bound = _build_eval_start_lower_bound(
-            project_id_param, eval_root_ids_param
-        )
-        eval_end_upper_bound = _build_eval_end_upper_bound(
-            project_id_param, eval_root_ids_param
-        )
-        return f"""page_calls AS (
-    SELECT
-        calls_merged.id AS call_id,
-        any(calls_merged.project_id) AS project_id,
-        any(calls_merged.trace_id) AS trace_id,
-        any(calls_merged.op_name) AS op_name,
-        any(calls_merged.started_at) AS started_at,
-        any(calls_merged.ended_at) AS ended_at,
-        any(calls_merged.attributes_dump) AS attributes_dump,
-        any(calls_merged.inputs_dump) AS inputs_dump,
-        any(calls_merged.output_dump) AS output_dump,
-        any(calls_merged.summary_dump) AS summary_dump
-    FROM calls_merged
-    PREWHERE calls_merged.project_id = {project_id_param}
-    WHERE calls_merged.id IN (SELECT call_id FROM page_rows)
-    AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
-    AND calls_merged.sortable_datetime <= {eval_end_upper_bound}
-    GROUP BY (calls_merged.project_id, calls_merged.id)
-)"""
-    else:
-        return f"""page_calls AS (
-    SELECT
-        calls_complete.id AS call_id,
-        calls_complete.project_id,
-        calls_complete.trace_id,
-        calls_complete.op_name,
-        calls_complete.started_at,
-        calls_complete.ended_at,
-        calls_complete.attributes_dump,
-        calls_complete.inputs_dump,
-        calls_complete.output_dump,
-        calls_complete.summary_dump
-    FROM calls_complete
-    WHERE calls_complete.project_id = {project_id_param}
-      AND calls_complete.id IN (SELECT call_id FROM page_rows)
-)"""
-
-
-def build_eval_results_query(
+def build_eval_results_page_query(
     project_id: str,
     eval_root_ids: list[str],
     sort_by: list[tsi.EvalResultsSortBy] | None,
@@ -619,11 +559,16 @@ def build_eval_results_query(
     read_table: str,
     filter_logic_operator: str = "or",
 ) -> str:
-    """Build the complete eval_results SQL query.
+    """Build the page-selection SQL: which rows to show, on light columns only.
 
-    The CTE chain carries only lightweight columns for sort/filter/pagination.
-    A page_calls CTE pre-filters the source table to just the page's call IDs,
-    then the outer SELECT joins two small tables (page_rows + page_calls).
+    Returns one row per page call with call_id, eval_call_id, row_digest,
+    row_order, resolved_inputs, and the total row count. Heavy call payloads
+    are fetched by a second statement (build_eval_results_hydration_query)
+    with the selected ids as a literal parameter: an in-statement
+    `id IN (SELECT ... FROM page_rows)` cannot sit in PREWHERE (chained-CTE
+    references re-evaluate pathologically), and from WHERE the dump columns
+    are read for every row in the surviving granules -- GBs on fat projects
+    to display 50 rows.
     """
     cte_chain = build_eval_results_cte_chain(
         project_id,
@@ -637,36 +582,64 @@ def build_eval_results_query(
         read_table,
         filter_logic_operator,
     )
-    project_id_param = param_slot(pb.add_param(project_id), "String")
-    page_eval_root_ids_param = None
-    if read_table == "calls_merged":
-        page_eval_root_ids_param = pb.add(eval_root_ids, None, "Array(String)")
-    page_calls_cte = _build_page_calls_cte(
-        project_id_param, read_table, page_eval_root_ids_param
-    )
-
-    return f"""WITH {cte_chain.strip()},
-
-{page_calls_cte}
+    return f"""WITH {cte_chain.strip()}
 SELECT
-    page_rows.call_id AS id,
-    page_rows.eval_call_id AS parent_id,
-    page_calls.project_id,
-    page_calls.trace_id,
-    page_calls.op_name,
-    page_calls.started_at,
-    page_calls.ended_at,
-    page_calls.attributes_dump,
-    page_calls.inputs_dump,
-    page_calls.output_dump,
-    page_calls.summary_dump,
-    page_rows.row_digest AS __row_digest,
-    page_rows.row_order AS __row_order,
-    page_rows.resolved_inputs AS __resolved_inputs,
-    (SELECT total_rows FROM ranked_digest_count) AS __total_rows
+    page_rows.call_id AS call_id,
+    page_rows.eval_call_id AS eval_call_id,
+    page_rows.row_digest AS row_digest,
+    page_rows.row_order AS row_order,
+    page_rows.resolved_inputs AS resolved_inputs,
+    (SELECT total_rows FROM ranked_digest_count) AS total_rows
 FROM page_rows
-LEFT JOIN page_calls ON page_calls.call_id = page_rows.call_id
 ORDER BY page_rows.row_order ASC"""
+
+
+def build_eval_results_hydration_query(
+    project_id: str,
+    call_ids: list[str],
+    pb: ParamBuilder,
+    read_table: str,
+) -> str:
+    """Build the hydration SQL: heavy call columns for a literal id list.
+
+    The literal id set sits in PREWHERE, so ClickHouse row-filters on
+    (project_id, id) before reading the dump columns -- reads stay
+    proportional to the page, not to the granules the page's rows live in.
+    """
+    project_id_param = param_slot(pb.add_param(project_id), "String")
+    call_ids_param = pb.add(call_ids, None, "Array(String)")
+
+    if read_table == "calls_merged":
+        return f"""SELECT
+    calls_merged.id AS id,
+    any(calls_merged.project_id) AS project_id,
+    any(calls_merged.trace_id) AS trace_id,
+    any(calls_merged.op_name) AS op_name,
+    any(calls_merged.started_at) AS started_at,
+    any(calls_merged.ended_at) AS ended_at,
+    any(calls_merged.attributes_dump) AS attributes_dump,
+    any(calls_merged.inputs_dump) AS inputs_dump,
+    any(calls_merged.output_dump) AS output_dump,
+    any(calls_merged.summary_dump) AS summary_dump
+FROM calls_merged
+PREWHERE calls_merged.project_id = {project_id_param}
+AND calls_merged.id IN {call_ids_param}
+GROUP BY (calls_merged.project_id, calls_merged.id)"""
+    else:
+        return f"""SELECT
+    calls_complete.id AS id,
+    calls_complete.project_id,
+    calls_complete.trace_id,
+    calls_complete.op_name,
+    calls_complete.started_at,
+    calls_complete.ended_at,
+    calls_complete.attributes_dump,
+    calls_complete.inputs_dump,
+    calls_complete.output_dump,
+    calls_complete.summary_dump
+FROM calls_complete
+PREWHERE calls_complete.project_id = {project_id_param}
+AND calls_complete.id IN {call_ids_param}"""
 
 
 def build_eval_results_cte_chain(


### PR DESCRIPTION
## Description

goal is to finish the /eval-results speedup started in #7761. that PR fixed how the query *selects* the eval's rows; this one fixes how the selected rows get *fetched*.
the core problem: fetching payloads for the 50-row page couldn't use the cheap-filter trick in a single statement, so we split the query into separate statements.
`calls_merged` path only; `calls_complete` untouched.

### The fixes

**1. Fetch page payloads in a separate statement with a literal id list.** Inside one statement, the page's ids only exist as a CTE — and a CTE reference can't go in `PREWHERE` (it re-evaluates the whole chain; this hung a ClickHouse locally). Stuck in `WHERE`, the filter ran *after* the payload columns were read: on the incident project, ~2.2GB decompressed to display 50 rows whose payloads total 27MB.

Before (one statement):
```sql
page_calls AS (
  SELECT id, ..., inputs_dump, output_dump, ...
  FROM calls_merged
  PREWHERE project_id = {proj}
  WHERE id IN (SELECT call_id FROM page_rows))   -- filter runs AFTER payload reads
...
SELECT ... FROM page_rows LEFT JOIN page_calls ...
```

After (two statements):
```sql
-- statement 1: pick the page, light columns only
WITH <cte chain> SELECT call_id, row_digest, row_order, total_rows FROM page_rows ORDER BY row_order

-- statement 2: fetch payloads for exactly those ids
SELECT id, ..., inputs_dump, output_dump, ...
FROM calls_merged
PREWHERE project_id = {proj} AND id IN {ids:Array(String)}  -- literal param: filter BEFORE reads
GROUP BY id
```

**2. Dataset-row resolution becomes opt-in, also literal-key.** The chain always joined `table_rows` to build a `resolved_inputs` field — up to 1.8GB of `val_dump` reads on fat-dataset projects — and the default request (`resolve_row_refs=false`, what the UI sends) throws that field away.

Before (inside the chain, always ran):
```sql
page_resolved_inputs AS (
  SELECT digest, any(val_dump) FROM table_rows
  PREWHERE project_id = {proj}
  WHERE digest IN (SELECT row_digest FROM page_digests))  -- val_dump read granule-wide
```

After (separate statement, only when `resolve_row_refs=true`):
```sql
SELECT digest, any(val_dump) FROM table_rows
PREWHERE project_id = {proj} AND digest IN {digests:Array(String)}
GROUP BY digest
```

server-side, `_eval_results_via_cte` now runs: page query → hydration per id batch (`MAX_FILTER_LENGTH`) → optional resolution → rows reassembled in page order.

### Why the query gets faster — the query planner, before vs after

`EXPLAIN PIPELINE` tells it at a glance — one fused mega-plan becomes two (optionally three) trivial ones:

```mermaid
flowchart TD
    subgraph B["BEFORE — one statement: 101 pipeline stages, 8 table scans, 3 joins"]
        direction TB
        B1["selection CTEs<br/><i>which 50 rows to show</i>"]
        B2["page_calls scan<br/><i>id IN (SELECT … FROM page_rows)<br/>filter AFTER payload reads → ~2.2GB decompressed</i>"]
        B3["table_rows scan<br/><i>digest IN (SELECT …)<br/>up to 1.8GB val_dump — for a field the UI discards</i>"]
        B4["3-way JOIN → result"]
        B1 --> B4
        B2 --> B4
        B3 --> B4
    end
    subgraph A["AFTER — separate statements"]
        direction TB
        A1["statement 1 — page selection<br/><i>same CTE machinery, light columns only<br/>returns 50 call ids + digests + order</i>"]
        A2["statement 2 — hydration (14 plan lines)<br/><i>PREWHERE id IN literal 50-id set<br/>Granules 135 / 18,483,593 — only the page's rows decompress</i>"]
        A3["statement 3 — dataset rows (optional)<br/><i>PREWHERE digest IN literal set<br/>runs only when resolve_row_refs=true</i>"]
        A1 -->|"literal ids"| A2
        A1 -.->|"literal digests"| A3
    end
    classDef heavy fill:#b91c1c,stroke:#7f1d1d,color:#ffffff
    classDef waste fill:#d97706,stroke:#92400e,color:#ffffff
    classDef light fill:#15803d,stroke:#14532d,color:#ffffff
    classDef optional fill:#374151,stroke:#1f2937,color:#ffffff
    class B2 heavy
    class B3 waste
    class B1,B4 optional
    class A1,A2 light
    class A3 optional
```

with the ids as a literal `PREWHERE` param, ClickHouse row-filters on the primary key before touching payload columns — inside those 135 granules only the page's ~50 rows get decompressed (red scan → green statement). the resolution statement has the same trivial shape and only runs on request.

### Benchmarks / Testing

same 9 cases / 7 real production projects as #7761 (read-only direct execution against prod ClickHouse, `log_comment` attribution; baseline = pre-stack master; wall = page + hydration statements; ordered by row count). identical result rows verified per case.

| case | wall p50 ms | mem MB | read MB | rows |
| --- | --- | --- | --- | --- |
| project A — single 27K-predict eval | 942 → 542 (**-42%**) | 1384 → 337 (**-76%**) | 22796 → 1471 (**-94%**) | 27359 |
| project A — 2-eval compare (2×25.6K) | 1001 → 620 (**-38%**) | 1476 → 495 (**-66%**) | 27145 → 2650 (**-90%**) | 25604 |
| project B — 2-eval compare (6 wk apart) | 1680 → 487 (**-71%**) | 2086 → 263 (**-87%**) | 13308 → 950 (**-93%**) | 2404 |
| project C — 2-eval compare (1 month apart) | 4892 → 1891 (**-61%**) | 3801 → 2062 (**-46%**) | 95602 → 14503 (**-85%**) | 1400 |
| project D — single eval (the WB-38786 repro) | 2499 → 351 (**-86%**) | 3771 → 125 (**-97%**) | 2617 → 288 (**-89%**) | 981 |
| project D — 2-eval compare | 2940 → 393 (**-87%**) | 3770 → 148 (**-96%**) | 3031 → 454 (**-85%**) | 981 |
| project E — 2-eval compare (2yr-old evals) | 8412 → 2977 (**-65%**) | 3340 → 938 (**-72%**) | 233344 → 14184 (**-94%**) | 716 |
| project F — 2-eval compare (small, high-traffic project) | 537 → 345 (**-36%**) | 294 → 127 (**-57%**) | 496 → 50 (**-90%**) | 100 |
| project G — tiny eval (3 rows, months old) | 921 → 351 (**-62%**) | 550 → 134 (**-76%**) | 1544 → 29 (**-98%**) | 3 |

with the full stack, **every case improves on every metric** — including the small/fresh cases that were flat or slightly worse under #7761 alone (the incident project goes 2.5s → 0.35s here vs +3% there). all page ids hydrate 1:1; row-content parity covered by the ClickHouse-backed suites (71 tests).

### Tail latency: warm p95 + cold-cache runs (the 30s+ cases)

same protocol as #7761 (warm N=8, cold = `enable_filesystem_cache=0`, N=2-3), baseline vs full stack:

| case | warm p50 ms | warm p95 ms | cold p50 ms | cold max ms | rows |
| --- | --- | --- | --- | --- | --- |
| project A — single 27K-predict eval | 1264 → 523 (**-59%**) | 1592 → 752 (**-53%**) | 4663 → 2126 (**-54%**) | 5287 → 2347 (**-56%**) | 27359 |
| project A — 2-eval compare (2×25.6K) | 1509 → 529 (**-65%**) | 1585 → 620 (**-61%**) | 5290 → 2911 (**-45%**) | 5534 → 2947 (**-47%**) | 25604 |
| project B — 2-eval compare (6 wk apart) | 1819 → 373 (**-80%**) | 2188 → 489 (**-78%**) | 6577 → 2425 (**-63%**) | 9364 → 2745 (**-71%**) | 2404 |
| project C — 2-eval compare (1 month apart) | 4789 → 1327 (**-72%**) | 6838 → 2192 (**-68%**) | 30152 → 11418 (**-62%**) | 33952 → 18301 (**-46%**) | 1400 |
| project D — single eval (the WB-38786 repro) | 3235 → 280 (**-91%**) | 3544 → 307 (**-91%**) | 6210 → 1753 (**-72%**) | 10677 → 3188 (**-70%**) | 981 |
| project D — 2-eval compare | 4225 → 279 (**-93%**) | 4404 → 334 (**-92%**) | 7521 → 1530 (**-80%**) | 8828 → 1845 (**-79%**) | 981 |
| project E — 2-eval compare (2yr-old evals) | 9155 → 1996 (**-78%**) | 9797 → 2547 (**-74%**) | 71663 → 9196 (**-87%**) | 73984 → 10878 (**-85%**) | 716 |
| project F — 2-eval compare (small project) | 615 → 222 (**-64%**) | 831 → 259 (**-69%**) | 1857 → 1878 (+1%) | 2977 → 2201 (-26%) | 100 |
| project G — tiny eval (3 rows, months old) | 921 → 351 (**-62%**) | 1617 → 394 (**-76%**) | 3503 → 3521 (+1%) | 5532 → 5038 (-9%) | 3 |

the worst real-world case (project E cold, 71.7s — matching the 71s p95 in production traffic) drops to 9.2s. note, cold columns are only 2-3 samples each since cold reads are expensive to repeat in prod.

test coverage: `test_eval_results_query_builder.py` rewritten for the split (20 tests), plus the ClickHouse-backed eval suites (51 tests) — all green.

