### PR TITLE
feat(weave): bind the remaining Stainless TSI routes

### DIFF
--- a/tests/trace_server_bindings/test_stainless_routes.py
+++ b/tests/trace_server_bindings/test_stainless_routes.py
@@ -100,7 +100,9 @@ V1_RESPONSE = {
     "conversations": [],
     "duplicates": 0,
     "end": "2026-08-20T00:00:00Z",
+    "entries": [],
     "evaluation_run_id": "run-id",
+    "files_storage_size_bytes": 0,
     "granularity": 86400,
     "groups": [],
     "has_more": False,
@@ -109,19 +111,24 @@ V1_RESPONSE = {
     "item": ITEM,
     "items": [],
     "limit": 0,
+    "links": [],
     "messages": [],
+    "memberships": [],
     "name": "my-runtime",
+    "objects_storage_size_bytes": 0,
     "offset": 0,
     "paths": [],
     "queue": QUEUE,
     "response": {},
     "results": [],
+    "retention_days": 30,
     "rows": [],
     "runtime_ids": [],
     "spans": [],
     "start": "2026-08-20T00:00:00Z",
     "stats": [],
     "status": {"code": "not_found"},
+    "tables_storage_size_bytes": 0,
     "timezone": "UTC",
     "total_cache_creation_input_tokens": 0,
     "total_cache_read_input_tokens": 0,
@@ -132,6 +139,7 @@ V1_RESPONSE = {
     "total_reasoning_tokens": 0,
     "total_rows": 0,
     "total_turns": 0,
+    "trace_storage_size_bytes": 0,
     "trace_id": "t1",
     "turns": [],
     "usage_buckets": [],
@@ -532,6 +540,79 @@ def test_v2_method_reaches_its_flat_route(
             "/image/create",
             tsi.ImageGenerationCreateRes,
             id="image_create",
+        ),
+        pytest.param(
+            "project_stats",
+            tsi.ProjectStatsReq(project_id=PROJECT),
+            "POST",
+            "/project/stats",
+            tsi.ProjectStatsRes,
+            id="project_stats",
+        ),
+        pytest.param(
+            "project_ttl_settings_read",
+            tsi.ProjectTTLSettingsReadReq(project_id=PROJECT),
+            "POST",
+            "/project/ttl_settings/read",
+            tsi.ProjectTTLSettingsReadRes,
+            id="project_ttl_settings_read",
+        ),
+        pytest.param(
+            "project_ttl_settings_update",
+            tsi.ProjectTTLSettingsUpdateReq(project_id=PROJECT, retention_days=30),
+            "POST",
+            "/project/ttl_settings/update",
+            tsi.ProjectTTLSettingsUpdateRes,
+            id="project_ttl_settings_update",
+        ),
+        pytest.param(
+            "dataset_sources_link",
+            tsi.DatasetSourcesLinkReq(
+                project_id=PROJECT,
+                dataset_object_id="ds",
+                dataset_digest="abc123",
+                links=[
+                    tsi.DatasetSourceLinkPayload(
+                        row_digest="row1",
+                        sources=[
+                            tsi.SourceRef(
+                                source_kind=tsi.SourceKind.CALL,
+                                source_id="c1",
+                                source_trace_id="t1",
+                            )
+                        ],
+                    )
+                ],
+            ),
+            "POST",
+            "/dataset_sources/link",
+            tsi.DatasetSourcesLinkRes,
+            id="dataset_sources_link",
+        ),
+        pytest.param(
+            "dataset_sources_query",
+            tsi.DatasetSourcesQueryReq(project_id=PROJECT, dataset_object_id="ds"),
+            "POST",
+            "/dataset_sources/query",
+            tsi.DatasetSourcesQueryRes,
+            id="dataset_sources_query",
+        ),
+        pytest.param(
+            "source_datasets_query",
+            tsi.SourceDatasetsQueryReq(
+                project_id=PROJECT,
+                sources=[
+                    tsi.SourceRef(
+                        source_kind=tsi.SourceKind.CALL,
+                        source_id="c1",
+                        source_trace_id="t1",
+                    )
+                ],
+            ),
+            "POST",
+            "/dataset_sources/source_datasets_query",
+            tsi.SourceDatasetsQueryRes,
+            id="source_datasets_query",
         ),
         pytest.param(
             "evaluate_model",
@@ -1070,6 +1151,114 @@ def test_create_sends_every_supported_field(
                 "wb_user_id": "user-id",
             },
             id="image_create",
+        ),
+        pytest.param(
+            "project_ttl_settings_update",
+            tsi.ProjectTTLSettingsUpdateReq(
+                project_id=PROJECT, retention_days=30, wb_user_id="user-id"
+            ),
+            {
+                "project_id": PROJECT,
+                "retention_days": 30,
+                "wb_user_id": "user-id",
+            },
+            id="project_ttl_settings_update",
+        ),
+        pytest.param(
+            "dataset_sources_link",
+            tsi.DatasetSourcesLinkReq(
+                project_id=PROJECT,
+                dataset_object_id="ds",
+                dataset_digest="abc123",
+                links=[
+                    tsi.DatasetSourceLinkPayload(
+                        row_digest="row1",
+                        sources=[
+                            tsi.SourceRef(
+                                source_kind=tsi.SourceKind.CALL,
+                                source_id="c1",
+                                source_trace_id="t1",
+                            )
+                        ],
+                        link_metadata={"note": "from-call"},
+                    )
+                ],
+                include_created_status=True,
+                wb_user_id="user-id",
+            ),
+            {
+                "project_id": PROJECT,
+                "dataset_object_id": "ds",
+                "dataset_digest": "abc123",
+                "links": [
+                    {
+                        "row_digest": "row1",
+                        "sources": [
+                            {
+                                "source_kind": "call",
+                                "source_id": "c1",
+                                "source_trace_id": "t1",
+                            }
+                        ],
+                        "link_metadata": {"note": "from-call"},
+                    }
+                ],
+                "include_created_status": True,
+                "wb_user_id": "user-id",
+            },
+            id="dataset_sources_link",
+        ),
+        pytest.param(
+            "dataset_sources_query",
+            tsi.DatasetSourcesQueryReq(
+                project_id=PROJECT,
+                dataset_object_id="ds",
+                row_digests=["row1"],
+                source_kinds=[tsi.SourceKind.CALL],
+                include_deleted=True,
+                limit=10,
+                offset=2,
+                wb_user_id="user-id",
+            ),
+            {
+                "project_id": PROJECT,
+                "dataset_object_id": "ds",
+                "row_digests": ["row1"],
+                "source_kinds": ["call"],
+                "include_deleted": True,
+                "limit": 10,
+                "offset": 2,
+                "wb_user_id": "user-id",
+            },
+            id="dataset_sources_query",
+        ),
+        pytest.param(
+            "source_datasets_query",
+            tsi.SourceDatasetsQueryReq(
+                project_id=PROJECT,
+                sources=[
+                    tsi.SourceRef(
+                        source_kind=tsi.SourceKind.SPAN,
+                        source_id="s1",
+                        source_trace_id="t1",
+                    )
+                ],
+                include_deleted=True,
+                wb_user_id="user-id",
+            ),
+            {
+                "project_id": PROJECT,
+                "sources": [
+                    {
+                        "source_kind": "span",
+                        "source_id": "s1",
+                        "source_trace_id": "t1",
+                    }
+                ],
+                "include_deleted": True,
+                "wb_user_id": "user-id",
+            },
+            id="source_datasets_query",
         ),
         pytest.param(
             "call_stats",
@@ -1683,14 +1872,9 @@ def test_custom_runtime_name_keeps_its_colon():
     ("method_name", "req"),
     [
         pytest.param(
-            "project_stats",
-            tsi.ProjectStatsReq(project_id=PROJECT),
-            id="project_stats",
-        ),
-        pytest.param(
-            "completions_create_stream",
-            tsi.CompletionsCreateReq(project_id=PROJECT, inputs={"model": "gpt-4o"}),
-            id="completions_create_stream",
+            "otel_export",
+            tsi.OTelExportReq(project_id=PROJECT, processed_spans=[]),
+            id="otel_export",
         ),
     ],
 )
@@ -1702,6 +1886,44 @@ def test_route_missing_from_the_spec_raises(method_name: str, req: BaseModel):
         getattr(mock_server.server, method_name)(req)
 
     assert mock_server.requests == []
+
+
+def test_completions_create_stream_reads_ndjson_chunks():
+    """Test that the stream keeps _meta on the first line and omits it later."""
+    mock_server = _mock_server(
+        httpx.Response(
+            200,
+            content="\n".join(
+                [
+                    json.dumps({"_meta": {"weave_call_id": "c1", "trace_id": "t1"}}),
+                    json.dumps({"choices": [{"delta": {"content": "hi"}}]}),
+                ]
+            ).encode(),
+            headers={"content-type": "application/x-ndjson"},
+        )
+    )
+
+    chunks = list(
+        mock_server.server.completions_create_stream(
+            tsi.CompletionsCreateReq(
+                project_id=PROJECT,
+                inputs={"model": "gpt-4o", "messages": [{"role": "user"}]},
+                wb_user_id="user-id",
+            )
+        )
+    )
+
+    assert len(mock_server.requests) == 1
+    request = mock_server.requests[0]
+    assert (request.method, request.url.path) == ("POST", "/completions/create_stream")
+    assert request.headers["accept"] == "application/x-ndjson"
+    assert "_meta" in chunks[0]
+    assert "api_meta" not in chunks[0]
+    assert chunks[0]["_meta"]["weave_call_id"] == "c1"
+    assert "_meta" not in chunks[1]
+    assert "error" not in chunks[1]
+    assert chunks[1]["choices"] == [{"delta": {"content": "hi"}}]
+    assert json.loads(request.content)["wb_user_id"] == "user-id"
 
 
 def test_file_create_sends_the_filename():

--- a/tests/trace_server_bindings/test_stainless_routes.py
+++ b/tests/trace_server_bindings/test_stainless_routes.py
@@ -1153,6 +1153,21 @@ def test_create_sends_every_supported_field(
             id="image_create",
         ),
         pytest.param(
+            "project_stats",
+            tsi.ProjectStatsReq(
+                project_id=PROJECT,
+                include_file_storage_size=False,
+            ),
+            {
+                "project_id": PROJECT,
+                "include_trace_storage_size": True,
+                "include_object_storage_size": True,
+                "include_table_storage_size": True,
+                "include_file_storage_size": False,
+            },
+            id="project_stats",
+        ),
+        pytest.param(
             "project_ttl_settings_update",
             tsi.ProjectTTLSettingsUpdateReq(
                 project_id=PROJECT, retention_days=30, wb_user_id="user-id"

--- a/weave/trace_server_bindings/stainless_remote_http_trace_server.py
+++ b/weave/trace_server_bindings/stainless_remote_http_trace_server.py
@@ -1313,9 +1313,11 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
         Yields:
             Dictionary chunks of the streamed response.
         """
-        raise NotImplementedError(
-            "completions_create_stream is not yet implemented in stainless client"
-        )
+        self._update_client_headers()
+        req_dict = req.model_dump(by_alias=True)
+        response = self._stainless_client.completions.create_stream(**req_dict)
+        for item in response:
+            yield item.model_dump(by_alias=True, exclude_unset=True)
 
     @validate_call
     def image_create(
@@ -1345,24 +1347,100 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
         Returns:
             Project stats response.
         """
-        raise NotImplementedError(
-            "project_stats is not yet implemented in stainless client"
+        return self._stainless_request(
+            req,
+            tsi.ProjectStatsRes,
+            self._stainless_client.projects.stats,
         )
 
     @validate_call
     def project_ttl_settings_read(
         self, req: tsi.ProjectTTLSettingsReadReq
     ) -> tsi.ProjectTTLSettingsReadRes:
-        raise NotImplementedError(
-            "project_ttl_settings_read is not yet implemented in stainless client"
+        """Read project TTL settings.
+
+        Args:
+            req: Project TTL settings read request.
+
+        Returns:
+            Project TTL settings read response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.ProjectTTLSettingsReadRes,
+            self._stainless_client.projects.ttl_settings.read,
         )
 
     @validate_call
     def project_ttl_settings_update(
         self, req: tsi.ProjectTTLSettingsUpdateReq
     ) -> tsi.ProjectTTLSettingsUpdateRes:
-        raise NotImplementedError(
-            "project_ttl_settings_update is not yet implemented in stainless client"
+        """Update project TTL settings.
+
+        Args:
+            req: Project TTL settings update request.
+
+        Returns:
+            Project TTL settings update response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.ProjectTTLSettingsUpdateRes,
+            self._stainless_client.projects.ttl_settings.update,
+        )
+
+    @validate_call
+    def dataset_sources_link(
+        self, req: tsi.DatasetSourcesLinkReq
+    ) -> tsi.DatasetSourcesLinkRes:
+        """Link dataset rows to their provenance sources.
+
+        Args:
+            req: Dataset sources link request.
+
+        Returns:
+            Dataset sources link response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.DatasetSourcesLinkRes,
+            self._stainless_client.dataset_sources.link,
+        )
+
+    @validate_call
+    def dataset_sources_query(
+        self, req: tsi.DatasetSourcesQueryReq
+    ) -> tsi.DatasetSourcesQueryRes:
+        """Query sources linked to a dataset.
+
+        Args:
+            req: Dataset sources query request.
+
+        Returns:
+            Dataset sources query response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.DatasetSourcesQueryRes,
+            self._stainless_client.dataset_sources.query,
+        )
+
+    @validate_call
+    def source_datasets_query(
+        self, req: tsi.SourceDatasetsQueryReq
+    ) -> tsi.SourceDatasetsQueryRes:
+        """Query datasets that contain the given sources.
+
+        Args:
+            req: Source datasets query request.
+
+        Returns:
+            Source datasets query response.
+        """
+        return self._stainless_request(
+            req,
+            tsi.SourceDatasetsQueryRes,
+            self._stainless_client.dataset_sources.source_datasets_query,
         )
 
     @validate_call


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-39693

## Description

The Stainless binding still raised `NotImplementedError` for project stats, TTL settings, and streamed completions, and it did not override the three dataset-sources methods, so the inherited Protocol stubs returned `None`. The generated client already has those routes after the vendor refresh in #7838. This wraps the six JSON methods with `_stainless_request`, the same shape `image_create` already uses.

The stream is the one success-response-shape difference from the hand-written client. That client calls non-streaming `completions_create` and yields one `{response, weave_call_id}` chunk. The binding now reads the real NDJSON stream, keeps `_meta` on the first line, and leaves provider deltas without that key. `use_stainless_server` stays off by default.

## Testing

In `tests/trace_server_bindings/test_stainless_routes.py` the six JSON methods join the route table, five of them also get a body assertion, and the stream has its own NDJSON test for the verb, path, `Accept` header, and `_meta` alias. The not-implemented table keeps only `otel_export`.

Locally: that file 103 passed, `tests/trace_server_bindings/` 180 passed, and the same directory with `--remote-http-trace-server=stainless` 164 passed.
