### PR TITLE
feat(weave): add a cluster merge threshold to the clustering recipe

### DIFF
--- a/tests/trace_server/test_insights_config.py
+++ b/tests/trace_server/test_insights_config.py
@@ -33,6 +33,7 @@ def test_clustering_config_is_typed_and_content_addressed(config_dir):
         "algorithm": "hdbscan",
         "scope": "category",
         "max_clusters": 100,
+        "merge_similarity": 0.9,
         "reduction": {
             "dimensions": 15,
             "neighbors": 15,
@@ -78,6 +79,11 @@ def test_clustering_config_is_typed_and_content_addressed(config_dir):
     with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
         raw["max_clusters"] = 0
     with pytest.raises(ValidationError, match="max_clusters"):
+        config.load_clustering_config()
+
+    with _edit_yaml(os.path.join(config_dir, "clustering.yaml")) as raw:
+        raw["merge_similarity"] = 1.5
+    with pytest.raises(ValidationError, match="merge_similarity"):
         config.load_clustering_config()
 
 
@@ -186,6 +192,7 @@ def test_the_clustering_recipe_is_a_separate_digest_from_the_signature_configs()
     assert clustering.algorithm == "hdbscan"
     assert clustering.scope == "category"
     assert clustering.max_clusters == 100
+    assert clustering.merge_similarity == 0.9
     # The reduced space is what gets clustered; the projection is drawn. Separate knobs,
     # because reading the projection's neighbor count as the partition's is a real mistake.
     assert clustering.reduction.dimensions == 15

--- a/weave/trace_server/insights/config.py
+++ b/weave/trace_server/insights/config.py
@@ -165,6 +165,9 @@ class ClusteringConfig(_Strict):
     # What one fit covers: the whole signature type, or each category on its own.
     scope: Literal["global", "category"]
     max_clusters: Annotated[int, Field(ge=1)]
+    # Cosine floor for folding two fitted clusters into one, measured between
+    # centroids after the run's mean centroid is removed. 0 merges nothing.
+    merge_similarity: Annotated[float, Field(ge=0, le=1)]
     reduction: Reduction
     density: Density
     projection: Projection

--- a/weave/trace_server/insights/configs/clustering.yaml
+++ b/weave/trace_server/insights/configs/clustering.yaml
@@ -8,6 +8,12 @@ scope: category
 # Cap on topics one fit may keep. The job reads this; changing it moves the digest.
 max_clusters: 100
 
+# HDBSCAN splits one topic into several when a category is dense, so clusters whose
+# centroids sit at or above this cosine become one. Measured after the run's mean
+# centroid is removed, because raw cosine between two unrelated signatures is already
+# ~0.8 and no useful floor exists in that frame. 0 merges nothing.
+merge_similarity: 0.9
+
 # What HDBSCAN actually clusters. Reducing first was chosen against a measurement rather than
 # taken as a default: on the reference corpus, reducing with UMAP or not reducing at all both
 # beat reducing with PCA, so these are the measured parameters and not tunables.


### PR DESCRIPTION
## Summary
- HDBSCAN reports one topic as several rows when a category is dense. `merge_similarity` is the cosine floor above which two fitted clusters are the same topic, so the clustering job can fold them before it names them. wandb/core#51523 is the consumer.
- The floor is measured between centroids **after the run's mean centroid is removed**. That clause is load-bearing rather than stylistic: raw cosine between two unrelated signatures already sits near 0.8, and on a measured week a 0.9 floor in the uncentred frame collapses the failure lens from 620 rows to 14, swallowing whole categories into one topic. Centred, the same 0.9 folds 620 into 578.
- Default 0.9, measured against two lenses of a real week with `offline_eval/merge_thresholds.py` in the pipeline spike, whose `--stability` mode shows the folds sit just inside that floor rather than comfortably inside it. 0.875 reaches the same families with more margin and is the open question on the consumer PR. `0` merges nothing, so the knob is a no-op until a recipe asks for it.

## Testing
unit test; the digest test asserts the new field's value, so a recipe edit that silently drops it fails rather than serving two different partitions under one `cluster_config_sha`.

