### PR TITLE
chore(weave): add wandbot-3000[bot] to the CLA allowlist

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -27,4 +27,4 @@ jobs:
           # branch should not be protected
           branch: "cla"
           # cannot use teams due to: https://github.com/contributor-assistant/github-action/issues/100
-          allowlist: actions-user, altay, andrewtruong, bdytx5, dannygoldstein, davidwallacejackson, jamie-rasmussen, jlzhao27, jo-fang, jwlee64, laxels, morganmcg1, nickpenaranda, openhands@all-hands.dev, scottire, shawnlewis, staceysv, tssweeney, vanpelt, vwrj, wandbmachine, weave@wandb.com, dependabot[bot], fixit-agent[bot]
+          allowlist: actions-user, altay, andrewtruong, bdytx5, dannygoldstein, davidwallacejackson, jamie-rasmussen, jlzhao27, jo-fang, jwlee64, laxels, morganmcg1, nickpenaranda, openhands@all-hands.dev, scottire, shawnlewis, staceysv, tssweeney, vanpelt, vwrj, wandbmachine, weave@wandb.com, dependabot[bot], fixit-agent[bot], wandbot-3000[bot]


### PR DESCRIPTION
## JIRA Issue(s)

[WB-39083](https://coreweave.atlassian.net/browse/WB-39083)

## Description

A GitHub Action in wandb/core will open weave PRs as `wandbot-3000[bot]` when the trace-server spec changes. The CLA check fails for that bot today, so those PRs cannot merge.

This PR adds `wandbot-3000[bot]` to the CLA allowlist, next to `dependabot[bot]` and `fixit-agent[bot]`. Same GitHub App as the Update Weave submodule PRs. The Action itself is wandb/core#51668.

## Testing

The GitHub App slug is `wandbot-3000`, which is the `wandbot-3000[bot]` login. The allowlist already uses that `[bot]` form for the other bots.


[WB-39083]: https://coreweave.atlassian.net/browse/WB-39083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