### PR TITLE
fix(weave): return stored external refs on read instead of 500

### DIFF
--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -235,11 +235,11 @@ def test_replace_external_weave_ref_rejects_malformed_tail():
         replace_external_weave_ref("weave:///just-entity", lambda p: p)
 
 
-def test_universal_int_to_ext_ref_converter_tolerate_external_refs(caplog):
-    """Egress: internal refs externalize and unresolvable projects fall back to
-    a private ref. A stored external ref raises by default (surfacing
-    corruption), but is logged and passed through when tolerate_external_refs is
-    set, so agent reads don't 500 on a ref their ingest path left external.
+def test_universal_int_to_ext_ref_converter_passes_through_stored_external_refs(caplog):
+    """Egress: internal refs externalize, unresolvable projects fall back to a
+    private ref, and a ref already stored in external form passes through
+    unchanged rather than failing the whole read. The pass-through warns once
+    per distinct ref so a row repeated across buckets can't flood the logs.
     """
     internal_project_id = "internal-project"
     internal_ref = f"weave-trace-internal:///{internal_project_id}/object/name:digest"
@@ -249,30 +249,32 @@ def test_universal_int_to_ext_ref_converter_tolerate_external_refs(caplog):
     def int_to_ext(project_id: str) -> str | None:
         return "entity/project" if project_id == internal_project_id else None
 
-    # Strict default: a stored external ref is a contract violation -> raise.
-    with pytest.raises(InvalidInternalRef):
-        universal_int_to_ext_ref_converter({"bad": external_ref}, int_to_ext)
-
     payload = {
         "resolved": internal_ref,
         "private": private_internal_ref,
         "stored_external": external_ref,
+        "stored_external_again": external_ref,
         "plain": "no-ref-here",
     }
 
     with caplog.at_level(logging.WARNING):
-        converted = universal_int_to_ext_ref_converter(
-            payload, int_to_ext, tolerate_external_refs=True
-        )
+        converted = universal_int_to_ext_ref_converter(payload, int_to_ext)
 
     assert converted == {
         "resolved": external_ref,
         "private": "weave-private://///object/name:digest",
         "stored_external": external_ref,
+        "stored_external_again": external_ref,
         "plain": "no-ref-here",
     }
-    assert "Returning stored external ref unchanged" in caplog.text
+    assert caplog.text.count("Returning stored external ref unchanged") == 1
     assert external_ref in caplog.text
+
+    # A malformed internal ref is still a hard error: nothing can externalize it.
+    with pytest.raises(InvalidInternalRef):
+        universal_int_to_ext_ref_converter(
+            {"bad": "weave-trace-internal:///only-project-id"}, int_to_ext
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -579,13 +581,13 @@ def test_deeply_nested_structure_raises_request_too_large():
 
 
 @pytest.mark.disable_logging_error_check
-def test_stored_embedded_external_ref_reads_back_through_server(trace_server):
-    """Functional guard for the legacy-data regression: rows written before the
-    converter descended into JSON strings hold external refs inside stringified
-    blobs. Reads through the external adapter must return them unchanged, not
-    raise InvalidInternalRef.
+def test_stored_external_refs_read_back_through_server(trace_server):
+    """Functional guard for the legacy-data regression: ingest paths that skip
+    ref conversion persist external refs both as a bare string leaf and inside a
+    stringified blob. Reads through the external adapter must return both
+    unchanged, not raise InvalidInternalRef.
     """
-    project_id = f"{TEST_ENTITY}/test-embedded-ext-ref-legacy"
+    project_id = f"{TEST_ENTITY}/test-ext-ref-legacy"
     external_ref = f"weave:///{project_id}/op/scorer:abc"
     blob = json.dumps({"source_refs": [external_ref], "note": "legacy"})
 
@@ -598,16 +600,17 @@ def test_stored_embedded_external_ref_reads_back_through_server(trace_server):
             obj=ObjSchemaForInsert(
                 project_id=internal_project_id,
                 object_id="legacy-obj",
-                val={"description": blob},
+                val={"description": blob, "scorer": external_ref},
             )
         )
     )
+    stored = {"description": blob, "scorer": external_ref}
 
     read = trace_server.obj_read(
         ObjReadReq(project_id=project_id, object_id="legacy-obj", digest="latest")
     )
