### PR TITLE
chore(weave): drop the per-insert clickhouse_insert success log

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7841,7 +7841,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if self._use_replicated_tables:
             settings = {**(settings or {}), "insert_deduplication_token": generate_id()}
 
-        start = time.monotonic()
         sanitized_invalid_utf8 = False
         # At most two attempts: the original, plus one retry after sanitizing
         # invalid client UTF-8.
@@ -7872,18 +7871,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 log_and_raise_insert_error(e, table, data, correlation_id)
 
             else:
-                duration_ms = round((time.monotonic() - start) * 1000, 1)
-                logger.info(
-                    "clickhouse_insert",
-                    extra={
-                        "trace_duration_ms": duration_ms,
-                        "table": table,
-                        "row_count": len(data),
-                        "async_insert": async_insert,
-                        "query_id": record_query_id(result),
-                        "correlation_id": correlation_id,
-                    },
-                )
+                # Unlogged: the `_insert` span already carries table, rows, and ids.
+                record_query_id(result)
                 return result
 
     def _async_insert_settings(self) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- Every successful ClickHouse insert emitted an INFO line. In prod that is ~71k lines/hour, dominated by `call_parts` (~41k) and `calls_complete` (~20k), and none of it is unique: `_insert` is already `@traced`, and the span carries `weave_trace_server.insert.table`, `weave_trace_server.insert.row_count`, `clickhouse_trace_server_batched._insert.async_insert`, `clickhouse.query_id`, `clickhouse.correlation_id`, and its own duration.
- `record_query_id(result)` still runs, since tagging the span with the server-minted query id is its only side effect that mattered here.
- `clickhouse_insert_error` is untouched: failures still log with the correlation id and payload size.

## Testing
non-functional change; no monitor, dashboard, or log-based metric references `clickhouse_insert`.