### PR TITLE
feat(weave): add agent identity to conversation tags

### DIFF
--- a/weave/trace_server/migrations/044_add_agent_identity_to_conversation_tags.down.sql
+++ b/weave/trace_server/migrations/044_add_agent_identity_to_conversation_tags.down.sql
@@ -1,0 +1,27 @@
+DROP VIEW IF EXISTS conversation_tags_by_tag_mv;
+
+ALTER TABLE conversation_tags_by_tag
+    DROP COLUMN IF EXISTS agent_version,
+    DROP COLUMN IF EXISTS agent_id;
+
+ALTER TABLE conversation_tags
+    DROP COLUMN IF EXISTS agent_version,
+    DROP COLUMN IF EXISTS agent_id;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS conversation_tags_by_tag_mv
+TO conversation_tags_by_tag AS
+SELECT
+    project_id,
+    conversation_id,
+    trace_id,
+    tag,
+    trace_ended_at,
+    agent_name,
+    source,
+    judge_version,
+    wb_user_id,
+    rationale,
+    is_removed,
+    expire_at,
+    inserted_at
+FROM conversation_tags;

--- a/weave/trace_server/migrations/044_add_agent_identity_to_conversation_tags.up.sql
+++ b/weave/trace_server/migrations/044_add_agent_identity_to_conversation_tags.up.sql
@@ -1,0 +1,29 @@
+ALTER TABLE conversation_tags
+    ADD COLUMN IF NOT EXISTS agent_id      String DEFAULT '' AFTER trace_ended_at,
+    ADD COLUMN IF NOT EXISTS agent_version String DEFAULT '' AFTER agent_name;
+
+ALTER TABLE conversation_tags_by_tag
+    ADD COLUMN IF NOT EXISTS agent_id      String DEFAULT '' AFTER trace_ended_at,
+    ADD COLUMN IF NOT EXISTS agent_version String DEFAULT '' AFTER agent_name;
+
+DROP VIEW IF EXISTS conversation_tags_by_tag_mv;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS conversation_tags_by_tag_mv
+TO conversation_tags_by_tag AS
+SELECT
+    project_id,
+    conversation_id,
+    trace_id,
+    tag,
+    trace_ended_at,
+    agent_id,
+    agent_name,
+    agent_version,
+    source,
+    judge_version,
+    wb_user_id,
+    rationale,
+    is_removed,
+    expire_at,
+    inserted_at
+FROM conversation_tags;


### PR DESCRIPTION
## Description

Denormalize two columns onto the tag tables: agent_version and agent_id.

A common filter we'll want to apply is "find all conversations for {`<tag>`, `<agent_name>`}" and likely also version or possibly id.