### PR TITLE
fix(weave): type the agent chat feedback projection

### DIFF
--- a/tests/trace_server/test_agent_chat_feedback_projection.py
+++ b/tests/trace_server/test_agent_chat_feedback_projection.py
@@ -1,0 +1,38 @@
+"""Serialization JSON Schema for the agent chat feedback projection."""
+
+from weave.trace_server.agents.types import AgentChatFeedback
+from weave.trace_server.trace_server_common import FEEDBACK_QUERY_FIELDS
+
+
+def test_agent_chat_feedback_fields_match_query_projection() -> None:
+    assert set(AgentChatFeedback.model_fields) == set(FEEDBACK_QUERY_FIELDS)
+
+
+def test_agent_chat_feedback_serialization_requires_every_property() -> None:
+    schema = AgentChatFeedback.model_json_schema(mode="serialization")
+    props = set(schema.get("properties") or {})
+    required = set(schema.get("required") or [])
+    assert required == props
+
+
+def test_agent_chat_feedback_validation_does_not_require_scorer_columns() -> None:
+    schema = AgentChatFeedback.model_json_schema(mode="validation")
+    required = set(schema.get("required") or [])
+    assert "scorer_tags" not in required
+    assert required == {"id", "feedback_type", "weave_ref", "payload"}
+
+
+def test_agent_chat_feedback_constructor_and_dump_keep_defaults() -> None:
+    row = AgentChatFeedback(
+        id="f1",
+        feedback_type="reaction",
+        weave_ref="weave:///entity/project/call/c1",
+        payload={"emoji": "👍"},
+    )
+    dumped = row.model_dump()
+    assert dumped["creator"] is None
+    assert dumped["created_at"] is None
+    assert dumped["wb_user_id"] is None
+    assert dumped["scorer_tags"] == []
+    assert dumped["scorer_tag_reasons"] == {}
+    assert dumped["scorer_ratings"] == {}

--- a/tests/trace_server/test_agent_chat_view_feedback.py
+++ b/tests/trace_server/test_agent_chat_view_feedback.py
@@ -96,12 +96,12 @@ def test_agent_traces_chat_folds_turn_and_step_feedback(ch_server):
 
     assert res.feedback is not None
     assert len(res.feedback) == 1
-    assert res.feedback[0]["payload"] == {"emoji": "👍"}
+    assert res.feedback[0].payload == {"emoji": "👍"}
 
     step_msgs = [m for m in res.messages if m.span_id == child_span_id and m.feedback]
     assert len(step_msgs) == 1
     assert step_msgs[0].feedback is not None
