### PR TITLE
fix(weave): classify Stainless HTTP errors by status code

### DIFF
--- a/tests/trace_server_bindings/test_http_utils.py
+++ b/tests/trace_server_bindings/test_http_utils.py
@@ -14,9 +14,41 @@ from weave.trace_server_bindings.http_utils import (
     process_batch_with_retry,
     retry_on_not_found,
 )
+from weave.vendor.weave_server_sdk import APIStatusError
 
 
-def test_413_splits_batch_and_retries():
+def _make_response(status_code: int, body: dict | None) -> httpx.Response:
+    """Build the response the two error builders below hang off."""
+    return httpx.Response(
+        status_code,
+        json=body or {},
+        request=httpx.Request("POST", "http://example.com"),
+    )
+
+
+def _make_httpx_error(
+    status_code: int, body: dict | None = None
+) -> httpx.HTTPStatusError:
+    """Build the error the hand-written client raises for a non-2xx response."""
+    response = _make_response(status_code, body)
+    return httpx.HTTPStatusError(
+        str(status_code), request=response.request, response=response
+    )
+
+
+def _make_stainless_error(status_code: int, body: dict | None = None) -> APIStatusError:
+    """Build the Stainless equivalent: an httpx response on a non-httpx error class."""
+    return APIStatusError(
+        str(status_code), response=_make_response(status_code, body), body=body
+    )
+
+
+@pytest.mark.parametrize(
+    "error",
+    [_make_httpx_error(413), _make_stainless_error(413)],
+    ids=["httpx", "stainless"],
+)
+def test_413_splits_batch_and_retries(error):
     """When server returns 413, split batch in half and retry both halves."""
     sent_batches = []
     first_call = True
@@ -25,9 +57,7 @@ def test_413_splits_batch_and_retries():
         nonlocal first_call
         if first_call:
             first_call = False
