### PR TITLE
chore(weave): honor org LLM enable policy for insights

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -14,6 +14,8 @@ import urllib3
 from clickhouse_connect.driver.exceptions import DatabaseError, ProgrammingError
 from clickhouse_connect.driver.query import QueryResult
 from clickhouse_connect.driver.summary import QuerySummary
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans, Span
 
 from tests.trace_server.test_project_version import make_project_id
 from weave.trace_server import ch_sentinel_values
@@ -22,7 +24,11 @@ from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents.clickhouse import AgentWriteHandler
 from weave.trace_server.agents.schema import AgentSpanCHInsertable
-from weave.trace_server.agents.types import GenAIOTelExportReq, GenAIOTelExportRes
+from weave.trace_server.agents.types import (
+    AgentSpansQueryReq,
+    GenAIOTelExportReq,
+    GenAIOTelExportRes,
+)
 from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER
 from weave.trace_server.clickhouse import utilities as chts_utilities
 from weave.trace_server.clickhouse.schema_converters import (
@@ -38,6 +44,9 @@ from weave.trace_server.clickhouse_schema import (
 from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 from weave.trace_server.project_version.types import ReadTable
 from weave.trace_server.secret_fetcher_context import secret_fetcher_context
+
+TURN_START_TIME_NS = 1_700_000_000_000_000_000
+TURN_END_TIME_NS = 1_700_000_001_000_000_000
 
 
 class MockObjectReadError(Exception):
@@ -2246,40 +2255,58 @@ def test_genai_otel_export_emit_gate(monkeypatch, online_eval, scoring, insights
         mock_producer.flush.assert_not_called()
 
 
-def test_genai_otel_export_request_disables_insights(monkeypatch):
-    """A request with `insights_enabled=False` skips only the Insights emit."""
-    mock_producer = MagicMock()
-    monkeypatch.setattr(
-        chts.ClickHouseTraceServer, "_mint_client", lambda self: MagicMock()
+@pytest.mark.parametrize("enable_llm_powered_features", [False, True])
+@pytest.mark.parametrize("insights", [False, True])
+def test_genai_otel_export_llm_policy(
+    ch_server, trace_server, monkeypatch, enable_llm_powered_features, insights
+):
+    """Store spans and emit scoring while policy gates Insights."""
+    producer = MagicMock()
+    ch_server._kafka_producer = producer
+    monkeypatch.setenv("WEAVE_ENABLE_AGENT_SCORING", "true")
+    monkeypatch.setenv("WEAVE_ENABLE_AGENT_INSIGHTS", str(insights).lower())
+    project_id = "test/privacy"
+    trace_id = uuid.uuid4().bytes
+    span_id = uuid.uuid4().bytes[:8]
+    span = Span(
+        trace_id=trace_id,
+        span_id=span_id,
+        name="assistant turn",
+        start_time_unix_nano=TURN_START_TIME_NS,
+        end_time_unix_nano=TURN_END_TIME_NS,
+        attributes=[
+            KeyValue(
+                key="gen_ai.operation.name",
+                value=AnyValue(string_value="invoke_agent"),
+            ),
+            KeyValue(
+                key="gen_ai.conversation.id",
+                value=AnyValue(string_value="conversation"),
+            ),
+        ],
     )
-    server = chts.ClickHouseTraceServer(host="test_host")
-    server._kafka_producer = mock_producer
+    processed = tsi.ProcessedResourceSpans(
+        entity="test",
+        project="privacy",
+        run_id=None,
+        resource_spans=ResourceSpans(scope_spans=[ScopeSpans(spans=[span])]),
+    )
 
-    monkeypatch.setattr(
-        AgentWriteHandler,
-        "insert_otel_spans",
-        lambda self, req: (
-            GenAIOTelExportRes(accepted_spans=1),
-            [_turn_ended_span_row()],
-        ),
+    res = trace_server.genai_otel_export(
+        GenAIOTelExportReq(processed_spans=[processed], project_id=project_id),
+        enable_llm_powered_features=enable_llm_powered_features,
     )
-    monkeypatch.setattr(
-        "weave.trace_server.environment.wf_enable_agent_scoring", lambda: True
-    )
-    monkeypatch.setattr(
-        "weave.trace_server.environment.wf_enable_agent_insights", lambda: True
-    )
+    stored = trace_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
 
-    res = server.genai_otel_export(
-        GenAIOTelExportReq(
-            processed_spans=[], project_id="p", wb_user_id="", insights_enabled=False
-        )
+    assert res == GenAIOTelExportRes(accepted_spans=1)
+    assert [(row.trace_id, row.span_id) for row in stored.spans] == [
+        (trace_id.hex(), span_id.hex())
+    ]
+    assert producer.produce_score_agent_spans.call_count == 1
+    assert producer.produce_embed_agent_spans.call_count == int(
+        insights and enable_llm_powered_features
     )
-
-    assert res.accepted_spans == 1
-    mock_producer.produce_score_agent_spans.assert_called_once()
-    mock_producer.produce_embed_agent_spans.assert_not_called()
-    mock_producer.flush.assert_called_once_with(0)
+    producer.flush.assert_called_once_with(0)
 
 
 def test_mint_client_forwards_send_receive_timeout():

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -2237,7 +2237,8 @@ def test_genai_otel_export_emit_gate(monkeypatch, online_eval, scoring, insights
     )
 
     res = server.genai_otel_export(
-        GenAIOTelExportReq(processed_spans=[], project_id="p", wb_user_id="")
+        GenAIOTelExportReq(processed_spans=[], project_id="p", wb_user_id=""),
+        enable_llm_powered_features=True,
     )
 
     assert res.accepted_spans == 1

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -2246,6 +2246,42 @@ def test_genai_otel_export_emit_gate(monkeypatch, online_eval, scoring, insights
         mock_producer.flush.assert_not_called()
 
 
+def test_genai_otel_export_request_disables_insights(monkeypatch):
+    """A request with `insights_enabled=False` skips only the Insights emit."""
+    mock_producer = MagicMock()
+    monkeypatch.setattr(
+        chts.ClickHouseTraceServer, "_mint_client", lambda self: MagicMock()
+    )
+    server = chts.ClickHouseTraceServer(host="test_host")
+    server._kafka_producer = mock_producer
+
+    monkeypatch.setattr(
+        AgentWriteHandler,
+        "insert_otel_spans",
+        lambda self, req: (
+            GenAIOTelExportRes(accepted_spans=1),
+            [_turn_ended_span_row()],
+        ),
+    )
+    monkeypatch.setattr(
+        "weave.trace_server.environment.wf_enable_agent_scoring", lambda: True
+    )
+    monkeypatch.setattr(
+        "weave.trace_server.environment.wf_enable_agent_insights", lambda: True
+    )
+
+    res = server.genai_otel_export(
+        GenAIOTelExportReq(
+            processed_spans=[], project_id="p", wb_user_id="", insights_enabled=False
+        )
+    )
+
+    assert res.accepted_spans == 1
+    mock_producer.produce_score_agent_spans.assert_called_once()
+    mock_producer.produce_embed_agent_spans.assert_not_called()
+    mock_producer.flush.assert_called_once_with(0)
+
+
 def test_mint_client_forwards_send_receive_timeout():
     server = chts.ClickHouseTraceServer(host="test_host")
     with (

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -3267,7 +3267,8 @@ def test_genai_otel_export_ref_boundary_internal_in_db_external_out(
             processed_spans=[processed],
             project_id=external_project_id,
             wb_user_id=external_user_id,
-        )
+        ),
+        enable_llm_powered_features=True,
     )
     assert res.accepted_spans == 1
     assert res.rejected_spans == 0
@@ -3448,7 +3449,8 @@ def test_genai_otel_export_redacts_credential_shaped_fields(ch_server, trace_ser
             processed_spans=[_build_credential_processed_span()],
             project_id=external_project_id,
             wb_user_id="user-42",
-        )
+        ),
+        enable_llm_powered_features=True,
     )
     assert res.accepted_spans == 1
     assert res.rejected_spans == 0

--- a/tests/trace_server/test_sensitive_data_span_ingest.py
+++ b/tests/trace_server/test_sensitive_data_span_ingest.py
@@ -137,7 +137,8 @@ def test_pii_policy_redacts_stored_span_details(ch_server) -> None:
             project_id,
             [_pii_proto_span(b"\x41" * 8)],
             SensitiveDataPolicy.PII_V1,
-        )
+        ),
+        enable_llm_powered_features=True,
     )
 
     assert res.rejected_spans == 0
@@ -196,7 +197,8 @@ def test_pii_policy_redacts_before_ingest_sampling(
             project_id,
             [_pii_proto_span(b"\x43" * 8)],
             SensitiveDataPolicy.PII_V1,
-        )
+        ),
+        enable_llm_powered_features=True,
     )
 
     assert observed_redacted_span
