### PR TITLE
fix(weave): mark agent response defaults required in the serialization schema

### DIFF
--- a/tests/trace_server/test_agent_response_serialization_required.py
+++ b/tests/trace_server/test_agent_response_serialization_required.py
@@ -1,0 +1,74 @@
+"""Serialization JSON Schema for agent *Res models marks defaults required."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from weave.trace_server.agents.types import (
+    AgentConversationChatRes,
+    AgentConversationSpansRes,
+    AgentCustomAttrsSchemaRes,
+    AgentSearchRes,
+    AgentSpanSchema,
+    AgentSpansQueryReq,
+    AgentSpansQueryRes,
+    AgentSpanStatsRes,
+    AgentsQueryReq,
+    AgentsQueryRes,
+    AgentTraceChatRes,
+    AgentVersionsQueryRes,
+)
+
+_RESPONSE_ROOTS = (
+    AgentsQueryRes,
+    AgentVersionsQueryRes,
+    AgentSpansQueryRes,
+    AgentSpanStatsRes,
+    AgentCustomAttrsSchemaRes,
+    AgentSearchRes,
+    AgentTraceChatRes,
+    AgentConversationChatRes,
+    AgentConversationSpansRes,
+)
+
+
+def _schemas_with_properties(
+    schema: dict[str, Any],
+) -> list[tuple[str, dict[str, Any]]]:
+    out: list[tuple[str, dict[str, Any]]] = [("root", schema)]
+    defs = schema.get("$defs") or {}
+    for name, sub in defs.items():
+        if isinstance(sub, dict) and "properties" in sub:
+            out.append((name, sub))
+    return out
+
+
+def test_agent_response_serialization_requires_every_property() -> None:
+    for model in _RESPONSE_ROOTS:
+        schema = model.model_json_schema(mode="serialization")
+        for name, sub in _schemas_with_properties(schema):
+            props = set(sub.get("properties") or {})
+            required = set(sub.get("required") or [])
+            assert required == props, f"{model.__name__}:{name} {required=} {props=}"
+
+
+def test_agent_span_schema_validation_still_allows_defaults() -> None:
+    schema = AgentSpanSchema.model_json_schema(mode="validation")
+    required = set(schema.get("required") or [])
+    props = set(schema.get("properties") or {})
+    assert required == {"project_id", "trace_id", "span_id"}
+    assert required < props
+
+
+def test_agent_query_request_validation_unchanged() -> None:
+    for model in (AgentsQueryReq, AgentSpansQueryReq):
+        schema = model.model_json_schema(mode="validation")
+        assert set(schema.get("required") or []) == {"project_id"}
+
+
+def test_agent_span_schema_constructor_and_dump_keep_defaults() -> None:
+    span = AgentSpanSchema(project_id="p", trace_id="t", span_id="s")
+    dumped = span.model_dump()
+    assert dumped["parent_span_id"] is None
+    assert dumped["finish_reasons"] == []
+    assert dumped["input_messages"] == []

--- a/weave/trace_server/agents/schema.py
+++ b/weave/trace_server/agents/schema.py
@@ -12,7 +12,7 @@ extraction logic that applies those conventions lives in
 import datetime
 from typing import Literal, TypeAlias
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER, SENTINEL_EPOCH
 
@@ -46,7 +46,13 @@ class NormalizedMessage(BaseModel):
     - content: plain text for simple messages, or JSON-serialized parts
       array for multimodal/structured messages
     - finish_reason: per-message finish reason (output messages only)
+
+    Serialization JSON Schema marks defaulted fields required. In the public
+    OpenAPI document this class appears only as an AgentSpanSchema message
+    element. Ingest validation is unchanged.
     """
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     role: str = ""
     content: str

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -3,6 +3,9 @@
 All types are Pydantic BaseModel subclasses used by both the FastAPI
 endpoints (services/weave-trace) and the ClickHouse query handlers
 (weave/trace_server/clickhouse_trace_server_batched.py).
