### PR TITLE
security(weave): add PII detection and redaction helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -697,6 +697,17 @@ deterministic.
   timing with `LLM.started_at` and an explicit `Tool.started_at` instead of
   keeping contexts open with `ExitStack`.
 
+### PII redaction primitives
+
+- `SensitiveDataPolicy` is a closed `off` or `pii-v1` enum. Unknown values
+  fail instead of falling back to a policy.
+- `redact_pii_value` walks supported trace values copy-on-write, combines
+  credential-key replacement with PII replacement, and never scans dictionary
+  keys. Clean subtrees retain their identity.
+- Complete Weave refs, valid base64 data URLs, and valid standalone base64
+  payloads pass through unchanged. Malformed lookalikes remain eligible for
+  scanning.
+
 ### Credential-shaped fields in client-authored call columns
 
 - The three call converters in `clickhouse/schema_converters.py` run
@@ -713,7 +724,6 @@ deterministic.
   are load-bearing — see the module docstring — so keep them if you touch it.
 
 ### Credential-shaped fields in agent span columns
-
 - The agents OTel ingest calls `redact_credentials_from_span` before
   `strip_inline_blobs_from_span`, and outside the file-storage guard around it.
   Both are load-bearing — see that function's docstring — so keep the order and

--- a/tests/trace_server/test_sensitive_data_redaction.py
+++ b/tests/trace_server/test_sensitive_data_redaction.py
@@ -164,6 +164,13 @@ def test_walker_redacts_json_escaped_values_without_scanning_keys() -> None:
     )
 
 
