### PR TITLE
perf(weave): bound eval_results calls_merged scan to the eval run window

### DIFF
--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -667,6 +667,19 @@ def test_full_query_calls_merged() -> None:
                         WHERE roots.id IN {pb_5:Array(String)}
                     ),
                     toDateTime64(0, 3))
+                AND calls_merged.sortable_datetime <= coalesce(
+                    (SELECT CASE
+                        WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
+                        ELSE max(root_ended_at) + toIntervalSecond(300)
+                    END
+                    FROM (
+                        SELECT max(roots.ended_at) AS root_ended_at
+                        FROM calls_merged AS roots
+                        PREWHERE roots.project_id = {pb_4:String}
+                        WHERE roots.id IN {pb_5:Array(String)}
+                        GROUP BY roots.id
+                    )),
+                    toDateTime64('2100-01-01 00:00:00', 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
             )
         SELECT

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -45,18 +45,41 @@ def test_cte_chain_calls_merged() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
-                    OR calls_merged.parent_id IS NULL)
-                    AND calls_merged.id NOT IN {pb_1:Array(String)}
-                    AND (multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
-                        OR calls_merged.op_name IS NULL)
-                    AND calls_merged.sortable_datetime >= coalesce(
-                        (SELECT min(roots.started_at) - toIntervalSecond(300)
-                            FROM calls_merged AS roots
-                            PREWHERE roots.project_id = {pb_0:String}
-                            WHERE roots.id IN {pb_1:Array(String)}
-                        ),
-                        toDateTime64(0, 3))
+                WHERE calls_merged.id IN (
+                    SELECT calls_merged.id
+                    FROM calls_merged
+                    PREWHERE calls_merged.project_id = {pb_0:String}
+                    WHERE calls_merged.parent_id IN {pb_1:Array(String)}
+                        AND calls_merged.id NOT IN {pb_1:Array(String)}
+                        AND multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
+                        AND calls_merged.sortable_datetime >= coalesce(
+                            (SELECT min(roots.started_at) - toIntervalSecond(300)
+                                FROM calls_merged AS roots
+                                PREWHERE roots.project_id = {pb_0:String}
+                                WHERE roots.id IN {pb_1:Array(String)}
+                            ),
+                            toDateTime64(0, 3))
+                        AND calls_merged.sortable_datetime <= coalesce(
+                            (SELECT CASE
+                                WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
+                                ELSE max(root_ended_at) + toIntervalSecond(300)
+                            END
+                            FROM (
+                                SELECT max(roots.ended_at) AS root_ended_at
+                                FROM calls_merged AS roots
+                                PREWHERE roots.project_id = {pb_0:String}
+                                WHERE roots.id IN {pb_1:Array(String)}
+                                GROUP BY roots.id
+                            )),
+                            toDateTime64('2100-01-01 00:00:00', 3))
+                )
+                AND calls_merged.sortable_datetime >= coalesce(
+                    (SELECT min(roots.started_at) - toIntervalSecond(300)
+                        FROM calls_merged AS roots
+                        PREWHERE roots.project_id = {pb_0:String}
+                        WHERE roots.id IN {pb_1:Array(String)}
+                    ),
+                    toDateTime64(0, 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
                     AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
@@ -410,18 +433,41 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
-                    OR calls_merged.parent_id IS NULL)
-                    AND calls_merged.id NOT IN {pb_1:Array(String)}
-                    AND (multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
-                        OR calls_merged.op_name IS NULL)
-                    AND calls_merged.sortable_datetime >= coalesce(
-                        (SELECT min(roots.started_at) - toIntervalSecond(300)
-                            FROM calls_merged AS roots
-                            PREWHERE roots.project_id = {pb_0:String}
-                            WHERE roots.id IN {pb_1:Array(String)}
-                        ),
-                        toDateTime64(0, 3))
+                WHERE calls_merged.id IN (
+                    SELECT calls_merged.id
+                    FROM calls_merged
+                    PREWHERE calls_merged.project_id = {pb_0:String}
+                    WHERE calls_merged.parent_id IN {pb_1:Array(String)}
+                        AND calls_merged.id NOT IN {pb_1:Array(String)}
+                        AND multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
+                        AND calls_merged.sortable_datetime >= coalesce(
+                            (SELECT min(roots.started_at) - toIntervalSecond(300)
+                                FROM calls_merged AS roots
+                                PREWHERE roots.project_id = {pb_0:String}
+                                WHERE roots.id IN {pb_1:Array(String)}
+                            ),
+                            toDateTime64(0, 3))
+                        AND calls_merged.sortable_datetime <= coalesce(
+                            (SELECT CASE
+                                WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
+                                ELSE max(root_ended_at) + toIntervalSecond(300)
+                            END
+                            FROM (
+                                SELECT max(roots.ended_at) AS root_ended_at
+                                FROM calls_merged AS roots
+                                PREWHERE roots.project_id = {pb_0:String}
+                                WHERE roots.id IN {pb_1:Array(String)}
+                                GROUP BY roots.id
+                            )),
+                            toDateTime64('2100-01-01 00:00:00', 3))
+                )
+                AND calls_merged.sortable_datetime >= coalesce(
+                    (SELECT min(roots.started_at) - toIntervalSecond(300)
+                        FROM calls_merged AS roots
+                        PREWHERE roots.project_id = {pb_0:String}
+                        WHERE roots.id IN {pb_1:Array(String)}
+                    ),
+                    toDateTime64(0, 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
                     AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
@@ -515,18 +561,41 @@ def test_full_query_calls_merged() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
-                    OR calls_merged.parent_id IS NULL)
-                    AND calls_merged.id NOT IN {pb_1:Array(String)}
-                    AND (multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
-                        OR calls_merged.op_name IS NULL)
-                    AND calls_merged.sortable_datetime >= coalesce(
-                        (SELECT min(roots.started_at) - toIntervalSecond(300)
-                            FROM calls_merged AS roots
-                            PREWHERE roots.project_id = {pb_0:String}
-                            WHERE roots.id IN {pb_1:Array(String)}
-                        ),
-                        toDateTime64(0, 3))
+                WHERE calls_merged.id IN (
+                    SELECT calls_merged.id
+                    FROM calls_merged
+                    PREWHERE calls_merged.project_id = {pb_0:String}
+                    WHERE calls_merged.parent_id IN {pb_1:Array(String)}
+                        AND calls_merged.id NOT IN {pb_1:Array(String)}
+                        AND multiSearchAny(calls_merged.op_name, [{pb_2:String}, {pb_3:String}])
+                        AND calls_merged.sortable_datetime >= coalesce(
+                            (SELECT min(roots.started_at) - toIntervalSecond(300)
+                                FROM calls_merged AS roots
+                                PREWHERE roots.project_id = {pb_0:String}
+                                WHERE roots.id IN {pb_1:Array(String)}
+                            ),
+                            toDateTime64(0, 3))
+                        AND calls_merged.sortable_datetime <= coalesce(
+                            (SELECT CASE
+                                WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
+                                ELSE max(root_ended_at) + toIntervalSecond(300)
+                            END
+                            FROM (
+                                SELECT max(roots.ended_at) AS root_ended_at
+                                FROM calls_merged AS roots
+                                PREWHERE roots.project_id = {pb_0:String}
+                                WHERE roots.id IN {pb_1:Array(String)}
+                                GROUP BY roots.id
+                            )),
+                            toDateTime64('2100-01-01 00:00:00', 3))
+                )
+                AND calls_merged.sortable_datetime >= coalesce(
+                    (SELECT min(roots.started_at) - toIntervalSecond(300)
+                        FROM calls_merged AS roots
+                        PREWHERE roots.project_id = {pb_0:String}
+                        WHERE roots.id IN {pb_1:Array(String)}
+                    ),
+                    toDateTime64(0, 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
                     AND (multiSearchAny(any(calls_merged.op_name), [{pb_2:String}, {pb_3:String}]))
@@ -591,6 +660,13 @@ def test_full_query_calls_merged() -> None:
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_4:String}
                 WHERE calls_merged.id IN (SELECT call_id FROM page_rows)
+                AND calls_merged.sortable_datetime >= coalesce(
+                    (SELECT min(roots.started_at) - toIntervalSecond(300)
+                        FROM calls_merged AS roots
+                        PREWHERE roots.project_id = {pb_4:String}
+                        WHERE roots.id IN {pb_5:Array(String)}
+                    ),
+                    toDateTime64(0, 3))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
             )
         SELECT
@@ -620,6 +696,7 @@ def test_full_query_calls_merged() -> None:
             "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
             "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
             "pb_4": "proj-1",
+            "pb_5": ["eval-1"],
         },
     )
 

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -45,7 +45,7 @@ def test_cte_chain_calls_merged() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE calls_merged.id IN (
+                AND calls_merged.id IN (
                     SELECT calls_merged.id
                     FROM calls_merged
                     PREWHERE calls_merged.project_id = {pb_0:String}
@@ -73,7 +73,7 @@ def test_cte_chain_calls_merged() -> None:
                             )),
                             toDateTime64('2100-01-01 00:00:00', 3))
                 )