+
+Response models inherit AgentResponseModel so defaulted fields are required
+in the serialization JSON Schema. Request models stay on BaseModel.
 """
 
 from __future__ import annotations
@@ -13,6 +16,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal
 from pydantic import (
     AwareDatetime,
     BaseModel,
+    ConfigDict,
     Field,
     field_validator,
     model_validator,
@@ -148,6 +152,16 @@ def _as_utc(dt: datetime.datetime) -> datetime.datetime:
     return dt.astimezone(datetime.timezone.utc)
 
 
+class AgentResponseModel(BaseModel):
+    """Agent API response models.
+
+    Constructor defaults stay for Python callers. Serialization JSON Schema
+    marks those fields required so OpenAPI matches the JSON FastAPI sends.
+    """
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+
 class AgentSpanValueRef(BaseModel):
     """Reference to a span field or typed custom attribute map value."""
 
@@ -247,7 +261,7 @@ class AgentSpanStatsMetricSpec(BaseModel):
         return self
 
 
-class AgentSpanStatsColumn(BaseModel):
+class AgentSpanStatsColumn(AgentResponseModel):
     """Metadata describing one column in an agent span stats result row."""
 
     name: str
@@ -426,7 +440,7 @@ class AgentSpanStatsReq(BaseModel):
         return self
 
 
-class AgentSpanStatsRes(BaseModel):
+class AgentSpanStatsRes(AgentResponseModel):
     """Response containing chart-ready agent span stats rows."""
 
     start: datetime.datetime
@@ -438,7 +452,7 @@ class AgentSpanStatsRes(BaseModel):
     rows: list[dict[str, AgentSpanStatsCell]] = Field(default_factory=list)
 
 
-class AgentSpanSchema(BaseModel):
+class AgentSpanSchema(AgentResponseModel):
     """A normalized agent span returned by query APIs."""
 
     project_id: str
@@ -616,7 +630,7 @@ class AgentSpanGroupDistributionSpec(BaseModel):
         raise ValueError(f"distribution spec source is not custom attr: {source!r}")
 
 
-class AgentSpanGroupDistributionBin(BaseModel):
+class AgentSpanGroupDistributionBin(AgentResponseModel):
     """One numeric histogram bin for a custom attribute in a span group."""
 
     # 0-based bucket position within the histogram; clients render bins in
@@ -627,14 +641,14 @@ class AgentSpanGroupDistributionBin(BaseModel):
     count: int
 
 
-class AgentSpanGroupDistributionValue(BaseModel):
+class AgentSpanGroupDistributionValue(AgentResponseModel):
     """One categorical custom attribute value count in a span group."""
 
     value: str
     count: int
 
 
-class AgentSpanGroupDistributionItem(BaseModel):
+class AgentSpanGroupDistributionItem(AgentResponseModel):
     """Distribution data for one span-group/custom-attribute pair."""
 
     alias: str
@@ -649,7 +663,7 @@ class AgentSpanGroupDistributionItem(BaseModel):
     values: list[AgentSpanGroupDistributionValue] = Field(default_factory=list)
 
 
-class AgentConversationMessagePreview(BaseModel):
+class AgentConversationMessagePreview(AgentResponseModel):
     """A truncated first/last message snippet for a grouped conversation row.
 
     `role` is the chat-timeline message type (e.g. "user_message",
@@ -661,7 +675,7 @@ class AgentConversationMessagePreview(BaseModel):
     text: str = ""
 
 
-class AgentConversationSpan(BaseModel):
+class AgentConversationSpan(AgentResponseModel):
     """One span in a conversation's trace.
 
     Returned by `agent_conversation_spans`, which reads span scalar columns
@@ -678,7 +692,7 @@ class AgentConversationSpan(BaseModel):
     duration_ms: int
 
 
-class AgentConversationSpanRating(BaseModel):
+class AgentConversationSpanRating(AgentResponseModel):
     """One numeric rating (a scorer score) applied to a turn or conversation."""
 
     name: str
@@ -687,7 +701,7 @@ class AgentConversationSpanRating(BaseModel):
     confidence: float | None = None
 
 
-class AgentConversationSpanFeedback(BaseModel):
+class AgentConversationSpanFeedback(AgentResponseModel):
     """Tags and ratings applied to a conversation's turn (or the conversation).
 
     Positioned client-side by matching `trace_id` (turn) against the spans;
@@ -709,7 +723,7 @@ class AgentConversationSpanFeedback(BaseModel):
     )
 
 
