### PR TITLE
chore(trace-server): add skipped status to signature cluster runs

### DIFF
--- a/weave/trace_server/migrations/045_add_skipped_cluster_run_status.down.sql
+++ b/weave/trace_server/migrations/045_add_skipped_cluster_run_status.down.sql
@@ -1,0 +1,6 @@
+-- Rows holding 'skipped' would fail this cast, so they are rewritten first.
+ALTER TABLE signature_cluster_runs
+    UPDATE status = 'canceled' WHERE status = 'skipped';
+ALTER TABLE signature_cluster_runs
+    MODIFY COLUMN status Enum8('pending' = 1, 'running' = 2, 'succeeded' = 3, 'failed' = 4, 'canceled' = 5)
+        DEFAULT 'pending';

--- a/weave/trace_server/migrations/045_add_skipped_cluster_run_status.up.sql
+++ b/weave/trace_server/migrations/045_add_skipped_cluster_run_status.up.sql
@@ -1,0 +1,4 @@
+-- A run that admitted a project but read too few signatures to fit ends here.
+ALTER TABLE signature_cluster_runs
+    MODIFY COLUMN status Enum8('pending' = 1, 'running' = 2, 'succeeded' = 3, 'failed' = 4, 'canceled' = 5, 'skipped' = 6)
+        DEFAULT 'pending';


### PR DESCRIPTION
## Summary
- Adds `skipped` to the `signature_cluster_runs.status` enum so a run that admitted a project but read too few signatures to fit records that outcome. The down migration rewrites `skipped` rows to `canceled` before narrowing the enum.

## Example
Sam's project clears the sweep's density floor with 120 signatures, but 30 of them were embedded under an older config with a different vector length, so the run fetches only 90 rows and stops before fitting.

```sql
SELECT status FROM signature_cluster_runs WHERE project_id = 'sam' ORDER BY inserted_at DESC LIMIT 1
```

| | Before | After |
| --- | --- | --- |
| Terminal status written | `canceled` | `skipped` |
| Reads as an interrupted run | yes | no |
| Sam's run history shows | a phantom cancellation | a run that found too little data |

Run history stops lying about why a project has no clusters: cancellations stay cancellations, and a skipped run is visibly a data-volume outcome rather than an operator or worker interruption.

## Testing
migrator round-trip and idempotence tests pass with 045 applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
