### PR TITLE
chore(weave): add sentiment_target column to intent_signatures

### DIFF
--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -623,6 +623,7 @@ _INTENT_COLUMNS = [
     ("extracted_at", "DateTime64(6, 'UTC')"),
     ("inserted_at", "DateTime64(6, 'UTC')"),
     ("expire_at", "DateTime"),
+    ("sentiment_target", "LowCardinality(String)"),
 ]
 
 _FAILURE_COLUMNS = [

--- a/weave/trace_server/migrations/045_add_sentiment_target_column.down.sql
+++ b/weave/trace_server/migrations/045_add_sentiment_target_column.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE intent_signatures
+    DROP COLUMN IF EXISTS sentiment_target;

--- a/weave/trace_server/migrations/045_add_sentiment_target_column.up.sql
+++ b/weave/trace_server/migrations/045_add_sentiment_target_column.up.sql
@@ -1,0 +1,8 @@
+/*
+Add `sentiment_target` to `intent_signatures`, the same way `sentiment_rationale`
+was added: a judge-emitted field distinguishing who negative sentiment is
+directed at (agent, product, own_work, unclear), stored so it can be filtered
+and queried independently of the sentiment label itself.
+*/
+ALTER TABLE intent_signatures
+    ADD COLUMN IF NOT EXISTS sentiment_target LowCardinality(String) DEFAULT 'unclear';


### PR DESCRIPTION
## Summary
- Adds `sentiment_target LowCardinality(String) DEFAULT 'unclear'` to `intent_signatures`, backing the insights judge's new sentiment-attribution field (agent/product/own_work/unclear) shipped in wandb/core#53446.
- Same pattern as `sentiment`/`sentiment_rationale` from migration 041: a judge-emitted field denormalized onto every row.
- `ADD COLUMN` with no `AFTER` clause; the writer inserts by named column, so physical position doesn't matter.

## Testing
`test_signature_tables_schema` (pins the exact `intent_signatures` column list) updated for the new column; ran the full `test_migrator_functional.py` suite against a real ClickHouse container, including `test_all_production_migrations_round_trip` and `test_production_migrations_are_idempotent`. 11/11 pass.