### PR TITLE
fix(weave): EvaluationLogger.log_summary no longer duplicates custom summary when auto_summarize=False

### DIFF
--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -1,4 +1,4 @@
-import asyncio
+﻿import asyncio
 import inspect
 import json
 from collections import defaultdict
@@ -542,7 +542,7 @@ def test_evaluation_no_auto_summarize(client):
     calls = client.get_calls()
     # assert len(calls) == 1
     summarize_call = calls[4]
-    assert summarize_call.output == {"output": {}}
+    assert summarize_call.output == {}
 
 
 def test_evaluation_fail_with_exception(client):
@@ -571,11 +571,24 @@ def test_evaluation_no_auto_summarize_with_custom_dict(client):
     calls = client.get_calls()
     # assert len(calls) == 1
     summarize_call = calls[4]
-    assert summarize_call.output == {
-        "something": 1,
-        "else": 2,
-        "output": {"something": 1, "else": 2},
-    }
+    assert summarize_call.output == {"something": 1, "else": 2}
+
+
+def test_evaluation_log_summary_auto_summarize_false_no_duplicate_output(client):
+    ev = weave.EvaluationLogger()
+    pred = ev.log_prediction(inputs={"a": 1}, output=2)
+    pred.log_score(scorer="s", score=0.9)
+    ev.log_summary(summary={"metric": 0.9}, auto_summarize=False)
+    ev.finish()
+    client.flush()
+
+    calls = client.get_calls()
+    summarize_call = calls[4]
+    output = summarize_call.output
+    assert "output" not in output, (
+        "log_summary with auto_summarize=False must not nest the summary under 'output'"
+    )
+    assert output == {"metric": 0.9}
 
 
 def test_evaluation_logger_model_inference_method_handling(weave_active):

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import asyncio
 import atexit
@@ -1141,7 +1141,7 @@ class EvaluationLogger:
         final_summary = {}
         if summary_data:
             final_summary = summary_data
-        if summary is not None:
+        if auto_summarize and summary:
             final_summary = {**final_summary, "output": summary}
 
         # Call the summarize op


### PR DESCRIPTION
## Summary

Fixes #7741.

`EvaluationLogger.log_summary(summary=..., auto_summarize=False)` was duplicating the caller's dict in the logged output. When `auto_summarize=False`, `summary_data` is set to `summary` (the same object), so `final_summary` starts as the user's dict. The unconditional:

```python
if summary is not None:
    final_summary = {**final_summary, "output": summary}
```

then re-adds that same dict nested under `"output"` — every custom key appears twice: once at the top level and once under `"output"`.

## Root cause

The `"output"` nesting is intentional only when `auto_summarize=True`: the auto-summarized scorer dict becomes `final_summary`, and the user-supplied custom dict is separately nested under `"output"` alongside it. When `auto_summarize=False`, the user dict IS `final_summary` — nesting it again is the bug.

## Fix

```python
# Before (buggy):
if summary is not None:
    final_summary = {**final_summary, "output": summary}

# After:
if auto_summarize and summary:
    final_summary = {**final_summary, "output": summary}
```

## Tests

- Updated `test_evaluation_no_auto_summarize` to expect `{}` instead of `{"output": {}}`.
- Updated `test_evaluation_no_auto_summarize_with_custom_dict` to expect `{"something": 1, "else": 2}` instead of `{"something": 1, "else": 2, "output": {"something": 1, "else": 2}}`.
- Added `test_evaluation_log_summary_auto_summarize_false_no_duplicate_output` which explicitly asserts that the `"output"` key is absent when `auto_summarize=False`.