-                AND calls_merged.sortable_datetime >= coalesce(
+                WHERE calls_merged.sortable_datetime >= coalesce(
                     (SELECT min(roots.started_at) - toIntervalSecond(300)
                         FROM calls_merged AS roots
                         PREWHERE roots.project_id = {pb_0:String}
@@ -433,7 +433,7 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE calls_merged.id IN (
+                AND calls_merged.id IN (
                     SELECT calls_merged.id
                     FROM calls_merged
                     PREWHERE calls_merged.project_id = {pb_0:String}
@@ -461,7 +461,7 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                             )),
                             toDateTime64('2100-01-01 00:00:00', 3))
                 )
-                AND calls_merged.sortable_datetime >= coalesce(
+                WHERE calls_merged.sortable_datetime >= coalesce(
                     (SELECT min(roots.started_at) - toIntervalSecond(300)
                         FROM calls_merged AS roots
                         PREWHERE roots.project_id = {pb_0:String}
@@ -561,7 +561,7 @@ def test_full_query_calls_merged() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE calls_merged.id IN (
+                AND calls_merged.id IN (
                     SELECT calls_merged.id
                     FROM calls_merged
                     PREWHERE calls_merged.project_id = {pb_0:String}
@@ -589,7 +589,7 @@ def test_full_query_calls_merged() -> None:
                             )),
                             toDateTime64('2100-01-01 00:00:00', 3))
                 )
-                AND calls_merged.sortable_datetime >= coalesce(
+                WHERE calls_merged.sortable_datetime >= coalesce(
                     (SELECT min(roots.started_at) - toIntervalSecond(300)
                         FROM calls_merged AS roots
                         PREWHERE roots.project_id = {pb_0:String}

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -676,9 +676,15 @@ def finalize_rows(
     limit: int | None,
 ) -> tuple[list[tsi.EvalResultsRow], int]:
     """Attach evaluations to rows, apply intersection filter, sort, and paginate."""
+    # Order each row's evaluations by the requested eval ids, not by call scan
+    # order, which varies with the query plan.
+    eval_order = {eval_id: i for i, eval_id in enumerate(eval_root_ids)}
     for row_digest, eval_entries in row_eval_map.items():
         if row_digest in row_map:
-            row_map[row_digest].evaluations = list(eval_entries.values())
+            row_map[row_digest].evaluations = sorted(
+                eval_entries.values(),
+                key=lambda e: eval_order.get(e.evaluation_call_id, len(eval_order)),
+            )
 
     rows = list(row_map.values())
 
@@ -738,9 +744,15 @@ def build_eval_rows(
 
         eval_entry.trials.append(_build_trial(predict_and_score_call, child_by_parent))
 
+    # Order each row's evaluations by the requested eval ids, not by call scan
+    # order, which varies with the query plan.
+    eval_order = {eval_id: i for i, eval_id in enumerate(eval_root_ids)}
     for row_digest, eval_entries in row_eval_map.items():
         if row_digest in row_map:
-            row_map[row_digest].evaluations = list(eval_entries.values())
+            row_map[row_digest].evaluations = sorted(
+                eval_entries.values(),
+                key=lambda e: eval_order.get(e.evaluation_call_id, len(eval_order)),
+            )
 
     return list(row_map.values())
 

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -667,6 +667,24 @@ def build_eval_rows_from_calls(
     return row_map, row_eval_map
 
 
+def _attach_evaluations(
+    row_map: dict[str, tsi.EvalResultsRow],
+    row_eval_map: dict[str, dict[str, tsi.EvalResultsRowEvaluation]],
+    eval_root_ids: list[str],
+) -> None:
+    """Attach each row's evaluations, ordered by the requested eval ids.
+
+    Scan order varies with the query plan, so it is not a stable ordering.
+    """
+    eval_order = {eval_id: i for i, eval_id in enumerate(eval_root_ids)}
+    for row_digest, eval_entries in row_eval_map.items():
+        if row_digest in row_map:
+            row_map[row_digest].evaluations = sorted(
+                eval_entries.values(),
+                key=lambda e: eval_order.get(e.evaluation_call_id, len(eval_order)),
+            )
+
+
 def finalize_rows(
     row_map: dict[str, tsi.EvalResultsRow],
     row_eval_map: dict[str, dict[str, tsi.EvalResultsRowEvaluation]],
@@ -676,15 +694,7 @@ def finalize_rows(
     limit: int | None,
 ) -> tuple[list[tsi.EvalResultsRow], int]:
     """Attach evaluations to rows, apply intersection filter, sort, and paginate."""
-    # Order each row's evaluations by the requested eval ids, not by call scan
-    # order, which varies with the query plan.
-    eval_order = {eval_id: i for i, eval_id in enumerate(eval_root_ids)}
-    for row_digest, eval_entries in row_eval_map.items():
-        if row_digest in row_map:
-            row_map[row_digest].evaluations = sorted(
-                eval_entries.values(),
-                key=lambda e: eval_order.get(e.evaluation_call_id, len(eval_order)),
-            )
+    _attach_evaluations(row_map, row_eval_map, eval_root_ids)
 
     rows = list(row_map.values())
 
@@ -744,15 +754,7 @@ def build_eval_rows(
 
         eval_entry.trials.append(_build_trial(predict_and_score_call, child_by_parent))
 
-    # Order each row's evaluations by the requested eval ids, not by call scan
-    # order, which varies with the query plan.
-    eval_order = {eval_id: i for i, eval_id in enumerate(eval_root_ids)}
-    for row_digest, eval_entries in row_eval_map.items():
-        if row_digest in row_map:
-            row_map[row_digest].evaluations = sorted(
-                eval_entries.values(),
-                key=lambda e: eval_order.get(e.evaluation_call_id, len(eval_order)),
-            )
+    _attach_evaluations(row_map, row_eval_map, eval_root_ids)
 
     return list(row_map.values())
 

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -552,10 +552,21 @@ def _build_page_calls_cte(
     read_table: str,
     eval_root_ids_param: str | None = None,
 ) -> str:
-    """Build page_calls CTE: pre-filter and pre-aggregate source table for page rows only."""
+    """Build page_calls CTE: pre-filter and pre-aggregate source table for page rows only.
+
+    page_calls only hydrates display columns for calls already selected by
+    page_rows, and every such call's start/end rows lie inside the eval run
+    window -- so both time bounds apply. The bounds prune granules via the
+    sortable_datetime minmax index from WHERE (the id filter must stay out of
+    PREWHERE: referencing a chained CTE there re-evaluates it pathologically),
+    which keeps the dump-column reads to the window instead of the project.
+    """
     if read_table == "calls_merged":
         assert eval_root_ids_param is not None
         eval_start_lower_bound = _build_eval_start_lower_bound(
+            project_id_param, eval_root_ids_param
+        )
+        eval_end_upper_bound = _build_eval_end_upper_bound(
             project_id_param, eval_root_ids_param
         )
         return f"""page_calls AS (
@@ -574,6 +585,7 @@ def _build_page_calls_cte(
     PREWHERE calls_merged.project_id = {project_id_param}
     WHERE calls_merged.id IN (SELECT call_id FROM page_rows)
     AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
+    AND calls_merged.sortable_datetime <= {eval_end_upper_bound}
     GROUP BY (calls_merged.project_id, calls_merged.id)
 )"""
     else:

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -152,11 +152,12 @@ def build_predict_and_score_calls_cte(
             project_id_param, eval_root_ids_param
         )
         # The inner id subquery matches on call-start rows only (they carry
-        # parent_id/op_name), reading light columns; the outer aggregation then
-        # touches inputs_dump/output_dump for just those ids instead of every
-        # call in the window. The outer keeps only the lower bound: delete rows
-        # are written at deletion time (after the eval window) and must still
-        # merge in so HAVING can exclude deleted calls.
+        # parent_id/op_name), reading light columns. It lives in PREWHERE (an
+        # explicit PREWHERE disables automatic condition movement) so the outer
+        # aggregation reads inputs_dump/output_dump for just those ids instead
+        # of every call in the window. The outer keeps only the lower time
+        # bound: delete rows are written at deletion time (after the eval
+        # window) and must still merge in so HAVING can exclude deleted calls.
         return f"""predict_and_score_calls AS (
     SELECT
         calls_merged.id AS call_id,
@@ -166,7 +167,7 @@ def build_predict_and_score_calls_cte(
         {row_digest_expr} AS row_digest
     FROM calls_merged
     PREWHERE calls_merged.project_id = {project_id_param}
-    WHERE calls_merged.id IN (
+    AND calls_merged.id IN (
         SELECT calls_merged.id
         FROM calls_merged
         PREWHERE calls_merged.project_id = {project_id_param}
@@ -176,7 +177,7 @@ def build_predict_and_score_calls_cte(
         AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
         AND calls_merged.sortable_datetime <= {eval_end_upper_bound}
     )
-    AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
+    WHERE calls_merged.sortable_datetime >= {eval_start_lower_bound}
     GROUP BY (calls_merged.project_id, calls_merged.id)
     HAVING any(calls_merged.parent_id) IN {eval_root_ids_param}
         AND ({op_match_having})

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -68,6 +68,32 @@ def _build_eval_start_lower_bound(
     )"""
 
 
+def _build_eval_end_upper_bound(project_id_param: str, eval_root_ids_param: str) -> str:
+    """sortable_datetime ceiling for the calls_merged scan, as a scalar subquery.
+
+    Predict-and-score calls finish before their eval root does, so bounding by
+    the roots' latest ended_at (plus a buffer) keeps the scan inside the eval
+    run window instead of eval start -> now. Falls back to a far-future
+    datetime (no ceiling) when any root is still running or has no rows.
+    """
+    return f"""coalesce(
+        (
+            SELECT CASE
+                WHEN countIf(root_ended_at IS NULL) > 0 THEN NULL
+                ELSE max(root_ended_at) + toIntervalSecond({DATETIME_BUFFER_TIME_SECONDS})
+            END
+            FROM (
+                SELECT max(roots.ended_at) AS root_ended_at
+                FROM calls_merged AS roots
+                PREWHERE roots.project_id = {project_id_param}
+                WHERE roots.id IN {eval_root_ids_param}
+                GROUP BY roots.id
+            )
+        ),
+        toDateTime64('2100-01-01 00:00:00', 3)
+    )"""
+
+
 def _sort_filter_uses_inputs(
     sort_by: list[tsi.EvalResultsSortBy] | None,
     filters: list[tsi.EvalResultsFilter] | None,
@@ -122,6 +148,15 @@ def build_predict_and_score_calls_cte(
         eval_start_lower_bound = _build_eval_start_lower_bound(
             project_id_param, eval_root_ids_param
         )
+        eval_end_upper_bound = _build_eval_end_upper_bound(
+            project_id_param, eval_root_ids_param
+        )
+        # The inner id subquery matches on call-start rows only (they carry
+        # parent_id/op_name), reading light columns; the outer aggregation then
+        # touches inputs_dump/output_dump for just those ids instead of every
+        # call in the window. The outer keeps only the lower bound: delete rows
+        # are written at deletion time (after the eval window) and must still
+        # merge in so HAVING can exclude deleted calls.
         return f"""predict_and_score_calls AS (
     SELECT
         calls_merged.id AS call_id,
@@ -131,14 +166,15 @@ def build_predict_and_score_calls_cte(
         {row_digest_expr} AS row_digest
     FROM calls_merged
     PREWHERE calls_merged.project_id = {project_id_param}
-    WHERE (
-        calls_merged.parent_id IN {eval_root_ids_param}
-        OR calls_merged.parent_id IS NULL
-    )
-    AND calls_merged.id NOT IN {eval_root_ids_param}
-    AND (
-        {op_match_where}
-        OR calls_merged.op_name IS NULL
+    WHERE calls_merged.id IN (
+        SELECT calls_merged.id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {project_id_param}
+        WHERE calls_merged.parent_id IN {eval_root_ids_param}
+        AND calls_merged.id NOT IN {eval_root_ids_param}
+        AND {op_match_where}
+        AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
+        AND calls_merged.sortable_datetime <= {eval_end_upper_bound}
     )
     AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
     GROUP BY (calls_merged.project_id, calls_merged.id)
@@ -510,9 +546,17 @@ def build_page_rows_cte() -> str:
 )"""
 
 
-def _build_page_calls_cte(project_id_param: str, read_table: str) -> str:
+def _build_page_calls_cte(
+    project_id_param: str,
+    read_table: str,
+    eval_root_ids_param: str | None = None,
+) -> str:
     """Build page_calls CTE: pre-filter and pre-aggregate source table for page rows only."""
     if read_table == "calls_merged":
+        assert eval_root_ids_param is not None
+        eval_start_lower_bound = _build_eval_start_lower_bound(
+            project_id_param, eval_root_ids_param
+        )
         return f"""page_calls AS (
     SELECT
         calls_merged.id AS call_id,
@@ -528,6 +572,7 @@ def _build_page_calls_cte(project_id_param: str, read_table: str) -> str:
     FROM calls_merged
     PREWHERE calls_merged.project_id = {project_id_param}
     WHERE calls_merged.id IN (SELECT call_id FROM page_rows)
+    AND calls_merged.sortable_datetime >= {eval_start_lower_bound}
     GROUP BY (calls_merged.project_id, calls_merged.id)
 )"""
     else:
@@ -580,7 +625,12 @@ def build_eval_results_query(
         filter_logic_operator,
     )
     project_id_param = param_slot(pb.add_param(project_id), "String")
-    page_calls_cte = _build_page_calls_cte(project_id_param, read_table)
+    page_eval_root_ids_param = None
+    if read_table == "calls_merged":
+        page_eval_root_ids_param = pb.add(eval_root_ids, None, "Array(String)")
+    page_calls_cte = _build_page_calls_cte(
+        project_id_param, read_table, page_eval_root_ids_param
+    )
 
     return f"""WITH {cte_chain.strip()},
 


### PR DESCRIPTION
## Description

- Internal ref: WB-38786

Restricts the `eval_results/query` ClickHouse scan to the evaluation's actual run window instead of aggregating every call written to the project since the eval started, and makes each row's `evaluations` ordering deterministic.

Production repro: loading the results tab for a single 981-row eval in a high-traffic customer project took ~46s per request, ~44s of it in one `clickhouse_trace_server_batched._query` ([internal trace](https://us5.datadoghq.com/apm/trace/da8200125ad4538b17c54023919572f6)). The `predict_and_score_calls` CTE's `(parent_id IN roots OR parent_id IS NULL)` / `(op-name match OR op_name IS NULL)` clauses admit every call-**end** row in the project into the `GROUP BY`, and the scan has only a lower time bound (eval start). For a 4-day-old eval in a busy project, that meant reading `inputs_dump`/`output_dump` for 4 days of the entire project's calls and discarding almost all of them in `HAVING`.

Changes to the `calls_merged` branch of the query builder (the same two-pass filter-then-hydrate idiom the calls query builder already uses — see `calls_query_builder.py`'s `filtered_calls` CTE and its id-subquery + time-bound pushdown):

- **ID prefilter subquery in PREWHERE**: matching call ids are first collected from call-start rows only (`parent_id IN roots AND op-name match`, light columns). The subquery sits in the outer query's `PREWHERE` — an explicit `PREWHERE` disables ClickHouse's automatic condition movement, so leaving it in `WHERE` still reads the heavy dump columns for every window row. The `HAVING` clause is unchanged, so merged-row semantics (deleted / never-started calls) are preserved.
- **Upper time bound**: the prefilter scan is additionally capped at `max(roots.ended_at) + 5min buffer`, falling back to no ceiling when any root is still running (or has no rows). Predict-and-score calls always finish before their eval root does.
- **page_calls hydration bound**: the `page_calls` CTE now also applies the eval-start lower bound. Its `id IN (SELECT ... FROM page_rows)` deliberately stays in `WHERE`: referencing a chained CTE from `PREWHERE` caused pathological CTE re-evaluation locally (runaway query).
- **Deterministic per-row `evaluations` order**: benchmarking surfaced that each row's `evaluations` array followed SQL scan order, which changes with the query plan (25/50 rows flipped between variants on a two-eval comparison). Both assembly paths now order by the requested eval ids.

The outer aggregation keeps only the lower bound: call-delete rows are written at deletion time (potentially long after the eval window) and must still merge in so `HAVING any(deleted_at) IS NULL` continues to exclude deleted calls.

The `calls_complete` branch is untouched (complete rows already filter on `parent_id` directly).

## Testing

- Unit + ClickHouse-backed suites: `test_eval_results_query_builder.py` (17), `test_trace_server_evaluation_apis.py` + `test_eval_results_genai_span_ref.py` + `test_rescore_evaluation.py` (51) — all passing.

### Production data A/B (read-only, direct ClickHouse execution of both query shapes)

8 request shapes over 6 real production projects taken from actual `eval_results/query` traffic (all `calls_merged`-resident), including the original incident repro and real **compare-page** requests with two eval roots. Both SQL variants executed serially against production ClickHouse with `log_comment` attribution, 1 warmup + 3-5 timed runs each; identical result rows verified per case (sorted call-id hash). Negative % = improvement; ordered by row count.

| case | wall p50 ms | CPU ms | mem MB | read MB | rows |
| --- | --- | --- | --- | --- | --- |
| project A — single 27K-predict eval | 942→694 (-26%) | 13332→4563 (**-66%**) | 1384→484 (**-65%**) | 22796→3388 (**-85%**) | 27359 |
| project A — 2-eval compare (2×25.6K) | 1001→885 (-12%) | 16229→5961 (**-63%**) | 1476→606 (**-59%**) | 27145→5899 (**-78%**) | 25604 |
| project B — 2-eval compare (6 wk apart) | 1680→1618 (-4%) | 7351→4303 (**-41%**) | 2086→2108 (+1%) | 13308→3542 (**-73%**) | 2404 |
| project C — 2-eval compare (1 month apart) | 4892→2806 (**-43%**) | 109433→38425 (**-65%**) | 3801→2205 (**-42%**) | 95602→33778 (**-65%**) | 1400 |
| project D — single eval (the WB-38786 repro) | 2499→2575 (+3%) | 3906→4431 (+13%) | 3771→3790 (+1%) | 2617→2173 (-17%) | 981 |
| project D — 2-eval compare | 2940→3129 (+6%) | 5441→5609 (+3%) | 3770→3792 (+1%) | 3031→2475 (-18%) | 981 |
| project E — 2-eval compare (evals from 2024, 2yr of later traffic) | 8412→3712 (**-56%**) | 288295→34628 (**-88%**) | 3340→1006 (**-70%**) | 233344→32760 (**-86%**) | 716 |
| project F — 2-eval compare (small, high-traffic project) | 537→456 (-15%) | 847→988 (+17%) | 294→327 (+11%) | 496→146 (**-71%**) | 100 |

Reading (negative % = improvement): the baseline scan window is *eval start → now*, so its cost grows without bound as the project keeps writing after the eval; this change pins it to the eval's own run window. That's why the win scales with eval **age**, not eval size — the 2-year-old comparison drops **88% CPU and 86% bytes read**, while week-old evals are near-flat today (+3-13% CPU, -17% reads; the original 44s trace hit when that window was wider and cold). Left on baseline, every aging eval drifts toward the project-E row. The smallest project pays +17% CPU (~140ms) for 71% fewer reads. All rows identical across variants. The remaining flat cases are addressed by the stacked follow-up PR (#7768).

### Tail latency: warm p95 + cold-cache runs (the 30s+ cases)

Real traffic shows 40-70s p95s on these endpoints; those tails are cold object-storage reads. Same 8 cases re-run with warm N=8 (p50/p95) and cold runs (`enable_filesystem_cache=0`, N=2-3), baseline = pre-stack master vs the full stack:

| case | warm p50 ms | warm p95 ms | cold p50 ms | cold max ms | rows |
| --- | --- | --- | --- | --- | --- |
| project A — single 27K-predict eval | 1264 → 523 (**-59%**) | 1592 → 752 (**-53%**) | 4663 → 2126 (**-54%**) | 5287 → 2347 (**-56%**) | 27359 |
| project A — 2-eval compare (2×25.6K) | 1509 → 529 (**-65%**) | 1585 → 620 (**-61%**) | 5290 → 2911 (**-45%**) | 5534 → 2947 (**-47%**) | 25604 |
| project B — 2-eval compare (6 wk apart) | 1819 → 373 (**-80%**) | 2188 → 489 (**-78%**) | 6577 → 2425 (**-63%**) | 9364 → 2745 (**-71%**) | 2404 |
| project C — 2-eval compare (1 month apart) | 4789 → 1327 (**-72%**) | 6838 → 2192 (**-68%**) | 30152 → 11418 (**-62%**) | 33952 → 18301 (**-46%**) | 1400 |
| project D — single eval (the WB-38786 repro) | 3235 → 280 (**-91%**) | 3544 → 307 (**-91%**) | 6210 → 1753 (**-72%**) | 10677 → 3188 (**-70%**) | 981 |
| project D — 2-eval compare | 4225 → 279 (**-93%**) | 4404 → 334 (**-92%**) | 7521 → 1530 (**-80%**) | 8828 → 1845 (**-79%**) | 981 |
| project E — 2-eval compare (2yr-old evals) | 9155 → 1996 (**-78%**) | 9797 → 2547 (**-74%**) | 71663 → 9196 (**-87%**) | 73984 → 10878 (**-85%**) | 716 |
| project F — 2-eval compare (small project) | 615 → 222 (**-64%**) | 831 → 259 (**-69%**) | 1857 → 1878 (+1%) | 2977 → 2201 (-26%) | 100 |

The worst real-world case (project E cold, 71.7s — matching the 71s p95 observed in production traffic) drops to 9.2s. Cold-run percentiles are from 2-3 samples (cold reads are expensive to repeat on prod); warm p95 is from 8. Note: the cold columns reflect the full stack; #7767 alone accounts for the scan-window share of the win (its own table above), the hydration split for the rest.
