### PR TITLE
fix(weave): fix the parallel-upload probe and the init failure message

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -71,7 +71,13 @@ from weave.trace_server.trace_server_interface import (
     TableQueryReq,
     TableSchemaForInsert,
 )
-from weave.trace_server_bindings.http_utils import _ENDPOINT_CACHE
+from weave.trace_server_bindings.http_utils import (
+    _ENDPOINT_CACHE,
+    ROW_COUNT_CHUNKING_THRESHOLD,
+)
+from weave.trace_server_bindings.stainless_remote_http_trace_server import (
+    StainlessRemoteHTTPTraceServer,
+)
 
 
 @pytest.mark.flaky(reruns=3, reruns_delay=0.2)
@@ -1662,6 +1668,37 @@ def test_table_partitioning(network_proxy_client, use_parallel_table_upload):
             f"Expected 2 obj_create/obj_read calls, got {len(obj_records)}"
         )
         assert len(records) == 6, f"Expected 6 total records, got {len(records)}"
+
+
+def test_parallel_chunk_probe_works_for_the_generated_client(client, monkeypatch):
+    """The probe must work for any client, not just the hand-written one.
+
+    It used to reach for `_post_request_executor`, an attribute only
+    RemoteHTTPTraceServer has, so it always answered "endpoint missing" for the
+    generated client and silently disabled parallel table upload.
+    """
+    probed: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        probed.append(request)
+        return httpx.Response(
+            200, json={"digest": "d", "row_digests": []}, request=request
+        )
+
+    server = StainlessRemoteHTTPTraceServer("http://example.com")
+    server._stainless_client = server._stainless_client.copy(
+        http_client=httpx.Client(transport=httpx.MockTransport(handle))
+    )
+    monkeypatch.setattr(client, "server", server)
+    monkeypatch.setenv("WEAVE_USE_PARALLEL_TABLE_UPLOAD", "true")
+    _ENDPOINT_CACHE.discard("table_create_from_digests")
+
+    rows = [{"a": i} for i in range(ROW_COUNT_CHUNKING_THRESHOLD + 1)]
+    config = client._should_use_chunking(weave_client.Table(rows))
+
+    assert config.use_chunking is True
+    assert config.use_parallel_chunks is True
+    assert [r.url.path for r in probed] == ["/table/create_from_digests"]
 
 
 def test_summary_tokens_cost(client):

--- a/tests/trace/test_weave_init_availability.py
+++ b/tests/trace/test_weave_init_availability.py
@@ -12,16 +12,16 @@ from weave.trace_server_bindings import remote_http_trace_server
 def test_get_server_info_reports_the_underlying_error():
     """Test that _get_server_info surfaces why the server could not be reached."""
     mock_server = MagicMock(spec=remote_http_trace_server.RemoteHTTPTraceServer)
-    mock_server.server_info.side_effect = json.JSONDecodeError("test error", "doc", 0)
+    underlying = json.JSONDecodeError("test error", "doc", 0)
+    mock_server.server_info.side_effect = underlying
 
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(
+        RuntimeError, match="Weave is not available on the server"
+    ) as excinfo:
         weave_init._get_server_info(mock_server)
 
-    assert str(excinfo.value) == (
-        "Weave is not available on the server: test error: line 1 column 1 (char 0). "
-        "Please contact support."
-    )
-    assert isinstance(excinfo.value.__cause__, json.JSONDecodeError)
+    assert str(underlying) in str(excinfo.value)
+    assert excinfo.value.__cause__ is underlying
     mock_server.server_info.assert_called_once()
 
 

--- a/tests/trace/test_weave_init_availability.py
+++ b/tests/trace/test_weave_init_availability.py
@@ -3,18 +3,25 @@
 import json
 from unittest.mock import MagicMock
 
+import pytest
+
 from weave.trace import weave_init
 from weave.trace_server_bindings import remote_http_trace_server
 
 
