### PR TITLE
chore(weave): bind completions create in the Stainless client

### DIFF
--- a/tests/trace_server_bindings/test_stainless_routes.py
+++ b/tests/trace_server_bindings/test_stainless_routes.py
@@ -516,6 +516,14 @@ def test_v2_method_reaches_its_flat_route(
             id="feedback_payload_schema",
         ),
         pytest.param(
+            "completions_create",
+            tsi.CompletionsCreateReq(project_id=PROJECT, inputs={"model": "gpt-4o"}),
+            "POST",
+            "/completions/create",
+            tsi.CompletionsCreateRes,
+            id="completions_create",
+        ),
+        pytest.param(
             "image_create",
             tsi.ImageGenerationCreateReq(
                 project_id=PROJECT, inputs={"model": "dall-e-3", "prompt": "a cat"}
@@ -997,6 +1005,57 @@ def test_create_sends_every_supported_field(
 @pytest.mark.parametrize(
     ("method_name", "req", "expected_body"),
     [
+        pytest.param(
+            "completions_create",
+            tsi.CompletionsCreateReq(
+                project_id=PROJECT,
+                inputs={"model": "gpt-4o", "messages": [{"role": "user"}]},
+                wb_user_id="user-id",
+            ),
+            {
+                "project_id": PROJECT,
+                "inputs": {
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user"}],
+                    "timeout": None,
+                    "temperature": None,
+                    "top_p": None,
+                    "n": None,
+                    "stop": None,
+                    "max_completion_tokens": None,
+                    "max_tokens": None,
+                    "modalities": None,
+                    "presence_penalty": None,
+                    "frequency_penalty": None,
+                    "stream": None,
+                    "logit_bias": None,
+                    "user": None,
+                    "response_format": None,
+                    "seed": None,
+                    "tools": None,
+                    "tool_choice": None,
+                    "logprobs": None,
+                    "top_logprobs": None,
+                    "parallel_tool_calls": None,
+                    "reasoning_effort": None,
+                    "extra_headers": None,
+                    "functions": None,
+                    "function_call": None,
+                    "api_version": None,
+                    "prompt": None,
+                    "template_vars": None,
+                    "vertex_credentials": None,
+                },
+                "wb_user_id": "user-id",
+                "track_llm_call": True,
+                "trace_id": None,
+                "parent_id": None,
+                "conversation_id": None,
+                "conversation_name": None,
+                "source": None,
+            },
+            id="completions_create",
+        ),
         pytest.param(
             "image_create",
             tsi.ImageGenerationCreateReq(
@@ -1623,11 +1682,6 @@ def test_custom_runtime_name_keeps_its_colon():
 @pytest.mark.parametrize(
     ("method_name", "req"),
     [
-        pytest.param(
-            "completions_create",
-            tsi.CompletionsCreateReq(project_id=PROJECT, inputs={"model": "gpt-4o"}),
-            id="completions_create",
-        ),
         pytest.param(
             "project_stats",
             tsi.ProjectStatsReq(project_id=PROJECT),

--- a/weave/trace_server_bindings/stainless_remote_http_trace_server.py
+++ b/weave/trace_server_bindings/stainless_remote_http_trace_server.py
@@ -1295,8 +1295,10 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
         Returns:
             Completions create response.
         """
-        raise NotImplementedError(
-            "completions_create is not yet implemented in stainless client"
+        return self._stainless_request(
+            req,
+            tsi.CompletionsCreateRes,
+            self._stainless_client.completions.create,
         )
 
     @validate_call


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-25925

## Description

The Stainless binding raised `NotImplementedError` for `completions_create`. #7777 put that stub in because the vendored SDK had no `completions` resource at the time. #7834 vendored `completions.create`, so this wires the method up with one call through `_stainless_request`, the same shape `image_create` already uses.

That method matters because it is the LLM call inside `LLMStructuredCompletionModel.predict`, which is what `LLMAsAJudgeScorer.score` runs. With `use_stainless_server=True` an LLM judge failed on its first generation. The flag is still off by default, so this changes nothing for anyone on the hand-written client.

## Testing

In `tests/trace_server_bindings/test_stainless_routes.py`, `completions_create` moves out of the not-implemented table and into the route table, and also gets a body assertion. It shares that with `image_create`, the only other route whose request carries a nested `inputs` model and a `wb_user_id` that has to survive the dump.

The file goes from 91 tests to 92. The body assertion earns its place: excluding any of the optional fields from the new call, or forwarding only `inputs["model"]`, leaves the route test green and reddens only the body one. The streaming variant stays unimplemented.
