### PR TITLE
chore(pulse): bound insight worker ClickHouse reads

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -2115,6 +2115,67 @@ class TestMakeConversationChatSpansQuery:
         """
         assert_sql(expected, expected_pb.get_params(), query, pb.get_params())
 
+    def test_with_started_at_bound(self) -> None:
+        started_at = datetime.datetime(2026, 8, 18, tzinfo=datetime.timezone.utc)
+        req = AgentConversationChatReq(
+            project_id="p1", conversation_id="c1", started_at_gte=started_at
+        )
+        spans_pb = ParamBuilder("genai")
+        spans_query = make_conversation_chat_spans_query(spans_pb, req)
+
+        expected_pb = ParamBuilder("genai")
+        expected_pb.add("p1", param_type="String")
+        expected_pb.add("c1", param_type="String")
+        expected_pb.add(50, param_type="UInt64")
+        expected_pb.add(0, param_type="UInt64")
+        expected_pb.add(started_at, param_type="DateTime64(6)")
+        source = cost_augmented_source_sql(expected_pb, "p1")
+        expected_spans = f"""
+            WITH turn_page AS (
+                SELECT trace_id, min(started_at) AS turn_started_at
+                FROM spans
+                WHERE project_id = {{genai_0:String}}
+                AND conversation_id = {{genai_1:String}}
+                AND started_at >= {{genai_4:DateTime64(6)}}
+                GROUP BY trace_id
+                ORDER BY turn_started_at DESC, trace_id DESC
+                LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
+            )
+            SELECT {QUALIFIED_CHAT_VIEW_COLS}, {QUALIFIED_SPANS_COST_COLS}
+            FROM {source} s
+            INNER JOIN turn_page t ON s.trace_id = t.trace_id
+            WHERE s.project_id = {{genai_0:String}}
+            AND s.trace_id IN (SELECT trace_id FROM turn_page)
+            AND s.conversation_id IN ({{genai_1:String}}, '')
+            AND s.started_at >= {{genai_4:DateTime64(6)}}
+            ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
+        """
+        assert_sql(
+            expected_spans,
+            expected_pb.get_params(),
+            spans_query,
+            spans_pb.get_params(),
+        )
+
+        count_pb = ParamBuilder("genai")
+        count_query = make_conversation_chat_turns_count_query(count_pb, req)
+        expected_count = """
+            SELECT count() FROM (
+                SELECT trace_id
+                FROM spans s
+                WHERE s.project_id = {genai_0:String}
+                AND s.conversation_id = {genai_1:String}
+                AND s.started_at >= {genai_2:DateTime64(6)}
+                GROUP BY trace_id
+            )
+        """
+        assert_sql(
+            expected_count,
+            {"genai_0": "p1", "genai_1": "c1", "genai_2": started_at},
+            count_query,
+            count_pb.get_params(),
+        )
+
     def test_with_pagination(self) -> None:
         pb = ParamBuilder("genai")
         query = make_conversation_chat_spans_query(

--- a/tests/trace_server/test_agent_scorer_events.py
+++ b/tests/trace_server/test_agent_scorer_events.py
@@ -50,6 +50,7 @@ def test_from_row() -> None:
         parent_span_id=None,
         conversation_id="c",
         operation_name="invoke_agent",
+        started_at=_STARTED_AT,
     )
     # The row itself carries no entity, so an unstamped event has none: consumers
     # that route by entity have to treat that as unroutable, not as allowed.

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -1749,6 +1749,14 @@ def test_index_operations_only_on_local_tables_distributed(distributed_migrator)
             "ALTER TABLE calls_merged DROP INDEX IF EXISTS idx_sortable_datetime",
             "ALTER TABLE calls_merged_local ON CLUSTER test_cluster DROP INDEX IF EXISTS idx_sortable_datetime",
         ),
+        (
+            "ALTER TABLE failure_signatures ADD INDEX IF NOT EXISTS idx_current_trace_id current_trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
+            "ALTER TABLE failure_signatures_local ON CLUSTER test_cluster ADD INDEX IF NOT EXISTS idx_current_trace_id current_trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
+        ),
+        (
+            "ALTER TABLE failure_signatures DROP INDEX IF EXISTS idx_current_trace_id",
+            "ALTER TABLE failure_signatures_local ON CLUSTER test_cluster DROP INDEX IF EXISTS idx_current_trace_id",
+        ),
     ]
 
     for command, expected_local_sql in test_cases:

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -677,6 +677,7 @@ _SIGNATURE_TABLES = [
         [
             ("idx_affected_trace_ids", "affected_trace_ids"),
             ("idx_conversation_id", "conversation_id"),
+            ("idx_current_trace_id", "current_trace_id"),
         ],
     ),
 ]

--- a/weave/trace_server/agents/kafka_events.py
+++ b/weave/trace_server/agents/kafka_events.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING, ClassVar
 
 from pydantic import BaseModel
@@ -87,8 +88,19 @@ class ScoreAgentSpansEvent(_AgentSpansEvent):
 class EmbedAgentSpansEvent(_AgentSpansEvent):
     """Trigger event for Agent Insights embedding."""
 
+    started_at: datetime | None = None
+
     # Insights only judges turns with real conversation semantics.
     requires_conversation: ClassVar[bool] = True
+
+    @classmethod
+    def from_row(
+        cls, row: AgentSpanCHInsertable, entity_name: str | None = None
+    ) -> Self | None:
+        event = super().from_row(row, entity_name)
+        if event is None:
+            return None
+        return event.model_copy(update={"started_at": row.started_at})
 
     def emit(self, producer: KafkaProducer | None) -> None:
         """Produce this event for Agent Insights without raising."""

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -1181,6 +1181,7 @@ class AgentConversationChatReq(BaseModel):
 
     project_id: str
     conversation_id: str
+    started_at_gte: datetime.datetime | None = None
     limit: int = Field(
         default=MAX_CONVERSATION_CHAT_TURNS,
         ge=0,

--- a/weave/trace_server/migrations/044_add_failure_current_trace_id_index.down.sql
+++ b/weave/trace_server/migrations/044_add_failure_current_trace_id_index.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE failure_signatures DROP INDEX IF EXISTS idx_current_trace_id;

--- a/weave/trace_server/migrations/044_add_failure_current_trace_id_index.up.sql
+++ b/weave/trace_server/migrations/044_add_failure_current_trace_id_index.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE failure_signatures
+    ADD INDEX IF NOT EXISTS idx_current_trace_id
+        current_trace_id TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1916,6 +1916,21 @@ def make_conversation_chat_spans_query(
     cid = pb.add(req.conversation_id, param_type="String")
     limit_slot = pb.add(req.limit, param_type="UInt64")
     offset_slot = pb.add(req.offset, param_type="UInt64")
+    started_at_slot = (
+        pb.add(req.started_at_gte, param_type="DateTime64(6)")
+        if req.started_at_gte is not None
+        else None
+    )
+    turn_time_filter = (
+        f"\n              AND started_at >= {started_at_slot}"
+        if started_at_slot is not None
+        else ""
+    )
+    span_time_filter = (
+        f"\n          AND s.started_at >= {started_at_slot}"
+        if started_at_slot is not None
+        else ""
+    )
     # Always cost-augmented so the multi-turn chat view can render per-message
     # and per-turn cost; bounded to one conversation's turns, so cheap.
     source = cost_augmented_source_sql(pb, req.project_id)
@@ -1927,7 +1942,7 @@ def make_conversation_chat_spans_query(
             SELECT trace_id, min(started_at) AS turn_started_at
             FROM spans
             WHERE {_project_filter_sql("project_id", pid)}
-              AND conversation_id = {cid}
+              AND conversation_id = {cid}{turn_time_filter}
             GROUP BY trace_id
             ORDER BY turn_started_at DESC, trace_id DESC
             LIMIT {limit_slot} OFFSET {offset_slot}
@@ -1937,7 +1952,7 @@ def make_conversation_chat_spans_query(
         INNER JOIN turn_page t ON s.trace_id = t.trace_id
         WHERE {_project_filter_sql("s.project_id", pid)}
           AND s.trace_id IN (SELECT trace_id FROM turn_page)
-          AND s.conversation_id IN ({cid}, '')
+          AND s.conversation_id IN ({cid}, ''){span_time_filter}
         ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
     """
 
