### PR TITLE
perf(weave): reduce peak memory during PII redaction

### DIFF
--- a/weave/trace_server/sensitive_data/detectors.py
+++ b/weave/trace_server/sensitive_data/detectors.py
@@ -9,6 +9,7 @@ American phone numbers, formatted international phone numbers, compact
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 from typing import Literal, NamedTuple
 
 PIIEntity = Literal["EMAIL_ADDRESS", "PHONE_NUMBER", "US_SSN", "CREDIT_CARD"]
@@ -76,57 +77,62 @@ class Detection(NamedTuple):
 
 def detect_pii(text: str) -> list[Detection]:
     """Return non-overlapping PII spans without retaining matched text."""
-    detections: list[Detection] = []
+    return list(_iter_detections(text))
 
-    if text.find("@") != -1:
-        for match in _EMAIL_RE.finditer(text):
-            candidate = match.group(0)
-            if _valid_email(candidate) and _absolute_token_boundaries(
-                text, match.start(), match.end()
-            ):
-                detections.append(
-                    Detection(match.start(), match.end(), "EMAIL_ADDRESS")
-                )
 
-    if _ASCII_DIGIT_RE.search(text) is not None:
-        # Only emails can overlap numerics, and both lists ascend by start.
-        email_count = len(detections)
-        email_index = 0
-        for run in _NUMERIC_RUN_RE.finditer(text):
-            if not _has_minimum_digits(text, run.start(), run.end()):
-                continue
-            candidate = run.group(0)
-            numeric_detections = _select_non_overlapping(
-                _detect_numeric(candidate, run.start(), text)
-            )
-            for detection in numeric_detections:
-                while (
-                    email_index < email_count
-                    and detections[email_index].end <= detection.start
-                ):
-                    email_index += 1
-                if (
-                    email_index < email_count
-                    and detections[email_index].start < detection.end
-                ):
-                    continue
-                detections.append(detection)
+def _iter_detections(text: str) -> Iterator[Detection]:
+    """Yield accepted detections in ascending order without collecting them.
 
-    return _select_non_overlapping(detections)
+    Emails and numeric runs each ascend and never self-overlap, so a two-stream
+    merge replaces collecting and sorting every detection; a numeric detection
+    overlapping the pending email is dropped, keeping email priority.
+    """
+    emails = _iter_email_detections(text) if text.find("@") != -1 else iter(())
+    numerics = (
+        _iter_numeric_detections(text)
+        if _ASCII_DIGIT_RE.search(text) is not None
+        else iter(())
+    )
+    email = next(emails, None)
+    for detection in numerics:
+        while email is not None and email.end <= detection.start:
+            yield email
+            email = next(emails, None)
+        if email is not None and email.start < detection.end:
+            continue
+        yield detection
+    while email is not None:
+        yield email
+        email = next(emails, None)
+
+
+def _iter_email_detections(text: str) -> Iterator[Detection]:
+    for match in _EMAIL_RE.finditer(text):
+        if _valid_email(match.group(0)) and _absolute_token_boundaries(
+            text, match.start(), match.end()
+        ):
+            yield Detection(match.start(), match.end(), "EMAIL_ADDRESS")
+
+
+def _iter_numeric_detections(text: str) -> Iterator[Detection]:
+    for run in _NUMERIC_RUN_RE.finditer(text):
+        if not _has_minimum_digits(text, run.start(), run.end()):
+            continue
+        yield from _select_non_overlapping(
+            _detect_numeric(run.group(0), run.start(), text)
+        )
 
 
 def redact_pii_string(text: str) -> str:
     """Replace supported PII spans with stable typed markers."""
-    detections = detect_pii(text)
-    if not detections:
-        return text
-
     parts: list[str] = []
     cursor = 0
-    for detection in detections:
+    for detection in _iter_detections(text):
         parts.append(text[cursor : detection.start])
         parts.append(REPLACEMENT_MARKERS[detection.entity])
         cursor = detection.end
+    if not parts:
+        return text
     parts.append(text[cursor:])
     return "".join(parts)
 


### PR DESCRIPTION
## Description

On merge, `redact_pii_string` consumes accepted PII detections as a stream instead of building and globally sorting a string-wide list. This reduces transient allocation in the `pii-v1` scan added by #7788. It does not change which entities are detected or how they are replaced.

Email detections and numeric detections each arrive in ascending order and do not overlap within their own stream. `_iter_detections` merges those streams and drops a numeric detection when it overlaps the pending email, preserving the existing email priority. `detect_pii` keeps its list-returning API; only the redaction path consumes the iterator directly.

### Peak allocation

The dense corpus repeats `jane.doe12@example.com 415-555-0123 `, which has two accepted matches per 36 characters. `tracemalloc` starts after the input is built, so the ratios exclude the input itself.

| Input | `master` | This PR |
| --- | ---: | ---: |
| Plain string, 1 MiB | 14.04× | 1.84× |
| Plain string, 3.5 MiB | 14.05× | 1.76× |
| JSON object containing one 1 MiB string | 15.04× | 3.59× |
| Digit-heavy string with no accepted PII | ~0× | ~0× |

The 3.5 MiB `detect_pii` call itself peaks at 7.61× on this PR because that API still returns the complete list. The production redaction path streams the same detections and peaks at 1.76×.

Fresh-process resident-memory measurements stay linear through the 100 MiB request cap:

| Plain input | `master` RSS delta | This PR RSS delta |
| --- | ---: | ---: |
| 8 MiB | 123.5 MiB (15.44×) | 15.6 MiB (1.95×) |
| 32 MiB | 487.5 MiB (15.23×) | 57.2 MiB (1.79×) |
| 100 MiB | 1,518.5 MiB (15.19×) | 177.8 MiB (1.78×) |

### CPU

Old and new implementations ran back to back in one process over 1 MiB of 4 KiB leaves. Each row is the median of nine paired samples with GC disabled. Inner loops were calibrated so the fast corpora had enough work per sample. Values are milliseconds per MiB.

| Corpus | `master` | This PR | Change |
| --- | ---: | ---: | ---: |
| clean | 3.71 | 3.76 | +1.1% |
| digit-heavy | 17.34 | 17.28 | -0.4% |
| pii-saturated | 125.76 | 121.34 | -3.5% |
| email-heavy | 46.40 | 43.76 | -5.7% |
| mixed-realistic | 17.44 | 17.46 | +0.1% |
| unicode-digits | 19.22 | 19.66 | +2.3% |
| json-payload | 57.36 | 56.30 | -1.8% |
| base64-blob | 2.84 | 2.69 | -5.4% |

The small changes on clean, digit-heavy, mixed, Unicode, and JSON inputs are within local run variance. The match-heavy corpora avoid the global sort and improve by 3.5% to 5.7% in this run.

This PR adds no dependency, schema, configuration, or public API change.

## Testing

- `uv run --group test python -m pytest tests/trace_server/test_sensitive_data_redaction.py tests/trace_server/test_agent_sensitive_data_policy.py` (`62 passed`)
- Differential fuzz over 20,000 random and PII-seeded strings, comparing both `detect_pii` and `redact_pii_string` against `master` (`0 mismatches`)
- `tracemalloc` at 1 MiB and 3.5 MiB, plus fresh-process `ru_maxrss` at 8, 32, and 100 MiB