-class AgentConversationSpans(BaseModel):
+class AgentConversationSpans(AgentResponseModel):
     """One conversation's span sequence and its feedback markers."""
 
     conversation_id: str
@@ -732,13 +746,13 @@ class AgentConversationSpansReq(BaseModel):
     started_before: AwareDatetime | None = None  # filter started_at < end
 
 
-class AgentConversationSpansRes(BaseModel):
+class AgentConversationSpansRes(AgentResponseModel):
     """Span sequences + feedback markers, one entry per requested conversation."""
 
     conversations: list[AgentConversationSpans] = Field(default_factory=list)
 
 
-class AgentSpanGroupRow(BaseModel):
+class AgentSpanGroupRow(AgentResponseModel):
     """A single row in a grouped spans query response.
 
     `group_keys` maps each group_by ref's alias to its value for this row.
@@ -901,7 +915,7 @@ class AgentSpansQueryReq(BaseModel):
         return self
 
 
-class AgentSpansQueryRes(BaseModel):
+class AgentSpansQueryRes(AgentResponseModel):
     """Response from a spans query.
 
     Exactly one of `spans` or `groups` will be populated, based on
@@ -928,7 +942,7 @@ class AgentCustomAttrsSchemaReq(BaseModel):
     offset: int = Field(default=0, ge=0)
 
 
-class AgentCustomAttrSchemaItem(BaseModel):
+class AgentCustomAttrSchemaItem(AgentResponseModel):
     """One custom attribute key/type observed in the matching spans."""
 
     source: AgentCustomAttrSource
@@ -937,7 +951,7 @@ class AgentCustomAttrSchemaItem(BaseModel):
     span_count: int
 
 
-class AgentCustomAttrsSchemaRes(BaseModel):
+class AgentCustomAttrsSchemaRes(AgentResponseModel):
     """Typed custom attribute keys available for spans query/group/stats APIs."""
 
     attributes: list[AgentCustomAttrSchemaItem] = Field(default_factory=list)
@@ -982,7 +996,7 @@ class AgentSearchReq(BaseModel):
     offset: int = Field(default=0, ge=0)
 
 
-class AgentSearchMatchedMessage(BaseModel):
+class AgentSearchMatchedMessage(AgentResponseModel):
     """A single message that matched the search query."""
 
     span_id: str
@@ -995,7 +1009,7 @@ class AgentSearchMatchedMessage(BaseModel):
     started_at: datetime.datetime
 
 
-class AgentSearchConversationResult(BaseModel):
+class AgentSearchConversationResult(AgentResponseModel):
     """A conversation containing messages that matched the search query."""
 
     conversation_id: str
@@ -1005,7 +1019,7 @@ class AgentSearchConversationResult(BaseModel):
     last_activity: datetime.datetime
 
 
-class AgentSearchRes(BaseModel):
+class AgentSearchRes(AgentResponseModel):
     """Response from a full-text search across agent messages."""
 
     results: list[AgentSearchConversationResult]
@@ -1022,14 +1036,14 @@ AgentChatMessageType = Literal[
 ]
 
 
-class AgentChatUserMessage(BaseModel):
+class AgentChatUserMessage(AgentResponseModel):
     """Payload for a user prompt in the chat timeline."""
 
     text: str
     content_refs: list[str] = Field(default_factory=list)
 
 
-class AgentChatAssistantMessage(BaseModel):
+class AgentChatAssistantMessage(AgentResponseModel):
     """Payload for assistant text emitted by an agent or LLM span."""
 
     text: str
@@ -1048,7 +1062,7 @@ class AgentChatAssistantMessage(BaseModel):
     content_refs: list[str] = Field(default_factory=list)
 
 