-    assert read.obj.val == {"description": blob}
+    assert read.obj.val == stored
 
     query = trace_server.objs_query(ObjQueryReq(project_id=project_id))
     assert [obj.object_id for obj in query.objs] == ["legacy-obj"]
-    assert query.objs[0].val == {"description": blob}
+    assert query.objs[0].val == stored

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -250,7 +250,6 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         method: Callable[[A], B],
         req: A,
         internal_project_id: str,
-        tolerate_external_refs: bool = False,
     ) -> B:
         req_conv = universal_ext_to_int_ref_converter(
             req,
@@ -259,7 +258,7 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         )
         res = method(req_conv)
         res_conv = universal_int_to_ext_ref_converter(
-            res, self._idc.int_to_ext_project_id, tolerate_external_refs
+            res, self._idc.int_to_ext_project_id
         )
         return res_conv
 
@@ -1486,7 +1485,6 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.agent_spans_query,
             req,
             req.project_id,
-            tolerate_external_refs=True,
         )
         for span in res.spans:
             if span.project_id != req.project_id:
@@ -1503,7 +1501,6 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.agent_spans_stats,
             req,
             req.project_id,
-            tolerate_external_refs=True,
         )
 
     def agent_custom_attrs_schema(
@@ -1514,7 +1511,6 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.agent_custom_attrs_schema,
             req,
             req.project_id,
-            tolerate_external_refs=True,
         )
 
     def agent_agents_query(
@@ -1526,7 +1522,6 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.agent_agents_query,
             req,
             req.project_id,
-            tolerate_external_refs=True,
         )
         for agent in res.agents:
             if agent.project_id != req.project_id:
@@ -1543,7 +1538,6 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.agent_versions_query,
             req,
             req.project_id,
-            tolerate_external_refs=True,
         )
         for version in res.versions:
             if version.project_id != req.project_id:
@@ -1559,7 +1553,6 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.agent_search,
             req,
             req.project_id,
