### PR TITLE
perf(weave): resolve wb_run_ids filter conversions concurrently

### DIFF
--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1,6 +1,7 @@
 import abc
 import asyncio
 from collections.abc import Awaitable, Callable, Iterable, Iterator
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, TypeVar
 
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
@@ -26,6 +27,9 @@ _OTEL_REF_ATTR_KEYS = frozenset(
         "weave.object_refs",
     }
 )
+
+# Bounds the fanout of concurrent run-id conversions for a single query.
+_MAX_RUN_ID_CONVERSION_WORKERS = 8
 
 
 def _rewrite_otel_ref_attrs_inplace(
@@ -402,11 +406,20 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     ) -> list[str]:
         # A bare run id (no "/") is prefixed with the queried "entity/project"
         # to form the "entity/project/run" that ext_to_int_run_id requires.
-        int_run_ids = []
-        for run_id in run_ids:
-            qualified = run_id if "/" in run_id else f"{ext_entity_project_id}/{run_id}"
-            int_run_ids.append(self._idc.ext_to_int_run_id(qualified))
-        return int_run_ids
+        qualified = [
+            run_id if "/" in run_id else f"{ext_entity_project_id}/{run_id}"
+            for run_id in run_ids
+        ]
+        if len(qualified) < 2:
+            return [self._idc.ext_to_int_run_id(run_id) for run_id in qualified]
+
+        # Each conversion is an independent gorilla round trip. `map` preserves
+        # input order and re-raises the first failure, as the serial loop did.
+        with ThreadPoolExecutor(
+            max_workers=min(len(qualified), _MAX_RUN_ID_CONVERSION_WORKERS),
+            thread_name_prefix="ext-to-int-run-id",
+        ) as pool:
+            return list(pool.map(self._idc.ext_to_int_run_id, qualified))
 
     def calls_query(self, req: tsi.CallsQueryReq) -> tsi.CallsQueryRes:
         req = req.model_copy(deep=True)


### PR DESCRIPTION
## Description

Converts the run ids in a calls filter concurrently instead of one at a time.

- `_ext_to_int_run_ids` looped serially, and each `ext_to_int_run_id` is a blocking gorilla GraphQL round trip
- on a `/calls/stream_query` with 4 run ids that was 4 sequential queries at 40/23/50/101ms, ~215ms of a 1518ms request, all before the ClickHouse query starts ([trace](https://us5.datadoghq.com/apm/trace/8391291273286804583?spanID=3771207695634197688))
- now runs through a `ThreadPoolExecutor` capped at 8 workers; `pool.map` keeps input order and re-raises the first failure, so ordering and errors are unchanged
- 0 or 1 run id keeps the serial path, which is what almost every request takes

A tail fix, not a p50 one. Over 7 days: 62,499 conversions across 61,978 traces, so mean fanout is 1.01 and ~99% of requests are unaffected.

Safe to parallelize: `lru_cache_with_ttl` holds a per-key lock and coalesces in-flight requests, so duplicate run ids collapse to one gorilla call, and `_get_authenticated_client` builds a fresh transport per call. `ThreadingInstrumentor` is already installed, so the calls stay attributed to the request.

One behavior change: `_connection_error_context` is a `ContextVar` and worker threads start fresh, so when gorilla is down the conversions no longer short-circuit each other's retries. Wall clock is the same since they run in parallel, but a multi-run filter puts up to 8 retry cycles on an unhealthy gorilla instead of 1.

Follow-up, not in this PR: the gorilla call these conversions make is redundant. It asks for the project's `internalId` and the run's name, discards the run name in favor of the one passed in, and the `internalId` was already fetched by `ext_to_int_project_id` earlier in the same request — so the internal run id can be built locally with no call at all. That removes a 118ms p50 round trip from ~62k requests a week, but it belongs in `wandb_gorilla_client` where the id format lives, and it also touches the `call_start` and OTel ingest write paths.

## Testing

- [x] Manual testing
- [x] Unit tests
- [ ] QA

`tests/trace_server` on the fake backend: 1673 passed, 198 skipped, 1 xfailed. `test_trace_call_query_filter_wb_run_ids` green. `test_opentelemetry.py` fails to collect here and on clean master alike, pre-existing.

The concurrent path has no dedicated test; existing run-id filter coverage passes a single run id, so it only exercises the serial branch.