@@ -214,7 +216,8 @@ def test_off_policy_stores_span_values_unchanged(ch_server) -> None:
             project_id,
             [_pii_proto_span(b"\x42" * 8)],
             SensitiveDataPolicy.OFF,
-        )
+        ),
+        enable_llm_powered_features=True,
     )
 
     assert res.rejected_spans == 0
@@ -262,7 +265,8 @@ def test_redaction_failure_rejects_request_before_any_side_effect(
                 project_id,
                 [_pii_proto_span(b"\x44" * 8), poison],
                 SensitiveDataPolicy.PII_V1,
-            )
+            ),
+            enable_llm_powered_features=True,
         )
 
     assert not extraction_started

--- a/tests/trace_server/test_spans_ingest_sampling.py
+++ b/tests/trace_server/test_spans_ingest_sampling.py
@@ -97,7 +97,8 @@ def _export(ch_server, project_id: str, *spans: PbSpan):
             processed_spans=[_processed(*spans)],
             project_id=project_id,
             wb_user_id="test-user",
-        )
+        ),
+        enable_llm_powered_features=True,
     )
 
 

--- a/tests/trace_server/test_trace_server_interface_util.py
+++ b/tests/trace_server/test_trace_server_interface_util.py
@@ -423,7 +423,7 @@ def _capture_genai_otel_export_req(
     inner = MagicMock(spec=tsi.FullTraceServerInterface)
     inner.genai_otel_export.return_value = tsi.agent_types.GenAIOTelExportRes()
     adapter = ExternalTraceServer(inner, _EncodingIdConverter())
-    adapter.genai_otel_export(req)
+    adapter.genai_otel_export(req, enable_llm_powered_features=True)
     assert inner.genai_otel_export.call_count == 1
     return inner.genai_otel_export.call_args.args[0]
 
@@ -720,7 +720,9 @@ def test_genai_otel_export_caches_project_id_lookup_across_batch() -> None:
     inner = MagicMock(spec=tsi.FullTraceServerInterface)
     inner.genai_otel_export.return_value = tsi.agent_types.GenAIOTelExportRes()
     converter = CountingIdConverter()
-    ExternalTraceServer(inner, converter).genai_otel_export(req)
+    ExternalTraceServer(inner, converter).genai_otel_export(
+        req, enable_llm_powered_features=True
+    )
 
     # One call for `req.project_id` translation + exactly one more for the
     # rewrite cache (not 6 — one per ref).

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -1364,6 +1364,11 @@ class GenAIOTelExportReq(BaseModel):
     wb_user_id: str | None = None
     entity_name: str | None = None
     sensitive_data_policy: SensitiveDataPolicy = SensitiveDataPolicy.OFF
+    insights_enabled: bool = Field(
+        default=True,
+        description="False skips Agent Insights emission for this batch, e.g. when "
+        "the org has AI-powered features turned off.",
+    )
 
 
 class GenAIOTelExportRes(BaseModel):

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -1364,11 +1364,6 @@ class GenAIOTelExportReq(BaseModel):
     wb_user_id: str | None = None
     entity_name: str | None = None
     sensitive_data_policy: SensitiveDataPolicy = SensitiveDataPolicy.OFF
-    insights_enabled: bool = Field(
-        default=True,
-        description="False skips Agent Insights emission for this batch, e.g. when "
-        "the org has AI-powered features turned off.",
-    )
 
 
 class GenAIOTelExportRes(BaseModel):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7435,26 +7435,34 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
     @tag_db_insert_path("genai_otel_export")
-    def genai_otel_export(self, req: GenAIOTelExportReq) -> GenAIOTelExportRes:
+    def genai_otel_export(
+        self,
+        req: GenAIOTelExportReq,
+        *,
+        enable_llm_powered_features: bool = True,
+    ) -> GenAIOTelExportRes:
+        """Store spans and gate Insights emission on server-side LLM policy."""
         res, span_rows = AgentWriteHandler(
             self.ch_client, self._async_insert_settings(), self
         ).insert_otel_spans(req)
 
         scoring_enabled = wf_env.wf_enable_agent_scoring()
-        insights_enabled = wf_env.wf_enable_agent_insights() and req.insights_enabled
+        insights_enabled = (
+            wf_env.wf_enable_agent_insights() and enable_llm_powered_features
+        )
         if not (scoring_enabled or insights_enabled):
             return res
 
         producer = self.kafka_producer
         for row in span_rows:
             if scoring_enabled and (
-                event := ScoreAgentSpansEvent.from_row(row, req.entity_name)
+                score_event := ScoreAgentSpansEvent.from_row(row, req.entity_name)
             ):
-                event.emit(producer)
+                score_event.emit(producer)
             if insights_enabled and (
-                event := EmbedAgentSpansEvent.from_row(row, req.entity_name)
+                insights_event := EmbedAgentSpansEvent.from_row(row, req.entity_name)
             ):
-                event.emit(producer)
+                insights_event.emit(producer)
 
         # Flush kafka producer
         if span_rows and producer:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7439,7 +7439,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self,
         req: GenAIOTelExportReq,
         *,
-        enable_llm_powered_features: bool,
+        enable_llm_powered_features: bool = True,
     ) -> GenAIOTelExportRes:
         """Store spans and gate Insights emission on server-side LLM policy."""
         res, span_rows = AgentWriteHandler(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7439,7 +7439,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self,
         req: GenAIOTelExportReq,
         *,
-        enable_llm_powered_features: bool = True,
+        enable_llm_powered_features: bool,
     ) -> GenAIOTelExportRes:
         """Store spans and gate Insights emission on server-side LLM policy."""
         res, span_rows = AgentWriteHandler(
@@ -7447,6 +7447,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         ).insert_otel_spans(req)
 
         scoring_enabled = wf_env.wf_enable_agent_scoring()