+def test_walker_drops_shadowed_duplicate_json_keys() -> None:
+    assert redact_pii_value('{"x":"ada@example.com","x":"safe"}') == '{"x":"safe"}'
+    assert redact_pii_value(
+        '{"nested":[{"x":"ada@example.com","x":"safe"}],"count":1}'
+    ) == ('{"nested":[{"x":"safe"}],"count":1}')
+
+
 def test_walker_does_not_rewrite_string_enum_discriminators() -> None:
     assert (
         redact_pii_value(_StructuralLabel.EMAIL_SHAPED) is _StructuralLabel.EMAIL_SHAPED

--- a/tests/trace_server/test_sensitive_data_redaction.py
+++ b/tests/trace_server/test_sensitive_data_redaction.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from enum import Enum
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Field
+
+from weave.trace_server.credential_redaction import REDACTED_VALUE
+from weave.trace_server.sensitive_data.detectors import redact_pii_string
+from weave.trace_server.sensitive_data.walker import redact_pii_value
+
+
+class _StructuralLabel(str, Enum):
+    EMAIL_SHAPED = "ada@example.com"
+
+
+class _PayloadModel(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    values: tuple[object, ...]
+    excluded: str = Field(exclude=True)
+
+
+def test_redacts_supported_pii_with_typed_markers() -> None:
+    text = (
+        "Email ada.lovelace@example.com, phone (415) 555-2671, SSN 123-45-6789, "
+        "card 4111 1111 1111 1111, international +44 20 7946 0958."
+    )
+
+    assert redact_pii_string(text) == (
+        "Email <EMAIL_ADDRESS>, phone <PHONE_NUMBER>, SSN <US_SSN>, "
+        "card <CREDIT_CARD>, international <PHONE_NUMBER>."
+    )
+
+
+def test_redacts_compact_luhn_valid_card() -> None:
+    assert redact_pii_string("4111111111111111") == "<CREDIT_CARD>"
+
+
+def test_redacts_compact_e164_phone() -> None:
+    assert redact_pii_string("Call +14155552671") == ("Call <PHONE_NUMBER>")
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("界ada@example.com界", "界<EMAIL_ADDRESS>界"),
+        ("界(415) 555-2671界", "界<PHONE_NUMBER>界"),
+        ("界123-45-6789界", "界<US_SSN>界"),
+        ("界4111 1111 1111 1111界", "界<CREDIT_CARD>界"),
+    ],
+)
+def test_unicode_neighbors_cannot_hide_ascii_pii(text: str, expected: str) -> None:
+    assert redact_pii_string(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("jane.doe@example.com", "<EMAIL_ADDRESS>"),
+        ("a.b@x.co", "<EMAIL_ADDRESS>"),
+        ("first.middle.last@sub.example.com", "<EMAIL_ADDRESS>"),
+        ("Contact jane.doe@example.com today", "Contact <EMAIL_ADDRESS> today"),
+    ],
+)
+def test_redacts_emails_with_dotted_local_parts(text: str, expected: str) -> None:
+    assert redact_pii_string(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "not-an-email@localhost",
+        "000-12-3456",
+        "666-12-3456",
+        "900-12-3456",
+        "123-00-6789",
+        "123-45-0000",
+        "123456789",
+        "0000 0000 0000 0000",
+        "4111 1111 1111 1112",
+        "abc4111111111111111xyz",
+        "4155552671",
+        "+141555526",
+        "prefix+14155552671",
+        "+14155552671suffix",
+        "++14155552671",
+        "12345-6789",
+        "123-456789",
+        "123e4567-e89b-12d3-a456-426614174000",
+        "192.168.1.1",
+        "2026-08-12 10:57:57",
+        "user@" + "a" * 64 + ".com",
+        "a" * 65 + "@example.com",
+        ".user@example.com",
+        "user.@example.com",
+        "first..last@example.com",
+        "user@example.com_suffix",
+        "user@example.com-extra",
+    ],
+)
+def test_leaves_common_numeric_non_matches_unchanged(text: str) -> None:
+    assert redact_pii_string(text) == text
+
+
+def test_walker_is_copy_on_write_and_does_not_scan_keys() -> None:
+    clean_subtree = {"message": "hello"}
+    payload = {
+        "ada@example.com": "dictionary key",
+        "contact": "ada@example.com",
+        "clean": clean_subtree,
+    }
+
+    redacted = redact_pii_value(payload)
+
+    assert redacted == {
+        "ada@example.com": "dictionary key",
+        "contact": "<EMAIL_ADDRESS>",
+        "clean": {"message": "hello"},
+    }
+    assert redacted is not payload
+    assert redacted["clean"] is clean_subtree
+    assert payload["contact"] == "ada@example.com"
+
+
+def test_walker_fuses_credential_key_and_pii_redaction() -> None:
+    payload = {
+        "api_key": "ada@example.com",
+        "nested": [
+            {"secret_access_key": "secret-value"},
+            {"contact": "grace@example.com"},
+        ],
+    }
+
+    redacted = redact_pii_value(payload)
+
+    assert redacted == {
+        "api_key": REDACTED_VALUE,
+        "nested": [
+            {"secret_access_key": REDACTED_VALUE},
+            {"contact": "<EMAIL_ADDRESS>"},
+        ],
+    }
+    assert payload == {
+        "api_key": "ada@example.com",
+        "nested": [
+            {"secret_access_key": "secret-value"},
+            {"contact": "grace@example.com"},
+        ],
+    }
+
+
+def test_walker_redacts_json_escaped_values_without_scanning_keys() -> None:
+    value = (
+        r'{"ada@example.com":"dictionary key",'
+        r'"contact":"ada\u0040example.com",'
+        r'"phone":"\u0028415\u0029 555-2671"}'
+    )
+
+    assert redact_pii_value(value) == (
+        '{"ada@example.com":"dictionary key",'
+        '"contact":"<EMAIL_ADDRESS>",'
+        '"phone":"<PHONE_NUMBER>"}'
+    )
+
+
+def test_walker_does_not_rewrite_string_enum_discriminators() -> None:
+    assert (
+        redact_pii_value(_StructuralLabel.EMAIL_SHAPED) is _StructuralLabel.EMAIL_SHAPED
+    )
+
+
+def test_walker_copies_models_and_tuples_only_along_changed_paths() -> None:
+    clean_list = ["hello"]
+    payload = _PayloadModel(
+        values=(clean_list, "ada@example.com"),
+        excluded="grace@example.com",
+        extra_contact="linus@example.com",
+    )
+
+    redacted = redact_pii_value(payload)
+
+    assert redacted is not payload
+    assert redacted.values == (clean_list, "<EMAIL_ADDRESS>")
+    assert redacted.values is not payload.values
+    assert redacted.values[0] is clean_list
+    assert redacted.excluded == "grace@example.com"
+    assert redacted.model_extra == {"extra_contact": "<EMAIL_ADDRESS>"}
+    assert payload.model_extra == {"extra_contact": "linus@example.com"}
+
+
+def test_walker_preserves_refs_base64_data_urls_and_inline_base64() -> None:
+    base64_value = "A" * 8200
+    payload = {
+        "external_ref": "weave:///entity/project/object/ada@example.com:latest",
+        "internal_ref": (
+            "weave-trace-internal:///cHJvamVjdA==/object/ada@example.com:latest"
+        ),
+        "private_ref": "weave-private://///object/ada@example.com:latest",
+        "base64_data": "data:text/plain;base64,YWRhQGV4YW1wbGUuY29t",
+        "base64": base64_value,
+    }
+
+    assert redact_pii_value(payload) is payload
+
+
+@pytest.mark.parametrize("prefix", ["data:", "DATA:"])
+def test_walker_scans_plaintext_data_urls(prefix: str) -> None:
+    assert redact_pii_value(f"{prefix}text/plain,ada@example.com") == (
+        f"{prefix}text/plain,<EMAIL_ADDRESS>"
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            "weave:///not-a-complete-ref ada@example.com",
+            "weave:///not-a-complete-ref <EMAIL_ADDRESS>",
+        ),
+        (
+            "weave-trace-internal:///missing-kind ada@example.com",
+            "weave-trace-internal:///missing-kind <EMAIL_ADDRESS>",
+        ),
+        (
+            "weave-private:///not-canonical ada@example.com",
+            "weave-private:///not-canonical <EMAIL_ADDRESS>",
+        ),
+    ],
+)
+def test_walker_scans_malformed_ref_prefixes(value: str, expected: str) -> None:
+    assert redact_pii_value(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "weave:///entity/project/object/ada@example.com:",
+        "weave-trace-internal:///project/object/ada@example.com:",
+        "weave-private://///object/ada@example.com:",
+    ],
+)
+def test_walker_scans_refs_with_missing_required_parts(value: str) -> None:
+    redacted = redact_pii_value(value)
+
+    assert "ada@example.com" not in redacted
+    assert "<EMAIL_ADDRESS>" in redacted
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_prefix"),
+    [
+        (
+            "data: not a URL; email ada@example.com",
+            "data: not a URL; email <EMAIL_ADDRESS>",
+        ),
+        (
+            "data:image/png;base64,ada@example.comA",
+            "data:image/png;base64,<EMAIL_ADDRESS>",
+        ),
+        ("/4111111111111111/" + "A" * (8192 - 18), "/<CREDIT_CARD>/"),
+        ("/4111111111111111/" + "A" * (8193 - 18), "/<CREDIT_CARD>/"),
+    ],
+    ids=[
+        "invalid-data-url",
+        "invalid-base64-data-url",
+        "base64-at-threshold",
+        "malformed-base64",
+    ],
+)
+def test_walker_does_not_preserve_invalid_encoded_content(
+    value: str, expected_prefix: str
+) -> None:
+    assert redact_pii_value(value).startswith(expected_prefix)
+
+
+def test_walker_fails_loudly_on_cyclic_input() -> None:
+    payload: dict[str, object] = {}
+    payload["self"] = payload
+
+    with pytest.raises(RecursionError):
+        redact_pii_value(payload)
+
+    assert payload["self"] is payload
+
+
+def test_numeric_run_without_minimum_digits_is_unchanged() -> None:
+    value = "1" + "-" * 600 + "2"
+
+    assert redact_pii_value(value) is value

