### PR TITLE
perf(weave): scan JSON-candidate edges without copying

### DIFF
--- a/tests/trace_server/test_sensitive_data_redaction.py
+++ b/tests/trace_server/test_sensitive_data_redaction.py
@@ -164,6 +164,13 @@ def test_walker_redacts_json_escaped_values_without_scanning_keys() -> None:
     )
 
 
+def test_walker_scans_whitespace_padded_json_strings() -> None:
+    assert redact_pii_value(' {"contact":"ada@example.com"} \n') == (
+        '{"contact":"<EMAIL_ADDRESS>"}'
+    )
+    assert redact_pii_value("  [1, 2, 3]  ") == "  [1, 2, 3]  "
+
+
 def test_walker_drops_shadowed_duplicate_json_keys() -> None:
     assert redact_pii_value('{"x":"ada@example.com","x":"safe"}') == '{"x":"safe"}'
     assert redact_pii_value(

--- a/weave/trace_server/sensitive_data/detectors.py
+++ b/weave/trace_server/sensitive_data/detectors.py
@@ -9,6 +9,7 @@ American phone numbers, formatted international phone numbers, compact
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 from typing import Literal, NamedTuple
 
 PIIEntity = Literal["EMAIL_ADDRESS", "PHONE_NUMBER", "US_SSN", "CREDIT_CARD"]
@@ -76,57 +77,62 @@ class Detection(NamedTuple):
 
 def detect_pii(text: str) -> list[Detection]:
     """Return non-overlapping PII spans without retaining matched text."""
-    detections: list[Detection] = []
+    return list(_iter_detections(text))
 
-    if text.find("@") != -1:
-        for match in _EMAIL_RE.finditer(text):
-            candidate = match.group(0)
-            if _valid_email(candidate) and _absolute_token_boundaries(
-                text, match.start(), match.end()
-            ):
-                detections.append(
-                    Detection(match.start(), match.end(), "EMAIL_ADDRESS")
-                )
 
-    if _ASCII_DIGIT_RE.search(text) is not None:
-        # Only emails can overlap numerics, and both lists ascend by start.
-        email_count = len(detections)
-        email_index = 0
-        for run in _NUMERIC_RUN_RE.finditer(text):
-            if not _has_minimum_digits(text, run.start(), run.end()):
-                continue
-            candidate = run.group(0)
-            numeric_detections = _select_non_overlapping(
-                _detect_numeric(candidate, run.start(), text)
-            )
-            for detection in numeric_detections:
-                while (
-                    email_index < email_count
-                    and detections[email_index].end <= detection.start
-                ):
-                    email_index += 1
-                if (
-                    email_index < email_count
-                    and detections[email_index].start < detection.end
-                ):
-                    continue
-                detections.append(detection)
+def _iter_detections(text: str) -> Iterator[Detection]:
+    """Yield accepted detections in ascending order without collecting them.
 
-    return _select_non_overlapping(detections)
+    Emails and numeric runs each ascend and never self-overlap, so a two-stream
+    merge replaces collecting and sorting every detection; a numeric detection
+    overlapping the pending email is dropped, keeping email priority.
+    """
+    emails = _iter_email_detections(text) if text.find("@") != -1 else iter(())
+    numerics = (
+        _iter_numeric_detections(text)
+        if _ASCII_DIGIT_RE.search(text) is not None
+        else iter(())
+    )
+    email = next(emails, None)
+    for detection in numerics:
+        while email is not None and email.end <= detection.start:
+            yield email
+            email = next(emails, None)
+        if email is not None and email.start < detection.end:
+            continue
+        yield detection
+    while email is not None:
+        yield email
+        email = next(emails, None)
+
+
+def _iter_email_detections(text: str) -> Iterator[Detection]:
+    for match in _EMAIL_RE.finditer(text):
+        if _valid_email(match.group(0)) and _absolute_token_boundaries(
+            text, match.start(), match.end()
+        ):
+            yield Detection(match.start(), match.end(), "EMAIL_ADDRESS")
+
+
+def _iter_numeric_detections(text: str) -> Iterator[Detection]:
+    for run in _NUMERIC_RUN_RE.finditer(text):
+        if not _has_minimum_digits(text, run.start(), run.end()):
+            continue
+        yield from _select_non_overlapping(
+            _detect_numeric(run.group(0), run.start(), text)
+        )
 
 
 def redact_pii_string(text: str) -> str:
     """Replace supported PII spans with stable typed markers."""
-    detections = detect_pii(text)
-    if not detections:
-        return text
-
     parts: list[str] = []
     cursor = 0
-    for detection in detections:
+    for detection in _iter_detections(text):
         parts.append(text[cursor : detection.start])
         parts.append(REPLACEMENT_MARKERS[detection.entity])
         cursor = detection.end
+    if not parts:
+        return text
     parts.append(text[cursor:])
     return "".join(parts)
 

--- a/weave/trace_server/sensitive_data/walker.py
+++ b/weave/trace_server/sensitive_data/walker.py
@@ -55,14 +55,19 @@ def redact_pii_value(value: T) -> T:
 
 
 def _is_json_candidate(value: str) -> bool:
-    stripped = value.strip()
-    if len(stripped) < 2 or (stripped[0], stripped[-1]) not in {
+    # Scan the edges in place; strip() would copy the whole string.
+    start, end = 0, len(value)
+    while start < end and value[start].isspace():
+        start += 1
+    while end > start and value[end - 1].isspace():
+        end -= 1
+    if end - start < 2 or (value[start], value[end - 1]) not in {
         ("{", "}"),
         ("[", "]"),
         ('"', '"'),
     }:
         return False
-    return "@" in stripped or any("0" <= character <= "9" for character in stripped)
+    return "@" in value or any("0" <= character <= "9" for character in value)
 
 
 def _redact_json_string(value: str) -> str:


### PR DESCRIPTION
## Description

Stacked on #7796. `_is_json_candidate` called `value.strip()`, which copies the entire string whenever it has leading or trailing whitespace — a transient full-size allocation for every large padded string, paid before any check. The edge characters are now scanned in place, and the `@`/digit presence check reads the original string (whitespace contains neither, so the result is identical).

A 3.4 MiB whitespace-padded string with no matches: peak allocation 3.4 MiB → 0.0 MiB, and the same string object is returned.

## Testing

- `uv run --group test python -m pytest tests/trace_server/test_sensitive_data_redaction.py tests/trace_server/test_agent_sensitive_data_policy.py` — 63 passed.
- `test_walker_scans_whitespace_padded_json_strings` pins the padded-JSON behavior; it passes on both the old and new implementation.