+        # Agent Insights require org consent to LLM-powered features. Scoring does not:
+        # the user opts in when creating an LLM scorer.
         insights_enabled = (
             wf_env.wf_enable_agent_insights() and enable_llm_powered_features
         )

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7441,7 +7441,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         ).insert_otel_spans(req)
 
         scoring_enabled = wf_env.wf_enable_agent_scoring()
-        insights_enabled = wf_env.wf_enable_agent_insights()
+        insights_enabled = wf_env.wf_enable_agent_insights() and req.insights_enabled
         if not (scoring_enabled or insights_enabled):
             return res
 

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1465,7 +1465,7 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         self,
         req: tsi.agent_types.GenAIOTelExportReq,
         *,
-        enable_llm_powered_features: bool,
+        enable_llm_powered_features: bool = True,
     ) -> tsi.agent_types.GenAIOTelExportRes:
         # Capture the entity before conversion, while `project_id` is still
         # `entity/project`: recovering it downstream costs a gorilla round-trip.

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1465,7 +1465,7 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         self,
         req: tsi.agent_types.GenAIOTelExportReq,
         *,
-        enable_llm_powered_features: bool = True,
+        enable_llm_powered_features: bool,
     ) -> tsi.agent_types.GenAIOTelExportRes:
         # Capture the entity before conversion, while `project_id` is still
         # `entity/project`: recovering it downstream costs a gorilla round-trip.

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1462,7 +1462,10 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         )
 
     def genai_otel_export(
-        self, req: tsi.agent_types.GenAIOTelExportReq
+        self,
+        req: tsi.agent_types.GenAIOTelExportReq,
+        *,
+        enable_llm_powered_features: bool = True,
     ) -> tsi.agent_types.GenAIOTelExportRes:
         # Capture the entity before conversion, while `project_id` is still
         # `entity/project`: recovering it downstream costs a gorilla round-trip.
