### PR TITLE
chore(weave): bind 29 already-generated routes in the Stainless client

### DIFF
--- a/tests/trace_server_bindings/test_stainless_routes.py
+++ b/tests/trace_server_bindings/test_stainless_routes.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 from tests.trace_server_bindings.conftest import generate_call_start_end_pair
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents import types as agent_types
+from weave.trace_server.interface import query
 from weave.trace_server_bindings.stainless_remote_http_trace_server import (
     StainlessRemoteHTTPTraceServer,
 )
@@ -79,8 +80,6 @@ ITEM = {
     "call_started_at": "2026-08-20T00:00:00Z",
     "display_fields": [],
     "annotation_state": "unstarted",
-    "annotator_user_id": "user-id",
-    "position": 0,
     "created_at": "2026-08-20T00:00:00Z",
     "created_by": "user-id",
     "updated_at": "2026-08-20T00:00:00Z",
@@ -423,9 +422,7 @@ def test_v2_method_reaches_its_flat_route(
         ),
         pytest.param(
             "agent_conversation_spans",
-            agent_types.AgentConversationSpansReq(
-                project_id=PROJECT, conversation_ids=["conv1"]
-            ),
+            agent_types.AgentConversationSpansReq(project_id=PROJECT),
             "POST",
             "/agents/conversations/spans",
             agent_types.AgentConversationSpansRes,
@@ -863,6 +860,148 @@ def test_annotation_queue_read_and_delete_send_project_id_in_the_query(
     )
     assert dict(mock_server.requests[0].url.params) == {"project_id": PROJECT}
     assert mock_server.requests[0].content == b""
+
+
+@pytest.mark.parametrize(
+    ("method_name", "req", "expected_body"),
+    [
+        pytest.param(
+            "image_create",
+            tsi.ImageGenerationCreateReq(
+                project_id=PROJECT,
+                inputs={"model": "dall-e-3", "prompt": "a cat"},
+                wb_user_id="user-id",
+            ),
+            {
+                "project_id": PROJECT,
+                "inputs": {"model": "dall-e-3", "prompt": "a cat", "n": None},
+                "track_llm_call": True,
+                "wb_user_id": "user-id",
+            },
+            id="image_create",
+        ),
+        pytest.param(
+            "call_stats",
+            tsi.CallStatsReq(
+                project_id=PROJECT, start=START, end=END, granularity=3600
+            ),
+            {
+                "project_id": PROJECT,
+                "start": "2026-08-20T00:00:00+00:00",
+                "end": "2026-08-21T00:00:00+00:00",
+                "granularity": 3600,
+                "usage_metrics": None,
+                "call_metrics": None,
+                "filter": None,
+                "timezone": "UTC",
+            },
+            id="call_stats",
+        ),
+        pytest.param(
+            "annotation_queue_create",
+            tsi.AnnotationQueueCreateReq(
+                project_id=PROJECT,
+                name="my-queue",
+                description="notes",
+                scorer_refs=["weave:///entity/project/object/s:abc123"],
+                wb_user_id="user-id",
+            ),
+            {
+                "project_id": PROJECT,
+                "name": "my-queue",
+                "description": "notes",
+                "scorer_refs": ["weave:///entity/project/object/s:abc123"],
+                "wb_user_id": "user-id",
+            },
+            id="annotation_queue_create",
+        ),
+        pytest.param(
+            "custom_runtime_apply",
+            tsi.CustomRuntimeApplyReq(
+                project_id=PROJECT,
+                runtime_name="my-runtime",
+                base_url="http://example.com",
+                runtime_ids=[tsi.CustomRuntimeID(id="my-model")],
+                wb_user_id="user-id",
+            ),
+            {
+                "base_url": "http://example.com",
+                "runtime_ids": [{"id": "my-model", "max_tokens": 4096}],
+                "api_key_secret": None,
+                "headers": {},
+            },
+            id="custom_runtime_apply",
+        ),
+        pytest.param(
+            "eval_results_query",
+            tsi.EvalResultsQueryReq(
+                project_id=PROJECT,
+                evaluation_call_ids=["c1"],
+                filters=[
+                    tsi.EvalResultsFilter(
+                        evaluation_call_id="c1",
+                        query=tsi.Query(
+                            expr_=query.EqOperation(
+                                eq_=(
+                                    query.GetFieldOperator(get_field_="output.x"),
+                                    query.LiteralOperation(literal_=1),
+                                )
+                            )
+                        ),
+                    )
+                ],
+                sort_by=[tsi.EvalResultsSortBy(field="output.x", direction="desc")],
+            ),
+            {
+                "evaluation_call_ids": ["c1"],
+                "evaluation_run_ids": None,
+                "filter_logic_operator": "or",
+                "filters": [
+                    {
+                        "evaluation_call_id": "c1",
+                        "query": {
+                            "$expr": {
+                                "$eq": [
+                                    {"$getField": "output.x"},
+                                    {"$literal": 1},
+                                ]
+                            }
+                        },
+                    }
+                ],
+                "include_costs": False,
+                "include_predict_and_score_children": True,
+                "include_raw_data_rows": False,
+                "include_rows": True,
+                "include_summary": False,
+                "limit": None,
+                "offset": 0,
+                "require_intersection": False,
+                "resolve_row_refs": False,
+                "sort_by": [
+                    {
+                        "field": "output.x",
+                        "direction": "desc",
+                        "evaluation_call_id": None,
+                        "mode": "value",
+                    }
+                ],
+                "summary_require_intersection": None,
+            },
+            id="eval_results_query",
+        ),
+    ],
+)
+def test_route_sends_every_supported_field(
+    method_name: str, req: BaseModel, expected_body: dict
+):
+    """Test that the fields the route accepts reach the wire under their aliases."""
+    mock_server = _mock_server(httpx.Response(200, json=V1_RESPONSE))
+
+    getattr(mock_server.server, method_name)(req)
+
+    assert len(mock_server.requests) == 1
+    assert json.loads(mock_server.requests[0].content) == expected_body
 
 
 @pytest.mark.parametrize(

--- a/tests/trace_server_bindings/test_stainless_routes.py
+++ b/tests/trace_server_bindings/test_stainless_routes.py
@@ -19,7 +19,6 @@ from pydantic import BaseModel
 from tests.trace_server_bindings.conftest import generate_call_start_end_pair
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents import types as agent_types
-from weave.trace_server.interface import query as tsi_query
 from weave.trace_server_bindings.stainless_remote_http_trace_server import (
     StainlessRemoteHTTPTraceServer,
 )
@@ -1052,16 +1051,14 @@ def test_create_sends_every_supported_field(
             "agent_spans_query",
             agent_types.AgentSpansQueryReq(
                 project_id=PROJECT,
-                query=tsi_query.Query.model_validate(
-                    {
-                        "$expr": {
-                            "$eq": [
-                                {"$getField": "attributes.model"},
-                                {"$literal": "gpt-4o"},
-                            ]
-                        }
+                query={
+                    "$expr": {
+                        "$eq": [
+                            {"$getField": "attributes.model"},
+                            {"$literal": "gpt-4o"},
+                        ]
                     }
-                ),
+                },
             ),
             {
                 "project_id": PROJECT,
@@ -1114,16 +1111,13 @@ def test_create_sends_every_supported_field(
                 filters=[
                     tsi.EvalResultsFilter(
                         evaluation_call_id="c1",
-                        query=tsi_query.Query.model_validate(
-                            {
-                                "$expr": {
-                                    "$eq": [{"$getField": "output.x"}, {"$literal": 1}]
-                                }
+                        query={
+                            "$expr": {
+                                "$eq": [{"$getField": "output.x"}, {"$literal": 1}]
                             }
-                        ),
+                        },
                     )
                 ],
-                sort_by=[tsi.EvalResultsSortBy(field="output.x", direction="desc")],
             ),
             {
                 "evaluation_call_ids": ["c1"],
@@ -1151,14 +1145,7 @@ def test_create_sends_every_supported_field(
                 "offset": 0,
                 "require_intersection": False,
                 "resolve_row_refs": False,
-                "sort_by": [
-                    {
-                        "field": "output.x",
-                        "direction": "desc",
-                        "evaluation_call_id": None,
-                        "mode": "value",
-                    }
-                ],
+                "sort_by": None,
                 "summary_require_intersection": None,
             },
             id="eval_results_query",

--- a/tests/trace_server_bindings/test_stainless_routes.py
+++ b/tests/trace_server_bindings/test_stainless_routes.py
@@ -8,6 +8,7 @@ the default one.
 
 from __future__ import annotations
 
+import datetime
 import json
 from dataclasses import dataclass
 
@@ -17,6 +18,7 @@ from pydantic import BaseModel
 
 from tests.trace_server_bindings.conftest import generate_call_start_end_pair
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.agents import types as agent_types
 from weave.trace_server_bindings.stainless_remote_http_trace_server import (
     StainlessRemoteHTTPTraceServer,
 )
@@ -25,6 +27,8 @@ from weave.vendor.weave_server_sdk import Client as StainlessClient
 BASE_URL = "http://example.com"
 PROJECT = "entity/project"
 V2 = "/v2/entity/project"
+START = datetime.datetime(2026, 8, 20, tzinfo=datetime.timezone.utc)
+END = datetime.datetime(2026, 8, 21, tzinfo=datetime.timezone.utc)
 
 V2_RESPONSE = {
     "code": "def f(): pass",
@@ -52,6 +56,89 @@ V2_RESPONSE = {
     "trials": 1,
     "value": None,
     "version_index": 0,
+}
+
+QUEUE = {
+    "id": "q1",
+    "project_id": PROJECT,
+    "name": "my-queue",
+    "description": "",
+    "scorer_refs": [],
+    "created_at": "2026-08-20T00:00:00Z",
+    "created_by": "user-id",
+    "updated_at": "2026-08-20T00:00:00Z",
+}
+
+ITEM = {
+    "id": "i1",
+    "queue_id": "q1",
+    "project_id": PROJECT,
+    "call_id": "c1",
+    "call_op_name": "my-op",
+    "call_trace_id": "t1",
+    "call_started_at": "2026-08-20T00:00:00Z",
+    "display_fields": [],
+    "annotation_state": "unstarted",
+    "annotator_user_id": "user-id",
+    "position": 0,
+    "created_at": "2026-08-20T00:00:00Z",
+    "created_by": "user-id",
+    "updated_at": "2026-08-20T00:00:00Z",
+}
+
+V1_RESPONSE = {
+    "added_count": 0,
+    "after_ms": 0,
+    "agents": [],
+    "attributes": [],
+    "base_url": "http://example.com",
+    "before_ms": 1,
+    "bucket_type": "time",
+    "buckets": [],
+    "call_buckets": [],
+    "call_id": "c1",
+    "columns": [],
+    "conversation_id": "conv1",
+    "conversations": [],
+    "duplicates": 0,
+    "end": "2026-08-20T00:00:00Z",
+    "evaluation_run_id": "run-id",
+    "granularity": 86400,
+    "groups": [],
+    "has_more": False,
+    "headers": {},
+    "id": "q1",
+    "item": ITEM,
+    "items": [],
+    "limit": 0,
+    "messages": [],
+    "name": "my-runtime",
+    "offset": 0,
+    "paths": [],
+    "queue": QUEUE,
+    "response": {},
+    "results": [],
+    "rows": [],
+    "runtime_ids": [],
+    "spans": [],
+    "start": "2026-08-20T00:00:00Z",
+    "stats": [],
+    "status": {"code": "not_found"},
+    "timezone": "UTC",
+    "total_cache_creation_input_tokens": 0,
+    "total_cache_read_input_tokens": 0,
+    "total_conversations": 0,
+    "total_count": 0,
+    "total_input_tokens": 0,
+    "total_output_tokens": 0,
+    "total_reasoning_tokens": 0,
+    "total_rows": 0,
+    "total_turns": 0,
+    "trace_id": "t1",
+    "turns": [],
+    "usage_buckets": [],
+    "versions": [],
+    "warnings": [],
 }
 
 
@@ -306,6 +393,262 @@ def test_v2_method_reaches_its_flat_route(
 
 
 @pytest.mark.parametrize(
+    ("method_name", "req", "expected_method", "expected_path", "res_type"),
+    [
+        pytest.param(
+            "agent_spans_query",
+            agent_types.AgentSpansQueryReq(project_id=PROJECT),
+            "POST",
+            "/agents/spans/query",
+            agent_types.AgentSpansQueryRes,
+            id="agent_spans_query",
+        ),
+        pytest.param(
+            "agent_traces_chat",
+            agent_types.AgentTraceChatReq(project_id=PROJECT, trace_id="t1"),
+            "POST",
+            "/agents/traces/chat",
+            agent_types.AgentTraceChatRes,
+            id="agent_traces_chat",
+        ),
+        pytest.param(
+            "agent_conversation_chat",
+            agent_types.AgentConversationChatReq(
+                project_id=PROJECT, conversation_id="conv1"
+            ),
+            "POST",
+            "/agents/conversations/chat",
+            agent_types.AgentConversationChatRes,
+            id="agent_conversation_chat",
+        ),
+        pytest.param(
+            "agent_conversation_spans",
+            agent_types.AgentConversationSpansReq(
+                project_id=PROJECT, conversation_ids=["conv1"]
+            ),
+            "POST",
+            "/agents/conversations/spans",
+            agent_types.AgentConversationSpansRes,
+            id="agent_conversation_spans",
+        ),
+        pytest.param(
+            "agent_agents_query",
+            agent_types.AgentsQueryReq(project_id=PROJECT),
+            "POST",
+            "/agents/query",
+            agent_types.AgentsQueryRes,
+            id="agent_agents_query",
+        ),
+        pytest.param(
+            "agent_versions_query",
+            agent_types.AgentVersionsQueryReq(
+                project_id=PROJECT, agent_name="my-agent"
+            ),
+            "POST",
+            "/agents/agent-versions/query",
+            agent_types.AgentVersionsQueryRes,
+            id="agent_versions_query",
+        ),
+        pytest.param(
+            "agent_spans_stats",
+            agent_types.AgentSpanStatsReq(
+                project_id=PROJECT,
+                start=START,
+                end=END,
+                metrics=[
+                    agent_types.AgentSpanStatsMetricSpec(
+                        alias="input_tokens",
+                        value_type="number",
+                        value=agent_types.AgentSpanValueRef(
+                            source="field", key="usage.input_tokens"
+                        ),
+                        aggregations=["sum"],
+                    )
+                ],
+            ),
+            "POST",
+            "/agents/spans/stats",
+            agent_types.AgentSpanStatsRes,
+            id="agent_spans_stats",
+        ),
+        pytest.param(
+            "agent_custom_attrs_schema",
+            agent_types.AgentCustomAttrsSchemaReq(project_id=PROJECT),
+            "POST",
+            "/agents/spans/custom-attrs/schema",
+            agent_types.AgentCustomAttrsSchemaRes,
+            id="agent_custom_attrs_schema",
+        ),
+        pytest.param(
+            "agent_search",
+            agent_types.AgentSearchReq(project_id=PROJECT),
+            "POST",
+            "/agents/search",
+            agent_types.AgentSearchRes,
+            id="agent_search",
+        ),
+        pytest.param(
+            "call_stats",
+            tsi.CallStatsReq(project_id=PROJECT, start=START, end=END),
+            "POST",
+            "/calls/stats",
+            tsi.CallStatsRes,
+            id="call_stats",
+        ),
+        pytest.param(
+            "feedback_stats",
+            tsi.FeedbackStatsReq(project_id=PROJECT, start=START, end=END),
+            "POST",
+            "/feedback/stats",
+            tsi.FeedbackStatsRes,
+            id="feedback_stats",
+        ),
+        pytest.param(
+            "feedback_aggregate",
+            tsi.FeedbackAggregateReq(project_id=PROJECT, after_ms=0, before_ms=1),
+            "POST",
+            "/feedback/aggregate",
+            tsi.FeedbackAggregateRes,
+            id="feedback_aggregate",
+        ),
+        pytest.param(
+            "feedback_payload_schema",
+            tsi.FeedbackPayloadSchemaReq(project_id=PROJECT, start=START, end=END),
+            "POST",
+            "/feedback/payload_schema",
+            tsi.FeedbackPayloadSchemaRes,
+            id="feedback_payload_schema",
+        ),
+        pytest.param(
+            "image_create",
+            tsi.ImageGenerationCreateReq(
+                project_id=PROJECT, inputs={"model": "dall-e-3", "prompt": "a cat"}
+            ),
+            "POST",
+            "/image/create",
+            tsi.ImageGenerationCreateRes,
+            id="image_create",
+        ),
+        pytest.param(
+            "evaluate_model",
+            tsi.EvaluateModelReq(
+                project_id=PROJECT,
+                evaluation_ref="weave:///entity/project/object/ev:abc123",
+                model_ref="weave:///entity/project/object/m:abc123",
+            ),
+            "POST",
+            "/evaluations/evaluate_model",
+            tsi.EvaluateModelRes,
+            id="evaluate_model",
+        ),
+        pytest.param(
+            "evaluation_status",
+            tsi.EvaluationStatusReq(project_id=PROJECT, call_id="c1"),
+            "POST",
+            "/evaluations/status",
+            tsi.EvaluationStatusRes,
+            id="evaluation_status",
+        ),
+        pytest.param(
+            "rescore",
+            tsi.RescoreReq(
+                project_id=PROJECT,
+                source_evaluation_run_id="run-id",
+                scorer_refs=["weave:///entity/project/object/s:abc123"],
+            ),
+            "POST",
+            "/evaluations/rescore",
+            tsi.RescoreRes,
+            id="rescore",
+        ),
+        pytest.param(
+            "calls_score",
+            tsi.CallsScoreReq(
+                project_id=PROJECT,
+                call_ids=["c1"],
+                scorer_refs=["weave:///entity/project/object/s:abc123"],
+            ),
+            "POST",
+            "/calls/score",
+            tsi.CallsScoreRes,
+            id="calls_score",
+        ),
+        pytest.param(
+            "annotation_queue_create",
+            tsi.AnnotationQueueCreateReq(
+                project_id=PROJECT, name="my-queue", scorer_refs=[]
+            ),
+            "POST",
+            "/annotation_queues",
+            tsi.AnnotationQueueCreateRes,
+            id="annotation_queue_create",
+        ),
+        pytest.param(
+            "annotation_queue_read",
+            tsi.AnnotationQueueReadReq(project_id=PROJECT, queue_id="q1"),
+            "GET",
+            "/annotation_queues/q1",
+            tsi.AnnotationQueueReadRes,
+            id="annotation_queue_read",
+        ),
+        pytest.param(
+            "annotation_queue_items_query",
+            tsi.AnnotationQueueItemsQueryReq(project_id=PROJECT, queue_id="q1"),
+            "POST",
+            "/annotation_queues/q1/items/query",
+            tsi.AnnotationQueueItemsQueryRes,
+            id="annotation_queue_items_query",
+        ),
+        pytest.param(
+            "annotation_queues_stats",
+            tsi.AnnotationQueuesStatsReq(project_id=PROJECT, queue_ids=["q1"]),
+            "POST",
+            "/annotation_queues/stats",
+            tsi.AnnotationQueuesStatsRes,
+            id="annotation_queues_stats",
+        ),
+        pytest.param(
+            "custom_runtime_apply",
+            tsi.CustomRuntimeApplyReq(
+                project_id=PROJECT,
+                runtime_name="my-runtime",
+                base_url="http://example.com",
+                runtime_ids=[],
+            ),
+            "PUT",
+            f"{V2}/runtimes/my-runtime",
+            tsi.CustomRuntimeApplyRes,
+            id="custom_runtime_apply",
+        ),
+        pytest.param(
+            "eval_results_query",
+            tsi.EvalResultsQueryReq(project_id=PROJECT, evaluation_call_ids=["c1"]),
+            "POST",
+            f"{V2}/eval_results/query",
+            tsi.EvalResultsQueryRes,
+            id="eval_results_query",
+        ),
+    ],
+)
+def test_route_reaches_its_path(
+    method_name: str,
+    req: BaseModel,
+    expected_method: str,
+    expected_path: str,
+    res_type: type[BaseModel],
+):
+    """Test that a bound method reaches its route and parses the response back."""
+    mock_server = _mock_server(httpx.Response(200, json=V1_RESPONSE))
+
+    res = getattr(mock_server.server, method_name)(req)
+
+    assert [(r.method, r.url.path) for r in mock_server.requests] == [
+        (expected_method, expected_path)
+    ]
+    assert isinstance(res, res_type)
+
+
+@pytest.mark.parametrize(
     ("method_name", "req", "expected_method", "expected_path", "expected_body"),
     [
         pytest.param(
@@ -416,6 +759,110 @@ def test_tag_and_alias_list_omits_wb_user_id(
         expected_path,
     )
     assert dict(mock_server.requests[0].url.params) == {"project_id": PROJECT}
+
+
+@pytest.mark.parametrize(
+    ("method_name", "req", "expected_method", "expected_path", "expected_body"),
+    [
+        pytest.param(
+            "annotation_queue_update",
+            tsi.AnnotationQueueUpdateReq(
+                project_id=PROJECT, queue_id="q1", wb_user_id="user-id"
+            ),
+            "PUT",
+            "/annotation_queues/q1",
+            {
+                "project_id": PROJECT,
+                "name": None,
+                "description": None,
+                "scorer_refs": None,
+            },
+            id="annotation_queue_update",
+        ),
+        pytest.param(
+            "annotation_queue_add_calls",
+            tsi.AnnotationQueueAddCallsReq(
+                project_id=PROJECT,
+                queue_id="q1",
+                call_ids=["c1"],
+                display_fields=[],
+                wb_user_id="user-id",
+            ),
+            "POST",
+            "/annotation_queues/q1/items",
+            {"project_id": PROJECT, "call_ids": ["c1"], "display_fields": []},
+            id="annotation_queue_add_calls",
+        ),
+        pytest.param(
+            "annotator_queue_items_progress_update",
+            tsi.AnnotatorQueueItemsProgressUpdateReq(
+                project_id=PROJECT,
+                queue_id="q1",
+                item_id="i1",
+                annotation_state="completed",
+                wb_user_id="user-id",
+            ),
+            "POST",
+            "/annotation_queues/q1/items/i1/progress",
+            {"project_id": PROJECT, "annotation_state": "completed"},
+            id="annotator_queue_items_progress_update",
+        ),
+    ],
+)
+def test_annotation_queue_method_omits_wb_user_id(
+    method_name: str,
+    req: BaseModel,
+    expected_method: str,
+    expected_path: str,
+    expected_body: dict,
+):
+    """Test that the server-populated wb_user_id stays out of the request."""
+    mock_server = _mock_server(httpx.Response(200, json=V1_RESPONSE))
+
+    getattr(mock_server.server, method_name)(req)
+
+    assert len(mock_server.requests) == 1
+    assert (mock_server.requests[0].method, mock_server.requests[0].url.path) == (
+        expected_method,
+        expected_path,
+    )
+    assert json.loads(mock_server.requests[0].content) == expected_body
+
+
+@pytest.mark.parametrize(
+    ("method_name", "req", "expected_method"),
+    [
+        pytest.param(
+            "annotation_queue_read",
+            tsi.AnnotationQueueReadReq(project_id=PROJECT, queue_id="q1"),
+            "GET",
+            id="annotation_queue_read",
+        ),
+        pytest.param(
+            "annotation_queue_delete",
+            tsi.AnnotationQueueDeleteReq(
+                project_id=PROJECT, queue_id="q1", wb_user_id="user-id"
+            ),
+            "DELETE",
+            id="annotation_queue_delete",
+        ),
+    ],
+)
+def test_annotation_queue_read_and_delete_send_project_id_in_the_query(
+    method_name: str, req: BaseModel, expected_method: str
+):
+    """Test that a bodyless annotation queue route carries project_id in the query."""
+    mock_server = _mock_server(httpx.Response(200, json=V1_RESPONSE))
+
+    getattr(mock_server.server, method_name)(req)
+
+    assert len(mock_server.requests) == 1
+    assert (mock_server.requests[0].method, mock_server.requests[0].url.path) == (
+        expected_method,
+        "/annotation_queues/q1",
+    )
+    assert dict(mock_server.requests[0].url.params) == {"project_id": PROJECT}
+    assert mock_server.requests[0].content == b""
 
 
 @pytest.mark.parametrize(
@@ -914,6 +1361,17 @@ def test_call_start_batch_reads_the_response_list():
             ],
             id="score_list",
         ),
+        pytest.param(
+            "annotation_queues_query_stream",
+            tsi.AnnotationQueuesQueryReq(project_id=PROJECT),
+            "/annotation_queues/query",
+            [QUEUE, {**QUEUE, "id": "q2"}],
+            [
+                tsi.AnnotationQueueSchema.model_validate(QUEUE),
+                tsi.AnnotationQueueSchema.model_validate({**QUEUE, "id": "q2"}),
+            ],
+            id="annotation_queues_query_stream",
+        ),
     ],
 )
 def test_typed_stream_reads_one_item_per_line(
@@ -955,6 +1413,23 @@ def test_file_content_read_keeps_bytes():
     assert len(mock_server.requests) == 1
     assert mock_server.requests[0].url.path == "/file/content"
     assert res.content == content
+
+
+def test_custom_runtime_name_keeps_its_colon():
+    """Test that a runtime name reaches the path without percent-encoding."""
+    mock_server = _mock_server(httpx.Response(200, json=V1_RESPONSE))
+
+    mock_server.server.custom_runtime_apply(
+        tsi.CustomRuntimeApplyReq(
+            project_id=PROJECT,
+            runtime_name="foo:bar",
+            base_url="http://example.com",
+            runtime_ids=[],
+        )
+    )
+
+    assert len(mock_server.requests) == 1
+    assert mock_server.requests[0].url.raw_path.endswith(b"/runtimes/foo:bar")
 
 
 @pytest.mark.parametrize(

--- a/tests/trace_server_bindings/test_stainless_routes.py
+++ b/tests/trace_server_bindings/test_stainless_routes.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel
 from tests.trace_server_bindings.conftest import generate_call_start_end_pair
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents import types as agent_types
-from weave.trace_server.interface import query
+from weave.trace_server.interface import query as tsi_query
 from weave.trace_server_bindings.stainless_remote_http_trace_server import (
     StainlessRemoteHTTPTraceServer,
 )
@@ -863,148 +863,6 @@ def test_annotation_queue_read_and_delete_send_project_id_in_the_query(
 
 
 @pytest.mark.parametrize(
-    ("method_name", "req", "expected_body"),
-    [
-        pytest.param(
-            "image_create",
-            tsi.ImageGenerationCreateReq(
-                project_id=PROJECT,
-                inputs={"model": "dall-e-3", "prompt": "a cat"},
-                wb_user_id="user-id",
-            ),
-            {
-                "project_id": PROJECT,
-                "inputs": {"model": "dall-e-3", "prompt": "a cat", "n": None},
-                "track_llm_call": True,
-                "wb_user_id": "user-id",
-            },
-            id="image_create",
-        ),
-        pytest.param(
-            "call_stats",
-            tsi.CallStatsReq(
-                project_id=PROJECT, start=START, end=END, granularity=3600
-            ),
-            {
-                "project_id": PROJECT,
-                "start": "2026-08-20T00:00:00+00:00",
-                "end": "2026-08-21T00:00:00+00:00",
-                "granularity": 3600,
-                "usage_metrics": None,
-                "call_metrics": None,
-                "filter": None,
-                "timezone": "UTC",
-            },
-            id="call_stats",
-        ),
-        pytest.param(
-            "annotation_queue_create",
-            tsi.AnnotationQueueCreateReq(
-                project_id=PROJECT,
-                name="my-queue",
-                description="notes",
-                scorer_refs=["weave:///entity/project/object/s:abc123"],
-                wb_user_id="user-id",
-            ),
-            {
-                "project_id": PROJECT,
-                "name": "my-queue",
-                "description": "notes",
-                "scorer_refs": ["weave:///entity/project/object/s:abc123"],
-                "wb_user_id": "user-id",
-            },
-            id="annotation_queue_create",
-        ),
-        pytest.param(
-            "custom_runtime_apply",
-            tsi.CustomRuntimeApplyReq(
-                project_id=PROJECT,
-                runtime_name="my-runtime",
-                base_url="http://example.com",
-                runtime_ids=[tsi.CustomRuntimeID(id="my-model")],
-                wb_user_id="user-id",
-            ),
-            {
-                "base_url": "http://example.com",
-                "runtime_ids": [{"id": "my-model", "max_tokens": 4096}],
-                "api_key_secret": None,
-                "headers": {},
-            },
-            id="custom_runtime_apply",
-        ),
-        pytest.param(
-            "eval_results_query",
-            tsi.EvalResultsQueryReq(
-                project_id=PROJECT,
-                evaluation_call_ids=["c1"],
-                filters=[
-                    tsi.EvalResultsFilter(
-                        evaluation_call_id="c1",
-                        query=tsi.Query(
-                            expr_=query.EqOperation(
-                                eq_=(
-                                    query.GetFieldOperator(get_field_="output.x"),
-                                    query.LiteralOperation(literal_=1),
-                                )
-                            )
-                        ),
-                    )
-                ],
-                sort_by=[tsi.EvalResultsSortBy(field="output.x", direction="desc")],
-            ),
-            {
-                "evaluation_call_ids": ["c1"],
-                "evaluation_run_ids": None,
-                "filter_logic_operator": "or",
-                "filters": [
-                    {
-                        "evaluation_call_id": "c1",
-                        "query": {
-                            "$expr": {
-                                "$eq": [
-                                    {"$getField": "output.x"},
-                                    {"$literal": 1},
-                                ]
-                            }
-                        },
-                    }
-                ],
-                "include_costs": False,
-                "include_predict_and_score_children": True,
-                "include_raw_data_rows": False,
-                "include_rows": True,
-                "include_summary": False,
-                "limit": None,
-                "offset": 0,
-                "require_intersection": False,
-                "resolve_row_refs": False,
-                "sort_by": [
-                    {
-                        "field": "output.x",
-                        "direction": "desc",
-                        "evaluation_call_id": None,
-                        "mode": "value",
-                    }
-                ],
-                "summary_require_intersection": None,
-            },
-            id="eval_results_query",
-        ),
-    ],
-)
-def test_route_sends_every_supported_field(
-    method_name: str, req: BaseModel, expected_body: dict
-):
-    """Test that the fields the route accepts reach the wire under their aliases."""
-    mock_server = _mock_server(httpx.Response(200, json=V1_RESPONSE))
-
-    getattr(mock_server.server, method_name)(req)
-
-    assert len(mock_server.requests) == 1
-    assert json.loads(mock_server.requests[0].content) == expected_body
-
-
-@pytest.mark.parametrize(
     ("method_name", "req", "expected_path"),
     [
         pytest.param(
@@ -1135,6 +993,210 @@ def test_create_sends_every_supported_field(
 
     assert len(mock_server.requests) == 1
     assert json.loads(mock_server.requests[0].content) == expected_body
+
+
+@pytest.mark.parametrize(
+    ("method_name", "req", "expected_body"),
+    [
+        pytest.param(
+            "image_create",
+            tsi.ImageGenerationCreateReq(
+                project_id=PROJECT,
+                inputs={"model": "dall-e-3", "prompt": "a cat"},
+                wb_user_id="user-id",
+            ),
+            {
+                "project_id": PROJECT,
+                "inputs": {"model": "dall-e-3", "prompt": "a cat", "n": None},
+                "track_llm_call": True,
+                "wb_user_id": "user-id",
+            },
+            id="image_create",
+        ),
+        pytest.param(
+            "call_stats",
+            tsi.CallStatsReq(
+                project_id=PROJECT, start=START, end=END, granularity=3600
+            ),
+            {
+                "project_id": PROJECT,
+                "start": "2026-08-20T00:00:00+00:00",
+                "end": "2026-08-21T00:00:00+00:00",
+                "granularity": 3600,
+                "usage_metrics": None,
+                "call_metrics": None,
+                "filter": None,
+                "timezone": "UTC",
+            },
+            id="call_stats",
+        ),
+        pytest.param(
+            "annotation_queue_create",
+            tsi.AnnotationQueueCreateReq(
+                project_id=PROJECT,
+                name="my-queue",
+                description="notes",
+                scorer_refs=["weave:///entity/project/object/s:abc123"],
+                wb_user_id="user-id",
+            ),
+            {
+                "project_id": PROJECT,
+                "name": "my-queue",
+                "description": "notes",
+                "scorer_refs": ["weave:///entity/project/object/s:abc123"],
+                "wb_user_id": "user-id",
+            },
+            id="annotation_queue_create",
+        ),
+        pytest.param(
+            "agent_spans_query",
+            agent_types.AgentSpansQueryReq(
+                project_id=PROJECT,
+                query=tsi_query.Query.model_validate(
+                    {
+                        "$expr": {
+                            "$eq": [
+                                {"$getField": "attributes.model"},
+                                {"$literal": "gpt-4o"},
+                            ]
+                        }
+                    }
+                ),
+            ),
+            {
+                "project_id": PROJECT,
+                "query": {
+                    "$expr": {
+                        "$eq": [
+                            {"$getField": "attributes.model"},
+                            {"$literal": "gpt-4o"},
+                        ]
+                    }
+                },
+                "custom_attr_columns": [],
+                "group_by": None,
+                "group_distributions": [],
+                "group_filters": [],
+                "include_costs": False,
+                "include_details": False,
+                "limit": 100,
+                "measures": [],
+                "offset": 0,
+                "signal_filters": None,
+                "sort_by": None,
+                "started_after": None,
+                "started_before": None,
+            },
+            id="agent_spans_query",
+        ),
+        pytest.param(
+            "custom_runtime_apply",
+            tsi.CustomRuntimeApplyReq(
+                project_id=PROJECT,
+                runtime_name="my-runtime",
+                base_url="http://example.com",
+                runtime_ids=[tsi.CustomRuntimeID(id="my-model")],
+                wb_user_id="user-id",
+            ),
+            {
+                "base_url": "http://example.com",
+                "runtime_ids": [{"id": "my-model", "max_tokens": 4096}],
+                "api_key_secret": None,
+                "headers": {},
+            },
+            id="custom_runtime_apply",
+        ),
+        pytest.param(
+            "eval_results_query",
+            tsi.EvalResultsQueryReq(
+                project_id=PROJECT,
+                evaluation_call_ids=["c1"],
+                filters=[
+                    tsi.EvalResultsFilter(
+                        evaluation_call_id="c1",
+                        query=tsi_query.Query.model_validate(
+                            {
+                                "$expr": {
+                                    "$eq": [{"$getField": "output.x"}, {"$literal": 1}]
+                                }
+                            }
+                        ),
+                    )
+                ],
+                sort_by=[tsi.EvalResultsSortBy(field="output.x", direction="desc")],
+            ),
+            {
+                "evaluation_call_ids": ["c1"],
+                "evaluation_run_ids": None,
+                "filter_logic_operator": "or",
+                "filters": [
+                    {
+                        "evaluation_call_id": "c1",
+                        "query": {
+                            "$expr": {
+                                "$eq": [
+                                    {"$getField": "output.x"},
+                                    {"$literal": 1},
+                                ]
+                            }
+                        },
+                    }
+                ],
+                "include_costs": False,
+                "include_predict_and_score_children": True,
+                "include_raw_data_rows": False,
+                "include_rows": True,
+                "include_summary": False,
+                "limit": None,
+                "offset": 0,
+                "require_intersection": False,
+                "resolve_row_refs": False,
+                "sort_by": [
+                    {
+                        "field": "output.x",
+                        "direction": "desc",
+                        "evaluation_call_id": None,
+                        "mode": "value",
+                    }
+                ],
+                "summary_require_intersection": None,
+            },
+            id="eval_results_query",
+        ),
+    ],
+)
+def test_route_sends_every_supported_field(
+    method_name: str, req: BaseModel, expected_body: dict
+):
+    """Test that the fields the route accepts reach the wire under their aliases."""
+    mock_server = _mock_server(httpx.Response(200, json=V1_RESPONSE))
+
+    getattr(mock_server.server, method_name)(req)
+
+    assert len(mock_server.requests) == 1
+    assert json.loads(mock_server.requests[0].content) == expected_body
+
+
+def test_stream_route_sends_every_supported_field():
+    """Test that the stream route, which dumps its own request, sends every field."""
+    mock_server = _mock_server(
+        httpx.Response(200, content=b"", headers={"content-type": "application/jsonl"})
+    )
+
+    list(
+        mock_server.server.annotation_queues_query_stream(
+            tsi.AnnotationQueuesQueryReq(project_id=PROJECT)
+        )
+    )
+
+    assert len(mock_server.requests) == 1
+    assert json.loads(mock_server.requests[0].content) == {
+        "project_id": PROJECT,
+        "limit": None,
+        "offset": None,
+        "name": None,
+        "sort_by": None,
+    }
 
 
 def test_call_end_reads_an_empty_response_body():

--- a/weave/trace_server_bindings/stainless_remote_http_trace_server.py
+++ b/weave/trace_server_bindings/stainless_remote_http_trace_server.py
@@ -14,6 +14,7 @@ from weave.trace.settings import max_calls_queue_size, should_enable_disk_fallba
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ids import generate_id
 from weave.trace_server.service_interface import ServerInfoRes
+from weave.trace_server.trace_server_interface import agent_types
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
 from weave.trace_server_bindings.client_interface import TraceServerClientInterface
 from weave.trace_server_bindings.http_utils import (
@@ -366,6 +367,169 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
         """
         raise NotImplementedError("Sending otel traces directly is not yet supported.")
 
+    # Agent Observability API
+    @validate_call
+    def agent_spans_query(
+        self, req: agent_types.AgentSpansQueryReq
+    ) -> agent_types.AgentSpansQueryRes:
+        """Query agent spans, either as raw rows or grouped aggregates.
+
+        Args:
+            req: Agent spans query request.
+
+        Returns:
+            Agent spans query response.
+        """
+        return self._stainless_request(
+            req,
+            agent_types.AgentSpansQueryRes,
+            self._stainless_client.agents.spans.query,
+        )
+
+    @validate_call
+    def agent_traces_chat(
+        self, req: agent_types.AgentTraceChatReq
+    ) -> agent_types.AgentTraceChatRes:
+        """Read an agent trace as a chat transcript.
+
+        Args:
+            req: Agent trace chat request.
+
+        Returns:
+            Agent trace chat response.
+        """
+        return self._stainless_request(
+            req,
+            agent_types.AgentTraceChatRes,
+            self._stainless_client.agents.traces.chat,
+        )
+
+    @validate_call
+    def agent_conversation_chat(
+        self, req: agent_types.AgentConversationChatReq
+    ) -> agent_types.AgentConversationChatRes:
+        """Read a conversation as a chat transcript.
+
+        Args:
+            req: Agent conversation chat request.
+
+        Returns:
+            Agent conversation chat response.
+        """
+        return self._stainless_request(
+            req,
+            agent_types.AgentConversationChatRes,
+            self._stainless_client.agents.conversations.chat,
+        )
+
+    @validate_call
+    def agent_conversation_spans(
+        self, req: agent_types.AgentConversationSpansReq
+    ) -> agent_types.AgentConversationSpansRes:
+        """Read the spans of one or more conversations.
+
+        Args:
+            req: Agent conversation spans request.
+
+        Returns:
+            Agent conversation spans response.
+        """
+        return self._stainless_request(
+            req,
+            agent_types.AgentConversationSpansRes,
+            self._stainless_client.agents.conversations.spans,
+        )
+
+    @validate_call
+    def agent_agents_query(
+        self, req: agent_types.AgentsQueryReq
+    ) -> agent_types.AgentsQueryRes:
+        """Query agents.
+
+        Args:
+            req: Agents query request.
+
+        Returns:
+            Agents query response.
+        """
+        return self._stainless_request(
+            req,
+            agent_types.AgentsQueryRes,
+            self._stainless_client.agents.query,
+        )
+
+    @validate_call
+    def agent_versions_query(
+        self, req: agent_types.AgentVersionsQueryReq
+    ) -> agent_types.AgentVersionsQueryRes:
+        """Query the versions of an agent.
+
+        Args:
+            req: Agent versions query request.
+
+        Returns:
+            Agent versions query response.
+        """
+        return self._stainless_request(
+            req,
+            agent_types.AgentVersionsQueryRes,
+            self._stainless_client.agents.agent_versions.query,
+        )
+
+    @validate_call
+    def agent_spans_stats(
+        self, req: agent_types.AgentSpanStatsReq
+    ) -> agent_types.AgentSpanStatsRes:
+        """Query chart-ready aggregations over agent spans.
+
+        Args:
+            req: Agent span stats request.
+
+        Returns:
+            Agent span stats response.
+        """
+        return self._stainless_request(
+            req,
+            agent_types.AgentSpanStatsRes,
+            self._stainless_client.agents.spans.stats,
+        )
+
+    @validate_call
+    def agent_custom_attrs_schema(
+        self, req: agent_types.AgentCustomAttrsSchemaReq
+    ) -> agent_types.AgentCustomAttrsSchemaRes:
+        """Discover typed custom attribute keys on matching agent spans.
+
+        Args:
+            req: Agent custom attrs schema request.
+
+        Returns:
+            Agent custom attrs schema response.
+        """
+        return self._stainless_request(
+            req,
+            agent_types.AgentCustomAttrsSchemaRes,
+            self._stainless_client.agents.spans.custom_attrs_schema,
+        )
+
+    @validate_call
+    def agent_search(
+        self, req: agent_types.AgentSearchReq
+    ) -> agent_types.AgentSearchRes:
+        """Search conversations.
+
+        Args:
+            req: Agent search request.
+
+        Returns:
+            Agent search response.
+        """
+        return self._stainless_request(
+            req,
+            agent_types.AgentSearchRes,
+            self._stainless_client.agents.search,
+        )
+
     # Call API
     @validate_call
     def call_start(self, req: tsi.CallStartReq) -> tsi.CallStartRes:
@@ -505,6 +669,22 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
             req,
             tsi.CallsQueryStatsRes,
             self._stainless_client.calls.query_stats,
+        )
+
+    @validate_call
+    def call_stats(self, req: tsi.CallStatsReq) -> tsi.CallStatsRes:
+        """Query call statistics bucketed over time.
+
+        Args:
+            req: Call stats request.
+
+        Returns:
+            Call stats response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.CallStatsRes,
+            self._stainless_client.calls.stats,
         )
 
     @validate_call
@@ -1002,6 +1182,58 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
             self._stainless_client.feedback.replace,
         )
 
+    @validate_call
+    def feedback_stats(self, req: tsi.FeedbackStatsReq) -> tsi.FeedbackStatsRes:
+        """Query feedback statistics bucketed over time.
+
+        Args:
+            req: Feedback stats request.
+
+        Returns:
+            Feedback stats response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.FeedbackStatsRes,
+            self._stainless_client.feedback.stats,
+        )
+
+    @validate_call
+    def feedback_aggregate(
+        self, req: tsi.FeedbackAggregateReq
+    ) -> tsi.FeedbackAggregateRes:
+        """Aggregate feedback payload values.
+
+        Args:
+            req: Feedback aggregate request.
+
+        Returns:
+            Feedback aggregate response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.FeedbackAggregateRes,
+            self._stainless_client.feedback.aggregate,
+        )
+
+    @validate_call
+    def feedback_payload_schema(
+        self, req: tsi.FeedbackPayloadSchemaReq
+    ) -> tsi.FeedbackPayloadSchemaRes:
+        """Discover the payload paths feedback rows use.
+
+        Args:
+            req: Feedback payload schema request.
+
+        Returns:
+            Feedback payload schema response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.FeedbackPayloadSchemaRes,
+            self._stainless_client.feedback.payload_schema,
+        )
+
     # Cost API
     @validate_call
     def cost_query(self, req: tsi.CostQueryReq) -> tsi.CostQueryRes:
@@ -1095,9 +1327,10 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
         Returns:
             Image generation create response.
         """
-        # Image generation may not be in stainless client yet
-        raise NotImplementedError(
-            "Image generation not yet implemented in stainless client"
+        return self._stainless_request(
+            req,
+            tsi.ImageGenerationCreateRes,
+            self._stainless_client.images.create,
         )
 
     @validate_call
@@ -1157,11 +1390,12 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
 
         Returns:
             Evaluate model response.
-
-        Raises:
-            NotImplementedError: Not implemented.
         """
-        raise NotImplementedError("evaluate_model is not implemented")
+        return self._stainless_request(
+            req,
+            tsi.EvaluateModelRes,
+            self._stainless_client.evaluations.evaluate_model,
+        )
 
     @validate_call
     def evaluation_status(
@@ -1174,11 +1408,28 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
 
         Returns:
             Evaluation status response.
-
-        Raises:
-            NotImplementedError: Not implemented.
         """
-        raise NotImplementedError("evaluation_status is not implemented")
+        return self._stainless_request(
+            req,
+            tsi.EvaluationStatusRes,
+            self._stainless_client.evaluations.status,
+        )
+
+    @validate_call
+    def rescore(self, req: tsi.RescoreReq) -> tsi.RescoreRes:
+        """Rescore an existing evaluation run with different scorers.
+
+        Args:
+            req: Rescore request.
+
+        Returns:
+            Rescore response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.RescoreRes,
+            self._stainless_client.evaluations.rescore,
+        )
 
     @validate_call
     def calls_score(self, req: tsi.CallsScoreReq) -> tsi.CallsScoreRes:
@@ -1189,11 +1440,179 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
 
         Returns:
             Calls score response.
-
-        Raises:
-            NotImplementedError: Not implemented.
         """
-        raise NotImplementedError("calls_score is not implemented")
+        return self._stainless_request(
+            req,
+            tsi.CallsScoreRes,
+            self._stainless_client.calls.score,
+        )
+
+    # Annotation Queue API
+    @validate_call
+    def annotation_queue_create(
+        self, req: tsi.AnnotationQueueCreateReq
+    ) -> tsi.AnnotationQueueCreateRes:
+        """Create an annotation queue.
+
+        Args:
+            req: Annotation queue create request.
+
+        Returns:
+            Annotation queue create response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.AnnotationQueueCreateRes,
+            self._stainless_client.annotation_queues.create,
+        )
+
+    @validate_call
+    def annotation_queues_query_stream(
+        self, req: tsi.AnnotationQueuesQueryReq
+    ) -> Iterator[tsi.AnnotationQueueSchema]:
+        """Stream query annotation queues.
+
+        Args:
+            req: Annotation queues query request.
+
+        Yields:
+            AnnotationQueueSchema instances.
+        """
+        self._update_client_headers()
+        req_dict = req.model_dump(by_alias=True)
+        response: Any = self._stainless_client.annotation_queues.query(**req_dict)
+        for item in response:
+            yield tsi.AnnotationQueueSchema.model_validate(item.model_dump())
+
+    @validate_call
+    def annotation_queue_read(
+        self, req: tsi.AnnotationQueueReadReq
+    ) -> tsi.AnnotationQueueReadRes:
+        """Read an annotation queue.
+
+        Args:
+            req: Annotation queue read request.
+
+        Returns:
+            Annotation queue read response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.AnnotationQueueReadRes,
+            self._stainless_client.annotation_queues.read,
+        )
+
+    @validate_call
+    def annotation_queue_delete(
+        self, req: tsi.AnnotationQueueDeleteReq
+    ) -> tsi.AnnotationQueueDeleteRes:
+        """Soft-delete an annotation queue.
+
+        Args:
+            req: Annotation queue delete request.
+
+        Returns:
+            Annotation queue delete response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.AnnotationQueueDeleteRes,
+            self._stainless_client.annotation_queues.delete,
+            exclude={"wb_user_id"},
+        )
+
+    @validate_call
+    def annotation_queue_update(
+        self, req: tsi.AnnotationQueueUpdateReq
+    ) -> tsi.AnnotationQueueUpdateRes:
+        """Update an annotation queue's metadata.
+
+        Args:
+            req: Annotation queue update request.
+
+        Returns:
+            Annotation queue update response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.AnnotationQueueUpdateRes,
+            self._stainless_client.annotation_queues.update,
+            exclude={"wb_user_id"},
+        )
+
+    @validate_call
+    def annotation_queue_add_calls(
+        self, req: tsi.AnnotationQueueAddCallsReq
+    ) -> tsi.AnnotationQueueAddCallsRes:
+        """Add calls to an annotation queue.
+
+        Args:
+            req: Annotation queue add calls request.
+
+        Returns:
+            Annotation queue add calls response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.AnnotationQueueAddCallsRes,
+            self._stainless_client.annotation_queues.items.add,
+            exclude={"wb_user_id"},
+        )
+
+    @validate_call
+    def annotation_queue_items_query(
+        self, req: tsi.AnnotationQueueItemsQueryReq
+    ) -> tsi.AnnotationQueueItemsQueryRes:
+        """Query the items of an annotation queue.
+
+        Args:
+            req: Annotation queue items query request.
+
+        Returns:
+            Annotation queue items query response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.AnnotationQueueItemsQueryRes,
+            self._stainless_client.annotation_queues.items.query,
+        )
+
+    @validate_call
+    def annotation_queues_stats(
+        self, req: tsi.AnnotationQueuesStatsReq
+    ) -> tsi.AnnotationQueuesStatsRes:
+        """Get stats for multiple annotation queues.
+
+        Args:
+            req: Annotation queues stats request.
+
+        Returns:
+            Annotation queues stats response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.AnnotationQueuesStatsRes,
+            self._stainless_client.annotation_queues.stats,
+        )
+
+    @validate_call
+    def annotator_queue_items_progress_update(
+        self, req: tsi.AnnotatorQueueItemsProgressUpdateReq
+    ) -> tsi.AnnotatorQueueItemsProgressUpdateRes:
+        """Update the annotation state of a queue item.
+
+        Args:
+            req: Annotator queue items progress update request.
+
+        Returns:
+            Annotator queue items progress update response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.AnnotatorQueueItemsProgressUpdateRes,
+            self._stainless_client.annotation_queues.items.update_progress,
+            exclude={"wb_user_id"},
+        )
 
     # === Object APIs ===
 
@@ -1351,6 +1770,28 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
             digests=req.digests,
         )
         return tsi.DatasetDeleteRes.model_validate(response.model_dump())
+
+    @validate_call
+    def custom_runtime_apply(
+        self, req: tsi.CustomRuntimeApplyReq
+    ) -> tsi.CustomRuntimeApplyRes:
+        """Create or replace a custom runtime configuration.
+
+        Args:
+            req: Custom runtime apply request.
+
+        Returns:
+            Custom runtime apply response.
+        """
+        entity, project = self._prepare_v2_request(req)
+        return self._stainless_request(
+            req,
+            tsi.CustomRuntimeApplyRes,
+            self._stainless_client.v2_runtimes.apply,
+            exclude={"project_id", "wb_user_id"},
+            entity=entity,
+            project=project,
+        )
 
     @validate_call
     def scorer_create(self, req: tsi.ScorerCreateReq) -> tsi.ScorerCreateRes:
@@ -1888,3 +2329,25 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
             score_ids=req.score_ids,
         )
         return tsi.ScoreDeleteRes.model_validate(response.model_dump())
+
+    @validate_call
+    def eval_results_query(
+        self, req: tsi.EvalResultsQueryReq
+    ) -> tsi.EvalResultsQueryRes:
+        """Read grouped evaluation result rows for one or more evaluations.
+
+        Args:
+            req: Eval results query request.
+
+        Returns:
+            Eval results query response.
+        """
+        entity, project = self._prepare_v2_request(req)
+        return self._stainless_request(
+            req,
+            tsi.EvalResultsQueryRes,
+            self._stainless_client.v2_eval_results.query,
+            exclude={"project_id"},
+            entity=entity,
+            project=project,
+        )

--- a/weave/trace_server_bindings/stainless_remote_http_trace_server.py
+++ b/weave/trace_server_bindings/stainless_remote_http_trace_server.py
@@ -1381,72 +1381,6 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
         for item in response:
             yield tsi.ThreadSchema.model_validate(item.model_dump())
 
-    @validate_call
-    def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
-        """Evaluate model.
-
-        Args:
-            req: Evaluate model request.
-
-        Returns:
-            Evaluate model response.
-        """
-        return self._stainless_request(
-            req,
-            tsi.EvaluateModelRes,
-            self._stainless_client.evaluations.evaluate_model,
-        )
-
-    @validate_call
-    def evaluation_status(
-        self, req: tsi.EvaluationStatusReq
-    ) -> tsi.EvaluationStatusRes:
-        """Get evaluation status.
-
-        Args:
-            req: Evaluation status request.
-
-        Returns:
-            Evaluation status response.
-        """
-        return self._stainless_request(
-            req,
-            tsi.EvaluationStatusRes,
-            self._stainless_client.evaluations.status,
-        )
-
-    @validate_call
-    def rescore(self, req: tsi.RescoreReq) -> tsi.RescoreRes:
-        """Rescore an existing evaluation run with different scorers.
-
-        Args:
-            req: Rescore request.
-
-        Returns:
-            Rescore response.
-        """
-        return self._stainless_request(
-            req,
-            tsi.RescoreRes,
-            self._stainless_client.evaluations.rescore,
-        )
-
-    @validate_call
-    def calls_score(self, req: tsi.CallsScoreReq) -> tsi.CallsScoreRes:
-        """Score calls.
-
-        Args:
-            req: Calls score request.
-
-        Returns:
-            Calls score response.
-        """
-        return self._stainless_request(
-            req,
-            tsi.CallsScoreRes,
-            self._stainless_client.calls.score,
-        )
-
     # Annotation Queue API
     @validate_call
     def annotation_queue_create(
@@ -1614,6 +1548,72 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
             exclude={"wb_user_id"},
         )
 
+    @validate_call
+    def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
+        """Evaluate model.
+
+        Args:
+            req: Evaluate model request.
+
+        Returns:
+            Evaluate model response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.EvaluateModelRes,
+            self._stainless_client.evaluations.evaluate_model,
+        )
+
+    @validate_call
+    def evaluation_status(
+        self, req: tsi.EvaluationStatusReq
+    ) -> tsi.EvaluationStatusRes:
+        """Get evaluation status.
+
+        Args:
+            req: Evaluation status request.
+
+        Returns:
+            Evaluation status response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.EvaluationStatusRes,
+            self._stainless_client.evaluations.status,
+        )
+
+    @validate_call
+    def rescore(self, req: tsi.RescoreReq) -> tsi.RescoreRes:
+        """Rescore an existing evaluation run with different scorers.
+
+        Args:
+            req: Rescore request.
+
+        Returns:
+            Rescore response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.RescoreRes,
+            self._stainless_client.evaluations.rescore,
+        )
+
+    @validate_call
+    def calls_score(self, req: tsi.CallsScoreReq) -> tsi.CallsScoreRes:
+        """Score calls.
+
+        Args:
+            req: Calls score request.
+
+        Returns:
+            Calls score response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.CallsScoreRes,
+            self._stainless_client.calls.score,
+        )
+
     # === Object APIs ===
 
     @validate_call
@@ -1775,7 +1775,7 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
     def custom_runtime_apply(
         self, req: tsi.CustomRuntimeApplyReq
     ) -> tsi.CustomRuntimeApplyRes:
-        """Create or replace a custom runtime configuration.
+        """Apply custom runtime.
 
         Args:
             req: Custom runtime apply request.
@@ -2334,7 +2334,7 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
     def eval_results_query(
         self, req: tsi.EvalResultsQueryReq
     ) -> tsi.EvalResultsQueryRes:
-        """Read grouped evaluation result rows for one or more evaluations.
+        """Query eval results.
 
         Args:
             req: Eval results query request.


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-25925

## Description

This binds 29 routes the generated client already had and the binding never wired up: the annotation queues, the agent read routes, image generation, evaluations and scoring, custom runtimes, eval results and stats.

Nothing was broken for users. `use_stainless_server` is off by default, so the hand-written client is what runs, and it implements 22 of the 29. The problem was waiting for whoever turned the flag on.

17 of the 29 sit behind public `WeaveClient` methods. The binding inherits from a Protocol, so a method it never defined still exists and returns `None` instead of raising. That left `register_custom_runtime` registering nothing, and `get_annotation_queue` dying a line later on `NoneType`.

Most of the wrappers are one line through `_stainless_request`, which was already in the file. The annotation-queue writes also strip `wb_user_id`, since those routes take the acting user from the auth header. The annotation-queue query is the only stream, and reuses the NDJSON loop calls and threads already use.

Both v2 routes split `project_id` into `entity` and `project` path segments. They go through the helper rather than passing fields to the generated client, because that would lose `runtime_ids[].max_tokens` and turn `$expr` into `expr_`.

The flag stays off here, so this changes nothing on the default path. It does not close the gap either: 10 interface methods are still unbound and 6 still raise `NotImplementedError`.

## Testing

The test file goes from 53 tests to 91. Each drives the binding over the mock transport the file already uses, so the assertion is on the request the generated client actually built: verb and path for the 24 routes in the route table, the query-string cases, the unencoded colon in a runtime name, and the stream.

7 routes also get their whole request body checked against the expected payload — the ones with a nested model, a datetime, a `$`-aliased filter, or a `wb_user_id` that has to survive. That is a sample, not a guarantee for every route.

I also ran 17 point mutations against the new tests. All 17 turn the suite red.

`tests/trace_server_bindings/` is green with and without `--remote-http-trace-server=stainless`.