-    assert step_msgs[0].feedback[0]["payload"] == {"emoji": "🔥"}
+    assert step_msgs[0].feedback[0].payload == {"emoji": "🔥"}
 
 
 def test_agent_traces_chat_include_feedback_false_leaves_feedback_fields_none(
@@ -174,15 +174,15 @@ def test_agent_conversation_chat_folds_conversation_turn_and_step_feedback(ch_se
 
     assert res.feedback is not None
     assert len(res.feedback) == 1
-    assert res.feedback[0]["payload"] == {"emoji": "💬"}
+    assert res.feedback[0].payload == {"emoji": "💬"}
 
     assert len(res.turns) == 1
     turn = res.turns[0]
     assert turn.feedback is not None
     assert len(turn.feedback) == 1
-    assert turn.feedback[0]["payload"] == {"emoji": "👍"}
+    assert turn.feedback[0].payload == {"emoji": "👍"}
 
     step_msgs = [m for m in turn.messages if m.span_id == child_span_id and m.feedback]
     assert len(step_msgs) == 1
     assert step_msgs[0].feedback is not None
-    assert step_msgs[0].feedback[0]["payload"] == {"emoji": "🔥"}
+    assert step_msgs[0].feedback[0].payload == {"emoji": "🔥"}

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -44,6 +44,7 @@ from weave.trace_server.agents.schema import (
 )
 from weave.trace_server.agents.types import (
     AGENT_CUSTOM_ATTR_SOURCE_VALUE_TYPES,
+    AgentChatFeedback,
     AgentConversationChatReq,
     AgentConversationChatRes,
     AgentConversationMessagePreview,
@@ -697,7 +698,9 @@ class AgentQueryHandler:
                     project_id=req.project_id,
                     conversation_ids=[req.conversation_id],
                 )
-                res.feedback = groups.by_conversation_id.get(req.conversation_id, [])
+                res.feedback = _as_agent_chat_feedback(
+                    groups.by_conversation_id.get(req.conversation_id, [])
+                )
             return res
 
         # Group spans by trace_id, preserving insertion order. Weave treats
@@ -739,7 +742,9 @@ class AgentQueryHandler:
                 trace_ids=[t.trace_id for t in turns],
                 span_ids=span_ids,
             )
-            res.feedback = groups.by_conversation_id.get(req.conversation_id, [])
+            res.feedback = _as_agent_chat_feedback(
+                groups.by_conversation_id.get(req.conversation_id, [])
+            )
             for turn in res.turns:
                 _fold_feedback_into_trace_chat(turn, groups)
 
@@ -1048,15 +1053,23 @@ def _build_agent_target_refs(
     return refs
 
 
+def _as_agent_chat_feedback(rows: list[dict[str, Any]]) -> list[AgentChatFeedback]:
+    return [AgentChatFeedback.model_validate(row) for row in rows]
+
+
 def _fold_feedback_into_trace_chat(
     trace_chat: AgentTraceChatRes,
     groups: AgentFeedbackByTarget,
 ) -> None:
     """Fold turn-level and step-level feedback into a trace chat response."""
-    trace_chat.feedback = groups.by_trace_id.get(trace_chat.trace_id, [])
+    trace_chat.feedback = _as_agent_chat_feedback(
+        groups.by_trace_id.get(trace_chat.trace_id, [])
+    )
     for message in trace_chat.messages:
         if message.span_id and message.span_id in groups.by_span_id:
-            message.feedback = groups.by_span_id[message.span_id]
+            message.feedback = _as_agent_chat_feedback(
+                groups.by_span_id[message.span_id]
+            )
 
 
 def _first_cell_int(result: QueryResult) -> int:

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -1094,6 +1094,33 @@ class AgentChatContextCompacted(AgentResponseModel):
     compaction_items_after: int | None = None
 
 
+class AgentChatFeedback(AgentResponseModel):
+    """Feedback row from the agent chat `include_feedback` projection.
+
+    Field names match FEEDBACK_QUERY_FIELDS. This is not the feedback
+    table row and not FeedbackCreateReq: project_id and span_* are not
+    selected.
+    """
+
+    id: str
+    feedback_type: str
+    weave_ref: str
+    payload: dict[str, Any]
+    creator: str | None = None
+    created_at: datetime.datetime | None = None
+    wb_user_id: str | None = None
+    runnable_ref: str | None = None
+    call_ref: str | None = None
+    trigger_ref: str | None = None
+    annotation_ref: str | None = None
+    scorer_tags: list[str] = Field(default_factory=list)
+    scorer_tag_reasons: dict[str, str] = Field(default_factory=dict)
+    scorer_tag_confidences: dict[str, float] = Field(default_factory=dict)
+    scorer_ratings: dict[str, float] = Field(default_factory=dict)
+    scorer_rating_reasons: dict[str, str] = Field(default_factory=dict)
+    scorer_rating_confidences: dict[str, float] = Field(default_factory=dict)
+
+
 class AgentChatMessage(AgentResponseModel):
     """A single element in the structured agent trajectory / chat view.
 
@@ -1142,7 +1169,7 @@ class AgentChatMessage(AgentResponseModel):
             )
         return self
 
-    feedback: list[dict[str, Any]] | None = None
+    feedback: list[AgentChatFeedback] | None = None
 
 
 class AgentTraceChatReq(BaseModel):
@@ -1188,7 +1215,7 @@ class AgentTraceChatRes(AgentResponseModel):
     total_cache_creation_input_tokens: int = 0
     total_cache_read_input_tokens: int = 0
     messages: list[AgentChatMessage] = Field(default_factory=list)
-    feedback: list[dict[str, Any]] | None = None
+    feedback: list[AgentChatFeedback] | None = None
 
 
 class AgentConversationChatReq(BaseModel):
@@ -1232,7 +1259,7 @@ class AgentConversationChatRes(AgentResponseModel):
     # Summed query-time cost (USD) across the returned turns. None when no turn
     # had a priced span.
     total_cost_usd: float | None = None
-    feedback: list[dict[str, Any]] | None = None
+    feedback: list[AgentChatFeedback] | None = None
 
 
 class AgentSchema(AgentResponseModel):


### PR DESCRIPTION
## JIRA Issue(s)

[WB-39240](https://coreweave.atlassian.net/browse/WB-39240)

Related: [WB-39109](https://coreweave.atlassian.net/browse/WB-39109). This is the chat-response contract, not the app client slice.

## Description

We're generating typed clients with Stainless. For those clients to type chat responses without extra casts, `feedback` has to match what the server sends. This PR adds that type.

Chat with `include_feedback=True` always returns a fixed set of columns, not a full Feedback row. The new type is `AgentChatFeedback`. Runtime JSON does not change.

## Testing

New tests pass. The old chat-feedback tests still pass.


[WB-39240]: https://coreweave.atlassian.net/browse/WB-39240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-39109]: https://coreweave.atlassian.net/browse/WB-39109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