### PR TITLE
feat(weave): add native async agent span, search and feedback reads [2/4]

### DIFF
--- a/tests/trace_server/test_async_agent_queries.py
+++ b/tests/trace_server/test_async_agent_queries.py
@@ -7,17 +7,17 @@ or what comes back -- not that the transport is faster.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from weave.trace_server.agents.clickhouse import (
     AgentQueryHandler,
     search_res_from_rows,
-    ungrouped_spans_res,
 )
 from weave.trace_server.agents.types import (
     AgentGroupByRef,
+    AgentSearchReq,
     AgentSpansQueryReq,
 )
 from weave.trace_server.async_clickhouse_trace_server import AsyncClickHouseTraceServer
@@ -34,13 +34,13 @@ def result(rows, columns):
 
 
 @pytest.mark.asyncio
-async def test_arun_paginated_issues_the_same_two_statements_as_the_sync_pair():
-    """The count and list SQL must match what `_run_paginated` would run."""
+async def test_arun_paginated_issues_the_sync_pair_with_one_param_builder():
+    """Count then page, built by the same builders and bound to one ParamBuilder."""
     req = AgentSpansQueryReq(project_id=PROJECT, limit=5)
-    seen: list[str] = []
+    seen: list[tuple[str, dict]] = []
 
     async def aquery(sql, params):
-        seen.append(sql)
+        seen.append((sql, params))
         return result([[0]], ["c"]) if len(seen) == 1 else result([], [])
 
     handler = AgentQueryHandler(MagicMock(), MagicMock())
@@ -48,31 +48,14 @@ async def test_arun_paginated_issues_the_same_two_statements_as_the_sync_pair():
         make_spans_count_query, make_spans_list_query, req, aquery
     )
 
-    assert total == 0
-    assert rows == []
-    # Same builders, same order: count first, then the page.
+    assert (total, rows) == (0, [])
     assert len(seen) == 2
-    assert "count" in seen[0].lower()
-    assert seen[0] != seen[1]
-
-
-@pytest.mark.asyncio
-async def test_arun_paginated_shares_one_param_builder():
-    """Both statements bind the same parameters, not two divergent sets."""
-    req = AgentSpansQueryReq(project_id=PROJECT, limit=5)
-    params_seen: list[dict] = []
-
-    async def aquery(sql, params):
-        params_seen.append(params)
-        return result([[0]], ["c"])
-
-    handler = AgentQueryHandler(MagicMock(), MagicMock())
-    await handler.arun_paginated(
-        make_spans_count_query, make_spans_list_query, req, aquery
-    )
-
-    assert params_seen[0] == params_seen[1]
-    assert any(PROJECT in str(v) for v in params_seen[0].values())
+    (count_sql, count_params), (list_sql, list_params) = seen
+    assert "count" in count_sql.lower()
+    assert count_sql != list_sql
+    # One builder: both statements bind the same parameters, not two sets.
+    assert count_params == list_params
+    assert any(PROJECT in str(v) for v in count_params.values())
 
 
 @pytest.mark.asyncio
@@ -90,8 +73,12 @@ async def test_aagent_spans_query_refuses_group_by():
 
 
 @pytest.mark.asyncio
-async def test_aagent_search_returns_the_same_shape_as_the_sync_transform():
-    """`aagent_search` reuses `search_res_from_rows`, so rows map identically."""
+async def test_aagent_search_returns_the_shared_transform_output():
+    """`aagent_search` must go through `search_res_from_rows`, not its own mapping.
+
+    The previous version of this test called the transform directly, so it
+    proved nothing about the async endpoint it was named for.
+    """
     rows = [
         {
             "conversation_id": "c-1",
@@ -104,17 +91,14 @@ async def test_aagent_search_returns_the_same_shape_as_the_sync_transform():
             "content_digest": "d-1",
         }
     ]
