### PR TITLE
fix(weave): let ClickHouse mint query_id

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1300,25 +1300,6 @@ def test_correlation_id_replaces_a_caller_supplied_log_comment():
     assert uuid.UUID(correlation_id).version == 7
 
 
-def test_each_call_gets_its_own_correlation_id():
-    """The settings merge helpers hand back a fresh dict, so ids never carry
-    over between calls.
-    """
-    mock_ch_client = MagicMock()
-    mock_ch_client.query.return_value = QueryResult(summary={})
-
-    with patch.object(
-        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
-    ):
-        server = chts.ClickHouseTraceServer(host="test_host")
-        server._query("SELECT 1", parameters={})
-        first = mock_ch_client.query.call_args.kwargs["settings"]["log_comment"]
-        server._query("SELECT 1", parameters={})
-        second = mock_ch_client.query.call_args.kwargs["settings"]["log_comment"]
-
-    assert first != second
-
-
 def test_one_correlation_id_across_an_insert_retry():
     """A sanitize-and-retry is one logical write, so both attempts carry the
     same correlation id while ClickHouse mints a query_id per attempt.

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1691,7 +1691,7 @@ def test_resent_request_vs_query_id_autogeneration(
     """Query-id guard: a client-side query_id is pinned in the request URL above
     the driver's retry loop, so a resent request hits the still-running original
     with code 216; with it disabled ClickHouse mints one per attempt and the
-    resend succeeds. Same shape as the session_id fix in PR #6655.
+    resend succeeds.
     """
     client = clickhouse_connect.get_client(
         host=ch_server._host,

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, Mock, patch
 import clickhouse_connect
 import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError, ProgrammingError
+from clickhouse_connect.driver.query import QueryResult
+from clickhouse_connect.driver.summary import QuerySummary
 
 from tests.trace_server.test_project_version import make_project_id
 from weave.trace_server import ch_sentinel_values
@@ -1284,12 +1286,26 @@ def test_insert_retries_only_invalid_utf8(error):
         assert mock_ch_client.insert.call_count == 1
 
 
+def test_record_query_id_reads_both_driver_result_types():
+    """`query_id` is a property on QueryResult but a method on QuerySummary, so
+    only `summary` reads the same on both.
+    """
+    assert (
+        chts_utilities.record_query_id(QueryResult(summary={"query_id": "read"}))
+        == "read"
+    )
+    assert (
+        chts_utilities.record_query_id(QuerySummary({"query_id": "write"})) == "write"
+    )
+    assert chts_utilities.record_query_id(QuerySummary({})) is None
+
+
 def test_no_query_id_is_sent_to_clickhouse():
     """A client-supplied query_id can collide with a running query (code 216),
     so the server mints it and our own id rides in log_comment.
     """
     mock_ch_client = MagicMock()
-    mock_ch_client.query.return_value = MagicMock(summary={}, query_id="server-side")
+    mock_ch_client.query.return_value = QueryResult(summary={"query_id": "server-side"})
 
     with patch.object(
         chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
@@ -1308,7 +1324,7 @@ def test_no_query_id_is_sent_to_clickhouse():
 def test_correlation_id_and_query_id_are_set_on_the_dd_span():
     """Both ids are on the span, so an APM trace can be pivoted to query_log."""
     mock_ch_client = MagicMock()
-    mock_ch_client.query.return_value = MagicMock(summary={}, query_id="server-side")
+    mock_ch_client.query.return_value = QueryResult(summary={"query_id": "server-side"})
     tagged: list[dict] = []
 
     with (
@@ -1337,8 +1353,8 @@ def test_correlation_id_is_logged_on_success_and_failure(caplog):
     server has answered.
     """
     mock_ch_client = MagicMock()
