### PR TITLE
feat(weave): add optional Agent PII policy field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -723,6 +723,14 @@ deterministic.
 - The walk is copy-on-write and replaces only non-empty strings. Both properties
   are load-bearing — see the module docstring — so keep them if you touch it.
 
+### Agent PII policy
+
+- `GenAIOTelExportReq.sensitive_data_policy` is an internal, omittable,
+  non-nullable field. Omission resolves to `off`.
+- An authorized server route may set `pii-v1` from the owning organization's
+  policy. Never populate the field from caller-controlled OTLP content or a
+  process environment fallback.
+
 ### Credential-shaped fields in agent span columns
 - The agents OTel ingest calls `redact_credentials_from_span` before
   `strip_inline_blobs_from_span`, and outside the file-storage guard around it.

--- a/tests/trace_server/test_agent_sensitive_data_policy.py
+++ b/tests/trace_server/test_agent_sensitive_data_policy.py
@@ -1,0 +1,36 @@
+import pytest
+from pydantic import ValidationError
+
+from weave.trace_server.agents.types import GenAIOTelExportReq
+from weave.trace_server.sensitive_data.policy import SensitiveDataPolicy
+
+
+def _request_payload() -> dict[str, object]:
+    return {
+        "processed_spans": [],
+        "project_id": "entity/project",
+        "wb_user_id": "user",
+    }
+
+
+def test_agent_sensitive_data_policy_defaults_off() -> None:
+    request = GenAIOTelExportReq.model_validate(_request_payload())
+
+    assert request.sensitive_data_policy is SensitiveDataPolicy.OFF
+
+
+def test_agent_sensitive_data_policy_accepts_pii_v1() -> None:
+    payload = _request_payload()
+    payload["sensitive_data_policy"] = "pii-v1"
+
+    request = GenAIOTelExportReq.model_validate(payload)
+
+    assert request.sensitive_data_policy is SensitiveDataPolicy.PII_V1
+
+
+def test_agent_sensitive_data_policy_rejects_null() -> None:
+    payload = _request_payload()
+    payload["sensitive_data_policy"] = None
+
+    with pytest.raises(ValidationError):
+        GenAIOTelExportReq.model_validate(payload)

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -42,6 +42,7 @@ from weave.trace_server.agents.schema import (
 )
 from weave.trace_server.interface.feedback_types import AgentSpanFeedbackType
 from weave.trace_server.interface.query import Query
+from weave.trace_server.sensitive_data.policy import SensitiveDataPolicy
 
 if TYPE_CHECKING:
     from weave.trace_server.trace_server_interface import ProcessedResourceSpans
@@ -1321,6 +1322,7 @@ class GenAIOTelExportReq(BaseModel):
     project_id: str
     wb_user_id: str | None = None
     entity_name: str | None = None
+    sensitive_data_policy: SensitiveDataPolicy = SensitiveDataPolicy.OFF
 
 
 class GenAIOTelExportRes(BaseModel):


### PR DESCRIPTION
## What

Add an internal `sensitive_data_policy` field to `GenAIOTelExportReq`.

The field is omittable and non-nullable. Omission resolves to `off`; an authorized host can pass `pii-v1`. This PR does not consume the field or change stored data.

## Why

The host service needs a typed request contract for propagating organization policy before storage integration is enabled. A default-off field keeps existing internal callers compatible during the staged rollout.

## How

- Reuse the closed `SensitiveDataPolicy` enum from the parent PR.
- Default omitted values to `SensitiveDataPolicy.OFF`.
- Accept an explicit `pii-v1` value and reject `null` or unknown values.
- Keep the field server-internal. Caller-controlled OTLP content and process environment settings do not set it.

## Testing

3 contract tests passed for omitted, explicit `pii-v1`, and `null` values.

## Anything Else

- Parent: https://github.com/wandb/weave/pull/7788.
- Child: [#7740](https://github.com/wandb/weave/pull/7740).
- Internal request contract change: existing callers continue to resolve to `off` when they omit the field.
