### PR TITLE
fix(weave): bound sensitive-data traversal depth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -711,7 +711,9 @@ deterministic.
   fail instead of falling back to a policy.
 - `redact_pii_value` walks supported trace values copy-on-write, combines
   credential-key replacement with PII replacement, and never scans dictionary
-  keys. Clean subtrees retain their identity.
+  keys. Clean subtrees retain their identity. Its traversal depth is capped at
+  200, including decoded JSON-string re-entry, and over-nested or cyclic values
+  raise `RequestTooLarge` instead of exhausting the Python stack.
 - Complete Weave refs, valid base64 data URLs, and valid standalone base64
   payloads pass through unchanged. Malformed lookalikes remain eligible for
   scanning.

--- a/tests/trace_server/test_sensitive_data_redaction.py
+++ b/tests/trace_server/test_sensitive_data_redaction.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import json
 from enum import Enum
 
 import pytest
 from pydantic import BaseModel, ConfigDict, Field
 
 from weave.trace_server.credential_redaction import REDACTED_VALUE
+from weave.trace_server.errors import RequestTooLarge
 from weave.trace_server.sensitive_data.detectors import redact_pii_string
 from weave.trace_server.sensitive_data.walker import redact_pii_value
 
@@ -19,6 +21,19 @@ class _PayloadModel(BaseModel):
 
     values: tuple[object, ...]
     excluded: str = Field(exclude=True)
+
+
+class _NestedPayload(BaseModel):
+    value: object
+
+
+def _assert_nesting_rejected(value: object) -> None:
+    with pytest.raises(RequestTooLarge) as exc_info:
+        redact_pii_value(value)
+
+    assert str(exc_info.value) == (
+        "Request payload nesting exceeds the maximum supported depth of 200."
+    )
 
 
 def test_redacts_supported_pii_with_typed_markers() -> None:
@@ -281,12 +296,35 @@ def test_walker_does_not_preserve_invalid_encoded_content(
     assert redact_pii_value(value).startswith(expected_prefix)
 
 
-def test_walker_fails_loudly_on_cyclic_input() -> None:
+@pytest.mark.parametrize("container", ["dict", "list", "tuple", "model"])
+def test_walker_rejects_deeply_nested_structures(container: str) -> None:
+    value: object = "ada@example.com"
+    for _ in range(800):
+        if container == "dict":
+            value = {"value": value}
+        elif container == "list":
+            value = [value]
+        elif container == "tuple":
+            value = (value,)
+        else:
+            value = _NestedPayload(value=value)
+
+    _assert_nesting_rejected(value)
+
+
+def test_walker_rejects_deeply_nested_json_string() -> None:
+    value: object = "ada@example.com"
+    for _ in range(800):
+        value = [value]
+
+    _assert_nesting_rejected(json.dumps(value))
+
+
+def test_walker_rejects_cyclic_input_without_recursion_error() -> None:
     payload: dict[str, object] = {}
     payload["self"] = payload
 
-    with pytest.raises(RecursionError):
-        redact_pii_value(payload)
+    _assert_nesting_rejected(payload)
 
     assert payload["self"] is payload
 

--- a/weave/trace_server/sensitive_data/walker.py
+++ b/weave/trace_server/sensitive_data/walker.py
@@ -17,6 +17,12 @@ from weave.trace_server.sensitive_data.detectors import redact_pii_string
 
 T = TypeVar("T")
 
+_MAX_STRUCTURE_DEPTH = 200
+_NESTING_ERROR = (
+    f"Request payload nesting exceeds the maximum supported depth of "
+    f"{_MAX_STRUCTURE_DEPTH}."
+)
+
 # Keep these aligned with the standalone-base64 gate in
 # ``base64_content_conversion``. That path considers only strings strictly
 # larger than 8 KiB and validates the encoding before offloading it.
@@ -35,23 +41,33 @@ _SYNTHETIC_PROJECT_ID = "cHJvamVjdA=="
 
 def redact_pii_value(value: T) -> T:
     """Redact credential-shaped fields and PII while reusing clean subtrees."""
+    return _redact_pii_value(value, 0)
+
+
+def _redact_pii_value(value: T, depth: int) -> T:
+    _check_depth(depth)
     if isinstance(value, Enum):
         return value
     if isinstance(value, str):
         if _preserve_string(value):
             return value
         if _is_json_candidate(value):
-            return cast(T, _redact_json_string(value))
+            return cast(T, _redact_json_string(value, depth))
         return cast(T, redact_pii_string(value))
     if isinstance(value, BaseModel):
-        return cast(T, _redact_model(value))
+        return cast(T, _redact_model(value, depth))
     if isinstance(value, dict):
-        return cast(T, _redact_mapping(value))
+        return cast(T, _redact_mapping(value, depth))
     if isinstance(value, list):
-        return cast(T, _redact_sequence(value, list))
+        return cast(T, _redact_sequence(value, list, depth))
     if isinstance(value, tuple):
-        return cast(T, _redact_sequence(value, tuple))
+        return cast(T, _redact_sequence(value, tuple, depth))
     return value
+
+
+def _check_depth(depth: int) -> None:
+    if depth > _MAX_STRUCTURE_DEPTH:
+        raise RequestTooLarge(_NESTING_ERROR)
 
 
 def _is_json_candidate(value: str) -> bool:
@@ -65,7 +81,7 @@ def _is_json_candidate(value: str) -> bool:
     return "@" in stripped or any("0" <= character <= "9" for character in stripped)
 
 
-def _redact_json_string(value: str) -> str:
+def _redact_json_string(value: str, depth: int) -> str:
     saw_duplicate_key = False
 
     def _build_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -80,10 +96,10 @@ def _redact_json_string(value: str) -> str:
     except ValueError:
         return redact_pii_string(value)
     except RecursionError as error:
-        raise RequestTooLarge("Sensitive-data nesting limit exceeded") from error
+        raise RequestTooLarge(_NESTING_ERROR) from error
     if not isinstance(parsed, (dict, list, str)):
         return redact_pii_string(value)
-    redacted = redact_pii_value(parsed)
+    redacted = _redact_pii_value(parsed, depth + 1)
     # A duplicate key shadows a value the walk never saw; reserialize to drop it.
     if redacted is parsed and not saw_duplicate_key:
         return value
@@ -163,26 +179,26 @@ def _is_base64_data_url(value: str) -> bool:
     )
 
 