-    mock_ch_client.query.return_value = MagicMock(
-        summary={"read_rows": "1"}, query_id="server-side"
+    mock_ch_client.query.return_value = QueryResult(
+        summary={"read_rows": "1", "query_id": "server-side"}
     )
 
     with patch.object(

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1684,19 +1684,6 @@ def test_delete_preserves_version_index_gaps(ch_server):
     assert by_digest[digests[2]].version_index == 2
 
 
-def test_mint_client_disables_both_client_side_ids() -> None:
-    """Neither the session_id nor the query_id may be minted client-side: both
-    collide server-side (codes 373 and 216). See PR #6655.
-    """
-    with patch.object(chts.clickhouse_connect, "get_client") as get_client:
-        server = chts.ClickHouseTraceServer(host="test_host")
-        server._mint_client()
-
-    kwargs = get_client.call_args.kwargs
-    assert kwargs["autogenerate_session_id"] is False
-    assert kwargs["autogenerate_query_id"] is False
-
-
 @pytest.mark.parametrize("autogenerate_query_id", [True, False])
 def test_resent_request_vs_query_id_autogeneration(
     ch_server, autogenerate_query_id: bool

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -20,6 +20,7 @@ from weave.trace_server.agents.clickhouse import AgentWriteHandler
 from weave.trace_server.agents.schema import AgentSpanCHInsertable
 from weave.trace_server.agents.types import GenAIOTelExportReq, GenAIOTelExportRes
 from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER
+from weave.trace_server.clickhouse import utilities as chts_utilities
 from weave.trace_server.clickhouse.schema_converters import (
     ch_call_to_row,
     ch_complete_call_to_row,
@@ -1283,38 +1284,62 @@ def test_insert_retries_only_invalid_utf8(error):
         assert mock_ch_client.insert.call_count == 1
 
 
-def test_query_id_is_set_on_the_dd_span():
-    """The id is on the span too, so an APM trace can be pivoted to query_log."""
+def test_no_query_id_is_sent_to_clickhouse():
+    """A client-supplied query_id can collide with a running query (code 216),
+    so the server mints it and our own id rides in log_comment.
+    """
     mock_ch_client = MagicMock()
-    mock_ch_client.command.return_value = None
-    mock_ch_client.query.return_value = MagicMock(summary={})
+    mock_ch_client.query.return_value = MagicMock(summary={}, query_id="server-side")
+
+    with patch.object(
+        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+    ):
+        server = chts.ClickHouseTraceServer(host="test_host")
+        server._query("SELECT 1", parameters={})
+        server._insert("t", data=[[1]], column_names=["a"])
+
+    query_settings = mock_ch_client.query.call_args.kwargs["settings"]
+    insert_settings = mock_ch_client.insert.call_args.kwargs["settings"]
+    assert "query_id" not in query_settings
+    assert "query_id" not in insert_settings
+    assert query_settings["log_comment"] != insert_settings["log_comment"]
+
+
+def test_correlation_id_and_query_id_are_set_on_the_dd_span():
+    """Both ids are on the span, so an APM trace can be pivoted to query_log."""
+    mock_ch_client = MagicMock()
+    mock_ch_client.query.return_value = MagicMock(summary={}, query_id="server-side")
     tagged: list[dict] = []
 
     with (
         patch.object(
             chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
         ),
-        patch.object(chts, "set_current_span_dd_tags", tagged.append),
+        patch.object(chts_utilities, "set_current_span_dd_tags", tagged.append),
     ):
         server = chts.ClickHouseTraceServer(host="test_host")
         server._query("SELECT 1", parameters={})
 
-    sent_id = mock_ch_client.query.call_args.kwargs["settings"]["query_id"]
-    assert {"clickhouse.query_id": sent_id} in tagged
+    correlation_id = mock_ch_client.query.call_args.kwargs["settings"]["log_comment"]
+    assert {"clickhouse.correlation_id": correlation_id} in tagged
+    assert {"clickhouse.query_id": "server-side"} in tagged
 
 
-def _logged_query_id(caplog, message: str) -> str:
-    return next(r.query_id for r in caplog.records if r.message == message)
+def _logged_ids(caplog, message: str) -> tuple[str, str | None]:
+    record = next(r for r in caplog.records if r.message == message)
+    return record.correlation_id, getattr(record, "query_id", None)
 
 
 @pytest.mark.disable_logging_error_check
-def test_query_id_is_logged_on_success_and_failure(caplog):
-    """The minted query_id reaches both log lines, so a failed query is still
-    correlatable with system.query_log.
+def test_correlation_id_is_logged_on_success_and_failure(caplog):
+    """The minted correlation_id reaches both log lines, so a failed query is
+    still correlatable with system.query_log; the query_id only exists once the
+    server has answered.
     """
     mock_ch_client = MagicMock()
-    mock_ch_client.command.return_value = None
-    mock_ch_client.query.return_value = MagicMock(summary={"read_rows": "1"})
+    mock_ch_client.query.return_value = MagicMock(
+        summary={"read_rows": "1"}, query_id="server-side"
+    )
 
     with patch.object(
         chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
@@ -1323,15 +1348,15 @@ def test_query_id_is_logged_on_success_and_failure(caplog):
 
         with caplog.at_level(logging.INFO):
             server._query("SELECT 1", parameters={})
-        sent_id = mock_ch_client.query.call_args.kwargs["settings"]["query_id"]
-        assert _logged_query_id(caplog, "clickhouse_query") == sent_id
+        sent_id = mock_ch_client.query.call_args.kwargs["settings"]["log_comment"]
+        assert _logged_ids(caplog, "clickhouse_query") == (sent_id, "server-side")
 
         caplog.clear()
         mock_ch_client.query.side_effect = DatabaseError("boom")
         with caplog.at_level(logging.INFO), pytest.raises(DatabaseError):
             server._query("SELECT 1", parameters={})
-        sent_id = mock_ch_client.query.call_args.kwargs["settings"]["query_id"]
-        assert _logged_query_id(caplog, "clickhouse_query_error") == sent_id
+        sent_id = mock_ch_client.query.call_args.kwargs["settings"]["log_comment"]
+        assert _logged_ids(caplog, "clickhouse_query_error") == (sent_id, None)
 
 
 @pytest.mark.disable_logging_error_check

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1288,6 +1288,62 @@ def test_insert_retries_only_invalid_utf8(error):
         assert mock_ch_client.insert.call_count == 1
 
 
+def test_correlation_id_replaces_a_caller_supplied_log_comment():
+    """The trace server owns `log_comment`: an inherited value could repeat
+    across queries and would silently become the correlation id.
+    """
+    settings = {"log_comment": "some-upstream-annotation"}
+    correlation_id = chts_utilities.set_correlation_id(settings)
+
+    assert correlation_id != "some-upstream-annotation"
+    assert settings["log_comment"] == correlation_id
+    assert uuid.UUID(correlation_id).version == 7
+
+
+def test_each_call_gets_its_own_correlation_id():
+    """The settings merge helpers hand back a fresh dict, so ids never carry
+    over between calls.
+    """
+    mock_ch_client = MagicMock()
+    mock_ch_client.query.return_value = QueryResult(summary={})
+
+    with patch.object(
+        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+    ):
+        server = chts.ClickHouseTraceServer(host="test_host")
+        server._query("SELECT 1", parameters={})
+        first = mock_ch_client.query.call_args.kwargs["settings"]["log_comment"]
+        server._query("SELECT 1", parameters={})
+        second = mock_ch_client.query.call_args.kwargs["settings"]["log_comment"]
+
+    assert first != second
+
+
+def test_one_correlation_id_across_an_insert_retry():
+    """A sanitize-and-retry is one logical write, so both attempts carry the
+    same correlation id while ClickHouse mints a query_id per attempt.
+    """
+    mock_ch_client = MagicMock()
+    stamps: list[str] = []
+
+    def capture(*args, **kwargs):
+        stamps.append(kwargs["settings"]["log_comment"])
+        if len(stamps) == 1:
+            raise UnicodeEncodeError("utf-8", "\ud800", 0, 1, "surrogate")
+        return QuerySummary({})
+
+    mock_ch_client.insert.side_effect = capture
+
+    with patch.object(
+        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+    ):
+        server = chts.ClickHouseTraceServer(host="test_host")
+        server._insert("t", data=[["\ud800"]], column_names=["a"])
+
+    assert len(stamps) == 2
+    assert stamps[0] == stamps[1]
+
+
 def test_record_query_id_reads_both_driver_result_types():
     """`query_id` is a property on QueryResult but a method on QuerySummary, so
     only `summary` reads the same on both.

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -2,6 +2,7 @@ import base64
 import datetime as dt
 import logging
 import threading
+import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
@@ -9,6 +10,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import clickhouse_connect
 import pytest
+import urllib3
 from clickhouse_connect.driver.exceptions import DatabaseError, ProgrammingError
 from clickhouse_connect.driver.query import QueryResult
 from clickhouse_connect.driver.summary import QuerySummary
@@ -1680,6 +1682,72 @@ def test_delete_preserves_version_index_gaps(ch_server):
     by_digest = {o.digest: o for o in non_deleted}
     assert by_digest[digests[0]].version_index == 0
     assert by_digest[digests[2]].version_index == 2
+
+
+def test_mint_client_disables_both_client_side_ids() -> None:
+    """Neither the session_id nor the query_id may be minted client-side: both
+    collide server-side (codes 373 and 216). See PR #6655.
+    """
+    with patch.object(chts.clickhouse_connect, "get_client") as get_client:
+        server = chts.ClickHouseTraceServer(host="test_host")
+        server._mint_client()
+
+    kwargs = get_client.call_args.kwargs
+    assert kwargs["autogenerate_session_id"] is False
+    assert kwargs["autogenerate_query_id"] is False
+
+
+@pytest.mark.parametrize("autogenerate_query_id", [True, False])
+def test_resent_request_vs_query_id_autogeneration(
+    ch_server, autogenerate_query_id: bool
+) -> None:
+    """Query-id guard: a client-side query_id is pinned in the request URL above
+    the driver's retry loop, so a resent request hits the still-running original
+    with code 216; with it disabled ClickHouse mints one per attempt and the
+    resend succeeds. Same shape as the session_id fix in PR #6655.
+    """
+    client = clickhouse_connect.get_client(
+        host=ch_server._host,
+        port=ch_server._port,
+        user=ch_server._user,
+        password=ch_server._password,
+        secure=ch_server._port == chts.CLICKHOUSE_SECURE_PORT,
+        pool_mgr=urllib3.PoolManager(maxsize=8, num_pools=4),
+        autogenerate_session_id=False,
+        autogenerate_query_id=autogenerate_query_id,
+    )
+    unpatched = urllib3.PoolManager.request
+
+    def resend_once(self, method, url, **kwargs):
+        """Land a copy of the query first, then let the driver's own copy go."""
+        if b"sleep" not in (kwargs.get("body") or b""):
+            return unpatched(self, method, url, **kwargs)
+
+        landed_first: list = []
+
+        def send_copy() -> None:
+            landed_first.append(unpatched(self, method, url, **kwargs))
+
+        copy = threading.Thread(target=send_copy)
+        copy.start()
+        time.sleep(0.5)
+        try:
+            return unpatched(self, method, url, **kwargs)
+        finally:
+            copy.join()
+            for response in landed_first:
+                response.close()
+
+    try:
+        with patch.object(urllib3.PoolManager, "request", resend_once):
+            if autogenerate_query_id:
+                with pytest.raises(DatabaseError) as exc_info:
+                    client.query("SELECT sleep(2)")
+                assert "QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING" in str(exc_info.value)
+            else:
+                assert client.query("SELECT sleep(2)").result_rows == [(0,)]
+    finally:
+        client.close()
 
 
 @pytest.mark.parametrize("autogenerate_session_id", [True, False])

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -308,10 +308,12 @@ def set_correlation_id(settings: dict[str, Any]) -> str:
 def record_query_id(result: QueryResult | QuerySummary) -> str | None:
     """Tag the span with the server-minted query_id off a driver result.
 
-    Both types read it off the `X-ClickHouse-Query-Id` response header, which is
-    absent on a summary the driver built without a response.
+    Read through `summary`, the accessor both types share and where the driver
+    stores the `X-ClickHouse-Query-Id` response header: `query_id` itself is a
+    property on QueryResult but a plain method on QuerySummary. It is absent on
+    a summary the driver built without a response.
     """
-    query_id = result.query_id or None
+    query_id = result.summary.get("query_id") or None
     if query_id:
         set_current_span_dd_tags({"clickhouse.query_id": query_id})
     return query_id

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -294,13 +294,18 @@ def convert_to_insert_too_large(e: Exception) -> Exception:
 def set_correlation_id(settings: dict[str, Any]) -> str:
     """Stamp our own id on a ClickHouse call via `log_comment` and return it.
 
+    The trace server owns `log_comment`: adopting an inherited value would make
+    the correlation id something that can repeat across queries, which breaks
+    the system.query_log pivot without any sign in the logs.
+
     We never send a `query_id`: the driver reuses the URL across its internal
     retries, and a client-supplied id that the server has already registered
     fails with QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING. ClickHouse mints the
     query_id per attempt; `log_comment` carries ours and is queryable in
     system.query_log without a uniqueness constraint.
     """
-    correlation_id = str(settings.setdefault("log_comment", generate_id()))
+    correlation_id = generate_id()
+    settings["log_comment"] = correlation_id
     set_current_span_dd_tags({"clickhouse.correlation_id": correlation_id})
     return correlation_id
 

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -323,7 +323,7 @@ def log_and_raise_insert_error(
     e: Exception,
     table: str,
     data: Sequence[Sequence[Any]],
-    correlation_id: str | None = None,
+    correlation_id: str,
 ) -> None:
     """Log insert error with data size info and re-raise."""
     data_bytes = sum(num_bytes(row) for row in data)

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -13,6 +13,8 @@ from collections.abc import Sequence
 from typing import Any, TypeVar, cast
 
 import sqlparse
+from clickhouse_connect.driver.query import QueryResult
+from clickhouse_connect.driver.summary import QuerySummary
 
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.datadog import set_current_span_dd_tags
@@ -303,9 +305,13 @@ def set_correlation_id(settings: dict[str, Any]) -> str:
     return correlation_id
 
 
-def record_query_id(result: Any) -> str | None:
-    """Tag the span with the server-minted query_id off a driver result."""
-    query_id = getattr(result, "query_id", None) or None
+def record_query_id(result: QueryResult | QuerySummary) -> str | None:
+    """Tag the span with the server-minted query_id off a driver result.
+
+    Both types read it off the `X-ClickHouse-Query-Id` response header, which is
+    absent on a summary the driver built without a response.
+    """
+    query_id = result.query_id or None
     if query_id:
         set_current_span_dd_tags({"clickhouse.query_id": query_id})
     return query_id

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -294,10 +294,6 @@ def convert_to_insert_too_large(e: Exception) -> Exception:
 def set_correlation_id(settings: dict[str, Any]) -> str:
     """Stamp our own id on a ClickHouse call via `log_comment` and return it.
 
-    The trace server owns `log_comment`: adopting an inherited value would make
-    the correlation id something that can repeat across queries, which breaks
-    the system.query_log pivot without any sign in the logs.
-
     We never send a `query_id`: the driver reuses the URL across its internal
     retries, and a client-supplied id that the server has already registered
     fails with QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING. ClickHouse mints the

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -17,6 +17,7 @@ import sqlparse
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.datadog import set_current_span_dd_tags
 from weave.trace_server.errors import InsertTooLarge
+from weave.trace_server.ids import generate_id
 from weave.trace_server.kafka import KafkaProducer
 from weave.trace_server.tracing import traced
 
@@ -288,11 +289,33 @@ def convert_to_insert_too_large(e: Exception) -> Exception:
     return e
 
 
+def set_correlation_id(settings: dict[str, Any]) -> str:
+    """Stamp our own id on a ClickHouse call via `log_comment` and return it.
+
+    We never send a `query_id`: the driver reuses the URL across its internal
+    retries, and a client-supplied id that the server has already registered
+    fails with QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING. ClickHouse mints the
+    query_id per attempt; `log_comment` carries ours and is queryable in
+    system.query_log without a uniqueness constraint.
+    """
+    correlation_id = str(settings.setdefault("log_comment", generate_id()))
+    set_current_span_dd_tags({"clickhouse.correlation_id": correlation_id})
+    return correlation_id
+
+
+def record_query_id(result: Any) -> str | None:
+    """Tag the span with the server-minted query_id off a driver result."""
+    query_id = getattr(result, "query_id", None) or None
+    if query_id:
+        set_current_span_dd_tags({"clickhouse.query_id": query_id})
+    return query_id
+
+
 def log_and_raise_insert_error(
     e: Exception,
     table: str,
     data: Sequence[Sequence[Any]],
-    query_id: str | None = None,
+    correlation_id: str | None = None,
 ) -> None:
     """Log insert error with data size info and re-raise."""
     data_bytes = sum(num_bytes(row) for row in data)
@@ -301,7 +324,7 @@ def log_and_raise_insert_error(
         extra={
             "error_str": str(e),
             "table": table,
-            "query_id": query_id,
+            "correlation_id": correlation_id,
             "data_len": len(data),
             "data_bytes": data_bytes,
         },

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7794,7 +7794,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 "trace_duration_ms": duration_ms,
                 "command": command,
                 "parameters": processed_params,
-                "query_id": record_query_id(result),
+                "query_id": (
+                    record_query_id(result)
+                    if isinstance(result, QuerySummary)
+                    else None
+                ),
                 "correlation_id": correlation_id,
             },
         )

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7793,17 +7793,15 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             return
 
         duration_ms = round((time.monotonic() - start) * 1000, 1)
+        # command() also returns scalars, which carry no query_id.
+        query_id = record_query_id(result) if isinstance(result, QuerySummary) else None
         logger.info(
             "clickhouse_command",
             extra={
                 "trace_duration_ms": duration_ms,
                 "command": command,
                 "parameters": processed_params,
-                "query_id": (
-                    record_query_id(result)
-                    if isinstance(result, QuerySummary)
-                    else None
-                ),
+                "query_id": query_id,
                 "correlation_id": correlation_id,
             },
         )

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7521,6 +7521,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         autogenerate_session_id=False: weave-trace uses no session features,
         and the default collides on overlapping queries with SESSION_IS_LOCKED
         (code 373). See PR #6655.
+        autogenerate_query_id=False: the id is pinned in the request URL above
+        the driver's retry loop, so a resent request hits the still-running
+        original as QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING (code 216). ClickHouse
+        mints one per attempt instead; our own id rides in `log_comment`.
         `send_receive_timeout` overrides the HTTP read timeout (migration clients
         need to outlast replicated-DDL propagation); None keeps the library default.
         """
@@ -7535,6 +7539,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             secure=self._port == CLICKHOUSE_SECURE_PORT,
             pool_mgr=_CH_POOL_MANAGER,
             autogenerate_session_id=False,
+            autogenerate_query_id=False,
             **optional_kwargs,
         )
         self._ensure_database(client)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7521,9 +7521,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         autogenerate_session_id=False: weave-trace uses no session features,
         and the default collides on overlapping queries with SESSION_IS_LOCKED
         (code 373). See PR #6655.
-        autogenerate_query_id=False: weave-trace correlates through
-        `log_comment` instead, and the default collides on a resent request with
-        QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING (code 216). See PR #7787.
+        autogenerate_query_id=False: the default collides on a resent request
+        with QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING (code 216). See PR #7787.
         `send_receive_timeout` overrides the HTTP read timeout (migration clients
         need to outlast replicated-DDL propagation); None keeps the library default.
         """

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -145,7 +145,9 @@ from weave.trace_server.clickhouse.utilities import (
     maybe_enqueue_minimal_call_end,
     num_bytes,
     process_parameters,
+    record_query_id,
     sanitize_invalid_utf8_surrogates,
+    set_correlation_id,
     started_at_gte_query,
     string_to_int_in_range,
 )
@@ -7647,10 +7649,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     ) -> Iterator[tuple]:
         """Streams the results of a query from the database."""
         merged = ch_settings.merge_default_query_settings(settings)
-        query_id = merged.setdefault("query_id", generate_id())
-        set_current_span_dd_tags({"clickhouse.query_id": query_id})
+        correlation_id = set_correlation_id(merged)
 
         summary = None
+        query_id = None
         parameters = process_parameters(parameters)
         start = time.monotonic()
         try:
@@ -7663,6 +7665,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             ) as stream:
                 if isinstance(stream.source, QueryResult):
                     summary = stream.source.summary
+                    query_id = record_query_id(stream.source)
                 duration_ms = round((time.monotonic() - start) * 1000, 1)
                 logger.info(
                     "clickhouse_stream_query",
@@ -7672,6 +7675,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                         "parameters": parameters,
                         "summary": summary,
                         "query_id": query_id,
+                        "correlation_id": correlation_id,
                     },
                 )
                 yield from stream
@@ -7685,6 +7689,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     "query": query,
                     "parameters": parameters,
                     "query_id": query_id,
+                    "correlation_id": correlation_id,
                 },
             )
             # always raises, optionally with custom error class
@@ -7700,8 +7705,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     ) -> QueryResult:
         """Directly queries the database and returns the result."""
         merged = ch_settings.merge_default_query_settings(settings)
-        query_id = merged.setdefault("query_id", generate_id())
-        set_current_span_dd_tags({"clickhouse.query_id": query_id})
+        correlation_id = set_correlation_id(merged)
 
         parameters = process_parameters(parameters)
         start = time.monotonic()
@@ -7722,7 +7726,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     "error_str": str(e),
                     "query": query,
                     "parameters": parameters,
-                    "query_id": query_id,
+                    "correlation_id": correlation_id,
                 },
             )
             # always raises, optionally with custom error class
@@ -7737,7 +7741,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 "query": query,
                 "parameters": parameters,
                 "summary": res.summary,
-                "query_id": query_id,
+                "query_id": record_query_id(res),
+                "correlation_id": correlation_id,
             },
         )
         return res
@@ -7757,13 +7762,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             settings: Optional dictionary of ClickHouse settings (overrides defaults).
         """
         merged = ch_settings.merge_default_command_settings(settings)
-        query_id = merged.setdefault("query_id", generate_id())
-        set_current_span_dd_tags({"clickhouse.query_id": query_id})
+        correlation_id = set_correlation_id(merged)
 
         processed_params = process_parameters(parameters) if parameters else None
         start = time.monotonic()
         try:
-            self.ch_client.command(
+            result = self.ch_client.command(
                 command,
                 parameters=processed_params,
                 settings=merged,
@@ -7777,7 +7781,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     "error_str": str(e),
                     "command": command,
                     "parameters": processed_params,
-                    "query_id": query_id,
+                    "correlation_id": correlation_id,
                 },
             )
             handle_clickhouse_query_error(e)
@@ -7790,7 +7794,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 "trace_duration_ms": duration_ms,
                 "command": command,
                 "parameters": processed_params,
-                "query_id": query_id,
+                "query_id": record_query_id(result),
+                "correlation_id": correlation_id,
             },
         )
         return
@@ -7836,10 +7841,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # At most two attempts: the original, plus one retry after sanitizing
         # invalid client UTF-8.
         settings = dict(settings or {})
-        # Reused across attempts: the only retry is a client-side encode
-        # failure, so ClickHouse never saw the first one.
-        query_id = settings.setdefault("query_id", generate_id())
-        set_current_span_dd_tags({"clickhouse.query_id": query_id})
+        # One correlation id covers both attempts: it is the same logical write.
+        correlation_id = set_correlation_id(settings)
         for _ in range(2):
             try:
                 result = self.ch_client.insert(
@@ -7849,7 +7852,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             # Invalid client Unicode: sanitize the batch and retry once.
             except UnicodeEncodeError as e:
                 if sanitized_invalid_utf8:
-                    log_and_raise_insert_error(e, table, data, query_id)
+                    log_and_raise_insert_error(e, table, data, correlation_id)
                 sanitized_invalid_utf8 = True
                 data = sanitize_invalid_utf8_surrogates(data)
                 continue
@@ -7857,11 +7860,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             # InsertTooLarge: raise immediately, no retry
             except ValueError as e:
                 converted = convert_to_insert_too_large(e)
-                log_and_raise_insert_error(converted, table, data, query_id)
+                log_and_raise_insert_error(converted, table, data, correlation_id)
 
             # All other errors (including exhausted empty-query retries): no retry
             except Exception as e:
-                log_and_raise_insert_error(e, table, data, query_id)
+                log_and_raise_insert_error(e, table, data, correlation_id)
 
             else:
                 duration_ms = round((time.monotonic() - start) * 1000, 1)
@@ -7872,7 +7875,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                         "table": table,
                         "row_count": len(data),
                         "async_insert": async_insert,
-                        "query_id": query_id,
+                        "query_id": record_query_id(result),
+                        "correlation_id": correlation_id,
                     },
                 )
                 return result

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7521,10 +7521,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         autogenerate_session_id=False: weave-trace uses no session features,
         and the default collides on overlapping queries with SESSION_IS_LOCKED
         (code 373). See PR #6655.