@@ -1948,12 +1963,22 @@ def make_conversation_chat_turns_count_query(
     """Count distinct trace_id turns in a conversation."""
     pid = pb.add(req.project_id, param_type="String")
     cid = pb.add(req.conversation_id, param_type="String")
+    started_at_slot = (
+        pb.add(req.started_at_gte, param_type="DateTime64(6)")
+        if req.started_at_gte is not None
+        else None
+    )
+    time_filter = (
+        f"\n              AND s.started_at >= {started_at_slot}"
+        if started_at_slot is not None
+        else ""
+    )
     return f"""
         SELECT count() FROM (
             SELECT trace_id
             FROM spans s
             WHERE {_project_filter_sql("s.project_id", pid)}
-              AND s.conversation_id = {cid}
+              AND s.conversation_id = {cid}{time_filter}
             GROUP BY trace_id
         )
     """


### PR DESCRIPTION
## Summary
- Adds optional `started_at_gte` pruning to both conversation chat queries while leaving the API default unbounded.
- Copies the source span timestamp into `EmbedAgentSpansEvent`, so the Pulse worker applies its seven-day source lookback to conversation reads.
- Adds migration 044 with a bloom index on `failure_signatures.current_trace_id`.

## Performance
Local ClickHouse 26.6.1, five warm-cache runs; medians on 600,000 spans and 140,000 failure signatures.
| Query | Latency | Peak RAM | Rows read |
| --- | ---: | ---: | ---: |
| Conversation spans | 17 → 12 ms | 9.3 → 5.9 MiB | 988,992 → 325,440 |
| Conversation turn count | 5 → 5 ms | 6.7 → 2.9 MiB | 403,392 → 124,864 |
| Failure trace bloom, one sparse ID | 2 → 2 ms | 1.2 → 1.2 MiB | 1,696 → 1,696 |

## Testing
Full-SQL query-builder coverage, Kafka event serialization, migration schema checks, and production migration up/down tests.

## Anything Else
- The 140,000-row local failure seed is too small to show an index gain. Core consumer: wandb/core#51857.