### PR TITLE
chore(weave): add Claude Fable 5.1 provider data

### DIFF
--- a/weave/trace_server/costs/cost_checkpoint.json
+++ b/weave/trace_server/costs/cost_checkpoint.json
@@ -32171,6 +32171,14 @@
       "cache_read_input": 2.8e-08,
       "cache_creation_input": 0.0,
       "created_at": "2026-08-31 16:21:06"
+    },
+    {
+      "provider": "fireworks_ai",
+      "input": 2.2e-07,
+      "output": 6.6e-07,
+      "cache_read_input": 7e-09,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
     }
   ],
   "fireworks_ai/glm-5p2-fast": [
@@ -33881,6 +33889,706 @@
       "cache_read_input": 2.6e-07,
       "cache_creation_input": 0.0,
       "created_at": "2026-08-31 16:21:06"
+    }
+  ],
+  "amazon.nova-sonic-v1:0": [
+    {
+      "provider": "bedrock",
+      "input": 6e-08,
+      "output": 2.4e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "amazon.nova-2-sonic-v1:0": [
+    {
+      "provider": "bedrock",
+      "input": 3.3e-07,
+      "output": 2.75e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "anthropic.claude-fable-5-1": [
+    {
+      "provider": "bedrock_converse",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 2.5e-07,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "global.anthropic.claude-fable-5-1": [
+    {
+      "provider": "bedrock_converse",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 2.5e-07,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "us.anthropic.claude-fable-5-1": [
+    {
+      "provider": "bedrock_converse",
+      "input": 1.1e-05,
+      "output": 5.5e-05,
+      "cache_read_input": 2.75e-07,
+      "cache_creation_input": 1.375e-05,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "eu.anthropic.claude-fable-5-1": [
+    {
+      "provider": "bedrock_converse",
+      "input": 1.1e-05,
+      "output": 5.5e-05,
+      "cache_read_input": 2.75e-07,
+      "cache_creation_input": 1.375e-05,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "azure_ai/claude-fable-5-1": [
+    {
+      "provider": "azure_ai",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 2.5e-07,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "azure_ai/deepseek-v4-flash-0731": [
+    {
+      "provider": "azure_ai",
+      "input": 1.9e-07,
+      "output": 5.1e-07,
+      "cache_read_input": 2.8e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "claude-fable-5-1": [
+    {
+      "provider": "anthropic",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 2.5e-07,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/deepseek-v4-flash": [
+    {
+      "provider": "qwencloud",
+      "input": 2e-07,
+      "output": 4e-07,
+      "cache_read_input": 4e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/deepseek-v4-flash-0731": [
+    {
+      "provider": "qwencloud",
+      "input": 2e-07,
+      "output": 4e-07,
+      "cache_read_input": 4e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/deepseek-v4-pro": [
+    {
+      "provider": "qwencloud",
+      "input": 2.4e-06,
+      "output": 4.8e-06,
+      "cache_read_input": 2e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/glm-5.1": [
+    {
+      "provider": "qwencloud",
+      "input": 1.4e-06,
+      "output": 4.4e-06,
+      "cache_read_input": 2.6e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/glm-5.2": [
+    {
+      "provider": "qwencloud",
+      "input": 1.4e-06,
+      "output": 4.4e-06,
+      "cache_read_input": 2.8e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/kimi-k2.7-code": [
+    {
+      "provider": "qwencloud",
+      "input": 9.5e-07,
+      "output": 4e-06,
+      "cache_read_input": 1.9e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen-coder": [
+    {
+      "provider": "qwencloud",
+      "input": 3e-07,
+      "output": 1.5e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen-max": [
+    {
+      "provider": "qwencloud",
+      "input": 1.6e-06,
+      "output": 6.4e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen-plus": [
+    {
+      "provider": "qwencloud",
+      "input": 4e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen-plus-2025-01-25": [
+    {
+      "provider": "qwencloud",
+      "input": 4e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen-plus-2025-04-28": [
+    {
+      "provider": "qwencloud",
+      "input": 4e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen-plus-2025-07-14": [
+    {
+      "provider": "qwencloud",
+      "input": 4e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen-turbo": [
+    {
+      "provider": "qwencloud",
+      "input": 5e-08,
+      "output": 2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen-turbo-2024-11-01": [
+    {
+      "provider": "qwencloud",
+      "input": 5e-08,
+      "output": 2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen-turbo-2025-04-28": [
+    {
+      "provider": "qwencloud",
+      "input": 5e-08,
+      "output": 2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen-turbo-latest": [
+    {
+      "provider": "qwencloud",
+      "input": 5e-08,
+      "output": 2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen3-next-80b-a3b-instruct": [
+    {
+      "provider": "qwencloud",
+      "input": 1.5e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen3-next-80b-a3b-thinking": [
+    {
+      "provider": "qwencloud",
+      "input": 1.5e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen3-vl-235b-a22b-instruct": [
+    {
+      "provider": "qwencloud",
+      "input": 4e-07,
+      "output": 1.6e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen3-vl-235b-a22b-thinking": [
+    {
+      "provider": "qwencloud",
+      "input": 4e-07,
+      "output": 4e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen3-vl-32b-instruct": [
+    {
+      "provider": "qwencloud",
+      "input": 1.6e-07,
+      "output": 6.4e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen3-vl-32b-thinking": [
+    {
+      "provider": "qwencloud",
+      "input": 1.6e-07,
+      "output": 2.87e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen3.7-max": [
+    {
+      "provider": "qwencloud",
+      "input": 2.5e-06,
+      "output": 7.5e-06,
+      "cache_read_input": 5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwen3.8-max": [
+    {
+      "provider": "qwencloud",
+      "input": 2e-06,
+      "output": 6e-06,
+      "cache_read_input": 2.5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwencloud/qwq-plus": [
+    {
+      "provider": "qwencloud",
+      "input": 8e-07,
+      "output": 2.4e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/deepseek-v4-flash": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 2e-07,
+      "output": 4e-07,
+      "cache_read_input": 4e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/deepseek-v4-flash-0731": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 2e-07,
+      "output": 4e-07,
+      "cache_read_input": 4e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/deepseek-v4-pro": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 2.4e-06,
+      "output": 4.8e-06,
+      "cache_read_input": 2e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/glm-5.1": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 1.4e-06,
+      "output": 4.4e-06,
+      "cache_read_input": 2.6e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/glm-5.2": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 1.4e-06,
+      "output": 4.4e-06,
+      "cache_read_input": 2.8e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/kimi-k2.7-code": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 9.5e-07,
+      "output": 4e-06,
+      "cache_read_input": 1.9e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen-coder": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 3e-07,
+      "output": 1.5e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen-max": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 1.6e-06,
+      "output": 6.4e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen-plus": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 4e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen-plus-2025-01-25": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 4e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen-plus-2025-04-28": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 4e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen-plus-2025-07-14": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 4e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen-turbo": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 5e-08,
+      "output": 2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen-turbo-2024-11-01": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 5e-08,
+      "output": 2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen-turbo-2025-04-28": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 5e-08,
+      "output": 2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen-turbo-latest": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 5e-08,
+      "output": 2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen3-next-80b-a3b-instruct": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 1.5e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen3-next-80b-a3b-thinking": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 1.5e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen3-vl-235b-a22b-instruct": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 4e-07,
+      "output": 1.6e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen3-vl-235b-a22b-thinking": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 4e-07,
+      "output": 4e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen3-vl-32b-instruct": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 1.6e-07,
+      "output": 6.4e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen3-vl-32b-thinking": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 1.6e-07,
+      "output": 2.87e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen3.7-max": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 2.5e-06,
+      "output": 7.5e-06,
+      "cache_read_input": 5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwen3.8-max": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 2e-06,
+      "output": 6e-06,
+      "cache_read_input": 2.5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "qwen_ai_platform/qwq-plus": [
+    {
+      "provider": "qwen_ai_platform",
+      "input": 8e-07,
+      "output": 2.4e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "databricks/databricks-deepseek-v4-flash-0731": [
+    {
+      "provider": "databricks",
+      "input": 1.4e-07,
+      "output": 2.8e-07,
+      "cache_read_input": 2.8e-08,
+      "cache_creation_input": 1.4e-07,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "databricks/databricks-deepseek-v4-pro-0813": [
+    {
+      "provider": "databricks",
+      "input": 1.31999e-06,
+      "output": 3.95997e-06,
+      "cache_read_input": 1.3202e-07,
+      "cache_creation_input": 1.31999e-06,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "friendliai/zai-org/GLM-5.3-Flash": [
+    {
+      "provider": "friendliai",
+      "input": 1.5e-07,
+      "output": 5e-07,
+      "cache_read_input": 3e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "friendliai/zai-org/GLM-5.3": [
+    {
+      "provider": "friendliai",
+      "input": 1.26e-06,
+      "output": 3.96e-06,
+      "cache_read_input": 2.34e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "gigachat/GigaChat-2": [
+    {
+      "provider": "gigachat",
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "gigachat/GigaEmbeddings-3B-2025-09": [
+    {
+      "provider": "gigachat",
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "vertex_ai/claude-fable-5-1": [
+    {
+      "provider": "vertex_ai-anthropic_models",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 2.5e-07,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "vertex_ai/claude-fable-5-1@default": [
+    {
+      "provider": "vertex_ai-anthropic_models",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 2.5e-07,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "zai/glm-5.2": [
+    {
+      "provider": "zai",
+      "input": 1.4e-06,
+      "output": 4.4e-06,
+      "cache_read_input": 2.6e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "together_ai/Qwen/Qwen3.8-Flash": [
+    {
+      "provider": "together_ai",
+      "input": 1.5e-07,
+      "output": 4.7e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
+    }
+  ],
+  "cerebras/gemma-4-31b": [
+    {
+      "provider": "cerebras",
+      "input": 9.9e-07,
+      "output": 1.49e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-09-02 00:03:54"
     }
   ]
 }

--- a/weave/trace_server/model_providers/model_providers.json
+++ b/weave/trace_server/model_providers/model_providers.json
@@ -11,6 +11,10 @@
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
   },
+  "ibm-granite/granite-4.2-8b": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
   "ibm-granite/granite-4.1-8b": {
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
@@ -24,6 +28,10 @@
     "api_key_name": "WANDB_API_KEY"
   },
   "MiniMaxAI/MiniMax-M2.5": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "zai-org/GLM-5.3-Flash": {
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
   },
@@ -52,6 +60,10 @@
     "api_key_name": "WANDB_API_KEY"
   },
   "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "Qwen/Qwen3.8-27B": {
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
   },
@@ -124,6 +136,10 @@
     "api_key_name": "WANDB_API_KEY"
   },
   "meta-llama/Llama-3.1-8B-Instruct": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "deepseek-ai/DeepSeek-V4-Pro-0813": {
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
   },
@@ -285,6 +301,14 @@
   },
   "amazon.nova-pro-v1:0": {
     "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "amazon.nova-sonic-v1:0": {
+    "litellm_provider": "bedrock",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "amazon.nova-2-sonic-v1:0": {
+    "litellm_provider": "bedrock",
     "api_key_name": "BEDROCK_API_KEY"
   },
   "amazon.rerank-v1:0": {
@@ -459,7 +483,15 @@
     "litellm_provider": "bedrock_converse",
     "api_key_name": "BEDROCK_API_KEY"
   },
+  "anthropic.claude-fable-5-1": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
   "global.anthropic.claude-fable-5": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "global.anthropic.claude-fable-5-1": {
     "litellm_provider": "bedrock_converse",
     "api_key_name": "BEDROCK_API_KEY"
   },
@@ -467,7 +499,15 @@
     "litellm_provider": "bedrock_converse",
     "api_key_name": "BEDROCK_API_KEY"
   },
+  "us.anthropic.claude-fable-5-1": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
   "eu.anthropic.claude-fable-5": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "eu.anthropic.claude-fable-5-1": {
     "litellm_provider": "bedrock_converse",
     "api_key_name": "BEDROCK_API_KEY"
   },
@@ -656,6 +696,10 @@
     "api_key_name": "AZURE_API_KEY"
   },
   "azure_ai/claude-fable-5": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/claude-fable-5-1": {
     "litellm_provider": "azure_ai",
     "api_key_name": "AZURE_API_KEY"
   },
@@ -959,6 +1003,10 @@
     "litellm_provider": "azure",
     "api_key_name": "AZURE_API_KEY"
   },
+  "azure/gpt-audio-mini": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
   "azure/gpt-audio-mini-2025-10-06": {
     "litellm_provider": "azure",
     "api_key_name": "AZURE_API_KEY"
@@ -988,6 +1036,10 @@
     "api_key_name": "AZURE_API_KEY"
   },
   "azure/gpt-realtime-1.5-2026-02-23": {
+    "litellm_provider": "azure",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure/gpt-realtime-mini": {
     "litellm_provider": "azure",
     "api_key_name": "AZURE_API_KEY"
   },
@@ -1835,6 +1887,10 @@
     "litellm_provider": "azure_ai",
     "api_key_name": "AZURE_API_KEY"
   },
+  "azure_ai/deepseek-v4-flash-0731": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
   "azure_ai/embed-v-4-0": {
     "litellm_provider": "azure_ai",
     "api_key_name": "AZURE_API_KEY"
@@ -1948,6 +2004,10 @@
     "api_key_name": "BEDROCK_API_KEY"
   },
   "bedrock/*/6-month-commitment/cohere.command-text-v14": {
+    "litellm_provider": "bedrock",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "bedrock/guardrails": {
     "litellm_provider": "bedrock",
     "api_key_name": "BEDROCK_API_KEY"
   },
@@ -2634,6 +2694,10 @@
     "litellm_provider": "anthropic",
     "api_key_name": "ANTHROPIC_API_KEY"
   },
+  "claude-fable-5-1": {
+    "litellm_provider": "anthropic",
+    "api_key_name": "ANTHROPIC_API_KEY"
+  },
   "claude-opus-5": {
     "litellm_provider": "anthropic",
     "api_key_name": "ANTHROPIC_API_KEY"
@@ -2871,6 +2935,10 @@
     "api_key_name": "FIREWORKS_API_KEY"
   },
   "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro-0813": {
     "litellm_provider": "fireworks_ai",
     "api_key_name": "FIREWORKS_API_KEY"
   },
@@ -3150,6 +3218,10 @@
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },
+  "gemini-3.1-flash-lite-image": {
+    "litellm_provider": "vertex_ai-language-models",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
   "gemini-3.1-flash-lite-preview": {
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
@@ -3175,6 +3247,10 @@
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },
   "gemini-2.5-flash-preview-09-2025": {
+    "litellm_provider": "vertex_ai-language-models",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
+  "gemini-live-2.5-flash-native-audio": {
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },
@@ -3326,11 +3402,19 @@
     "litellm_provider": "gemini",
     "api_key_name": "GEMINI_API_KEY"
   },
+  "gemini/nano-banana-pro-preview": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
   "gemini/gemini-3.1-flash-image": {
     "litellm_provider": "gemini",
     "api_key_name": "GEMINI_API_KEY"
   },
   "gemini/gemini-3.1-flash-image-preview": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/gemini-3.1-flash-lite-image": {
     "litellm_provider": "gemini",
     "api_key_name": "GEMINI_API_KEY"
   },
@@ -3486,6 +3570,14 @@
     "deprecated_date": "2026-01-29T21:44:57.324937"
   },
   "gemini/gemma-3-27b-it": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/gemma-4-26b-a4b-it": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/gemma-4-31b-it": {
     "litellm_provider": "gemini",
     "api_key_name": "GEMINI_API_KEY"
   },
@@ -3978,6 +4070,22 @@
     "api_key_name": "OPENAI_API_KEY"
   },
   "gpt-5.6-luna": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-5.6-cyber": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "daybreak-red-latest": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "daybreak-blue-latest": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "chat-latest": {
     "litellm_provider": "openai",
     "api_key_name": "OPENAI_API_KEY"
   },
@@ -4474,6 +4582,54 @@
     "litellm_provider": "mistral",
     "api_key_name": "MISTRAL_API_KEY"
   },
+  "mistral/ministral-14b-2512": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/ministral-14b-latest": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/ministral-3b-2512": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/ministral-3b-latest": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-embed-2312": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-medium-3": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/voxtral-mini-transcribe-realtime-latest": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/voxtral-mini-tts-latest": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/voxtral-small-2507": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/voxtral-small-latest": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/zai-glm-5-2": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/glm-5-2": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
   "mistral/magistral-medium-2506": {
     "litellm_provider": "mistral",
     "api_key_name": "MISTRAL_API_KEY"
@@ -4491,6 +4647,10 @@
     "api_key_name": "MISTRAL_API_KEY"
   },
   "mistral/mistral-ocr-4-0": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-ocr-4-1": {
     "litellm_provider": "mistral",
     "api_key_name": "MISTRAL_API_KEY"
   },
@@ -4674,6 +4834,10 @@
     "litellm_provider": "moonshot",
     "api_key_name": "MOONSHOT_API_KEY"
   },
+  "moonshot/kimi-k2.7-code": {
+    "litellm_provider": "moonshot",
+    "api_key_name": "MOONSHOT_API_KEY"
+  },
   "moonshot/kimi-k2-turbo-preview": {
     "litellm_provider": "moonshot",
     "api_key_name": "MOONSHOT_API_KEY"
@@ -4683,6 +4847,10 @@
     "api_key_name": "MOONSHOT_API_KEY"
   },
   "moonshot/kimi-k2.6": {
+    "litellm_provider": "moonshot",
+    "api_key_name": "MOONSHOT_API_KEY"
+  },
+  "moonshot/kimi-k3": {
     "litellm_provider": "moonshot",
     "api_key_name": "MOONSHOT_API_KEY"
   },
@@ -5190,6 +5358,10 @@
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },
+  "vertex_ai/gemini-3.1-flash-lite-image": {
+    "litellm_provider": "vertex_ai-language-models",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
   "vertex_ai/gemini-3.1-flash-lite-preview": {
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
@@ -5233,39 +5405,6 @@
   "whisper-1": {
     "litellm_provider": "openai",
     "api_key_name": "OPENAI_API_KEY"
-  },
-  "xai/grok-2": {
-    "litellm_provider": "xai",
-    "api_key_name": "XAI_API_KEY",
-    "deprecated": true,
-    "deprecated_reason": "litellm.NotFoundError: NotFoundError: XaiException - {\"code\":\"Some requested entity was not found\",\"error\":\"The model grok-2 does not exist or your teams",
-    "deprecated_date": "2026-01-29T18:47:19.050059"
-  },
-  "xai/grok-2-1212": {
-    "litellm_provider": "xai",
-    "api_key_name": "XAI_API_KEY",
-    "deprecated": true,
-    "deprecated_reason": "litellm.NotFoundError: NotFoundError: XaiException - {\"code\":\"Some requested entity was not found\",\"error\":\"The model grok-2-1212 was deprecated on 2025-09-15 and is no longer accessible via the API. ",
-    "deprecated_date": "2026-01-29T18:47:19.050127"
-  },
-  "xai/grok-2-latest": {
-    "litellm_provider": "xai",
-    "api_key_name": "XAI_API_KEY",
-    "deprecated": true,
-    "deprecated_reason": "litellm.NotFoundError: NotFoundError: XaiException - {\"code\":\"Some requested entity was not found\",\"error\":\"The model grok-2-latest does not exist or your team",
-    "deprecated_date": "2026-01-29T18:47:19.050157"
-  },
-  "xai/grok-2-vision": {
-    "litellm_provider": "xai",
-    "api_key_name": "XAI_API_KEY"
-  },
-  "xai/grok-2-vision-1212": {
-    "litellm_provider": "xai",
-    "api_key_name": "XAI_API_KEY"
-  },
-  "xai/grok-2-vision-latest": {
-    "litellm_provider": "xai",
-    "api_key_name": "XAI_API_KEY"
   },
   "xai/grok-3": {
     "litellm_provider": "xai",
@@ -5387,13 +5526,6 @@
     "litellm_provider": "xai",
     "api_key_name": "XAI_API_KEY"
   },
-  "xai/grok-beta": {
-    "litellm_provider": "xai",
-    "api_key_name": "XAI_API_KEY",
-    "deprecated": true,
-    "deprecated_reason": "litellm.NotFoundError: NotFoundError: XaiException - {\"code\":\"Some requested entity was not found\",\"error\":\"The model grok-beta was deprecated on 2025-09-15 and is no longer accessible via the API. Pl",
-    "deprecated_date": "2026-01-29T18:47:19.050191"
-  },
   "xai/grok-code-fast": {
     "litellm_provider": "xai",
     "api_key_name": "XAI_API_KEY"
@@ -5405,13 +5537,6 @@
   "xai/grok-code-fast-1-0825": {
     "litellm_provider": "xai",
     "api_key_name": "XAI_API_KEY"
-  },
-  "xai/grok-vision-beta": {
-    "litellm_provider": "xai",
-    "api_key_name": "XAI_API_KEY",
-    "deprecated": true,
-    "deprecated_reason": "litellm.NotFoundError: NotFoundError: XaiException - {\"code\":\"Some requested entity was not found\",\"error\":\"The model grok-vision-beta does not exist or your team",
-    "deprecated_date": "2026-01-29T18:47:19.050217"
   },
   "zai.glm-4.7": {
     "litellm_provider": "bedrock_converse",
@@ -6505,6 +6630,38 @@
     "litellm_provider": "gemini",
     "api_key_name": "GEMINI_API_KEY"
   },
+  "us.openai.gpt-5.6-sol": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "global.openai.gpt-5.6-sol": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "us.openai.gpt-5.6-terra": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "global.openai.gpt-5.6-terra": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "us.openai.gpt-5.6-luna": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "global.openai.gpt-5.6-luna": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "us.xai.grok-4.6": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "global.xai.grok-4.6": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
   "bedrock/us-east-1/zai.glm-5": {
     "litellm_provider": "bedrock",
     "api_key_name": "BEDROCK_API_KEY"
@@ -6525,11 +6682,19 @@
     "litellm_provider": "deepseek",
     "api_key_name": "DEEPSEEK_API_KEY"
   },
+  "deepseek-v4-flash-vision-exp": {
+    "litellm_provider": "deepseek",
+    "api_key_name": "DEEPSEEK_API_KEY"
+  },
   "deepseek-v4-pro": {
     "litellm_provider": "deepseek",
     "api_key_name": "DEEPSEEK_API_KEY"
   },
   "deepseek/deepseek-v4-flash": {
+    "litellm_provider": "deepseek",
+    "api_key_name": "DEEPSEEK_API_KEY"
+  },
+  "deepseek/deepseek-v4-flash-vision-exp": {
     "litellm_provider": "deepseek",
     "api_key_name": "DEEPSEEK_API_KEY"
   },
@@ -6596,5 +6761,237 @@
   "mistral/voxtral-mini-tts-2603": {
     "litellm_provider": "mistral",
     "api_key_name": "MISTRAL_API_KEY"
+  },
+  "gemini/gemini-3.5-live-translate-preview": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/gemini-3.5-transcribe": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/gemini-3.5-transcribe-live": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "vertex_ai/gemini-3.5-transcribe-preview": {
+    "litellm_provider": "vertex_ai",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
+  "vertex_ai/gemini-3.5-transcribe-live-preview": {
+    "litellm_provider": "vertex_ai",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/accounts/fireworks/models/kimi-k3": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/deepseek-v4-flash-0731": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/glm-5p2-fast": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/glm-5p2-fast-us": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/kimi-k3": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/kimi-k3-fast": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/kimi-k3-us": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/qwen3p8-max": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/muse-glimmer-30b": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/nemotron-lightning-3p5-30b-a3b": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/nemotron-3-ultra-nvfp4": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/accounts/fireworks/models/muse-glimmer-30b": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/accounts/fireworks/models/nemotron-3-ultra-nvfp4": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3p8-max": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/accounts/fireworks/routers/glm-5p2-fast": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/accounts/fireworks/routers/glm-5p2-fast-us": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/accounts/fireworks/routers/kimi-k3-fast": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/accounts/fireworks/routers/kimi-k3-us": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "gemini/gemini-omni-1.1-flash": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "xai/grok-4.20": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-4.20-reasoning": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-4.20-reasoning-latest": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-imagine-image": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-imagine-image-2026-03-02": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-imagine-image-quality": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-imagine-image-quality-20260403": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-imagine-image-quality-latest": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-imagine-image-pro": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-imagine-image-2.0": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "low/1024-x-1024/grok-imagine-image-2.0": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-4.20-non-reasoning": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-4.20-non-reasoning-latest": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-4.20-multi-agent": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "xai/grok-4.20-multi-agent-latest": {
+    "litellm_provider": "xai",
+    "api_key_name": "XAI_API_KEY"
+  },
+  "groq/qwen/qwen3.8-27b": {
+    "litellm_provider": "groq",
+    "api_key_name": "GROQ_API_KEY"
+  },
+  "mistral/mistral-medium-3.5": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-vibe-cli-latest": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-vibe-cli-with-tools": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-vibe-cli-fast": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-code-latest": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-code-fim-latest": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-code-agent-latest": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-ocr-3": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-ocr-3-0": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/mistral-ocr-4": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/voxtral-mini-latest": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/voxtral-mini-realtime-2602": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/voxtral-mini-realtime-latest": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/labs-leanstral-1-5-1": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "fireworks_ai/accounts/fireworks/models/glm-5p3": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-embedding-8b": {
+    "litellm_provider": "fireworks_ai",
+    "api_key_name": "FIREWORKS_API_KEY"
   }
 }


### PR DESCRIPTION
## Summary

- regenerate LiteLLM-backed model provider routing with `make update_model_providers`
- regenerate the cost checkpoint with `make update_costs`
- add Claude Fable 5.1 Anthropic, Bedrock, and Azure routes and current pricing

## Claude Fable 5.1

The generated data includes six routable provider aliases. The native Anthropic cost record is:

- input: $10 per million tokens
- output: $50 per million tokens
- cache reads: $0.25 per million tokens
- cache creation: $12.50 per million tokens

## Generated diff audit

This is a full upstream regeneration rather than a hand-edited Fable-only patch:

- provider map: 1,624 -> 1,727 keys (111 added, 8 removed, 0 changed)
- cost checkpoint: 3,213 -> 3,283 keys (70 added, 0 removed, 1 changed)
- new provider modes: 73 chat and 38 non-chat/unknown

The playground remains curated separately by Core's `LLM_MAX_TOKENS`. The existing raw `/inference/v1/models` behavior can advertise generated non-chat routes even though the service only supports chat completions; this PR does not change that pre-existing behavior.

## Verification

- `uv run --group test python -m pytest tests/trace_server/costs/test_update_costs.py -v` — 17 passed
- exact assertions for all six Fable 5.1 provider aliases and native pricing
- pinned LiteLLM resolved `claude-fable-5-1` to Anthropic
- intentionally invalid-key request reached Anthropic and returned the expected 401
- `git diff --check`