-def test_get_server_info_json_decode_error():
-    """Test that _get_server_info returns None when server info cannot be decoded."""
+def test_get_server_info_reports_the_underlying_error():
+    """Test that _get_server_info surfaces why the server could not be reached."""
     mock_server = MagicMock(spec=remote_http_trace_server.RemoteHTTPTraceServer)
     mock_server.server_info.side_effect = json.JSONDecodeError("test error", "doc", 0)
 
-    result = weave_init._get_server_info(mock_server)
+    with pytest.raises(RuntimeError) as excinfo:
+        weave_init._get_server_info(mock_server)
 
-    assert result is None
+    assert str(excinfo.value) == (
+        "Weave is not available on the server: test error: line 1 column 1 (char 0). "
+        "Please contact support."
+    )
+    assert isinstance(excinfo.value.__cause__, json.JSONDecodeError)
     mock_server.server_info.assert_called_once()
 
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -3096,19 +3096,10 @@ class WeaveClient:
                 project_id=self.project_id, row_digests=[]
             )
 
-            def test_func(req: TableCreateFromDigestsReq) -> Any:
-                server = self.server
-                if hasattr(server, "_next_trace_server"):
-                    server = server._next_trace_server
-
-                assert hasattr(server, "_post_request_executor")
-                assert hasattr(server._post_request_executor, "__wrapped__")
-                return server._post_request_executor.__wrapped__(
-                    server, "/table/create_from_digests", req
-                )
-
             use_parallel_chunks = check_endpoint_exists(
-                test_func, test_req, "table_create_from_digests"
+                self.server.table_create_from_digests,
+                test_req,
+                "table_create_from_digests",
             )
 
         return ChunkingConfig(

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -114,17 +114,14 @@ Args:
 """
 
 
-def _get_server_info(server: TraceServerClientInterface) -> ServerInfoRes | None:
-    """Fetch server_info or return None if the server is unavailable."""
+def _get_server_info(server: TraceServerClientInterface) -> ServerInfoRes:
+    """Fetch server_info, or raise a RuntimeError naming the underlying cause."""
     try:
         return server.server_info()
-    except Exception:
-        logger.warning(
-            "Unexpected error when checking if Weave is available on the server. "
-            "Please contact support.",
-            exc_info=True,
-        )
-        return None
+    except Exception as e:
+        raise RuntimeError(
+            f"Weave is not available on the server: {e}. Please contact support."
+        ) from e
 
 
 def _setup_conversation_tracing(
@@ -291,10 +288,6 @@ def init_weave(
 
     remote_server = init_weave_get_server(credentials)
     server_info = _get_server_info(remote_server)
-    if server_info is None:
-        raise RuntimeError(
-            "Weave is not available on the server.  Please contact support."
-        )
     server: TraceServerClientInterface = remote_server
     if use_server_cache():
         server = CachingMiddlewareTraceServer.from_env(server)

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -316,12 +316,10 @@ def check_endpoint_exists(
 ) -> bool:
     """Check if a function/endpoint exists and works by calling it with a test request.
 
-    This allows bypassing retry logic by passing the unwrapped function directly,
-    or testing any callable with consistent caching and error handling.
+    Tests any callable with consistent caching and error handling.
 
     Args:
-        func: The function to test (e.g., server.table_create_from_digests or
-              server._post_request_executor.__wrapped__)
+        func: The function to test (e.g., server.table_create_from_digests)
         test_req: A test request to use for checking the function
         cache_key: Optional cache key. If not provided, uses id(func)
 


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-39822

## Description

Two small fixes.

The first is the probe that decides if a large table can be uploaded in parallel chunks. It used an attribute that only the hand-written client has. On the generated client it raised. The probe read that as "route missing", so parallel upload silently stayed off.

It now calls the public `table_create_from_digests` instead.

The second is what `weave.init` raises when the startup `server_info` call fails. It always raised the same generic "Weave is not available on the server". A TLS failure against a self-signed certificate looked like everything else. The real cause is now in the message.

## Testing

New test: parallel chunks turn on, and the probe really hits `/table/create_from_digests`. It fails on master.

Locally: 1940 passed in `tests/trace/` and `tests/utils/`, 183 in `tests/trace_server_bindings/`, 167 with `--remote-http-trace-server=stainless`.
