### PR TITLE
feat(weave): add category clustering scope

### DIFF
--- a/tests/trace_server/test_insights_config.py
+++ b/tests/trace_server/test_insights_config.py
@@ -37,6 +37,7 @@ def test_clustering_config_is_typed_and_content_addressed(config_dir):
         "cluster_selection_method": "eom",
         "allow_single_cluster": False,
         "umap": {"n_neighbors": 15, "min_dist": 0.0, "random_state": 0},
+        "scope": "global",
     }
 
     before = config.config_sha(clustering)

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -1003,6 +1003,7 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
                 ("id", "UUID"),
                 ("run_window_end", "DateTime64(6, 'UTC')"),
                 ("topic_id", "UUID"),
+                ("category", "LowCardinality(String)"),
                 ("centroid", "Array(Float32)"),
                 ("label", "String"),
                 ("description", "String"),

--- a/weave/trace_server/insights/config.py
+++ b/weave/trace_server/insights/config.py
@@ -137,6 +137,9 @@ class ClusteringConfig(_Strict):
     cluster_selection_method: Literal["eom"]
     allow_single_cluster: bool
     umap: UmapProjection
+    # "category" fits one HDBSCAN model per signature category; "global" fits one
+    # model over the whole window. Either way UMAP still fits once, globally.
+    scope: Literal["global", "category"]
 
 
 _E = TypeVar("_E", bound=Extraction)

--- a/weave/trace_server/insights/configs/clustering.yaml
+++ b/weave/trace_server/insights/configs/clustering.yaml
@@ -6,6 +6,7 @@ min_samples: 3
 metric: euclidean
 cluster_selection_method: eom
 allow_single_cluster: false
+scope: global
 
 # Projection persisted per assignment, so a finished run's scatter plot redraws
 # without reprojecting. Fixed at two components by umap_x and umap_y.

--- a/weave/trace_server/migrations/044_add_signature_clusters_category.down.sql
+++ b/weave/trace_server/migrations/044_add_signature_clusters_category.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE signature_clusters
+    DROP COLUMN IF EXISTS category;

--- a/weave/trace_server/migrations/044_add_signature_clusters_category.up.sql
+++ b/weave/trace_server/migrations/044_add_signature_clusters_category.up.sql
@@ -1,0 +1,3 @@
+-- Populated only under `scope: category`; global runs leave every row ''.
+ALTER TABLE signature_clusters
+    ADD COLUMN IF NOT EXISTS category LowCardinality(String) DEFAULT '' AFTER topic_id;


### PR DESCRIPTION
## Summary
- Adds migration 044: `signature_clusters.category` (`LowCardinality(String)`, default `''`), so a clustering run can record which category a cluster came from.
- Adds `scope: Literal["global", "category"]` to `ClusteringConfig`, defaulted to `global` in `clustering.yaml`. It's a plain field, so it lands inside `cluster_config_sha` automatically.
- The wandb/core clustering job (companion PR, not yet merged) reads `scope` to decide whether to fit one HDBSCAN model over a window or one per category.

## Testing
`uv run pytest tests/trace_server/test_insights_config.py` and `nox -e lint`; the functional migrator test needs a real ClickHouse and wasn't run here.
