### PR TITLE
chore(weave): pin CI ClickHouse to 26.2 to match production

### DIFF
--- a/.github/scripts/ch-image.sh
+++ b/.github/scripts/ch-image.sh
@@ -5,7 +5,8 @@
 set -uo pipefail
 
 # Single source of truth for the ClickHouse image version used across CI.
-tag="${1:-26.4}"
+# Pinned to match the Weave production ClickHouse version.
+tag="${1:-26.2}"
 ghcr="ghcr.io/wandb/clickhouse-server:${tag}"
 hub="clickhouse/clickhouse-server:${tag}"
 

--- a/tests/trace_server/conftest_lib/test_overrides.xml
+++ b/tests/trace_server/conftest_lib/test_overrides.xml
@@ -10,7 +10,7 @@
      skip-indexed column (our calls_merged trace_id bloom-filter CTE): the query
      condition cache is poisoned and later reads under-count / drop rows. See
      https://github.com/ClickHouse/ClickHouse/issues/104781 (fixed by PR #105686,
-     backported to 26.3/26.4/26.5 but not yet in the pinned image). conftest
+     backported to 26.3+, so it never lands on the pinned 26.2 image). conftest
      disables it per-query, but only on trace-server reads; setting it
      server-side also covers the direct clickhouse-connect queries
      (truncate/migrate/etc.) that would otherwise poison the shared cache.

--- a/tests/trace_server/conftest_lib/topologies/1s3r.yaml
+++ b/tests/trace_server/conftest_lib/topologies/1s3r.yaml
@@ -32,7 +32,7 @@
 #   docker compose -f 1s3r.yaml down -v
 
 x-ch-node: &ch-node
-  image: clickhouse/clickhouse-server:26.4
+  image: clickhouse/clickhouse-server:26.2
   environment:
     CLICKHOUSE_DB: default
     CLICKHOUSE_USER: default

--- a/tests/trace_server/conftest_lib/topologies/2s2r.yaml
+++ b/tests/trace_server/conftest_lib/topologies/2s2r.yaml
@@ -46,7 +46,7 @@
 #   docker compose -f 2s2r.yaml down -v
 
 x-ch-node: &ch-node
-  image: clickhouse/clickhouse-server:26.4
+  image: clickhouse/clickhouse-server:26.2
   environment:
     CLICKHOUSE_DB: default
     CLICKHOUSE_USER: default


### PR DESCRIPTION
## Description

Pins the CI ClickHouse image to 26.2, the version Weave production runs, so CI stops testing against a newer server than we ship to.

- `ch-image.sh` default tag 26.4 to 26.2. This drives the PR test job and the nightly single-node job.
- `1s3r.yaml` and `2s2r.yaml` replicated topologies 26.4 to 26.2.
- The `use_query_condition_cache=0` workaround from #7117 stays. The upstream fix was backported to 26.3 and later, so it never reaches 26.2. Updated the comment in `test_overrides.xml` to say so.

Companion PRs pinning 26.2 elsewhere: wandb/core#52596, wandb/wandbench#139.

## Testing

- CI on this PR runs the full trace_server suite and the replicated topology legs against 26.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)