### PR TITLE
chore(weave): persist cluster run results

### DIFF
--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -1038,6 +1038,17 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
                     "Enum8('pending' = 1, 'running' = 2, 'succeeded' = 3, "
                     "'failed' = 4, 'canceled' = 5)",
                 ),
+                ("signature_count", "UInt64"),
+                ("cluster_count", "UInt32"),
+                ("noise_count", "UInt64"),
+                ("skipped_generation_count", "UInt64"),
+                ("truncated", "Bool"),
+                (
+                    "failure_code",
+                    "Nullable(Enum8('no_signatures' = 1, "
+                    "'insufficient_signatures' = 2, 'inference_unavailable' = 3, "
+                    "'storage_unavailable' = 4, 'internal' = 5))",
+                ),
                 ("started_at", "DateTime64(6, 'UTC')"),
                 ("completed_at", "DateTime64(6, 'UTC')"),
                 ("inserted_at", "DateTime64(6, 'UTC')"),

--- a/weave/trace_server/migrations/045_add_signature_cluster_run_results.down.sql
+++ b/weave/trace_server/migrations/045_add_signature_cluster_run_results.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE signature_cluster_runs
+    DROP COLUMN IF EXISTS failure_code,
+    DROP COLUMN IF EXISTS truncated,
+    DROP COLUMN IF EXISTS skipped_generation_count,
+    DROP COLUMN IF EXISTS noise_count,
+    DROP COLUMN IF EXISTS cluster_count,
+    DROP COLUMN IF EXISTS signature_count;

--- a/weave/trace_server/migrations/045_add_signature_cluster_run_results.up.sql
+++ b/weave/trace_server/migrations/045_add_signature_cluster_run_results.up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE signature_cluster_runs
+    ADD COLUMN IF NOT EXISTS signature_count UInt64 DEFAULT 0 AFTER status,
+    ADD COLUMN IF NOT EXISTS cluster_count UInt32 DEFAULT 0 AFTER signature_count,
+    ADD COLUMN IF NOT EXISTS noise_count UInt64 DEFAULT 0 AFTER cluster_count,
+    ADD COLUMN IF NOT EXISTS skipped_generation_count UInt64 DEFAULT 0 AFTER noise_count,
+    ADD COLUMN IF NOT EXISTS truncated Bool DEFAULT false AFTER skipped_generation_count,
+    ADD COLUMN IF NOT EXISTS failure_code Nullable(Enum8(
+        'no_signatures' = 1,
+        'insufficient_signatures' = 2,
+        'inference_unavailable' = 3,
+        'storage_unavailable' = 4,
+        'internal' = 5
+    )) DEFAULT NULL AFTER truncated;


### PR DESCRIPTION
## Summary
- Add migration 045 for persisted cluster counts, noise counts, skipped-generation counts, truncation, and a nullable bounded failure code on `signature_cluster_runs`.
- The down migration removes only the added columns. This is stack 1 of 6; wandb/core requires migration commit `bb6976ea94d` before rollout.

## Testing
`uv run --group test python -m pytest tests/trace_server_migrator/test_migrator_functional.py::test_signature_cluster_tables_schema_and_retry -q`; pre-push type, import, Ruff, and formatting hooks.