### PR TITLE
fix(weave): mark usage response defaults required in the serialization schema

### DIFF
--- a/tests/trace_server/test_usage_response_serialization_required.py
+++ b/tests/trace_server/test_usage_response_serialization_required.py
@@ -1,0 +1,72 @@
+"""Serialization JSON Schema for usage *Res models marks defaults required."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from weave.trace_server.trace_server_interface import (
+    CallsUsageReq,
+    CallsUsageRes,
+    LLMAggregatedUsage,
+    TableCreateRes,
+    TraceUsageReq,
+    TraceUsageRes,
+)
+
+_RESPONSE_ROOTS = (TraceUsageRes, CallsUsageRes)
+
+
+def _schemas_with_properties(
+    schema: dict[str, Any],
+) -> list[tuple[str, dict[str, Any]]]:
+    out: list[tuple[str, dict[str, Any]]] = [("root", schema)]
+    defs = schema.get("$defs") or {}
+    for name, sub in defs.items():
+        if isinstance(sub, dict) and "properties" in sub:
+            out.append((name, sub))
+    return out
+
+
+def test_usage_response_serialization_requires_every_property() -> None:
+    for model in _RESPONSE_ROOTS:
+        schema = model.model_json_schema(mode="serialization")
+        for name, sub in _schemas_with_properties(schema):
+            props = set(sub.get("properties") or {})
+            required = set(sub.get("required") or [])
+            assert required == props, f"{model.__name__}:{name} {required=} {props=}"
+
+
+def test_usage_response_validation_still_allows_defaults() -> None:
+    for model in (LLMAggregatedUsage, TraceUsageRes, CallsUsageRes):
+        schema = model.model_json_schema(mode="validation")
+        required = set(schema.get("required") or [])
+        props = set(schema.get("properties") or {})
+        assert required == set()
+        assert required < props
+
+
+def test_usage_request_validation_unchanged() -> None:
+    usage_req = TraceUsageReq.model_json_schema(mode="validation")
+    assert set(usage_req.get("required") or []) == {"project_id"}
+    calls_req = CallsUsageReq.model_json_schema(mode="validation")
+    assert set(calls_req.get("required") or []) == {"project_id", "call_ids"}
+
+
+def test_table_create_row_digests_stay_optional() -> None:
+    schema = TableCreateRes.model_json_schema(mode="serialization")
+    required = set(schema.get("required") or [])
+    props = set(schema.get("properties") or {})
+    assert "row_digests" in props
+    assert "row_digests" not in required
+
+
+def test_usage_models_constructor_and_dump_keep_defaults() -> None:
+    usage = LLMAggregatedUsage()
+    dumped = usage.model_dump()
+    assert dumped["requests"] == 0
+    assert dumped["prompt_tokens_total_cost"] is None
+
+    res = TraceUsageRes()
+    dumped_res = res.model_dump()
+    assert dumped_res["call_usage"] == {}
+    assert dumped_res["unfinished_call_ids"] == []

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -4039,7 +4039,13 @@ class CallStatsRes(BaseModel):
 
 
 class LLMAggregatedUsage(BaseModel):
-    """Aggregated usage metrics for a specific LLM."""
+    """Aggregated usage metrics for a specific LLM.
+
+    Constructor defaults stay for Python callers. Serialization JSON Schema
+    marks those fields required so OpenAPI matches the JSON FastAPI sends.
+    """
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     requests: int = 0
     prompt_tokens: int = 0
@@ -4091,6 +4097,8 @@ class TraceUsageReq(BaseModelStrict):
 class TraceUsageRes(BaseModel):
     """Response with per-call usage metrics (each includes descendant contributions)."""
 
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
     # Mapping from call_id to usage metrics (own + descendants)
     call_usage: dict[str, dict[str, LLMAggregatedUsage]] = Field(default_factory=dict)
     # Unique IDs of calls in the result set that have not ended yet.
@@ -4127,6 +4135,8 @@ class CallsUsageReq(BaseModelStrict):
 
 class CallsUsageRes(BaseModel):
     """Response with aggregated usage metrics per root call."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     # Mapping from root call_id to aggregated usage metrics (root + descendants)
     call_usage: dict[str, dict[str, LLMAggregatedUsage]] = Field(default_factory=dict)


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-39414

## Description

The generated TypeScript client marks `call_usage`, the nested token counters, and `unfinished_call_ids` optional. The server always sends those keys. OpenAPI drops them from `required` because the Python fields have defaults.

This is the same Pydantic flag we used on agent responses in #7805: `json_schema_serialization_defaults_required=True` on `TraceUsageRes`, `CallsUsageRes`, and `LLMAggregatedUsage`. Constructors and request schemas do not change. Table `row_digests` is left optional on purpose. The usual spec and client sync will pick this up after merge.

## Testing

`uv run --group test python -m pytest tests/trace_server/test_usage_response_serialization_required.py tests/trace_server/test_agent_response_serialization_required.py -q --trace-server=fake` — 9 passed.