-class AgentChatToolCall(BaseModel):
+class AgentChatToolCall(AgentResponseModel):
     """Payload for a tool call timeline event."""
 
     tool_name: str | None = None
@@ -1059,7 +1073,7 @@ class AgentChatToolCall(BaseModel):
     content_refs: list[str] = Field(default_factory=list)
 
 
-class AgentChatAgentStart(BaseModel):
+class AgentChatAgentStart(AgentResponseModel):
     """Payload for an agent lifecycle boundary."""
 
     model: str | None = None
@@ -1068,11 +1082,11 @@ class AgentChatAgentStart(BaseModel):
     status: StatusCodeLiteral | None = None
 
 
-class AgentChatAgentHandoff(BaseModel):
+class AgentChatAgentHandoff(AgentResponseModel):
     """Payload for a future agent-to-agent handoff event."""
 
 
-class AgentChatContextCompacted(BaseModel):
+class AgentChatContextCompacted(AgentResponseModel):
     """Payload for a context-window compaction event."""
 
     compaction_summary: str | None = None
@@ -1080,7 +1094,7 @@ class AgentChatContextCompacted(BaseModel):
     compaction_items_after: int | None = None
 
 
-class AgentChatMessage(BaseModel):
+class AgentChatMessage(AgentResponseModel):
     """A single element in the structured agent trajectory / chat view.
 
     Common event fields live at the top level. Type-specific fields are
@@ -1139,7 +1153,7 @@ class AgentTraceChatReq(BaseModel):
     include_feedback: bool = False
 
 
-class AgentTraceChatRes(BaseModel):
+class AgentTraceChatRes(AgentResponseModel):
     """Structured chat view: a linear sequence of messages representing
     the agent trajectory for a single trace.
     """
@@ -1199,7 +1213,7 @@ class AgentConversationChatReq(BaseModel):
     include_feedback: bool = False
 
 
-class AgentConversationChatRes(BaseModel):
+class AgentConversationChatRes(AgentResponseModel):
     """Multi-turn chat view: an ordered list of per-turn chat responses.
 
     Each entry in `turns` corresponds to one trace_id, which Weave treats as
@@ -1221,7 +1235,7 @@ class AgentConversationChatRes(BaseModel):
     feedback: list[dict[str, Any]] | None = None
 
 
-class AgentSchema(BaseModel):
+class AgentSchema(AgentResponseModel):
     """Aggregated per-agent stats from the agents table."""
 
     project_id: str
@@ -1262,7 +1276,7 @@ class AgentsQueryReq(BaseModel):
     include_costs: bool = False
 
 
-class AgentsQueryRes(BaseModel):
+class AgentsQueryRes(AgentResponseModel):
     """Response containing aggregated agent stats."""
 
     agents: list[AgentSchema]
@@ -1295,7 +1309,7 @@ class AgentVersionsQueryReq(BaseModel):
     include_costs: bool = False
 
 
-class AgentVersionsQueryRes(BaseModel):
+class AgentVersionsQueryRes(AgentResponseModel):
     """Response containing agent version stats."""
 
     versions: list[AgentVersionSchema]


### PR DESCRIPTION
## JIRA Issue(s)

[WB-39210](https://coreweave.atlassian.net/browse/WB-39210)

Related: [WB-39109](https://coreweave.atlassian.net/browse/WB-39109).

## Description

https://github.com/wandb/core/pull/51853 (draft) fills in missing fields on the client after each agent call. That is the coalescing we said we should not ship.

The generated client treats those fields as optional because OpenAPI does. The server already sends them. This PR marks the defaults on agent responses as required. Requests and constructors do not change.

Once this merges, the usual spec and client sync will pick it up. Then the draft can return the SDK response as-is, without coalescing.

## Testing

`pytest tests/trace_server/test_agent_response_serialization_required.py tests/trace_server/test_genai_schema.py -q --trace-server=fake` — 7 passed. The new tests check that agent responses require every serialized field, and that request schemas did not get stricter.

[WB-39210]: https://coreweave.atlassian.net/browse/WB-39210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-39109]: https://coreweave.atlassian.net/browse/WB-39109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