-        autogenerate_query_id=False: the id is pinned in the request URL above
-        the driver's retry loop, so a resent request hits the still-running
-        original as QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING (code 216). ClickHouse
-        mints one per attempt instead; our own id rides in `log_comment`.
+        autogenerate_query_id=False: weave-trace correlates through
+        `log_comment` instead, and the default collides on a resent request with
+        QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING (code 216). See PR #7787.
         `send_receive_timeout` overrides the HTTP read timeout (migration clients
         need to outlast replicated-DDL propagation); None keeps the library default.
         """


### PR DESCRIPTION
## Description

the bump from ch 0.x to 1.6 fixed a very longstanding [bug](https://github.com/ClickHouse/clickhouse-connect/pull/732) which now enables the ch-connect driver to auto-retry failed connections to clickhouse.

this surfaced this new [issue](https://us5.datadoghq.com/apm/trace/9c388f8c37dabfd5b6052762315092e1?spanID=6092360037035044935&timeHint=1787467474661).

this is due to the fact that ch-connect now auto-retries requests that failed, keeping the same query_id when calling CH. was not an issue before because the retry mechanism was just broken.

so we need to stop client-side generation of query_ids. this is in 2 steps:


1. [i introduced setting query_id explicitly](https://github.com/wandb/weave/pull/7757). this was so even on exceptions, we could log/trace the query_id (oops)
2. the ch-connect client also autogenerates the query_id by default. u need to set `autogenerate_query_id=False` to disable this.

however, if we do these changes we lose the ability to see the query_id on exceptions. the way to fix that is by passing a separate id (this pr calls it the `correlation_id`) that is safe even if it collides and pass it into `log_comment`.

so this pr does:
1. undo passing query_id explicitly in settings.
2. set `autogenerate_query_id=False`. similar to [griffin's pr here](https://github.com/wandb/weave/pull/6655).
3. use `correlation_id` instead of `query_id` when dealing with exceptions, but log/trace both ids.


so we can now do the following if we see a query blew up, and we dont have the query_id:
```sql
SELECT
    type,
    query_id,
    log_comment                       AS correlation_id,
    query_duration_ms,
    read_rows,
    formatReadableSize(read_bytes)    AS read,
    formatReadableSize(memory_usage)  AS memory,
    exception_code,
    exception
FROM system.query_log
WHERE log_comment = '01a034f8-2dfd-7910-a1eb-704986ae6350'
  AND event_date >= today() - 1
ORDER BY event_time_microseconds
```

```
Output:

type        | query_id                             | query_duration_ms | read_rows | read      | memory
QueryStart  | 47833a2a-0c71-4607-8715-0ddf75a56691 |                 0 |         0 | 0.00 B    | 0.00 B
QueryFinish | 47833a2a-0c71-4607-8715-0ddf75a56691 |                 9 |   5000000 | 38.15 MiB | 4.18 MiB
```

## Testing

- [x] Manual testing
- [x] Unit tests
- [x] QA

## QA Validation

Deployed to multi-qa as core `d7abe31676c0` (version `suddenly-champion-gannet-d7abe31`, versionId `d71dc570-cd7c-4616-8a3c-03d52a36b9d7`), pinning this branch at `8516dff2f897`. Rollout verified homogeneous — 25/25 `/version` probes on the new sha before, during and after measurement, with the Minecart lock held across the window.

Both ids present on QA spans, and the version nibbles are the point:

| build | `clickhouse.correlation_id` | `clickhouse.query_id` |
| --- | --- | --- |
| before (`daba808bf5`) | — | `01a0352f-20fd-7dbe-…` (uuid**7**, client-minted) |
| after (`d7abe31676`) | `01a0353e-7fb2-74d7-…` (uuid**7**, ours) | `14293d32-7fe5-4220-…` (uuid**4**, server-minted) |
