### PR TITLE
chore(weave): carry the entity name on agent span events

### DIFF
--- a/tests/trace_server/test_agent_scorer_events.py
+++ b/tests/trace_server/test_agent_scorer_events.py
@@ -28,27 +28,32 @@ def test_from_row() -> None:
         conversation_id="c",
         operation_name="invoke_agent",
     )
-    event = ScoreAgentSpansEvent.from_row(root_row)
+    event = ScoreAgentSpansEvent.from_row(root_row, "acme")
     assert event == ScoreAgentSpansEvent(
         event_type="weave.genai.turn_ended",
         status_code="OK",
         project_id="p",
+        entity_name="acme",
         trace_id="tr",
         span_id="root",
         parent_span_id=None,
         conversation_id="c",
         operation_name="invoke_agent",
     )
-    assert EmbedAgentSpansEvent.from_row(root_row) == EmbedAgentSpansEvent(
+    assert EmbedAgentSpansEvent.from_row(root_row, "acme") == EmbedAgentSpansEvent(
         event_type="weave.genai.turn_ended",
         status_code="OK",
         project_id="p",
+        entity_name="acme",
         trace_id="tr",
         span_id="root",
         parent_span_id=None,
         conversation_id="c",
         operation_name="invoke_agent",
     )
+    # The row itself carries no entity, so an unstamped event has none: consumers
+    # that route by entity have to treat that as unroutable, not as allowed.
+    assert EmbedAgentSpansEvent.from_row(root_row).entity_name is None
 
     child_row = AgentSpanCHInsertable(
         project_id="p",

--- a/tests/trace_server/test_trace_server_interface_util.py
+++ b/tests/trace_server/test_trace_server_interface_util.py
@@ -473,6 +473,34 @@ def test_genai_otel_export_rewrites_flat_ref_attrs() -> None:
     ]
 
 
+def test_genai_otel_export_stamps_the_entity_before_converting_the_project() -> None:
+    """The entity survives as a field even though `project_id` becomes opaque.
+
+    Emitters downstream of the adapter see only the internal id, so without this
+    they would need an id lookup to learn which entity a span belongs to.
+    """
+    internal_proj = _EncodingIdConverter().ext_to_int_project_id("ent/proj")
+    req = _make_otel_export_req_with_ref_attrs({}, project_id="ent/proj")
+    assert req.entity_name is None
+
+    forwarded = _capture_genai_otel_export_req(req)
+
+    assert forwarded.entity_name == "ent"
+    assert forwarded.project_id == internal_proj
+
+
+def test_genai_otel_export_overwrites_a_caller_supplied_entity() -> None:
+    """The authorized project decides the entity, never the incoming field.
+
+    Consumers route on this, so a value that survived from the caller would let
+    one entity's spans claim another's routing.
+    """
+    req = _make_otel_export_req_with_ref_attrs({}, project_id="ent/proj")
+    req.entity_name = "someone-else"
+
+    assert _capture_genai_otel_export_req(req).entity_name == "ent"
+
+
 def test_genai_otel_export_rewrites_nested_kvlist_ref_attrs() -> None:
     """The nested `weave` → `object_refs` kvlist form is rewritten too;
     the walker descends through kvlist children and matches the dotted

--- a/weave/trace_server/agents/kafka_events.py
+++ b/weave/trace_server/agents/kafka_events.py
@@ -30,6 +30,7 @@ class _AgentSpansEvent(BaseModel):
     event_type: AgentSpanOpName
     status_code: StatusCodeLiteral
     project_id: str
+    entity_name: str | None = None
     trace_id: str
     span_id: str
     operation_name: str | None
@@ -37,7 +38,9 @@ class _AgentSpansEvent(BaseModel):
     conversation_id: str | None
 
     @classmethod
-    def from_row(cls, row: AgentSpanCHInsertable) -> Self | None:
+    def from_row(
+        cls, row: AgentSpanCHInsertable, entity_name: str | None = None
+    ) -> Self | None:
         """Return an event from a finished span row if it matches an event type.
 
         Currently only "turn_ended" is supported, but the interface is designed to support multiple types.
@@ -52,6 +55,7 @@ class _AgentSpansEvent(BaseModel):
                 event_type=event_type,
                 status_code=row.status_code,
                 project_id=row.project_id,
+                entity_name=entity_name,
                 trace_id=row.trace_id,
                 span_id=row.span_id,
                 # Resolve optional fields to None (instead of empty strings)

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -1307,6 +1307,7 @@ class GenAIOTelExportReq(BaseModel):
     )
     project_id: str
     wb_user_id: str | None = None
+    entity_name: str | None = None
 
 
 class GenAIOTelExportRes(BaseModel):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7445,9 +7445,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         producer = self.kafka_producer
         for row in span_rows:
-            if scoring_enabled and (event := ScoreAgentSpansEvent.from_row(row)):
+            if scoring_enabled and (
+                event := ScoreAgentSpansEvent.from_row(row, req.entity_name)
+            ):
                 event.emit(producer)
-            if insights_enabled and (event := EmbedAgentSpansEvent.from_row(row)):
+            if insights_enabled and (
+                event := EmbedAgentSpansEvent.from_row(row, req.entity_name)
+            ):
                 event.emit(producer)
 
         # Flush kafka producer

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1464,6 +1464,9 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     def genai_otel_export(
         self, req: tsi.agent_types.GenAIOTelExportReq
     ) -> tsi.agent_types.GenAIOTelExportRes:
+        # Capture the entity before conversion, while `project_id` is still
+        # `entity/project`: recovering it downstream costs a gorilla round-trip.
+        req.entity_name = req.project_id.split("/", 1)[0] or None
         # Convert `req.project_id` DIRECTLY: this is the request's own project
         # translation and must always hit the id converter once.
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)


### PR DESCRIPTION
## Summary
- An agent span row holds only the internal project id, so a Kafka consumer that routes by entity has to convert one into the other through gorilla, once per project. The ingest request already knows the entity: `project_id` arrives as `entity/project` and the adapter converts it in place, discarding the entity on the way in.
- `genai_otel_export` now captures the entity before that conversion and stamps it onto both agent span events, so consumers read it off the message instead of paying a round trip for it.
- The field is optional because a message already sitting on a topic when a consumer restarts will not carry one, and an absent entity is not routable. Consumers decide what that means for them.

## Testing
unit test; the adapter test asserts the entity survives as a field while `project_id` becomes opaque, which is the whole point of capturing it before conversion.
