### PR TITLE
feat(weave): add native async calls and calls-stats reads [3/4]

### DIFF
--- a/tests/trace_server/test_async_calls_queries.py
+++ b/tests/trace_server/test_async_calls_queries.py
@@ -1,0 +1,112 @@
+"""Guards for the two ways the async calls reads can silently diverge from sync.
+
+Both are failure modes that produce wrong data or wrong threading rather than an
+exception, so neither would show up in a smoke test.
+"""
+
+import asyncio
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.async_clickhouse_trace_server import (
+    AsyncClickHouseTraceServer,
+)
+from weave.trace_server.calls_query_builder.calls_query_builder import (
+    CallsMergedField,
+    OrderField,
+)
+from weave.trace_server.token_costs import get_cost_result_columns
+
+PROJECT = "UHJvamVjdEludGVybmFsSWQ6MQ=="
+
+
+def test_acalls_query_stats_never_touches_ch_client_on_the_event_loop():
+    """`ch_client` is thread-local and minting one blocks.
+
+    Passed as an argument to `to_thread` it would be evaluated on the loop:
+    blocking it on first use, and then handing one thread's client to every
+    other thread running this concurrently.
+    """
+    server = AsyncClickHouseTraceServer(host="test_host")
+    loop_thread = threading.get_ident()
+    touched_on_loop: list[bool] = []
+
+    class Guard:
+        def __get__(self, obj, owner=None):
+            touched_on_loop.append(threading.get_ident() == loop_thread)
+            return MagicMock()
+
+    async def run():
+        with (
+            patch.object(type(server), "ch_client", Guard()),
+            patch.object(type(server), "table_routing_resolver", MagicMock()),
+            patch.object(server, "_aquery", return_value=MagicMock(result_rows=[[0]])),
+            patch(
+                "weave.trace_server.async_clickhouse_trace_server.build_calls_stats_query",
+                return_value=("SELECT 1", ["count"], None),
+            ),
+            patch(
+                "weave.trace_server.async_clickhouse_trace_server.calls_stats_res",
+                return_value=tsi.CallsQueryStatsRes(count=0),
+            ),
+        ):
+            await server.acalls_query_stats(tsi.CallsQueryStatsReq(project_id=PROJECT))
+
+    asyncio.run(run())
+    assert touched_on_loop, "ch_client was never resolved; the test proves nothing"
+    assert not any(touched_on_loop), (
+        "ch_client was resolved on the event loop thread; it must be resolved "
+        "inside the executor callback"
+    )
+
+
+class _Captured(Exception):
+    """Carries the zip keys out before any downstream validation runs."""
+
+    def __init__(self, columns):
+        self.columns = columns
+
+
+@pytest.mark.parametrize("include_costs", [True, False])
+def test_acalls_query_maps_columns_the_way_sync_does(include_costs: bool):
+    """A cost query's SELECT carries sort-only columns ahead of `summary_dump`.
+
+    Zipping row values against `select_fields` alone shifts every value after
+    that point onto the wrong key, which is silent rather than an error.
+    """
+    server = AsyncClickHouseTraceServer(host="test_host")
+    select = ["id", "project_id", "summary_dump"]
+    order = [OrderField(field=CallsMergedField(field="started_at"), direction="ASC")]
+    cq = MagicMock(
+        select_fields=[MagicMock(field=f) for f in select], order_fields=order
+    )
+    cq.as_sql.return_value = "SELECT 1"
+
+    expected = get_cost_result_columns(select, order) if include_costs else select
+
+    def capture(d):
+        raise _Captured(list(d))
+
+    async def run():
+        with (
+            patch.object(server, "_build_calls_query", return_value=(cq, None)),
+            patch.object(
+                server,
+                "_aquery",
+                return_value=MagicMock(result_rows=[list(range(len(expected)))]),
+            ),
+            patch(
+                "weave.trace_server.async_clickhouse_trace_server.ch_call_dict_to_call_schema_dict",
+                side_effect=capture,
+            ),
+        ):
+            await server.acalls_query(
+                tsi.CallsQueryReq(project_id=PROJECT, include_costs=include_costs)
+            )
+
+    with pytest.raises(_Captured) as exc:
+        asyncio.run(run())
+    assert exc.value.columns == expected