-    direct = search_res_from_rows(rows)
-    assert direct.total_conversations == 1
-    assert direct.results[0].conversation_id == "c-1"
-    assert direct.results[0].matched_messages[0].span_id == "s-1"
+    server = AsyncClickHouseTraceServer(host="test")
+    with patch.object(
+        AgentQueryHandler, "arun_message_search_query", AsyncMock(return_value=rows)
+    ):
+        res = await server.aagent_search(AgentSearchReq(project_id=PROJECT))
 
-
-def test_ungrouped_spans_res_is_the_shared_transform():
-    """Both paths build the ungrouped response through this one function."""
-    res = ungrouped_spans_res(0, [])
-    assert res.total_count == 0
-    assert res.spans == []
+    assert res == search_res_from_rows(rows)
+    assert res.results[0].matched_messages[0].span_id == "s-1"
 
 
 @pytest.mark.asyncio

--- a/tests/trace_server/test_async_agent_queries.py
+++ b/tests/trace_server/test_async_agent_queries.py
@@ -21,6 +21,7 @@ from weave.trace_server.agents.types import (
     AgentSpansQueryReq,
 )
 from weave.trace_server.async_clickhouse_trace_server import AsyncClickHouseTraceServer
+from weave.trace_server.errors import GroupedQueryNotSupportedAsync
 from weave.trace_server.query_builder.agent_query_builder import (
     make_spans_count_query,
     make_spans_list_query,
@@ -68,7 +69,7 @@ async def test_aagent_spans_query_refuses_group_by():
         limit=1,
     )
 
-    with pytest.raises(ValueError, match="does not support group_by"):
+    with pytest.raises(GroupedQueryNotSupportedAsync):
         await server.aagent_spans_query(req)
 
 