@@ -1475,7 +1478,11 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         # This path doesn't use `_ref_apply`, so rewrite refs carried in the raw
         # protobuf span attributes here. See `_rewrite_processed_spans_refs_inplace`.
         self._rewrite_processed_spans_refs_inplace(req.processed_spans, req.project_id)
-        return self._internal_trace_server.genai_otel_export(req)
+        res = self._internal_trace_server.genai_otel_export(
+            req, enable_llm_powered_features=enable_llm_powered_features
+        )
+
+        return res
 
     def agent_spans_query(
         self, req: tsi.agent_types.AgentSpansQueryReq

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3613,7 +3613,7 @@ class TraceServerInterface(Protocol):
         self,
         req: agent_types.GenAIOTelExportReq,
         *,
-        enable_llm_powered_features: bool = True,
+        enable_llm_powered_features: bool,
     ) -> agent_types.GenAIOTelExportRes: ...
     def agent_spans_query(
         self, req: agent_types.AgentSpansQueryReq

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3613,7 +3613,7 @@ class TraceServerInterface(Protocol):
         self,
         req: agent_types.GenAIOTelExportReq,
         *,
-        enable_llm_powered_features: bool,
+        enable_llm_powered_features: bool = True,
     ) -> agent_types.GenAIOTelExportRes: ...
     def agent_spans_query(
         self, req: agent_types.AgentSpansQueryReq

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3610,7 +3610,10 @@ class TraceServerInterface(Protocol):
 
     # GenAI / Agent Observability API
     def genai_otel_export(
-        self, req: agent_types.GenAIOTelExportReq
+        self,
+        req: agent_types.GenAIOTelExportReq,
+        *,
+        enable_llm_powered_features: bool = True,
     ) -> agent_types.GenAIOTelExportRes: ...
     def agent_spans_query(
         self, req: agent_types.AgentSpansQueryReq


### PR DESCRIPTION
## Summary
- Accept server-side `enable_llm_powered_features` as a keyword-only argument to `genai_otel_export`, defaulting to true and forwarded through the external adapter.
- Insights emission requires both `WEAVE_ENABLE_AGENT_INSIGHTS` and org policy. Span storage and scoring remain independent. The authorized route supplies policy in [Core](https://github.com/wandb/core/pull/53723).

## Example
Sam disables AI-powered features in Privacy > Smart features, then exports one finished agent turn. The authorized server calls:

```python
server.genai_otel_export(validated_req, enable_llm_powered_features=False)
```

| | Before | After |
| --- | --- | --- |
| Span rows stored | yes | yes |
| Scoring emitted | yes | yes |
| Insights emitted | yes | no |
| Sam sees | Insights processes the opted-out turn | Turn remains visible without Insights processing |

The org privacy setting now prevents new turns from entering the Insights pipeline while preserving tracing and scoring.

## Testing
Real ClickHouse ingestion through the external adapter covers all four policy/deployment flag combinations and verifies stored spans plus scoring emission. Existing emission tests cover omitted policy and consumer flags.