-def _redact_model(model: BaseModel) -> BaseModel:
+def _redact_model(model: BaseModel, depth: int) -> BaseModel:
     updates: dict[str, Any] = {}
     for field_name, field_info in model.__class__.model_fields.items():
         if field_info.exclude is True:
             continue
         original = getattr(model, field_name)
-        redacted = _redact_named_value(field_name, original)
+        redacted = _redact_named_value(field_name, original, depth + 1)
         if redacted is not original:
             updates[field_name] = redacted
     for field_name, original in (model.model_extra or {}).items():
-        redacted = _redact_named_value(field_name, original)
+        redacted = _redact_named_value(field_name, original, depth + 1)
         if redacted is not original:
             updates[field_name] = redacted
     return model if not updates else model.model_copy(update=updates)
 
 
-def _redact_mapping(value: dict[Any, Any]) -> dict[Any, Any]:
+def _redact_mapping(value: dict[Any, Any], depth: int) -> dict[Any, Any]:
     redacted: dict[Any, Any] | None = None
     for key, original in value.items():
-        item = _redact_named_value(key, original)
+        item = _redact_named_value(key, original, depth + 1)
         if item is original:
             continue
         if redacted is None:
@@ -191,7 +207,8 @@ def _redact_mapping(value: dict[Any, Any]) -> dict[Any, Any]:
     return value if redacted is None else redacted
 
 
-def _redact_named_value(name: Any, value: Any) -> Any:
+def _redact_named_value(name: Any, value: Any, depth: int) -> Any:
+    _check_depth(depth)
     if (
         isinstance(name, str)
         and isinstance(value, str)
@@ -200,16 +217,17 @@ def _redact_named_value(name: Any, value: Any) -> Any:
         and should_redact(name)
     ):
         return REDACTED_VALUE
-    return redact_pii_value(value)
+    return _redact_pii_value(value, depth)
 
 
 def _redact_sequence(
     value: Sequence[Any],
     rebuild: Callable[[list[Any]], Sequence[Any]],
+    depth: int,
 ) -> Sequence[Any]:
     redacted: list[Any] | None = None
     for index, original in enumerate(value):
-        item = redact_pii_value(original)
+        item = _redact_pii_value(original, depth + 1)
         if item is original:
             continue
         if redacted is None:


### PR DESCRIPTION
## Purpose

Deeply nested or cyclic values can still exhaust the Python stack in the redaction walk and escape as an HTTP 500; only the JSON-decode step caught `RecursionError`. Bound the walk explicitly, following the ref-converter precedent from #7578.

## Changes

- Thread a depth counter through dict, list, tuple, Pydantic model, and decoded JSON-string traversal; raise `RequestTooLarge` (HTTP 413) past 200 levels.
- Cyclic values now hit the same bound instead of raising `RecursionError`.
- Document the cap in AGENTS.md.

## Testing

- `uv run --group test python -m pytest tests/trace_server/test_sensitive_data_redaction.py -v` (64 passed)
- `uvx ruff check` / `uvx ruff format --check` clean

## Breaking changes

None. Pathologically nested or cyclic values now return a typed 413 instead of a 500.

## Related

- #7788, #7740
- Precedent: #7578
