### PR TITLE
fix(weave): limit agent search by conversation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -612,6 +612,9 @@ deterministic.
 
 ### Python Conversation Turn messages
 
+- Message search returns conversation pages, not raw message-occurrence pages.
+  Keep untagged messages and replayed copies from consuming the SQL limit while
+  preserving occurrence-level retrieval for requests with an empty query.
 - `Turn.messages` stores input messages, while `Turn.output_messages` stores
   the terminal agent response. `Turn.record(messages=..., output_messages=...)`
   replaces the two lists independently.

--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -1939,7 +1939,9 @@ class TestMakeMessageSearchQuery:
             FROM messages
             WHERE project_id = {genai_0:String}
             AND content LIKE {genai_1:String}
+              AND conversation_id != ''
             ORDER BY started_at DESC
+            LIMIT 1 BY conversation_id
             LIMIT {genai_2:UInt64} OFFSET {genai_3:UInt64}
         """
         expected_params = {
@@ -1971,10 +1973,12 @@ class TestMakeMessageSearchQuery:
             FROM messages
             WHERE project_id = {genai_0:String}
             AND content LIKE {genai_1:String}
+              AND conversation_id != ''
               AND role IN {genai_2:Array(String)}
               AND agent_name = {genai_3:String}
               AND conversation_id = {genai_4:String}
             ORDER BY started_at DESC
+            LIMIT 1 BY conversation_id
             LIMIT {genai_5:UInt64} OFFSET {genai_6:UInt64}
         """
         expected_params = {
@@ -2003,8 +2007,10 @@ class TestMakeMessageSearchQuery:
             FROM messages
             WHERE project_id = {genai_0:String}
             AND content LIKE {genai_1:String}
+              AND conversation_id != ''
               AND role IN {genai_2:Array(String)}
             ORDER BY started_at DESC
+            LIMIT 1 BY conversation_id
             LIMIT {genai_3:UInt64} OFFSET {genai_4:UInt64}
         """
         expected_params = {

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -2894,6 +2894,50 @@ def test_message_search_shared_digest_across_spans(ch_server):
     assert len(digests) == 1
 
 
+def test_message_search_limits_distinct_conversations(ch_server):
+    project_id = _make_project_id("search_distinct_conversations")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    content = "A repeated message search result."
+
+    spans = [
+        _make_span(
+            project_id,
+            conversation_id="older-conversation",
+            output_messages=[NormalizedMessage(role="assistant", content=content)],
+            started_at=now,
+        )
+    ]
+    spans.extend(
+        _make_span(
+            project_id,
+            conversation_id="newer-conversation",
+            output_messages=[NormalizedMessage(role="assistant", content=content)],
+            started_at=now + datetime.timedelta(seconds=offset),
+        )
+        for offset in range(1, 4)
+    )
+    spans.extend(
+        _make_span(
+            project_id,
+            conversation_id="",
+            output_messages=[NormalizedMessage(role="assistant", content=content)],
+            started_at=now + datetime.timedelta(seconds=offset),
+        )
+        for offset in range(4, 7)
+    )
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_search(
+        AgentSearchReq(project_id=project_id, query=content, limit=2)
+    )
+
+    assert [result.conversation_id for result in res.results] == [
+        "newer-conversation",
+        "older-conversation",
+    ]
+    assert [len(result.matched_messages) for result in res.results] == [1, 1]
+
+
 def test_message_search_trace_id_full_content(ch_server):
     """Structured retrieval: empty query + trace_id + full_content returns the
     trace's user/assistant/system messages untruncated, excluding tool roles.

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1089,6 +1089,7 @@ def _search_filter_sql(pb: ParamBuilder, req: AgentSearchReq) -> _FilterSQL:
             f"%{_escape_like_pattern(req.query)}%", param_type="String"
         )
         conditions.append(f"content LIKE {content_slot}")
+        conditions.append("conversation_id != ''")
     if req.trace_id:
         trace_slot = pb.add(req.trace_id, param_type="String")
         conditions.append(f"trace_id = {trace_slot}")
@@ -1894,6 +1895,7 @@ def make_message_search_query(pb: ParamBuilder, req: AgentSearchReq) -> str:
         if req.truncate_content
         else "content"
     )
+    conversation_limit = "LIMIT 1 BY conversation_id" if req.query else ""
     # content_digest is stored raw as FixedString(16); hex-encode here so
     # the Python API surface (AgentSearchMatchedMessage.content_digest: str)
     # keeps a portable text representation.
@@ -1905,6 +1907,7 @@ def make_message_search_query(pb: ParamBuilder, req: AgentSearchReq) -> str:
         FROM messages
         WHERE {filters.where}
         ORDER BY started_at DESC
+        {conversation_limit}
         LIMIT {limit_slot} OFFSET {offset_slot}
     """
 


### PR DESCRIPTION
## Description

Agent message search currently applies its page limit to raw message occurrences before grouping them into conversations. Replayed conversation context and untagged spans can consume the page, leaving the UI with no visible results even when a matching conversation exists.

This PR filters untagged rows from text search and uses `LIMIT 1 BY conversation_id` before the page limit. Each slot now represents one navigable conversation. Empty-query structured retrieval remains occurrence-based.

This change does not add a migration or change the request or response schema.

## Testing

- `uv run --group test python -m pytest tests/trace_server/query_builder/test_agent_query_builder.py::TestMakeMessageSearchQuery tests/trace_server/test_genai_agent_queries.py -k 'TestMakeMessageSearchQuery or message_search' -q` (14 passed)
- `uvx ruff check` on the three changed Python files
- `uvx ruff format --check` on the three changed Python files