--- a/tests/trace_server/test_async_calls_queries.py
+++ b/tests/trace_server/test_async_calls_queries.py
@@ -18,6 +18,7 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     CallsMergedField,
     OrderField,
 )
+from weave.trace_server.errors import HydratedQueryNotSupportedAsync
 from weave.trace_server.token_costs import get_cost_result_columns
 
 PROJECT = "UHJvamVjdEludGVybmFsSWQ6MQ=="
@@ -110,3 +111,17 @@ def test_acalls_query_maps_columns_the_way_sync_does(include_costs: bool):
     with pytest.raises(_Captured) as exc:
         asyncio.run(run())
     assert exc.value.columns == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"expand_columns": ["inputs.x"]}, {"include_feedback": True}],
+)
+async def test_acalls_query_refuses_hydration(kwargs):
+    """Hydration issues further reads per batch and stays on the sync path."""
+    server = AsyncClickHouseTraceServer(host="test")
+    req = tsi.CallsQueryReq(project_id="entity/project", **kwargs)
+
+    with pytest.raises(HydratedQueryNotSupportedAsync):
+        await server.acalls_query(req)

--- a/tests/trace_server/test_async_calls_queries.py
+++ b/tests/trace_server/test_async_calls_queries.py
@@ -44,7 +44,9 @@ def test_acalls_query_stats_never_touches_ch_client_on_the_event_loop():
         with (
             patch.object(type(server), "ch_client", Guard()),
             patch.object(type(server), "table_routing_resolver", MagicMock()),
-            patch.object(server, "_aquery", return_value=MagicMock(result_rows=[[0]])),
+            patch.object(
+                server, "_query_async", return_value=MagicMock(result_rows=[[0]])
+            ),
             patch(
                 "weave.trace_server.async_clickhouse_trace_server.build_calls_stats_query",
                 return_value=("SELECT 1", ["count"], None),
@@ -96,7 +98,7 @@ def test_acalls_query_maps_columns_the_way_sync_does(include_costs: bool):
             patch.object(server, "_build_calls_query", return_value=(cq, None)),
             patch.object(
                 server,
-                "_aquery",
+                "_query_async",
                 return_value=MagicMock(result_rows=[list(range(len(expected)))]),
             ),
             patch(

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -57,6 +57,7 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_spans_count_query,
     make_spans_list_query,
 )
+from weave.trace_server.token_costs import get_cost_result_columns
 from weave.trace_server.tracing import traced
 
 _T = TypeVar("_T")
@@ -283,11 +284,17 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         cq, settings = await asyncio.to_thread(self._build_calls_query, req)
         pb = ParamBuilder()
         raw_res = await self._aquery(cq.as_sql(pb), pb.get_params(), settings=settings)
-        select_columns = [c.field for c in cq.select_fields]
+        if req.include_costs:
+            # Cost query SELECT adds ORDER BY fields; result columns must match.
+            select_columns = get_cost_result_columns(
+                [c.field for c in cq.select_fields], cq.order_fields
+            )
+        else:
+            select_columns = [c.field for c in cq.select_fields]
         calls = [
             tsi.CallSchema.model_validate(
                 ch_call_dict_to_call_schema_dict(
-                    dict(zip(select_columns, row, strict=False))
+                    dict(zip(select_columns, row, strict=True))
                 )
             )
             for row in raw_res.result_rows
@@ -299,10 +306,14 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         self, req: tsi.CallsQueryStatsReq
     ) -> tsi.CallsQueryStatsRes:
         """Native-async twin of `calls_query_stats`."""
-        read_table = await asyncio.to_thread(
-            self.table_routing_resolver.resolve_read_table,
-            req.project_id,
-            self.ch_client,
+        # `ch_client` is thread-local and minting one blocks. Resolve it inside
+        # the pool thread: as an argument it would be evaluated on the event
+        # loop, blocking it on first use and then handing one thread's client to
+        # every other thread that runs this concurrently.
+        read_table = await self._run_on_ch_executor(
+            lambda: self.table_routing_resolver.resolve_read_table(
+                req.project_id, self.ch_client
+            )
         )
         pb = ParamBuilder()
         query, columns, settings = build_calls_stats_query(req, pb, read_table)

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -35,16 +35,24 @@ from weave.trace_server.agents.types import (
     AgentSpansQueryReq,
     AgentSpansQueryRes,
 )
+from weave.trace_server.calls_query_builder.calls_query_builder import (
+    build_calls_stats_query,
+)
 from weave.trace_server.clickhouse import transport as ch_transport
+from weave.trace_server.clickhouse.schema_converters import (
+    ch_call_dict_to_call_schema_dict,
+)
 from weave.trace_server.clickhouse.transport import AsyncClickHouseTransport
 from weave.trace_server.clickhouse_trace_server_batched import (
     ClickHouseTraceServer,
     CompletionPrepResult,
+    calls_stats_res,
 )
 from weave.trace_server.datadog import tag_db_insert_path
 from weave.trace_server.errors import GroupedQueryNotSupportedAsync
 from weave.trace_server.feedback import TABLE_FEEDBACK, format_feedback_to_res
 from weave.trace_server.llm_completion import lite_llm_acompletion
+from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.agent_query_builder import (
     make_spans_count_query,
     make_spans_list_query,
@@ -258,6 +266,48 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
             do_sync_insert=True,
         )
         return format_feedback_to_res(row)
+
+    # -- Calls reads over the native transport ---------------------------------
+
+    @traced(name="async_clickhouse_trace_server.acalls_query")
+    async def acalls_query(self, req: tsi.CallsQueryReq) -> tsi.CallsQueryRes:
+        """Native-async twin of `calls_query`, for the unhydrated shape.
+
+        Ref expansion and feedback hydration issue further reads per batch and
+        stay on `calls_query_stream`.
+        """
+        if req.expand_columns or req.include_feedback:
+            raise ValueError(
+                "acalls_query does not hydrate refs or feedback; use calls_query"
+            )
+        cq, settings = await asyncio.to_thread(self._build_calls_query, req)
+        pb = ParamBuilder()
+        raw_res = await self._aquery(cq.as_sql(pb), pb.get_params(), settings=settings)
+        select_columns = [c.field for c in cq.select_fields]
+        calls = [
+            tsi.CallSchema.model_validate(
+                ch_call_dict_to_call_schema_dict(
+                    dict(zip(select_columns, row, strict=False))
+                )
+            )
+            for row in raw_res.result_rows
+        ]
+        return tsi.CallsQueryRes(calls=calls)
+
+    @traced(name="async_clickhouse_trace_server.acalls_query_stats")
+    async def acalls_query_stats(
+        self, req: tsi.CallsQueryStatsReq
+    ) -> tsi.CallsQueryStatsRes:
+        """Native-async twin of `calls_query_stats`."""
+        read_table = await asyncio.to_thread(
+            self.table_routing_resolver.resolve_read_table,
+            req.project_id,
+            self.ch_client,
+        )
+        pb = ParamBuilder()
+        query, columns, settings = build_calls_stats_query(req, pb, read_table)
+        raw_res = await self._aquery(query, pb.get_params(), settings=settings or None)
+        return calls_stats_res(raw_res, columns)
 
     async def _run_on_ch_executor(self, fn: Callable[..., _T], *args: object) -> _T:
         """Run `fn(*args)` on `_ch_executor`.

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -49,7 +49,10 @@ from weave.trace_server.clickhouse_trace_server_batched import (
     calls_stats_res,
 )
 from weave.trace_server.datadog import tag_db_insert_path
-from weave.trace_server.errors import GroupedQueryNotSupportedAsync
+from weave.trace_server.errors import (
+    GroupedQueryNotSupportedAsync,
+    HydratedQueryNotSupportedAsync,
+)
 from weave.trace_server.feedback import TABLE_FEEDBACK, format_feedback_to_res
 from weave.trace_server.llm_completion import lite_llm_acompletion
 from weave.trace_server.orm import ParamBuilder
@@ -278,9 +281,7 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         stay on `calls_query_stream`.
         """
         if req.expand_columns or req.include_feedback:
-            raise ValueError(
-                "acalls_query does not hydrate refs or feedback; use calls_query"
-            )
+            raise HydratedQueryNotSupportedAsync()
         cq, settings = await asyncio.to_thread(self._build_calls_query, req)
         pb = ParamBuilder()
         raw_res = await self._aquery(cq.as_sql(pb), pb.get_params(), settings=settings)

--- a/weave/trace_server/async_clickhouse_trace_server.py
+++ b/weave/trace_server/async_clickhouse_trace_server.py
@@ -284,7 +284,9 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
             raise HydratedQueryNotSupportedAsync()
         cq, settings = await asyncio.to_thread(self._build_calls_query, req)
         pb = ParamBuilder()
-        raw_res = await self._aquery(cq.as_sql(pb), pb.get_params(), settings=settings)
+        raw_res = await self._query_async(
+            cq.as_sql(pb), pb.get_params(), settings=settings
+        )
         if req.include_costs:
             # Cost query SELECT adds ORDER BY fields; result columns must match.
             select_columns = get_cost_result_columns(
@@ -318,7 +320,9 @@ class AsyncClickHouseTraceServer(ClickHouseTraceServer):
         )
         pb = ParamBuilder()
         query, columns, settings = build_calls_stats_query(req, pb, read_table)
-        raw_res = await self._aquery(query, pb.get_params(), settings=settings or None)
+        raw_res = await self._query_async(
+            query, pb.get_params(), settings=settings or None
+        )
         return calls_stats_res(raw_res, columns)
 
     async def _run_on_ch_executor(self, fn: Callable[..., _T], *args: object) -> _T:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1856,7 +1856,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             unfinished_call_ids=sorted(unfinished_call_ids),
         )
 
-    @traced_generator(name="clickhouse_trace_server_batched.calls_query_stream")
     def _build_calls_query(
         self, req: tsi.CallsQueryReq
     ) -> tuple[CallsQuery, dict[str, Any] | None]:
@@ -1964,6 +1963,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return cq, settings
 
+    @traced_generator(name="clickhouse_trace_server_batched.calls_query_stream")
     def calls_query_stream(self, req: tsi.CallsQueryReq) -> Iterator[tsi.CallSchema]:
         """Returns a stream of calls that match the given query."""
         cq, settings = self._build_calls_query(req)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6,7 +6,7 @@ import json
 import logging
 import threading
 from collections import defaultdict
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from functools import partial
@@ -391,7 +391,9 @@ _CALLS_COMPLETE_SENTINEL_COLUMNS: list[tuple[int, str]] = [
 ]
 
 
-def calls_stats_res(raw_res: QueryResult, columns: list[str]) -> tsi.CallsQueryStatsRes:
+def calls_stats_res(
+    raw_res: QueryResult, columns: Iterable[str]
+) -> tsi.CallsQueryStatsRes:
     """Stats row -> response, shared by the sync and async paths."""
     res_dict = (
         dict(zip(columns, raw_res.result_rows[0], strict=False))

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -391,6 +391,20 @@ _CALLS_COMPLETE_SENTINEL_COLUMNS: list[tuple[int, str]] = [
 ]
 
 
+def calls_stats_res(raw_res: QueryResult, columns: list[str]) -> tsi.CallsQueryStatsRes:
+    """Stats row -> response, shared by the sync and async paths."""
+    res_dict = (
+        dict(zip(columns, raw_res.result_rows[0], strict=False))
+        if raw_res.result_rows
+        else {}
+    )
+    return tsi.CallsQueryStatsRes(
+        count=res_dict.get("count", 0),
+        has_more=bool(res_dict.get("has_more", 0)),
+        total_storage_size_bytes=res_dict.get("total_storage_size_bytes"),
+    )
+
+
 class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def __init__(
         self,
@@ -1542,17 +1556,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         query, columns, settings = build_calls_stats_query(req, pb, read_table)
         raw_res = self._query(query, pb.get_params(), settings=settings or None)
 
-        res_dict = (
-            dict(zip(columns, raw_res.result_rows[0], strict=False))
-            if raw_res.result_rows
-            else {}
-        )
-
-        return tsi.CallsQueryStatsRes(
-            count=res_dict.get("count", 0),
-            has_more=bool(res_dict.get("has_more", 0)),
-            total_storage_size_bytes=res_dict.get("total_storage_size_bytes"),
-        )
+        return calls_stats_res(raw_res, columns)
 
     def _get_prices_for_models(
         self, models: set[str], project_id: str
@@ -1853,8 +1857,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
     @traced_generator(name="clickhouse_trace_server_batched.calls_query_stream")
-    def calls_query_stream(self, req: tsi.CallsQueryReq) -> Iterator[tsi.CallSchema]:
-        """Returns a stream of calls that match the given query."""
+    def _build_calls_query(
+        self, req: tsi.CallsQueryReq
+    ) -> tuple[CallsQuery, dict[str, Any] | None]:
+        """Everything `calls_query_stream` decides before it reads.
+
+        Split out so the native-async twin runs the identical query rather
+        than a second, drifting copy of the column and settings logic.
+        """
         read_table = self.table_routing_resolver.resolve_read_table(
             req.project_id, self.ch_client
         )
@@ -1952,6 +1962,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if read_table == ReadTable.CALLS_COMPLETE:
             settings = ch_settings.update_settings_for_calls_complete_read(settings)
 
+        return cq, settings
+
+    def calls_query_stream(self, req: tsi.CallsQueryReq) -> Iterator[tsi.CallSchema]:
+        """Returns a stream of calls that match the given query."""
+        cq, settings = self._build_calls_query(req)
         pb = ParamBuilder()
         raw_res = self._query_stream(cq.as_sql(pb), pb.get_params(), settings=settings)
 


### PR DESCRIPTION
## Description

Adds async versions of the calls and calls-stats reads, so the scoring worker can await a socket instead of a thread.

- `acalls_query` and `acalls_query_stats` sit next to their sync twins and run the same SQL.
- `acalls_query` returns the unhydrated shape a worker asks for. `calls_query` collects its whole stream anyway, so reading it in one round trip loses nothing. Ref expansion and feedback hydration need extra reads per batch, so those stay on `calls_query_stream` — ask for them here and it raises rather than handing back rows that are missing them.
- `resolve_read_table` still hops to a thread. It's cached and only hits ClickHouse on a miss.
- Pulled `_build_calls_query` and `calls_stats_res` out so both paths build the same query and share the same transform. Sync behaviour is unchanged.

Stacked on wandb/weave#7803. The consumer is wandb/core#52045.

## Testing

565 calls/agent/trace-server tests pass, including the 190 covering `calls_query_stream`, so the extraction didn't change it. `tests/trace_server/test_async_calls_queries.py` covers the two things that would break quietly: cost queries add sort-only columns to the SELECT, and `ch_client` has to be resolved on the pool thread rather than the event loop.

7 `test_feedback_stats` failures also fail on master and aren't related to this.

- [x] Manual testing
- [x] Unit tests