--- a/weave/trace_server/sensitive_data/__init__.py
+++ b/weave/trace_server/sensitive_data/__init__.py
@@ -1,0 +1,1 @@
+"""Server-side sensitive-data redaction primitives."""

--- a/weave/trace_server/sensitive_data/detectors.py
+++ b/weave/trace_server/sensitive_data/detectors.py
@@ -1,0 +1,278 @@
+"""Bounded recognizers for the versioned ``pii-v1`` entity set.
+
+The first version covers plausible ASCII email addresses, formatted North
+American phone numbers, formatted international phone numbers, compact
+``+``-prefixed numbers containing 10 to 15 digits, dashed US SSNs, and
+13-to-19-digit card candidates that pass Luhn validation.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal, NamedTuple
+
+PIIEntity = Literal["EMAIL_ADDRESS", "PHONE_NUMBER", "US_SSN", "CREDIT_CARD"]
+
+REPLACEMENT_MARKERS: dict[PIIEntity, str] = {
+    "EMAIL_ADDRESS": "<EMAIL_ADDRESS>",
+    "PHONE_NUMBER": "<PHONE_NUMBER>",
+    "US_SSN": "<US_SSN>",
+    "CREDIT_CARD": "<CREDIT_CARD>",
+}
+
+_DETECTOR_PRIORITY: dict[PIIEntity, int] = {
+    "EMAIL_ADDRESS": 0,
+    "US_SSN": 1,
+    "CREDIT_CARD": 2,
+    "PHONE_NUMBER": 3,
+}
+
+_ASCII_DIGIT_RE = re.compile(r"[0-9]")
+_MIN_NUMERIC_CANDIDATE_DIGITS = 9
+# One C-level search for "at least 9 digits in the window".
+_MIN_NUMERIC_DIGITS_RE = re.compile(
+    rf"(?:[0-9][^0-9]*){{{_MIN_NUMERIC_CANDIDATE_DIGITS - 1}}}[0-9]", re.ASCII
+)
+_EMAIL_RE = re.compile(
+    r"(?<![A-Za-z0-9.!#$%&'*+/=?^_`{|}~-])"
+    r"[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]{1,64}"
+    r"@[A-Za-z0-9][A-Za-z0-9.-]{0,251}\.[A-Za-z]{2,63}"
+    r"(?![A-Za-z0-9-])",
+    re.ASCII,
+)
+_NUMERIC_RUN_RE = re.compile(r"[+()0-9][+()0-9 .-]{5,}[0-9)]", re.ASCII)
+_SSN_RE = re.compile(r"(?<![0-9])([0-9]{3})-([0-9]{2})-([0-9]{4})(?![0-9])")
+_CARD_RE = re.compile(r"(?<![0-9])(?:[0-9][ -]?){12,18}[0-9](?![0-9])")
+_US_PHONE_RE = re.compile(
+    r"(?<![A-Za-z0-9])(?:\+?1[ .-])?"
+    r"(?:\([2-9][0-9]{2}\)[ .-]?|[2-9][0-9]{2}[ .-])"
+    r"[2-9][0-9]{2}[ .-][0-9]{4}(?![A-Za-z0-9])"
+)
+_INTERNATIONAL_PHONE_RE = re.compile(
+    r"(?<![A-Za-z0-9+])\+[1-9][0-9]{0,2}[ .-]"
+    r"(?:[0-9]{2,4}[ .-]){1,3}[0-9]{2,4}(?![A-Za-z0-9])"
+)
+_COMPACT_INTERNATIONAL_PHONE_RE = re.compile(
+    r"(?<![A-Za-z0-9+])\+[1-9][0-9]{9,14}(?![A-Za-z0-9])"
+)
+# Numeric candidates contain only digits and these separators.
+_DROP_NUMERIC_SEPARATORS = str.maketrans("", "", "+() .-")
+# Dot-separated 1-to-63 character labels with no edge hyphens.
+_DOMAIN_LABELS_RE = re.compile(
+    r"(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*"
+    r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?",
+    re.ASCII,
+)
+_IDENTIFIER_CHARACTERS = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_"
+)
+
+
+class Detection(NamedTuple):
+    start: int
+    end: int
+    entity: PIIEntity
+
+
+def detect_pii(text: str) -> list[Detection]:
+    """Return non-overlapping PII spans without retaining matched text."""
+    detections: list[Detection] = []
+
+    if text.find("@") != -1:
+        for match in _EMAIL_RE.finditer(text):
+            candidate = match.group(0)
+            if _valid_email(candidate) and _absolute_token_boundaries(
+                text, match.start(), match.end()
+            ):
+                detections.append(
+                    Detection(match.start(), match.end(), "EMAIL_ADDRESS")
+                )
+
+    if _ASCII_DIGIT_RE.search(text) is not None:
+        # Only emails can overlap numerics, and both lists ascend by start.
+        email_count = len(detections)
+        email_index = 0
+        for run in _NUMERIC_RUN_RE.finditer(text):
+            if not _has_minimum_digits(text, run.start(), run.end()):
+                continue
+            candidate = run.group(0)
+            numeric_detections = _select_non_overlapping(
+                _detect_numeric(candidate, run.start(), text)
+            )
+            for detection in numeric_detections:
+                while (
+                    email_index < email_count
+                    and detections[email_index].end <= detection.start
+                ):
+                    email_index += 1
+                if (
+                    email_index < email_count
+                    and detections[email_index].start < detection.end
+                ):
+                    continue
+                detections.append(detection)
+
+    return _select_non_overlapping(detections)
+
+
+def redact_pii_string(text: str) -> str:
+    """Replace supported PII spans with stable typed markers."""
+    detections = detect_pii(text)
+    if not detections:
+        return text
+
+    parts: list[str] = []
+    cursor = 0
+    for detection in detections:
+        parts.append(text[cursor : detection.start])
+        parts.append(REPLACEMENT_MARKERS[detection.entity])
+        cursor = detection.end
+    parts.append(text[cursor:])
+    return "".join(parts)
+
+
+def _valid_email(candidate: str) -> bool:
+    local, domain = candidate.rsplit("@", 1)
+    if local.startswith(".") or local.endswith(".") or ".." in local:
+        return False
+    return _DOMAIN_LABELS_RE.fullmatch(domain) is not None
+
+
+def _has_minimum_digits(text: str, start: int, end: int) -> bool:
+    """Check a numeric run's cheap signal without regex backtracking."""
+    return _MIN_NUMERIC_DIGITS_RE.search(text, start, end) is not None
+
+
+def _detect_numeric(candidate: str, offset: int, text: str) -> list[Detection]:
+    # A digits-only run can only be a card under ``pii-v1``.
+    if candidate.isdecimal():
+        if (
+            13 <= len(candidate) <= 19
+            and _absolute_token_boundaries(text, offset, offset + len(candidate))
+            and _valid_card(candidate)
+        ):
+            return [
+                Detection(offset, offset + len(candidate), "CREDIT_CARD"),
+            ]
+        return []
+
+    # Skip sub-detectors whose required characters are absent.
+    detections: list[Detection] = []
+    if "-" in candidate:
+        for match in _SSN_RE.finditer(candidate):
+            if _valid_ssn(match) and _token_boundaries(text, offset, match):
+                detections.append(
+                    Detection(offset + match.start(), offset + match.end(), "US_SSN"),
+                )
+
+    if len(candidate) >= 13:
+        for match in _CARD_RE.finditer(candidate):
+            value = match.group(0)
+            if (
+                _card_boundaries(candidate, match)
+                and _token_boundaries(text, offset, match)
+                and _valid_card(value)
+            ):
+                detections.append(
+                    Detection(
+                        offset + match.start(), offset + match.end(), "CREDIT_CARD"
+                    ),
+                )
+
+    patterns = (
+        (_US_PHONE_RE, _INTERNATIONAL_PHONE_RE, _COMPACT_INTERNATIONAL_PHONE_RE)
+        if "+" in candidate
+        else (_US_PHONE_RE,)
+    )
+    for pattern in patterns:
+        for match in pattern.finditer(candidate):
+            if _valid_phone(match.group(0)) and _token_boundaries(text, offset, match):
+                detections.append(
+                    Detection(
+                        offset + match.start(), offset + match.end(), "PHONE_NUMBER"
+                    ),
+                )
+    return detections
+
+
+def _valid_ssn(match: re.Match[str]) -> bool:
+    area, group, serial = match.groups()
+    area_number = int(area)
+    return (
+        area_number not in {0, 666}
+        and area_number <= 899
+        and group != "00"
+        and serial != "0000"
+    )
+
+
+_LUHN_DOUBLED = (0, 2, 4, 6, 8, 1, 3, 5, 7, 9)
+
+
+def _valid_card(candidate: str) -> bool:
+    digits = candidate.translate(_DROP_NUMERIC_SEPARATORS)
+    if not 13 <= len(digits) <= 19 or len(set(digits)) == 1:
+        return False
+    checksum = 0
+    parity = len(digits) % 2
+    for index, character in enumerate(digits):
+        digit = ord(character) - 48
+        checksum += _LUHN_DOUBLED[digit] if index % 2 == parity else digit
+    return checksum % 10 == 0
+
+
+def _valid_phone(candidate: str) -> bool:
+    return 10 <= len(candidate.translate(_DROP_NUMERIC_SEPARATORS)) <= 15
+
+
+def _token_boundaries(text: str, offset: int, match: re.Match[str]) -> bool:
+    start = offset + match.start()
+    end = offset + match.end()
+    return _absolute_token_boundaries(text, start, end)
+
+
+def _absolute_token_boundaries(text: str, start: int, end: int) -> bool:
+    return (start == 0 or not _identifier_character(text[start - 1])) and (
+        end == len(text) or not _identifier_character(text[end])
+    )
+
+
+def _identifier_character(character: str) -> bool:
+    return character in _IDENTIFIER_CHARACTERS
+
+
+def _card_boundaries(candidate: str, match: re.Match[str]) -> bool:
+    start = match.start()
+    end = match.end()
+    if start >= 2 and candidate[start - 1] in " -" and candidate[start - 2].isdigit():
+        return False
+    return not (
+        end + 1 < len(candidate)
+        and candidate[end] in " -"
+        and candidate[end + 1].isdigit()
+    )
+
+
+def _detections_overlap(left: Detection, right: Detection) -> bool:
+    return left.start < right.end and right.start < left.end
+
+
+def _select_non_overlapping(detections: list[Detection]) -> list[Detection]:
+    if len(detections) < 2:
+        return detections
+    ordered = sorted(
+        detections,
+        key=lambda detection: (
+            detection.start,
+            -(detection.end - detection.start),
+            _DETECTOR_PRIORITY[detection.entity],
+        ),
+    )
+    selected: list[Detection] = []
+    end = -1
+    for detection in ordered:
+        if detection.start < end:
+            continue
+        selected.append(detection)
+        end = detection.end
+    return selected

