### PR TITLE
chore(weave): only produce insights events for spans with a conversation

### DIFF
--- a/tests/trace_server/test_agent_scorer_events.py
+++ b/tests/trace_server/test_agent_scorer_events.py
@@ -66,3 +66,23 @@ def test_from_row() -> None:
     )
     assert ScoreAgentSpansEvent.from_row(child_row) is None
     assert EmbedAgentSpansEvent.from_row(child_row) is None
+
+
+def test_embed_requires_conversation_but_score_does_not() -> None:
+    """A root span with no `conversation_id` still scores, but never feeds insights embedding."""
+    no_convo_row = AgentSpanCHInsertable(
+        project_id="p",
+        trace_id="tr",
+        span_id="root",
+        parent_span_id="",
+        span_name="root",
+        status_code="OK",
+        started_at=_STARTED_AT,
+        ended_at=_ENDED_AT,
+        conversation_id="",
+        operation_name="invoke_agent",
+    )
+    assert EmbedAgentSpansEvent.from_row(no_convo_row, "acme") is None
+    score_event = ScoreAgentSpansEvent.from_row(no_convo_row, "acme")
+    assert score_event is not None
+    assert score_event.conversation_id is None

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -2031,7 +2031,7 @@ def test_alias_pointing_at_soft_deleted_version_yields_clean_failure(ch_server):
 
 
 def _turn_ended_span_row() -> AgentSpanCHInsertable:
-    """A finished root span; ScoreAgentSpansEvent.from_row yields a turn_ended event."""
+    """A finished root span with a conversation; both event classes yield a turn_ended event."""
     return AgentSpanCHInsertable(
         project_id="p",
         trace_id="tr",
@@ -2042,6 +2042,7 @@ def _turn_ended_span_row() -> AgentSpanCHInsertable:
         ended_at=dt.datetime(2024, 1, 1, 12, 0, 0),
         agent_name="a",
         operation_name="invoke_agent",
+        conversation_id="c",
     )
 
 

--- a/weave/trace_server/agents/kafka_events.py
+++ b/weave/trace_server/agents/kafka_events.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from pydantic import BaseModel
 from typing_extensions import Self
@@ -37,6 +37,9 @@ class _AgentSpansEvent(BaseModel):
     parent_span_id: str | None
     conversation_id: str | None
 
+    # Subclasses set this to require a non-empty `conversation_id` on the row.
+    requires_conversation: ClassVar[bool] = False
+
     @classmethod
     def from_row(
         cls, row: AgentSpanCHInsertable, entity_name: str | None = None
@@ -45,6 +48,8 @@ class _AgentSpansEvent(BaseModel):
 
         Currently only "turn_ended" is supported, but the interface is designed to support multiple types.
         """
+        if cls.requires_conversation and not row.conversation_id:
+            return None
         event_type: AgentSpanOpName | None = None
         # A span with no parent is assumed to represent the end of a turn
         if not row.parent_span_id:
@@ -81,6 +86,9 @@ class ScoreAgentSpansEvent(_AgentSpansEvent):
 
 class EmbedAgentSpansEvent(_AgentSpansEvent):
     """Trigger event for Agent Insights embedding."""
+
+    # Insights only judges turns with real conversation semantics.
+    requires_conversation: ClassVar[bool] = True
 
     def emit(self, producer: KafkaProducer | None) -> None:
         """Produce this event for Agent Insights without raising."""


### PR DESCRIPTION
## Summary
- `EmbedAgentSpansEvent` now requires a non-empty `conversation_id` on the span row, so the insights pipeline only judges turns with real conversation semantics. Across three days of production insights rows, every row with a blank `conversation_id` came from one project and all eleven other projects were 0% blank, so this drops exactly the non-conversational traffic while keeping that project's genuine conversations. Expect insights volume to roughly halve, which is the intent.
- The gate is a `requires_conversation` ClassVar honored by the shared `from_row`, so `ScoreAgentSpansEvent` is unaffected. Agent scoring does not depend on conversation semantics and must keep firing for non-conversational root spans.

## Testing
unit test asserting that asymmetry directly: a root span with an empty `conversation_id` yields no `EmbedAgentSpansEvent` but still yields a `ScoreAgentSpansEvent`.
