### PR TITLE
fix(weave): publish call-ended events after ClickHouse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,6 +361,14 @@ pnpm exec tsx examples/claudeAgents.ts
 - Include meaningful error messages
 - Add error handling tests
 
+### Online-evaluation event ordering
+
+Call-ended Kafka records are a notification that the corresponding source call
+is durable in ClickHouse. `confluent_kafka.Producer.produce()` can deliver from
+its background thread immediately, so deferring only `flush()` does not enforce
+that invariant. Any ClickHouse batch path must stage call-ended event metadata
+and invoke `produce()` only after the call insert succeeds.
+
 ### Integration Testing
 
 - Since autopatching was removed from `weave.init()`, integration tests must explicitly patch their integrations

--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -187,6 +187,7 @@ def _reset_server_state(server: ClickHouseTraceServer) -> None:
     server._call_batch = []
     server._file_batch = []
     server._calls_complete_batch = []
+    server._call_end_event_batch = []
     server._bucket_uploads = BucketUploadBatch()
     server._flush_immediately = False
 

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1486,6 +1486,40 @@ def test_call_batch_flushes_kafka_once_not_per_call_end(server_with_mock_kafka):
     mock_producer.flush.assert_called_once()
 
 
+def test_call_batch_publishes_kafka_only_after_clickhouse_insert(
+    server_with_mock_kafka,
+):
+    """A background producer must not expose an event before its call is durable."""
+    server, mock_producer = server_with_mock_kafka
+
+    def assert_no_early_publish(*_args, **_kwargs):
+        mock_producer.produce_call_end.assert_not_called()
+        return MagicMock()
+
+    server.ch_client.insert.side_effect = assert_no_early_publish
+
+    with server.call_batch():
+        server.call_end(_make_call_end_req())
+        mock_producer.produce_call_end.assert_not_called()
+
+    mock_producer.produce_call_end.assert_called_once()
+    mock_producer.flush.assert_called_once()
+
+
+@pytest.mark.disable_logging_error_check
+def test_call_batch_does_not_publish_kafka_when_clickhouse_insert_fails(
+    server_with_mock_kafka,
+):
+    server, mock_producer = server_with_mock_kafka
+    server.ch_client.insert.side_effect = _MockInsertError("Connection refused")
+
+    with pytest.raises(_MockInsertError), server.call_batch():
+        server.call_end(_make_call_end_req())
+
+    mock_producer.produce_call_end.assert_not_called()
+    mock_producer.flush.assert_not_called()
+
+
 @pytest.mark.disable_logging_error_check
 def test_file_batch_clears_on_insert_failure():
     """Verify _file_batch is cleared even when insert fails."""

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -433,12 +433,15 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     def __del__(self) -> None:
         """Flush batches and the Kafka producer on cleanup."""
