### PR TITLE
chore(weave): exclude eval traces from agent insights

### DIFF
--- a/tests/trace_server/test_agent_scorer_events.py
+++ b/tests/trace_server/test_agent_scorer_events.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import datetime
 
+import pytest
+
 from weave.trace_server.agents.kafka_events import (
     EmbedAgentSpansEvent,
     ScoreAgentSpansEvent,
@@ -86,3 +88,31 @@ def test_embed_requires_conversation_but_score_does_not() -> None:
     score_event = ScoreAgentSpansEvent.from_row(no_convo_row, "acme")
     assert score_event is not None
     assert score_event.conversation_id is None
+
+
+@pytest.mark.parametrize(
+    "eval_fields",
+    [
+        {"eval_run_id": "eval-run"},
+        {"eval_predict_and_score_call_id": "predict-and-score"},
+        {"eval_kind": "agent"},
+    ],
+)
+def test_embed_excludes_evaluation_spans(eval_fields: dict[str, str]) -> None:
+    """Evaluation roots still score but never feed Insights embedding."""
+    eval_row = AgentSpanCHInsertable(
+        project_id="p",
+        trace_id="tr",
+        span_id="root",
+        parent_span_id="",
+        span_name="root",
+        status_code="OK",
+        started_at=_STARTED_AT,
+        ended_at=_ENDED_AT,
+        conversation_id="c",
+        operation_name="invoke_agent",
+        **eval_fields,
+    )
+
+    assert ScoreAgentSpansEvent.from_row(eval_row, "acme") is not None
+    assert EmbedAgentSpansEvent.from_row(eval_row, "acme") is None

--- a/tests/trace_server/test_agent_scorer_events.py
+++ b/tests/trace_server/test_agent_scorer_events.py
@@ -95,7 +95,6 @@ def test_embed_requires_conversation_but_score_does_not() -> None:
     [
         {"eval_run_id": "eval-run"},
         {"eval_predict_and_score_call_id": "predict-and-score"},
-        {"eval_kind": "agent"},
     ],
 )
 def test_embed_excludes_evaluation_spans(eval_fields: dict[str, str]) -> None:

--- a/weave/trace_server/agents/kafka_events.py
+++ b/weave/trace_server/agents/kafka_events.py
@@ -90,6 +90,18 @@ class EmbedAgentSpansEvent(_AgentSpansEvent):
     # Insights only judges turns with real conversation semantics.
     requires_conversation: ClassVar[bool] = True
 
+    @classmethod
+    def from_row(
+        cls, row: AgentSpanCHInsertable, entity_name: str | None = None
+    ) -> Self | None:
+        """Return an Insights event unless the span belongs to an evaluation."""
+        if _is_evaluation_span(row):
+            return None
+
+        event = super().from_row(row, entity_name)
+
+        return event
+
     def emit(self, producer: KafkaProducer | None) -> None:
         """Produce this event for Agent Insights without raising."""
         if producer is None:
@@ -98,3 +110,7 @@ class EmbedAgentSpansEvent(_AgentSpansEvent):
             producer.produce_embed_agent_spans(self)
         except Exception:
             logger.exception("Failed to emit EmbedAgentSpansEvent")
+
+
+def _is_evaluation_span(row: AgentSpanCHInsertable) -> bool:
+    return bool(row.eval_run_id or row.eval_predict_and_score_call_id or row.eval_kind)

--- a/weave/trace_server/agents/kafka_events.py
+++ b/weave/trace_server/agents/kafka_events.py
@@ -51,7 +51,7 @@ class _AgentSpansEvent(BaseModel):
         """
         if cls.requires_conversation and not row.conversation_id:
             return None
-        if cls.excludes_evaluations and _has_evaluation_link(row):
+        if cls.excludes_evaluations and _is_evaluation(row):
             return None
         event_type: AgentSpanOpName | None = None
         # A span with no parent is assumed to represent the end of a turn
@@ -104,7 +104,7 @@ class EmbedAgentSpansEvent(_AgentSpansEvent):
             logger.exception("Failed to emit EmbedAgentSpansEvent")
 
 
-def _has_evaluation_link(row: AgentSpanCHInsertable) -> bool:
+def _is_evaluation(row: AgentSpanCHInsertable) -> bool:
     # Eval span processors write both IDs before optional display metadata.
     # Either surviving an attribute limit still identifies evaluation work.
     return bool(row.eval_run_id or row.eval_predict_and_score_call_id)

--- a/weave/trace_server/agents/kafka_events.py
+++ b/weave/trace_server/agents/kafka_events.py
@@ -37,8 +37,9 @@ class _AgentSpansEvent(BaseModel):
     parent_span_id: str | None
     conversation_id: str | None
 
-    # Subclasses set this to require a non-empty `conversation_id` on the row.
+    # Subclasses declare source-row requirements next to their event type.
     requires_conversation: ClassVar[bool] = False
+    excludes_evaluations: ClassVar[bool] = False
 
     @classmethod
     def from_row(
@@ -49,6 +50,8 @@ class _AgentSpansEvent(BaseModel):
         Currently only "turn_ended" is supported, but the interface is designed to support multiple types.
         """
         if cls.requires_conversation and not row.conversation_id:
+            return None
+        if cls.excludes_evaluations and _has_evaluation_link(row):
             return None
         event_type: AgentSpanOpName | None = None
         # A span with no parent is assumed to represent the end of a turn
@@ -87,20 +90,9 @@ class ScoreAgentSpansEvent(_AgentSpansEvent):
 class EmbedAgentSpansEvent(_AgentSpansEvent):
     """Trigger event for Agent Insights embedding."""
 
-    # Insights only judges turns with real conversation semantics.
+    # Insights needs a conversation and never judges evaluation traffic.
     requires_conversation: ClassVar[bool] = True
-
-    @classmethod
-    def from_row(
-        cls, row: AgentSpanCHInsertable, entity_name: str | None = None
-    ) -> Self | None:
-        """Return an Insights event unless the span belongs to an evaluation."""
-        if _is_evaluation_span(row):
-            return None
-
-        event = super().from_row(row, entity_name)
-
-        return event
+    excludes_evaluations: ClassVar[bool] = True
 
     def emit(self, producer: KafkaProducer | None) -> None:
         """Produce this event for Agent Insights without raising."""
@@ -112,5 +104,7 @@ class EmbedAgentSpansEvent(_AgentSpansEvent):
             logger.exception("Failed to emit EmbedAgentSpansEvent")
 
 
-def _is_evaluation_span(row: AgentSpanCHInsertable) -> bool:
-    return bool(row.eval_run_id or row.eval_predict_and_score_call_id or row.eval_kind)
+def _has_evaluation_link(row: AgentSpanCHInsertable) -> bool:
+    # Eval span processors write both IDs before optional display metadata.
+    # Either surviving an attribute limit still identifies evaluation work.
+    return bool(row.eval_run_id or row.eval_predict_and_score_call_id)


### PR DESCRIPTION
## Summary
- suppress Insights embedding events for spans carrying evaluation metadata
- recognize both declarative and imperative evaluation markers
- preserve agent scoring events for evaluation traces

## Testing
- uv run --group test python -m pytest tests/trace_server/test_agent_scorer_events.py -v
- uv run nox -s lint