-            raise httpx.HTTPStatusError(
-                "413", request=Mock(), response=Mock(status_code=413)
-            )
+            raise error
         sent_batches.append(data)
 
     process_batch_with_retry(
@@ -57,15 +87,6 @@ def test_calls_complete_mode_required_raises():
         handle_response_error(response, "/call/upsert_batch")
 
 
-def _make_404(body: dict) -> httpx.HTTPStatusError:
-    response = httpx.Response(
-        404,
-        json=body,
-        request=httpx.Request("POST", "http://example.com"),
-    )
-    return httpx.HTTPStatusError("404", request=response.request, response=response)
-
-
 def test_retry_on_not_found_behavior(monkeypatch):
     """Retry a non-deleted 404; skip authoritative deletes and non-404s."""
     monkeypatch.setenv("WEAVE_RETRY_MAX_ATTEMPTS", "2")
@@ -76,7 +97,7 @@ def test_retry_on_not_found_behavior(monkeypatch):
     def flaky_http_404():
         calls["http"] += 1
         if calls["http"] == 1:
-            raise _make_404({"reason": "Obj foo:bar not found"})
+            raise _make_httpx_error(404, {"reason": "Obj foo:bar not found"})
         return "ok"
 
     @retry_on_not_found
@@ -89,7 +110,9 @@ def test_retry_on_not_found_behavior(monkeypatch):
     @retry_on_not_found
     def deleted_http():
         calls["deleted_http"] += 1
-        raise _make_404({"reason": "deleted", "deleted_at": "2024-01-01T00:00:00Z"})
+        raise _make_httpx_error(
+            404, {"reason": "deleted", "deleted_at": "2024-01-01T00:00:00Z"}
+        )
 
     @retry_on_not_found
     def deleted_local():
@@ -111,3 +134,45 @@ def test_retry_on_not_found_behavior(monkeypatch):
     with pytest.raises(ObjectDeletedError):
         deleted_local()
     assert calls["deleted_local"] == 1
+
+
+def test_permanent_stainless_error_drops_batch():
+    """A 4xx from the Stainless client is reported dropped, not requeued."""
+    error = _make_stainless_error(400, {"reason": "project is in complete mode"})
+    processor = Mock()
+    processor.is_accepting_new_work.return_value = True
+    dropped = []
+
+    def mock_send(data: bytes) -> None:
+        raise error
+
+    process_batch_with_retry(
+        [1, 2],
+        batch_name="test",
+        remote_request_bytes_limit=100_000,
+        send_batch_fn=mock_send,
+        processor_obj=processor,
+        log_dropped_fn=lambda batch, err: dropped.append((batch, err)),
+        encode_batch_fn=lambda b: str(b).encode(),
+    )
+
+    assert dropped == [([1, 2], error)]
+    processor.enqueue.assert_not_called()
+
+
+def test_retry_on_not_found_retries_stainless_404(monkeypatch):
+    """A 404 from the Stainless client is retried like an httpx 404."""
+    monkeypatch.setenv("WEAVE_RETRY_MAX_ATTEMPTS", "2")
+    monkeypatch.setattr(http_utils, "NOT_FOUND_RETRY_WAIT_SECONDS", 0.0)
+    attempts = 0
+
+    @retry_on_not_found
+    def flaky_read():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _make_stainless_error(404, {"reason": "Obj foo:bar not found"})
+        return "ok"
+
+    assert flaky_read() == "ok"
+    assert attempts == 2

--- a/tests/utils/test_retry.py
+++ b/tests/utils/test_retry.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import httpx
+import pytest
+
 from weave.utils import retry
+from weave.vendor.weave_server_sdk import APIStatusError
 
 
 @patch("weave.utils.retry.retry_max_attempts")
@@ -57,3 +61,34 @@ def test_retry_creates_correct_instance(mock_retrying):
 
     # Check that reraise is True
     assert call_kwargs["reraise"] is True
+
+
+@pytest.mark.parametrize(
+    ("status_code", "retryable"),
+    [
+        (400, False),
+        (401, False),
+        (403, False),
+        (404, False),
+        (422, False),
+        (429, True),
+        (500, True),
+    ],
+)
+def test_status_errors_are_classified_by_status_code(status_code, retryable):
+    """The Stainless client's error is classified like the httpx one."""
+    request = httpx.Request("POST", "http://example.com")
+    response = httpx.Response(status_code, json={}, request=request)
+
+    assert (
+        retry._is_retryable_exception(
+            APIStatusError(str(status_code), response=response, body=None)
+        )
+        is retryable
+    )
+    assert (
+        retry._is_retryable_exception(
+            httpx.HTTPStatusError(str(status_code), request=request, response=response)
+        )
+        is retryable
+    )

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -10,7 +10,7 @@ from typing_extensions import ParamSpec
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
-from weave.utils.retry import _is_retryable_exception, with_retry
+from weave.utils.retry import _http_response, _is_retryable_exception, with_retry
 
 if TYPE_CHECKING:
     from weave.trace_server_bindings.models import EndBatchItem, StartBatchItem
@@ -357,11 +357,8 @@ def check_endpoint_exists(
 
 def _is_413_error(e: Exception) -> bool:
     """Check if an exception is an HTTP 413 (Payload Too Large) error."""
-    return (
-        isinstance(e, httpx.HTTPStatusError)
-        and e.response is not None
-        and e.response.status_code == 413
-    )
+    response = _http_response(e)
+    return response is not None and response.status_code == 413
 
 
 def _is_retryable_not_found(exc: BaseException) -> bool:
@@ -379,12 +376,11 @@ def _is_retryable_not_found(exc: BaseException) -> bool:
     if isinstance(exc, NotFoundError):
         return True
     # Remote HTTP 404 -- retry unless the body indicates a delete.
-    if not isinstance(exc, httpx.HTTPStatusError) or exc.response is None:
-        return False
-    if exc.response.status_code != 404:
+    response = _http_response(exc)
+    if response is None or response.status_code != 404:
         return False
     try:
-        body = exc.response.json()
+        body = response.json()
     except (json.JSONDecodeError, ValueError):
         return False
     if not isinstance(body, dict):

--- a/weave/utils/retry.py
+++ b/weave/utils/retry.py
@@ -96,6 +96,17 @@ def get_current_retry_id() -> str | None:
         return None
 
 
+def _http_response(e: BaseException) -> httpx.Response | None:
+    """The HTTP response an exception carries, if any.
+
+    Read off the exception rather than matching its class, because the
+    Stainless client's `APIStatusError` does not inherit from
+    `httpx.HTTPStatusError`.
+    """
+    response = getattr(e, "response", None)
+    return response if isinstance(response, httpx.Response) else None
+
+
 def _is_retryable_exception(e: BaseException) -> bool:
     # Don't retry pydantic validation errors
     if isinstance(e, ValidationError):
@@ -109,11 +120,12 @@ def _is_retryable_exception(e: BaseException) -> bool:
         return False
 
     # Don't retry on HTTP 4xx (except 429)
-    if isinstance(e, httpx.HTTPStatusError) and e.response is not None:
-        code_class = e.response.status_code // 100
+    response = _http_response(e)
+    if response is not None:
+        code_class = response.status_code // 100
 
         # Bad request, not rate-limiting
-        if code_class == 4 and e.response.status_code != 429:
+        if code_class == 4 and response.status_code != 429:
             return False
 
     # Otherwise, retry: 5xx, OSError, ConnectionError, ConnectionResetError, IOError, etc...


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-39797

## Description

A smoke test with `WEAVE_USE_STAINLESS_SERVER=true` wrote into a project that already had `calls_complete` rows. The server rejected the batch with a 400. The SDK lost 26 batch items and exited 0.

It was silent for one reason. Three predicates read a failure's HTTP status by matching the exception class, `httpx.HTTPStatusError`. The Stainless client raises `APIStatusError`: same response, different class. All three miss.

So every 4xx looks temporary. The 400 was retried, then refused by a queue that had already started closing. The same gap stops 413 batch splitting and 404 retries.

The fix reads the response off the exception instead, through one accessor all three share. A permanent 4xx now fails on the first response and names the lost calls. Nothing changes for the hand-written client, and `use_stainless_server` stays off by default.

## Testing

`tests/utils/test_retry.py` pins the two error types against each other over seven statuses. `tests/trace_server_bindings/test_http_utils.py` adds two tests: a permanent 4xx is dropped rather than requeued, and a 404 is retried. Its 413 test now covers both types. Revert the fix and eight cases go red.

Locally: 308 passed in those two dirs, 167 with `--remote-http-trace-server=stainless`, 93 in `tests/durability/`.
