### PR TITLE
fix(weave_ts): honor Retry-After to distinguish 429 WAIT vs STOP

### DIFF
--- a/sdks/node/src/__tests__/util/retry.test.ts
+++ b/sdks/node/src/__tests__/util/retry.test.ts
@@ -62,4 +62,45 @@ describe('retry', () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(response).toEqual(mockSuccess);
   });
+
+  test('429 with a long Retry-After is treated as quota exhaustion and not retried', async () => {
+    const mockRateLimited = {
+      ok: false,
+      status: 429,
+      headers: {get: (name: string) => (name === 'retry-after' ? '600' : null)},
+    } as unknown as Response;
+    const mockFetch = jest.fn(() => Promise.resolve(mockRateLimited));
+    global.fetch = mockFetch;
+    const fetchWithRetry = createFetchWithRetry({
+      baseDelay,
+      maxDelay: 5000,
+      retryOnStatus: (status: number) => status === 429,
+    });
+
+    const response = await fetchWithRetry('https://api.test.com');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(response).toEqual(mockRateLimited);
+  });
+
+  test('429 with a short Retry-After is retried using that delay', async () => {
+    const mockRateLimited = {
+      ok: false,
+      status: 429,
+      headers: {get: (name: string) => (name === 'retry-after' ? '0' : null)},
+    } as unknown as Response;
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce(mockRateLimited)
+      .mockResolvedValue(mockSuccess);
+    global.fetch = mockFetch;
+    const fetchWithRetry = createFetchWithRetry({
+      baseDelay,
+      maxDelay: 5000,
+      retryOnStatus: (status: number) => status === 429,
+    });
+
+    const response = await fetchWithRetry('https://api.test.com');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(response).toEqual(mockSuccess);
+  });
 });

--- a/sdks/node/src/utils/retry.ts
+++ b/sdks/node/src/utils/retry.ts
@@ -6,6 +6,27 @@ type RetryOptions = {
   retryOnStatus?: (status: number) => boolean;
 };
 
+/**
+ * Parses a `Retry-After` header value (seconds, or an HTTP date) into a
+ * millisecond delay. Returns `null` when the header is absent or
+ * unparseable, so the caller can fall back to exponential backoff.
+ */
+function parseRetryAfterMs(response: Response): number | null {
+  const header = response.headers?.get?.('retry-after');
+  if (!header) {
+    return null;
+  }
+  const seconds = Number(header);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, seconds * 1000);
+  }
+  const dateMs = Date.parse(header);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+  return null;
+}
+
 export function createFetchWithRetry(options: RetryOptions = {}) {
   const {
     maxRetries = 5,
@@ -25,9 +46,18 @@ export function createFetchWithRetry(options: RetryOptions = {}) {
       try {
         const response = await fetch(...fetchParams);
 
+        // A 429 with a `Retry-After` longer than we're willing to wait is
+        // quota/billing exhaustion, not transient pressure: retrying just
+        // amplifies load against a limit that isn't about to lift. Surface
+        // it to the caller immediately instead of burning the retry budget.
+        const retryAfterMs =
+          response.status === 429 ? parseRetryAfterMs(response) : null;
+        const quotaExhausted = retryAfterMs !== null && retryAfterMs > maxDelay;
+
         if (
           response.ok ||
           !retryOnStatus(response.status) ||
+          quotaExhausted ||
           attempt === maxRetries ||
           Date.now() - startTime > maxRetryTime
         ) {
@@ -35,8 +65,13 @@ export function createFetchWithRetry(options: RetryOptions = {}) {
           return response;
         }
 
-        // Exponential backoff delay
-        const delay = Math.min(baseDelay * 2 ** attempt, maxDelay);
+        // Prefer the server's own `Retry-After` when it gave us one; it
+        // knows its rate-limit window better than our exponential guess
+        // does. Fall back to exponential backoff otherwise.
+        const delay =
+          retryAfterMs !== null
+            ? Math.min(retryAfterMs, maxDelay)
+            : Math.min(baseDelay * 2 ** attempt, maxDelay);
         console.log(
           `Return code: ${response.status}. Retrying fetch after ${delay}ms`
         );


### PR DESCRIPTION
## Summary
`createFetchWithRetry` (`sdks/node/src/utils/retry.ts`) and its caller in `clientApi.ts` treated every 429 the same way: always retry with exponential backoff. As the issue notes, different 429s call for different handling:

- Transient pressure → wait and retry
- Quota / billing exhaustion → do not retry

Collapsing these means a caller that hits a hard quota limit just keeps retrying into it instead of surfacing the failure, amplifying pressure rather than absorbing it.

## Fix
On a 429 response, parse the `Retry-After` header (seconds or an HTTP date):

- If it exceeds `maxDelay`, treat it as quota/billing exhaustion and return the response immediately instead of retrying (STOP).
- Otherwise, use it as the actual wait instead of the exponential-backoff guess, since the server knows its own rate-limit window (WAIT).
- No `Retry-After` header, or a non-429 status: unchanged behavior (exponential backoff / existing `retryOnStatus`).

This only touches the shared `retry.ts` primitive, so both call sites named in the issue (`clientApi.ts:108` and `retry.ts:15`) get the fix from one place.

Fixes #6543

## Test plan
- [x] Added two tests: a 429 with a long `Retry-After` is not retried (STOP), a 429 with a short `Retry-After` is retried using that delay (WAIT)
- [x] `npx jest retry.test.ts` — 6/6 passed (4 existing + 2 new)
- [x] `npx eslint` / `npx prettier --check` clean on the changed files
- [ ] Full CI (could not run the whole monorepo suite locally)