-            tolerate_external_refs=True,
         )
 
     def agent_traces_chat(
@@ -1570,7 +1563,6 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.agent_traces_chat,
             req,
             req.project_id,
-            tolerate_external_refs=True,
         )
 
     def agent_conversation_chat(
@@ -1581,7 +1573,6 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.agent_conversation_chat,
             req,
             req.project_id,
-            tolerate_external_refs=True,
         )
 
     def agent_conversation_spans(
@@ -1592,7 +1583,6 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.agent_conversation_spans,
             req,
             req.project_id,
-            tolerate_external_refs=True,
         )
 
     def projects_info(self, req: tsi.ProjectsInfoReq) -> list[tsi.ProjectsInfoRes]:

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -84,13 +84,12 @@ def _convert_embedded_json_refs(
 
 
 def _make_ref_string_mapper(
-    convert_ref: Callable[[str, bool], str],
+    convert_ref: Callable[[str], str],
 ) -> Callable[[B, int], B]:
     """Build a copy-on-write mapper that rewrites weave refs in string leaves.
 
-    ``convert_ref`` handles a string that starts with a ref prefix (plus a bool
-    marking whether the leaf sits inside an embedded JSON blob), returning its
-    converted form (or raising for a disallowed ref). A string that instead
+    ``convert_ref`` handles a string that starts with a ref prefix, returning
+    its converted form (or raising for a disallowed ref). A string that instead
     embeds a ref inside a JSON blob (e.g. a message ``content`` parts array) is
     decoded and re-run through the same mapper so embedded refs convert like
     top-level ones. The substring pre-check keeps ref-free strings off the
@@ -104,7 +103,7 @@ def _make_ref_string_mapper(
         if not isinstance(obj, str):
             return obj
         if obj.startswith(weave_prefix) or obj.startswith(weave_internal_prefix):
-            return cast(B, convert_ref(obj, search_depth > 0))
+            return cast(B, convert_ref(obj))
         if search_depth < _MAX_REF_SEARCH_DEPTH and (
             weave_prefix in obj or weave_internal_prefix in obj
         ):
@@ -175,7 +174,7 @@ def universal_ext_to_int_ref_converter(
     """
     ext_to_int_project_cache: dict[str, str] = {}
 
-    def convert_ref(ref_str: str, _embedded: bool) -> str:
+    def convert_ref(ref_str: str) -> str:
         if ref_str.startswith(weave_prefix):
             return replace_external_weave_ref(
                 ref_str, convert_ext_to_int_project_id, ext_to_int_project_cache
@@ -204,33 +203,30 @@ C = TypeVar("C")
 def universal_int_to_ext_ref_converter(
     obj: C,
     convert_int_to_ext_project_id: Callable[[str], str | None],
-    tolerate_external_refs: bool = False,
 ) -> C:
     """Takes any object and recursively replaces all internal references with
     external references. The internal references are expected to be in the
     format of `weave-trace-internal:///project_id/...` and the external references are
     expected to be in the format of `weave:///entity/project/...`.
 
-    External refs embedded in JSON-string leaves always pass through (logged):
-    rows written before the converter descended into JSON strings legitimately
-    contain them.
+    A ref already stored in external form passes through unchanged, logged once
+    per distinct ref. Several ingest paths (agent spans, OTel, refs nested in a
+    JSON-serialized leaf) persist external refs, so raising here would fail a
+    whole read over one stored value the caller can do nothing about.
 
     Args:
         obj: The object to convert.
         convert_int_to_ext_project_id: A function that takes an internal
             project ID and returns the external project ID.
-        tolerate_external_refs: When True, a top-level ref already in
-            external (`weave:///`) form is logged and passed through instead
-            of raising. Used by agent reads, whose ingest path does not fully
-            convert refs and can therefore persist external refs.
 
     Returns:
         The object with all internal references replaced with external
         references.
     """
     int_to_ext_project_cache: dict[str, str | None] = {}
+    warned_external_refs: set[str] = set()
 
-    def convert_ref(ref_str: str, embedded: bool) -> str:
+    def convert_ref(ref_str: str) -> str:
         if ref_str.startswith(weave_internal_prefix):
             rest = ref_str[len(weave_internal_prefix) :]
             parts = rest.split("/", 1)
@@ -245,13 +241,11 @@ def universal_int_to_ext_ref_converter(
             if not external_project_id:
                 return f"{ri.WEAVE_PRIVATE_SCHEME}://///{tail}"
             return f"{ri.WEAVE_SCHEME}:///{external_project_id}/{tail}"
-        # External ref stored where an internal one belongs. Embedded ones are
-        # expected legacy state (writes only started converting inside JSON
-        # strings mid-2026) and are already external-shaped, so they always
-        # pass through; top-level ones raise unless the caller opted in.
-        if not (embedded or tolerate_external_refs):
-            raise InvalidInternalRef("Encountered unexpected ref format.")
-        logger.warning("Returning stored external ref unchanged: %s", ref_str)
+        # Already external-shaped, so the stored value is what the caller
+        # wants; warn once per ref so the unconverted write path stays visible.
+        if ref_str not in warned_external_refs:
+            warned_external_refs.add(ref_str)
+            logger.warning("Returning stored external ref unchanged: %s", ref_str)
         return ref_str
 
     return _map_values(obj, _make_ref_string_mapper(convert_ref))


### PR DESCRIPTION
## Summary
- `POST /calls/stats` 500s with `InvalidInternalRef: Encountered unexpected ref format.` whenever a project's `summary.usage` holds a key that looks like a `weave:///` ref: `model` comes from `JSONExtractKeysAndValuesRaw(summary.usage)`, so a user op returning `{"model": "<a weave ref>", "usage": {...}}` puts one in the response and takes the whole stats panel down. 11 requests over the last 14 days, one project.
- `universal_int_to_ext_ref_converter` now logs and returns a ref already stored in external form on every read, deduped to one warning per distinct ref so a value repeated across buckets can't flood the logs. The stored string is what the caller wants back, and only the write path can stop it from being persisted.
- `tolerate_external_refs` and the `embedded` flag threaded through `_make_ref_string_mapper` are gone with it, along with the nine agent-endpoint opt-ins in `ExternalTraceServer`. A malformed *internal* ref still raises; nothing can externalize it.

## Testing
unit test plus the existing ClickHouse read-back guard, extended to cover a bare external ref alongside one nested in a JSON leaf. The `/calls/stats` shape itself is not exercised end to end.