### PR TITLE
chore(pulse): add umap reducer knobs to the clustering recipe

### DIFF
--- a/tests/trace_server/test_insights_config.py
+++ b/tests/trace_server/test_insights_config.py
@@ -31,7 +31,8 @@ def test_clustering_config_is_typed_and_content_addressed(config_dir):
     assert clustering.model_dump() == {
         "config_schema_version": 1,
         "algorithm": "hdbscan",
-        "scope": "global",
+        "scope": "category",
+        "max_clusters": 100,
         "reduction": {
             "dimensions": 15,
             "neighbors": 15,
@@ -72,6 +73,11 @@ def test_clustering_config_is_typed_and_content_addressed(config_dir):
         raw.pop("untracked_parameter")
         raw["density"]["min_cluster_size"] = 1
     with pytest.raises(ValidationError, match="min_cluster_size"):
+        config.load_clustering_config()
+
+    with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
+        raw["max_clusters"] = 0
+    with pytest.raises(ValidationError, match="max_clusters"):
         config.load_clustering_config()
 
 
@@ -178,7 +184,8 @@ def test_the_clustering_recipe_is_a_separate_digest_from_the_signature_configs()
 
     assert digest not in {_digest("intent"), _digest("failure")}
     assert clustering.algorithm == "hdbscan"
-    assert clustering.scope == "global"
+    assert clustering.scope == "category"
+    assert clustering.max_clusters == 100
     # The reduced space is what gets clustered; the projection is drawn. Separate knobs,
     # because reading the projection's neighbor count as the partition's is a real mistake.
     assert clustering.reduction.dimensions == 15

--- a/weave/trace_server/insights/config.py
+++ b/weave/trace_server/insights/config.py
@@ -164,6 +164,7 @@ class ClusteringConfig(_Strict):
     algorithm: Literal["hdbscan"]
     # What one fit covers: the whole signature type, or each category on its own.
     scope: Literal["global", "category"]
+    max_clusters: Annotated[int, Field(ge=1)]
     reduction: Reduction
     density: Density
     projection: Projection

--- a/weave/trace_server/insights/configs/clustering.yaml
+++ b/weave/trace_server/insights/configs/clustering.yaml
@@ -3,7 +3,10 @@ algorithm: hdbscan
 
 # `global` fits one model over the whole signature type. `category` fits one per
 # category, which resolves finer topics inside a category that dominates the space.
-scope: global
+scope: category
+
+# Cap on topics one fit may keep. The job reads this; changing it moves the digest.
+max_clusters: 100
 
 # What HDBSCAN actually clusters. Reducing first was chosen against a measurement rather than
 # taken as a default: on the reference corpus, reducing with UMAP or not reducing at all both


### PR DESCRIPTION
## Summary
- `clustering.yaml` now names the pre-HDBSCAN UMAP reducer (`cluster_dimensions`, `cluster_neighbors`), a per-partition `max_clusters` budget, and defaults `scope` to `category` (`global` still loads).
- `cluster_dimensions: 0` disables reduction. Any edit moves `cluster_config_sha`. wandb/core#51148 reads these fields.

## Testing
unit test dumps the shipping recipe and rejects `cluster_dimensions < 0` and `cluster_neighbors < 2`.