--- a/tests/trace_server/test_async_agent_queries.py
+++ b/tests/trace_server/test_async_agent_queries.py
@@ -1,0 +1,136 @@
+"""The async agent reads issue the same SQL as their sync twins.
+
+`aagent_spans_query` and `aagent_search` exist so the agent scoring worker can
+await a socket instead of a thread. They share the sync path's SQL builders and
+row transforms, so what these assert is that the split did not change what runs
+or what comes back -- not that the transport is faster.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from weave.trace_server.agents.clickhouse import (
+    AgentQueryHandler,
+    search_res_from_rows,
+    ungrouped_spans_res,
+)
+from weave.trace_server.agents.types import (
+    AgentGroupByRef,
+    AgentSpansQueryReq,
+)
+from weave.trace_server.async_clickhouse_trace_server import AsyncClickHouseTraceServer
+from weave.trace_server.query_builder.agent_query_builder import (
+    make_spans_count_query,
+    make_spans_list_query,
+)
+
+PROJECT = "entity/project"
+
+
+def result(rows, columns):
+    return SimpleNamespace(result_rows=rows, column_names=columns)
+
+
+@pytest.mark.asyncio
+async def test_arun_paginated_issues_the_same_two_statements_as_the_sync_pair():
+    """The count and list SQL must match what `_run_paginated` would run."""
+    req = AgentSpansQueryReq(project_id=PROJECT, limit=5)
+    seen: list[str] = []
+
+    async def aquery(sql, params):
+        seen.append(sql)
+        return result([[0]], ["c"]) if len(seen) == 1 else result([], [])
+
+    handler = AgentQueryHandler(MagicMock(), MagicMock())
+    total, rows = await handler.arun_paginated(
+        make_spans_count_query, make_spans_list_query, req, aquery
+    )
+
+    assert total == 0
+    assert rows == []
+    # Same builders, same order: count first, then the page.
+    assert len(seen) == 2
+    assert "count" in seen[0].lower()
+    assert seen[0] != seen[1]
+
+
+@pytest.mark.asyncio
+async def test_arun_paginated_shares_one_param_builder():
+    """Both statements bind the same parameters, not two divergent sets."""
+    req = AgentSpansQueryReq(project_id=PROJECT, limit=5)
+    params_seen: list[dict] = []
+
+    async def aquery(sql, params):
+        params_seen.append(params)
+        return result([[0]], ["c"])
+
+    handler = AgentQueryHandler(MagicMock(), MagicMock())
+    await handler.arun_paginated(
+        make_spans_count_query, make_spans_list_query, req, aquery
+    )
+
+    assert params_seen[0] == params_seen[1]
+    assert any(PROJECT in str(v) for v in params_seen[0].values())
+
+
+@pytest.mark.asyncio
+async def test_aagent_spans_query_refuses_group_by():
+    """Grouped queries hydrate with further reads and stay on the sync path."""
+    server = AsyncClickHouseTraceServer(host="test")
+    req = AgentSpansQueryReq(
+        project_id=PROJECT,
+        group_by=[AgentGroupByRef(source="field", key="agent_name")],
+        limit=1,
+    )
+
+    with pytest.raises(ValueError, match="does not support group_by"):
+        await server.aagent_spans_query(req)
+
+
+@pytest.mark.asyncio
+async def test_aagent_search_returns_the_same_shape_as_the_sync_transform():
+    """`aagent_search` reuses `search_res_from_rows`, so rows map identically."""
+    rows = [
+        {
+            "conversation_id": "c-1",
+            "conversation_name": "Export work",
+            "agent_name": "coding-agent",
+            "span_id": "s-1",
+            "trace_id": "t-1",
+            "role": "user",
+            "content": "add a CSV export",
+            "content_digest": "d-1",
+        }
+    ]
+    direct = search_res_from_rows(rows)
+    assert direct.total_conversations == 1
+    assert direct.results[0].conversation_id == "c-1"
+    assert direct.results[0].matched_messages[0].span_id == "s-1"
+
+
+def test_ungrouped_spans_res_is_the_shared_transform():
+    """Both paths build the ungrouped response through this one function."""
+    res = ungrouped_spans_res(0, [])
+    assert res.total_count == 0
+    assert res.spans == []
+
+
+@pytest.mark.asyncio
+async def test_afeedback_create_keeps_the_sync_insert_override():
+    """Feedback backs a waiting caller, so the write must not be async-inserted."""
+    server = AsyncClickHouseTraceServer(host="test")
+    server._prepare_feedback_create = MagicMock(
+        return_value=(SimpleNamespace(data=[["x"]], column_names=["a"]), {"id": "f-1"})
+    )
+    server._ainsert = AsyncMock()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "weave.trace_server.async_clickhouse_trace_server.format_feedback_to_res",
+            lambda row: row,
+        )
+        await server.afeedback_create(MagicMock())
+
+    assert server._ainsert.await_args.kwargs["do_sync_insert"] is True

--- a/tests/trace_server/test_async_agent_queries.py
+++ b/tests/trace_server/test_async_agent_queries.py
@@ -109,7 +109,7 @@ async def test_afeedback_create_keeps_the_sync_insert_override():
     server._prepare_feedback_create = MagicMock(
         return_value=(SimpleNamespace(data=[["x"]], column_names=["a"]), {"id": "f-1"})
     )
-    server._ainsert = AsyncMock()
+    server._insert_async = AsyncMock()
 
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(
@@ -118,4 +118,4 @@ async def test_afeedback_create_keeps_the_sync_insert_override():
         )
         await server.afeedback_create(MagicMock())
 
-    assert server._ainsert.await_args.kwargs["do_sync_insert"] is True
+    assert server._insert_async.await_args.kwargs["do_sync_insert"] is True

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -7,9 +7,10 @@ handling) and hydrates result rows into agent schemas.
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, TypeVar, cast
 
@@ -144,6 +145,7 @@ logger = logging.getLogger(__name__)
 QueryParams: TypeAlias = dict[str, Any]
 ClickHouseRow: TypeAlias = dict[str, Any]
 QueryFn = Callable[[str, QueryParams], "QueryResult"]
+AsyncQueryFn = Callable[[str, QueryParams], "Awaitable[QueryResult]"]
 
 #: Signature of the server's `feedback_query` method.
 FeedbackQueryFn = Callable[[FeedbackQueryReq], FeedbackQueryRes]
@@ -163,6 +165,51 @@ class _SpanGroupDistKey(NamedTuple):
 
     group_key: str
     alias: str
+
+
+def ungrouped_spans_res(total: int, rows: list[ClickHouseRow]) -> AgentSpansQueryRes:
+    """Rows -> response for a spans query with no `group_by`."""
+    return AgentSpansQueryRes(
+        spans=[AgentSpanSchema(**normalize_span_row(r)) for r in rows],
+        total_count=total,
+    )
+
+
+def search_res_from_rows(rows: list[ClickHouseRow]) -> AgentSearchRes:
+    """Matched message rows -> conversations, newest activity first."""
+    convs: dict[str, AgentSearchConversationResult] = {}
+    for r in rows:
+        cid = safe_str(r.get("conversation_id")) or NO_CONVERSATION_LABEL
+        started_at = _datetime_or_min(r.get("started_at"))
+        if cid not in convs:
+            convs[cid] = AgentSearchConversationResult(
+                conversation_id=cid,
+                conversation_name=safe_str(r.get("conversation_name")),
+                agent_name=safe_str(r.get("agent_name")),
+                matched_messages=[],
+                last_activity=started_at,
+            )
+        convs[cid].matched_messages.append(
+            AgentSearchMatchedMessage(
+                span_id=safe_str(r.get("span_id")),
+                trace_id=safe_str(r.get("trace_id")),
+                role=safe_str(r.get("role")),
+                content_preview=safe_str(r.get("content")),
+                content_digest=safe_str(r.get("content_digest")),
+                started_at=started_at,
+            )
+        )
+        # Track the most recent match across all rows for this
+        # conversation so the sidebar sort order is stable regardless
+        # of row arrival order.
+        convs[cid].last_activity = max(convs[cid].last_activity, started_at)
+
+    results = sorted(
+        convs.values(),
+        key=lambda c: c.last_activity,
+        reverse=True,
+    )
+    return AgentSearchRes(results=results, total_conversations=len(results))
 
 
 @dataclass(frozen=True)
@@ -196,8 +243,7 @@ class AgentQueryHandler:
         )
 
         if not req.group_by:
-            spans = [AgentSpanSchema(**normalize_span_row(r)) for r in rows]
-            return AgentSpansQueryRes(spans=spans, total_count=total)
+            return ungrouped_spans_res(total, rows)
 
         aliases = [group_by_ref_alias(ref) for ref in req.group_by]
         measure_aliases = [measure.alias for measure in req.measures]
@@ -611,41 +657,7 @@ class AgentQueryHandler:
 
     def search_messages(self, req: AgentSearchReq) -> AgentSearchRes:
         """Full-text search across message content."""
-        rows = self._run_message_search_query(req)
-
-        convs: dict[str, AgentSearchConversationResult] = {}
-        for r in rows:
-            cid = safe_str(r.get("conversation_id")) or NO_CONVERSATION_LABEL
-            started_at = _datetime_or_min(r.get("started_at"))
-            if cid not in convs:
-                convs[cid] = AgentSearchConversationResult(
-                    conversation_id=cid,
-                    conversation_name=safe_str(r.get("conversation_name")),
-                    agent_name=safe_str(r.get("agent_name")),
-                    matched_messages=[],
-                    last_activity=started_at,
-                )
-            convs[cid].matched_messages.append(
-                AgentSearchMatchedMessage(
-                    span_id=safe_str(r.get("span_id")),
-                    trace_id=safe_str(r.get("trace_id")),
-                    role=safe_str(r.get("role")),
-                    content_preview=safe_str(r.get("content")),
-                    content_digest=safe_str(r.get("content_digest")),
-                    started_at=started_at,
-                )
-            )
-            # Track the most recent match across all rows for this
-            # conversation so the sidebar sort order is stable regardless
-            # of row arrival order.
-            convs[cid].last_activity = max(convs[cid].last_activity, started_at)
-
-        results = sorted(
-            convs.values(),
-            key=lambda c: c.last_activity,
-            reverse=True,
-        )
-        return AgentSearchRes(results=results, total_conversations=len(results))
+        return search_res_from_rows(self._run_message_search_query(req))
 
     # ------------------------------------------------------------------
     # Internal: spans-for-one-trace with chat projection
@@ -794,6 +806,35 @@ class AgentQueryHandler:
         total = _first_cell_int(self._query(count_sql, params))
         rows = _rows_as_dicts(self._query(list_sql, params))
         return total, rows
+
+    async def arun_paginated(
+        self,
+        count_builder: Callable[[ParamBuilder, PaginatedReqT], str],
+        list_builder: Callable[[ParamBuilder, PaginatedReqT], str],
+        req: PaginatedReqT,
+        aquery: AsyncQueryFn,
+    ) -> tuple[int, list[ClickHouseRow]]:
+        """`_run_paginated` over an awaitable query function.
+
+        The SQL is built by the same builders; only the two round trips differ,
+        and they are issued together because neither depends on the other.
+        """
+        pb = ParamBuilder(PARAM_NAMESPACE)
+        count_sql = count_builder(pb, req)
+        list_sql = list_builder(pb, req)
+        params = pb.get_params()
+        count_res, list_res = await asyncio.gather(
+            aquery(count_sql, params), aquery(list_sql, params)
+        )
+        return _first_cell_int(count_res), _rows_as_dicts(list_res)
+
+    async def arun_message_search_query(
+        self, req: AgentSearchReq, aquery: AsyncQueryFn
+    ) -> list[ClickHouseRow]:
+        """`_run_message_search_query` over an awaitable query function."""
+        pb = ParamBuilder(PARAM_NAMESPACE)
+        sql = make_message_search_query(pb, req)
+        return _rows_as_dicts(await aquery(sql, pb.get_params()))
 
     def _run_message_search_query(self, req: AgentSearchReq) -> list[ClickHouseRow]:
         """Build and run the message search SQL, returning rows as dicts."""

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -42,6 +42,7 @@ from weave.trace_server.clickhouse_trace_server_batched import (
     CompletionPrepResult,
 )
 from weave.trace_server.datadog import tag_db_insert_path
+from weave.trace_server.errors import GroupedQueryNotSupportedAsync
 from weave.trace_server.feedback import TABLE_FEEDBACK, format_feedback_to_res
 from weave.trace_server.llm_completion import lite_llm_acompletion
 from weave.trace_server.query_builder.agent_query_builder import (
@@ -227,9 +228,7 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         `agent_spans_query`.
         """
         if req.group_by:
-            raise ValueError(
-                "aagent_spans_query does not support group_by; use agent_spans_query"
-            )
+            raise GroupedQueryNotSupportedAsync()
         handler = AgentQueryHandler(self._query, self.feedback_query)
         total, rows = await handler.arun_paginated(
             make_spans_count_query, make_spans_list_query, req, self._aquery

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -22,8 +22,19 @@ from clickhouse_connect.driver.query import QueryResult
 from clickhouse_connect.driver.summary import QuerySummary
 
 from weave.trace_server import trace_server_interface as tsi
-from weave.trace_server.agents.clickhouse import AgentWriteHandler
+from weave.trace_server.agents.clickhouse import (
+    AgentQueryHandler,
+    AgentWriteHandler,
+    search_res_from_rows,
+    ungrouped_spans_res,
+)
 from weave.trace_server.agents.schema import AgentSpanCHInsertable
+from weave.trace_server.agents.types import (
+    AgentSearchReq,
+    AgentSearchRes,
+    AgentSpansQueryReq,
+    AgentSpansQueryRes,
+)
 from weave.trace_server.clickhouse import transport as ch_transport
 from weave.trace_server.clickhouse.transport import AsyncClickHouseTransport
 from weave.trace_server.clickhouse_trace_server_batched import (
@@ -31,7 +42,12 @@ from weave.trace_server.clickhouse_trace_server_batched import (
     CompletionPrepResult,
 )
 from weave.trace_server.datadog import tag_db_insert_path
+from weave.trace_server.feedback import TABLE_FEEDBACK, format_feedback_to_res
 from weave.trace_server.llm_completion import lite_llm_acompletion
+from weave.trace_server.query_builder.agent_query_builder import (
+    make_spans_count_query,
+    make_spans_list_query,
+)
 from weave.trace_server.tracing import traced
 
 _T = TypeVar("_T")
@@ -200,6 +216,49 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
                 continue
             ch_transport.record_insert_success(prepared, result)
             return result
+
+    # -- Agent reads and writes over the native transport ----------------------
+
+    @traced(name="async_clickhouse_trace_server.aagent_spans_query")
+    async def aagent_spans_query(self, req: AgentSpansQueryReq) -> AgentSpansQueryRes:
+        """Native-async twin of `agent_spans_query`, for ungrouped queries.
+
+        Grouped queries hydrate with further reads and stay on
+        `agent_spans_query`.
+        """
+        if req.group_by:
+            raise ValueError(
+                "aagent_spans_query does not support group_by; use agent_spans_query"
+            )
+        handler = AgentQueryHandler(self._query, self.feedback_query)
+        total, rows = await handler.arun_paginated(
+            make_spans_count_query, make_spans_list_query, req, self._aquery
+        )
+        return ungrouped_spans_res(total, rows)
+
+    @traced(name="async_clickhouse_trace_server.aagent_search")
+    async def aagent_search(self, req: AgentSearchReq) -> AgentSearchRes:
+        """Native-async twin of `agent_search`."""
+        handler = AgentQueryHandler(self._query, self.feedback_query)
+        rows = await handler.arun_message_search_query(req, self._aquery)
+        return search_res_from_rows(rows)
+
+    @tag_db_insert_path("feedback_create")
+    async def afeedback_create(
+        self, req: tsi.FeedbackCreateReq
+    ) -> tsi.FeedbackCreateRes:
+        """Native-async twin of `feedback_create`.
+
+        Keeps the sync-insert override: a caller is waiting on the write.
+        """
+        prepared, row = await asyncio.to_thread(self._prepare_feedback_create, req)
+        await self._ainsert(
+            TABLE_FEEDBACK.name,
+            prepared.data,
+            prepared.column_names,
+            do_sync_insert=True,
+        )
+        return format_feedback_to_res(row)
 
     async def _run_on_ch_executor(self, fn: Callable[..., _T], *args: object) -> _T:
         """Run `fn(*args)` on `_ch_executor`.

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -231,7 +231,7 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
             raise GroupedQueryNotSupportedAsync()
         handler = AgentQueryHandler(self._query, self.feedback_query)
         total, rows = await handler.arun_paginated(
-            make_spans_count_query, make_spans_list_query, req, self._aquery
+            make_spans_count_query, make_spans_list_query, req, self._query_async
         )
         return ungrouped_spans_res(total, rows)
 
@@ -239,7 +239,7 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
     async def aagent_search(self, req: AgentSearchReq) -> AgentSearchRes:
         """Native-async twin of `agent_search`."""
         handler = AgentQueryHandler(self._query, self.feedback_query)
-        rows = await handler.arun_message_search_query(req, self._aquery)
+        rows = await handler.arun_message_search_query(req, self._query_async)
         return search_res_from_rows(rows)
 
     @tag_db_insert_path("feedback_create")
@@ -251,7 +251,7 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         Keeps the sync-insert override: a caller is waiting on the write.
         """
         prepared, row = await asyncio.to_thread(self._prepare_feedback_create, req)
-        await self._ainsert(
+        await self._insert_async(
             TABLE_FEEDBACK.name,
             prepared.data,
             prepared.column_names,

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6799,13 +6799,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @tag_db_insert_path("feedback_create")
     def feedback_create(self, req: tsi.FeedbackCreateReq) -> tsi.FeedbackCreateRes:
-        assert_non_null_wb_user_id(req)
-        validate_feedback_create_req(req, self)
-        validate_feedback_agent_req_targets(req)
-
-        processed_payload = process_feedback_payload(req)
-        row = format_feedback_to_row(req, processed_payload)
-        prepared = TABLE_FEEDBACK.insert(row).prepare()
+        prepared, row = self._prepare_feedback_create(req)
         self._insert(
             TABLE_FEEDBACK.name,
             prepared.data,
@@ -6815,6 +6809,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
         return format_feedback_to_res(row)
+
+    def _prepare_feedback_create(self, req: tsi.FeedbackCreateReq):
+        """Validate and format one feedback row, up to the insert."""
+        assert_non_null_wb_user_id(req)
+        validate_feedback_create_req(req, self)
+        validate_feedback_agent_req_targets(req)
+
+        processed_payload = process_feedback_payload(req)
+        row = format_feedback_to_row(req, processed_payload)
+        return TABLE_FEEDBACK.insert(row).prepare(), row
 
     @traced(name="clickhouse_trace_server_batched.feedback_create_batch")
     @tag_db_insert_path("feedback_create_batch")

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -249,7 +249,7 @@ from weave.trace_server.model_providers.model_providers import (
 )
 from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
 from weave.trace_server.opentelemetry.python_spans import Resource, Span
-from weave.trace_server.orm import ParamBuilder, Row
+from weave.trace_server.orm import ParamBuilder, PreparedInsert, Row
 from weave.trace_server.parallel_bucket_uploads import (
     BucketUploadBatch,
     file_chunks_for,
@@ -6810,7 +6810,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return format_feedback_to_res(row)
 
-    def _prepare_feedback_create(self, req: tsi.FeedbackCreateReq):
+    def _prepare_feedback_create(
+        self, req: tsi.FeedbackCreateReq
+    ) -> tuple[PreparedInsert, Row]:
         """Validate and format one feedback row, up to the insert."""
         assert_non_null_wb_user_id(req)
         validate_feedback_create_req(req, self)

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -48,6 +48,35 @@ class InvalidRequest(Error):
     pass
 
 
+class GroupedQueryNotSupportedAsync(InvalidRequest):
+    """Raised when the async agent-spans endpoint receives a grouped request.
+
+    Grouped queries need per-group hydration reads that only the sync
+    `agent_spans_query` knows how to issue, so the async twin refuses rather
+    than return a partial result.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "aagent_spans_query does not support group_by; "
+            "use agent_spans_query for grouped requests."
+        )
+
+
+class HydratedQueryNotSupportedAsync(InvalidRequest):
+    """Raised when the async calls endpoint is asked to hydrate.
+
+    Ref expansion and feedback hydration issue further reads per batch, which
+    only `calls_query_stream` knows how to issue.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "acalls_query does not hydrate refs or feedback; "
+            "use calls_query for hydrated requests."
+        )
+
+
 class ObjectNameTypeCollision(InvalidRequest):
     """Raised when obj_create targets an object_id already bound to a different base_object_class.
 


### PR DESCRIPTION
## Description

Adds async versions of the agent span, search and feedback reads, so the agent scoring worker can await a socket instead of a thread.

- `aagent_spans_query`, `aagent_search` and `afeedback_create` sit next to their sync twins. Same SQL builders, same row transforms — only the round trip is different.
- `aagent_spans_query` only handles ungrouped queries, which is all a worker asks for. Grouped queries need extra reads to fill in distributions and conversation previews, so they stay on `agent_spans_query`. Passing `group_by` raises instead of quietly giving you half an answer.
- `afeedback_create` still forces a sync insert. Someone is waiting to see that write land.
- Pulled `ungrouped_spans_res`, `search_res_from_rows` and `_prepare_feedback_create` out so both paths use them instead of growing their own copies. Sync behaviour is unchanged.

Stacked on wandb/weave#7801, which adds the transport. Nothing calls these yet — the consumer is wandb/core#52039.

## Testing

`tests/trace_server/test_async_agent_queries.py` checks the async path runs the same two statements as `_run_paginated` with one shared `ParamBuilder`, rejects `group_by`, and keeps `do_sync_insert=True` on feedback.

402 existing agent/feedback/trace-server tests pass. 7 `test_feedback_stats` failures also fail on master and aren't related to this.

- [x] Manual testing
- [x] Unit tests