-        if (
-            self._call_batch
-            or self._calls_complete_batch
-            or self._file_batch
-            or self._content_obj_batch
-            or self._bucket_uploads
+        if any(
+            (
+                self._call_batch,
+                self._calls_complete_batch,
+                self._file_batch,
+                self._content_obj_batch,
+                self._bucket_uploads,
+                self._call_end_event_batch,
+            )
         ):
             try:
                 self._flush_all_batches_in_order()
@@ -450,6 +453,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 self._calls_complete_batch = []
                 self._content_obj_batch = []
                 self._bucket_uploads = BucketUploadBatch()
+                self._call_end_event_batch = []
                 self._flush_immediately = True
 
         # Always drain remaining kafka messages at shutdown.
@@ -518,6 +522,18 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     @_content_obj_batch.setter
     def _content_obj_batch(self, value: list[tsi.ObjSchemaForInsert]) -> None:
         self._thread_local.content_obj_batch = value
+
+    @property
+    def _call_end_event_batch(self) -> list[tuple[str, str, datetime.datetime]]:
+        if not hasattr(self._thread_local, "call_end_event_batch"):
+            self._thread_local.call_end_event_batch = []
+        return self._thread_local.call_end_event_batch
+
+    @_call_end_event_batch.setter
+    def _call_end_event_batch(
+        self, value: list[tuple[str, str, datetime.datetime]]
+    ) -> None:
+        self._thread_local.call_end_event_batch = value
 
     @classmethod
     def from_env(cls, use_async_insert: bool = True, **kwargs: Any) -> Self:
@@ -896,6 +912,30 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             # Non-blocking flush to avoid convoy effect — see KafkaProducer.produce_call_end.
             producer.flush(timeout=0)
 
+    def _publish_call_end_after_insert(
+        self,
+        project_id: str,
+        call_id: str,
+        ended_at: datetime.datetime,
+    ) -> None:
+        """Publish now, or stage until the enclosing ClickHouse batch commits.
+
+        ``confluent_kafka.Producer.produce`` is asynchronous, but its background
+        thread may deliver immediately; delaying only ``flush`` does not preserve
+        ClickHouse-before-Kafka ordering. Batch callers therefore stage event
+        metadata and publish it only after all call inserts return successfully.
+        """
+        if not self._flush_immediately:
+            self._call_end_event_batch.append((project_id, call_id, ended_at))
+            return
+        maybe_enqueue_minimal_call_end(
+            self.kafka_producer,
+            project_id,
+            call_id,
+            ended_at,
+            True,
+        )
+
     @contextmanager
     def call_batch(self) -> Iterator[None]:
         """Batch call operations and flush them all at the end."""
@@ -911,6 +951,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._calls_complete_batch = []
             self._content_obj_batch = []
             self._bucket_uploads = BucketUploadBatch()
+            self._call_end_event_batch = []
             self._flush_immediately = True
 
     def _flush_all_batches_in_order(self) -> None:
@@ -954,8 +995,22 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             logger.exception("Failed to flush calls")
             raise
 
+        # Publish only after the call rows are durable. Calling produce() while
+        # building the batch is unsafe: librdkafka can deliver from its
+        # background thread before ClickHouse has flushed.
+        call_end_events = self._call_end_event_batch
+        self._call_end_event_batch = []
+
         # Catch and continue on fail
         try:
+            for project_id, call_id, ended_at in call_end_events:
+                maybe_enqueue_minimal_call_end(
+                    self.kafka_producer,
+                    project_id,
+                    call_id,
+                    ended_at,
+                    False,
+                )
             self._flush_kafka_producer()
         except Exception:
             logger.exception("Failed to flush kafka producer")
@@ -1153,12 +1208,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self._insert_call(ch_call)
 
         if publish:
-            maybe_enqueue_minimal_call_end(
-                self.kafka_producer,
+            self._publish_call_end_after_insert(
                 req.end.project_id,
                 req.end.id,
                 req.end.ended_at,
-                self._flush_immediately,
             )
 
         # Returns the id of the newly created call
@@ -1223,8 +1276,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 else:
                     self._insert_call_to_v1(ch_call)
 
-                maybe_enqueue_minimal_call_end(
-                    self.kafka_producer,
+                self._publish_call_end_after_insert(
                     processed_complete_call.project_id,
                     processed_complete_call.id,
                     processed_complete_call.ended_at,
@@ -1359,12 +1411,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             if self._flush_immediately:
                 self._flush_calls()
 
-        maybe_enqueue_minimal_call_end(
-            self.kafka_producer,
+        self._publish_call_end_after_insert(
             req.end.project_id,
             req.end.id,
             req.end.ended_at,
-            self._flush_immediately,
         )
 
         return tsi.CallEndV2Res()


### PR DESCRIPTION
## Summary
- stage call-ended Kafka notifications while a ClickHouse call batch is open
- publish them only after the corresponding call inserts succeed
- discard staged notifications when ClickHouse insertion fails

`confluent_kafka.Producer.produce()` may deliver from its background thread immediately, so postponing only `flush()` did not enforce the documented ClickHouse-before-Kafka invariant. Under load this let scoring workers consume events before source calls were query-visible and exhaust `CallNotWrittenError` retries.

## Testing
- `uv run --group test python -m pytest tests/trace_server/test_clickhouse_trace_server_batched.py -k "call_end or call_batch_flushes_kafka or publishes_kafka or does_not_publish_kafka" -q` (6 passed)
- `git diff --check`

## Breaking changes
None.