--- a/weave/trace_server/sensitive_data/policy.py
+++ b/weave/trace_server/sensitive_data/policy.py
@@ -1,0 +1,16 @@
+"""Closed deployment policy for trace-ingest sensitive-data handling."""
+
+from enum import Enum
+
+
+class SensitiveDataPolicy(str, Enum):
+    OFF = "off"
+    PII_V1 = "pii-v1"
+
+
+def pii_enabled(policy: SensitiveDataPolicy) -> bool:
+    if policy is SensitiveDataPolicy.OFF:
+        return False
+    if policy is SensitiveDataPolicy.PII_V1:
+        return True
+    raise ValueError(f"Unknown sensitive-data policy: {policy!r}")

--- a/weave/trace_server/sensitive_data/walker.py
+++ b/weave/trace_server/sensitive_data/walker.py
@@ -66,8 +66,17 @@ def _is_json_candidate(value: str) -> bool:
 
 
 def _redact_json_string(value: str) -> str:
+    saw_duplicate_key = False
+
+    def _build_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        nonlocal saw_duplicate_key
+        mapping = dict(pairs)
+        if len(mapping) != len(pairs):
+            saw_duplicate_key = True
+        return mapping
+
     try:
-        parsed = json.loads(value)
+        parsed = json.loads(value, object_pairs_hook=_build_object)
     except ValueError:
         return redact_pii_string(value)
     except RecursionError as error:
