### PR TITLE
fix(weave): drop stale upgrade hint from object-name errors

### DIFF
--- a/tests/trace_server/test_validation.py
+++ b/tests/trace_server/test_validation.py
@@ -1,7 +1,28 @@
 import pytest
 
 from weave.trace_server import validation
-from weave.trace_server.errors import InvalidRequest
+from weave.trace_server.errors import InvalidFieldError, InvalidRequest
+
+
+def test_object_id_validator_invalid_chars():
+    # Invalid characters should raise an error describing the constraint,
+    # not a stale version-upgrade hint.
+    with pytest.raises(InvalidFieldError) as e:
+        validation.object_id_validator("bad name!")
+    msg = str(e.value)
+    assert "Invalid object name" in msg
+    assert "Contains invalid characters" in msg
+    assert "alphanumeric" in msg, "Error should describe valid character constraint"
+    assert "0.51" not in msg, "Error must not reference a stale version number"
+    assert "upgrade" not in msg.lower(), "Error must not suggest an upgrade"
+
+    # Valid names must pass through unchanged
+    assert validation.object_id_validator("valid-name_1.0") == "valid-name_1.0"
+
+    # Empty name should also raise
+    with pytest.raises(InvalidFieldError, match="cannot be empty"):
+        validation.object_id_validator("")
+
 
 
 def test_validate_dict_one_key():

--- a/weave/trace_server/validation.py
+++ b/weave/trace_server/validation.py
@@ -81,7 +81,7 @@ def _validate_object_name_charset(name: str) -> None:
     if invalid_chars:
         invalid_char_set = list(set(invalid_chars))
         raise InvalidFieldError(
-            f"Invalid object name: {name}. Contains invalid characters: {invalid_char_set}. Please upgrade your `weave` package to `>0.51.0` to prevent this error."
+            f"Invalid object name: {name}. Contains invalid characters: {invalid_char_set}. Object names must only contain alphanumeric characters, dashes, underscores, and periods."
         )
 
     if not name:


### PR DESCRIPTION
## Summary
Fixes #5771. Invalid object-name validation still told users to upgrade to weave `>0.51.0` even on current releases. The error now describes the allowed charset instead of suggesting an upgrade.

## Test plan
- [x] `uv run --with pytest pytest --noconftest tests/trace_server/test_validation.py` (4 passed)
- [ ] CI green