### PR TITLE
fix(weave): support current-version call queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,14 @@ If `sdks/node/node_modules` is missing, run `pnpm install --frozen-lockfile` in 
   ClickHouse backend. Build inputs with the real APIs
   (`obj_create`, `table_create`, etc.). Mock only external services we don't own.
 
+### Current logical calls
+
+- `calls_complete` uses `ReplacingMergeTree(created_at)`, so more than one
+  physical version of a call can remain visible until background merges run.
+- Set `CallsQueryReq.latest_only=True` when correctness requires filtering the
+  current logical version. It enables ClickHouse `FINAL` for that request, so
+  use it for bounded correctness-sensitive reads rather than broad list scans.
+
 ### Assert on the complete payload (no substring / membership checks)
 
 Assert on the **full value**, not that a fragment appears somewhere inside a

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -245,6 +245,76 @@ def _make_completed_call(
     )
 
 
+def test_calls_query_latest_only_deduplicates_before_filter(
+    trace_server, clickhouse_trace_server
+):
+    """latest_only filters the newest logical call, not stale physical rows."""
+    project_id = f"{TEST_ENTITY}/calls_complete_latest_only"
+    internal_project_id = b64(project_id)
+    ch_client = clickhouse_trace_server.ch_client
+    call_id = str(uuid.uuid4())
+    trace_id = str(uuid.uuid4())
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+
+    ch_client.command("SYSTEM STOP MERGES calls_complete")
+    try:
+        trace_server.calls_complete(
+            tsi.CallsUpsertCompleteReq(
+                batch=[
+                    _make_completed_call(
+                        project_id,
+                        call_id,
+                        trace_id,
+                        started_at,
+                        started_at + datetime.timedelta(seconds=1),
+                        output={"monitor_match": True},
+                    )
+                ]
+            )
+        )
+        ch_client.command("SELECT sleep(0.01)")
+        trace_server.calls_complete(
+            tsi.CallsUpsertCompleteReq(
+                batch=[
+                    _make_completed_call(
+                        project_id,
+                        call_id,
+                        trace_id,
+                        started_at,
+                        started_at + datetime.timedelta(seconds=2),
+                        output={"monitor_match": False},
+                    )
+                ]
+            )
+        )
+
+        assert (
+            _count_project_rows(ch_client, "calls_complete", internal_project_id) == 2
+        )
+
+        matching_calls = list(
+            trace_server.calls_query_stream(
+                tsi.CallsQueryReq(
+                    project_id=project_id,
+                    filter=tsi.CallsFilter(call_ids=[call_id]),
+                    query={
+                        "$expr": {
+                            "$eq": [
+                                {"$getField": "output.monitor_match"},
+                                {"$literal": True},
+                            ]
+                        }
+                    },
+                    latest_only=True,
+                )
+            )
+        )
+
+        assert matching_calls == []
+    finally:
+        ch_client.command("SYSTEM START MERGES calls_complete")
+
+
 @pytest.mark.parametrize(
     (
         "project_suffix",

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1955,6 +1955,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # CH lazy materialization (see CLICKHOUSE_CALLS_COMPLETE_READ_SETTINGS).
         if read_table == ReadTable.CALLS_COMPLETE:
             settings = ch_settings.update_settings_for_calls_complete_read(settings)
+            if req.latest_only:
+                settings = {**settings, "final": 1}
 
         pb = ParamBuilder()
         raw_res = self._query_stream(cq.as_sql(pb), pb.get_params(), settings=settings)

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -622,6 +622,14 @@ class CallsQueryReq(BaseModelStrict):
     filter: CallsFilter | None = None
     limit: int | None = None
     offset: int | None = None
+    latest_only: bool = Field(
+        default=False,
+        description=(
+            "If true, collapse multiple physical versions of each call before "
+            "applying filters. This provides current logical-row semantics for "
+            "calls_complete reads while ReplacingMergeTree merges are pending."
+        ),
+    )
     # Sort by multiple fields
     sort_by: list[SortBy] | None = None
     query: Query | None = None


### PR DESCRIPTION
## Summary

- add an opt-in latest_only mode for correctness-sensitive calls queries
- use ClickHouse FINAL for calls_complete when that mode is requested
- prove filters run against the newest logical call while physical ReplacingMergeTree versions remain unmerged

## Why

The scoring worker filters a bounded set of call IDs. A stale physical calls_complete version can match the monitor filter even when the newest version does not. Client-side de-duplication happens too late to recover correct semantics.

## Validation

- uv run ruff check weave/trace_server/trace_server_interface.py weave/trace_server/clickhouse_trace_server_batched.py tests/trace_server/test_calls_complete.py
- uv run --group test python -m pytest tests/trace_server/test_calls_complete.py -q (39 passed)