@@ -75,7 +84,8 @@ def _redact_json_string(value: str) -> str:
     if not isinstance(parsed, (dict, list, str)):
         return redact_pii_string(value)
     redacted = redact_pii_value(parsed)
-    if redacted is parsed:
+    # A duplicate key shadows a value the walk never saw; reserialize to drop it.
+    if redacted is parsed and not saw_duplicate_key:
         return value
     return json.dumps(redacted, separators=(",", ":"))
 

--- a/weave/trace_server/sensitive_data/walker.py
+++ b/weave/trace_server/sensitive_data/walker.py
@@ -1,0 +1,208 @@
+"""Copy-on-write credential and PII traversal of trace values."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Sequence
+from enum import Enum
+from typing import Any, TypeVar, cast
+
+from pydantic import BaseModel
+
+from weave.shared import refs_internal as ri
+from weave.trace_server.credential_redaction import REDACTED_VALUE, should_redact
+from weave.trace_server.errors import RequestTooLarge
+from weave.trace_server.sensitive_data.detectors import redact_pii_string
+
+T = TypeVar("T")
+
+# Keep these aligned with the standalone-base64 gate in
+# ``base64_content_conversion``. That path considers only strings strictly
+# larger than 8 KiB and validates the encoding before offloading it.
+_INLINE_BASE64_MIN_CHARACTERS = 8192
+_INLINE_BASE64_RE = re.compile(r"[A-Za-z0-9+/]+={0,2}", re.ASCII)
+_DATA_URL_RE = re.compile(
+    r"data:(?:[\w/+.-]+)?(?:;[\w-]+=[\w.-]+)*"
+    r"(?P<base64>;base64)?,(?P<data>[^\r\n]*)",
+    re.ASCII | re.IGNORECASE,
+)
+_EXTERNAL_REF_PREFIX = f"{ri.WEAVE_SCHEME}:///"
+_INTERNAL_REF_PREFIX = f"{ri.WEAVE_INTERNAL_SCHEME}:///"
+_PRIVATE_REF_PREFIX = f"{ri.WEAVE_PRIVATE_SCHEME}://///"
+_SYNTHETIC_PROJECT_ID = "cHJvamVjdA=="
+
+
+def redact_pii_value(value: T) -> T:
+    """Redact credential-shaped fields and PII while reusing clean subtrees."""
+    if isinstance(value, Enum):
+        return value
+    if isinstance(value, str):
+        if _preserve_string(value):
+            return value
+        if _is_json_candidate(value):
+            return cast(T, _redact_json_string(value))
+        return cast(T, redact_pii_string(value))
+    if isinstance(value, BaseModel):
+        return cast(T, _redact_model(value))
+    if isinstance(value, dict):
+        return cast(T, _redact_mapping(value))
+    if isinstance(value, list):
+        return cast(T, _redact_sequence(value, list))
+    if isinstance(value, tuple):
+        return cast(T, _redact_sequence(value, tuple))
+    return value
+
+
+def _is_json_candidate(value: str) -> bool:
+    stripped = value.strip()
+    if len(stripped) < 2 or (stripped[0], stripped[-1]) not in {
+        ("{", "}"),
+        ("[", "]"),
+        ('"', '"'),
+    }:
+        return False
+    return "@" in stripped or any("0" <= character <= "9" for character in stripped)
+
+
+def _redact_json_string(value: str) -> str:
+    try:
+        parsed = json.loads(value)
+    except ValueError:
+        return redact_pii_string(value)
+    except RecursionError as error:
+        raise RequestTooLarge("Sensitive-data nesting limit exceeded") from error
+    if not isinstance(parsed, (dict, list, str)):
+        return redact_pii_string(value)
+    redacted = redact_pii_value(parsed)
+    if redacted is parsed:
+        return value
+    return json.dumps(redacted, separators=(",", ":"))
+
+
+def _preserve_string(value: str) -> bool:
+    if _is_complete_weave_ref(value):
+        return True
+    if value[:5].lower() == "data:" and _is_base64_data_url(value):
+        return True
+    return (
+        len(value) > _INLINE_BASE64_MIN_CHARACTERS
+        and len(value) % 4 == 0
+        and _INLINE_BASE64_RE.fullmatch(value) is not None
+    )
+
+
+def _is_complete_weave_ref(value: str) -> bool:
+    if value.startswith(_INTERNAL_REF_PREFIX):
+        return _internal_ref_round_trips(value)
+    if value.startswith(_EXTERNAL_REF_PREFIX):
+        parts = value[len(_EXTERNAL_REF_PREFIX) :].split("/", 2)
+        if len(parts) != 3 or not all(parts):
+            return False
+        return _ref_tail_round_trips(parts[2])
+    if value.startswith(_PRIVATE_REF_PREFIX):
+        tail = value[len(_PRIVATE_REF_PREFIX) :]
+        return bool(tail) and _ref_tail_round_trips(tail)
+    return False
+
+
+def _ref_tail_round_trips(tail: str) -> bool:
+    return _internal_ref_round_trips(
+        f"{_INTERNAL_REF_PREFIX}{_SYNTHETIC_PROJECT_ID}/{tail}"
+    )
+
+
+def _internal_ref_round_trips(value: str) -> bool:
+    try:
+        parsed = ri.parse_internal_uri(value)
+    except (IndexError, ValueError):
+        return False
+    else:
+        return _has_complete_ref_parts(parsed) and parsed.uri == value
+
+
+def _has_complete_ref_parts(ref: ri.InternalRef) -> bool:
+    if not ref.project_id:
+        return False
+    if isinstance(ref, ri.InternalTableRef):
+        return bool(ref.digest)
+    if isinstance(ref, ri.InternalObjectRef):
+        return bool(ref.name and ref.version)
+    if isinstance(ref, ri.InternalCallRef):
+        return bool(ref.id)
+    if isinstance(ref, ri.InternalArtifactRef):
+        return bool(ref.id)
+    if isinstance(ref, ri.InternalAgentTurnRef):
+        return bool(ref.trace_id)
+    if isinstance(ref, ri.InternalAgentConversationRef):
+        return bool(ref.conversation_id)
+    if isinstance(ref, ri.InternalAgentSpanRef):
+        return bool(ref.span_id)
+    return False
+
+
+def _is_base64_data_url(value: str) -> bool:
+    match = _DATA_URL_RE.fullmatch(value)
+    if match is None or match.group("base64") is None:
+        return False
+    data_start, data_end = match.span("data")
+    data_length = data_end - data_start
+    return data_length == 0 or (
+        data_length % 4 == 0
+        and _INLINE_BASE64_RE.fullmatch(value, data_start, data_end) is not None
+    )
+
+
+def _redact_model(model: BaseModel) -> BaseModel:
+    updates: dict[str, Any] = {}
+    for field_name, field_info in model.__class__.model_fields.items():
+        if field_info.exclude is True:
+            continue
+        original = getattr(model, field_name)
+        redacted = _redact_named_value(field_name, original)
+        if redacted is not original:
+            updates[field_name] = redacted
+    for field_name, original in (model.model_extra or {}).items():
+        redacted = _redact_named_value(field_name, original)
+        if redacted is not original:
+            updates[field_name] = redacted
+    return model if not updates else model.model_copy(update=updates)
+
+
+def _redact_mapping(value: dict[Any, Any]) -> dict[Any, Any]:
+    redacted: dict[Any, Any] | None = None
+    for key, original in value.items():
+        item = _redact_named_value(key, original)
+        if item is original:
+            continue
+        if redacted is None:
+            redacted = dict(value)
+        redacted[key] = item
+    return value if redacted is None else redacted
+
+
+def _redact_named_value(name: Any, value: Any) -> Any:
+    if (
+        isinstance(name, str)
+        and isinstance(value, str)
+        and value
+        and value != REDACTED_VALUE
+        and should_redact(name)
+    ):
+        return REDACTED_VALUE
+    return redact_pii_value(value)
+
+
+def _redact_sequence(
+    value: Sequence[Any],
+    rebuild: Callable[[list[Any]], Sequence[Any]],
+) -> Sequence[Any]:
+    redacted: list[Any] | None = None
+    for index, original in enumerate(value):
+        item = redact_pii_value(original)
+        if item is original:
+            continue
+        if redacted is None:
+            redacted = list(value)
+        redacted[index] = item
+    return value if redacted is None else rebuild(redacted)


### PR DESCRIPTION
## What

Add the versioned `off` and `pii-v1` policy enum, bounded PII detectors, and a copy-on-write traversal for trace values.

This PR adds dormant library code only. No write path calls these helpers when this PR merges.

## Why

Calls and Agent OTel writes need one shared implementation for recognizing and replacing supported PII before storage. Keeping the primitives separate lets reviewers evaluate the detector and traversal contract without route or storage integration.

## How

- Replace supported email addresses, phone numbers, US Social Security numbers, and Luhn-valid payment card numbers with typed markers.
- Use a cheap character check to run only applicable recognizers for each string.
- Combine credential-key replacement and PII replacement in one copy-on-write traversal. Clean subtrees retain their identity, and dictionary keys are not scanned.
- Preserve complete Weave refs, valid base64 data URLs, and valid standalone base64 payloads. Malformed lookalikes remain eligible for scanning.
- Reject unknown policy values instead of choosing a fallback.

## Testing

58 focused tests passed for detector boundaries, false-positive exclusions, structured and escaped JSON values, copy-on-write behavior, credential-key handling, and preserved encoded content.

## Anything Else

- No runtime dependency, migration, permission change, public schema change, or active redaction behavior.
- Child: https://github.com/wandb/weave/pull/7789.
