### PR TITLE
chore(weave): add incremental cluster run columns

### DIFF
--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -1031,6 +1031,9 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
                 ("signature_config_sha", "LowCardinality(String)"),
                 ("cluster_config_sha", "LowCardinality(String)"),
                 ("naming_config_sha", "LowCardinality(String)"),
+                ("mode", "Enum8('full' = 1, 'incremental' = 2)"),
+                ("anchor_run_id", "UUID"),
+                ("continuity_config", "String"),
                 ("window_start", "DateTime64(6, 'UTC')"),
                 ("window_end", "DateTime64(6, 'UTC')"),
                 (
@@ -1054,6 +1057,7 @@ def test_signature_cluster_tables_schema_and_retry(ch_client):
                 ("run_window_end", "DateTime64(6, 'UTC')"),
                 ("signature_type", "Enum8('intent' = 1, 'failure' = 2)"),
                 ("topic_id", "UUID"),
+                ("parent_topic_ids", "Array(UUID)"),
                 ("category", "LowCardinality(String)"),
                 ("centroid", "Array(Float32)"),
                 ("label", "String"),

--- a/weave/trace_server/migrations/046_add_incremental_cluster_columns.down.sql
+++ b/weave/trace_server/migrations/046_add_incremental_cluster_columns.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE signature_clusters
+    DROP COLUMN IF EXISTS parent_topic_ids;
+
+ALTER TABLE signature_cluster_runs
+    DROP COLUMN IF EXISTS continuity_config,
+    DROP COLUMN IF EXISTS anchor_run_id,
+    DROP COLUMN IF EXISTS mode;

--- a/weave/trace_server/migrations/046_add_incremental_cluster_columns.up.sql
+++ b/weave/trace_server/migrations/046_add_incremental_cluster_columns.up.sql
@@ -1,0 +1,12 @@
+-- How the run produced its partition. `incremental` carries the anchor run's topics,
+-- attaches new signatures by centroid, and fits only the residue.
+ALTER TABLE signature_cluster_runs
+    ADD COLUMN IF NOT EXISTS mode Enum8('full' = 1, 'incremental' = 2) DEFAULT 'full' AFTER naming_config_sha,
+    -- The succeeded run whose topics this run carried. Nil on a `full` run.
+    ADD COLUMN IF NOT EXISTS anchor_run_id UUID DEFAULT toUUID('00000000-0000-0000-0000-000000000000') AFTER mode,
+    -- The serialized incremental config the run used, so a later run can tell whether its anchor is comparable.
+    ADD COLUMN IF NOT EXISTS continuity_config String DEFAULT '' AFTER anchor_run_id;
+
+-- Topics this cluster split from or merged out of. Empty on continuations and births.
+ALTER TABLE signature_clusters
+    ADD COLUMN IF NOT EXISTS parent_topic_ids Array(UUID) DEFAULT [] AFTER topic_id;


### PR DESCRIPTION
## Summary
- Adds migration 046 with the columns the incremental clustering mode in wandb/core needs: `mode`, `anchor_run_id`, `continuity_config` on `signature_cluster_runs`, and `parent_topic_ids` on `signature_clusters`.
- Numbered after #7835, which claims 045 and is expected to land first; the migrator requires contiguous versions, so this PR's migrator test passes only once #7835 is on master.
- Consumed by wandb/core#53679.

## Example
A support bot's Monday run clusters its turns into "Login errors" and "Billing questions". Tuesday's scheduled run only needs to place a few dozen new turns into those topics rather than refit everything.

```sql
SELECT mode, anchor_run_id, continuity_config FROM signature_cluster_runs WHERE id = tuesdays_run_id;
```

| | Before | After |
| --- | --- | --- |
| Tuesday's run mode | not recorded | `incremental`, `anchor_run_id` = Monday's run |
| Can a later run tell whether the anchor is comparable | no | yes, via `continuity_config` |
| "Login errors" splitting into two topics | no lineage recorded | both new topics list Monday's topic in `parent_topic_ids` |

A reader of a cluster run row can tell whether it was a full refit or an incremental attach, which run it carried forward, and which topics a split or merge descended from.

## Testing
`pytest tests/trace_server_migrator/test_migrator_functional.py -k signature_cluster` passes locally with #7835's 045 files present; fails on master until #7835 merges because of the version gap.
