### PR TITLE
feat(weave): teach the generated client the calls_complete write path

### DIFF
--- a/tests/trace/test_dataset.py
+++ b/tests/trace/test_dataset.py
@@ -49,8 +49,6 @@ def test_dataset_laziness(client):
     dataset = Dataset(rows=[{"input": i} for i in range(300)])
     log = client.server.attribute_access_log
     assert _top_level_logs(log) == [
-        "get_call_processor",
-        "get_call_processor",
         "get_feedback_processor",
         "get_feedback_processor",
     ]
@@ -80,8 +78,6 @@ def test_published_dataset_laziness(client):
     dataset = Dataset(rows=[{"input": i} for i in range(300)])
     log = client.server.attribute_access_log
     assert _top_level_logs(log) == [
-        "get_call_processor",
-        "get_call_processor",
         "get_feedback_processor",
         "get_feedback_processor",
     ]

--- a/tests/trace/test_evaluate.py
+++ b/tests/trace/test_evaluate.py
@@ -484,8 +484,6 @@ async def test_evaluate_table_lazy_iter(client, monkeypatch):
 
     log = client.server.attribute_access_log
     assert [l for l in log if not l.startswith("_")] == [
-        "get_call_processor",
-        "get_call_processor",
         "get_feedback_processor",
         "get_feedback_processor",
         "table_create",

--- a/tests/trace/test_evaluation_performance.py
+++ b/tests/trace/test_evaluation_performance.py
@@ -112,8 +112,6 @@ async def test_evaluation_performance(client: WeaveClient):
     log = [l for l in client.server.attribute_access_log if not l.startswith("_")]
 
     gold_log = [
-        "get_call_processor",
-        "get_call_processor",
         "get_feedback_processor",
         "get_feedback_processor",
     ]
@@ -138,7 +136,6 @@ async def test_evaluation_performance(client: WeaveClient):
     assert (
         counts
         == {
-            "get_call_processor": 2,
             "get_feedback_processor": 2,
             "table_create": 2,  # dataset and score results
             "obj_create": 9,  # Evaluate Op, Score Op, Predict and Score Op, Summarize Op, predict Op, PIL Image Serializer, Eval Results DS, MainDS, Evaluation Object

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -71,8 +71,10 @@ from weave.trace_server.trace_server_interface import (
     TableQueryReq,
     TableSchemaForInsert,
 )
+from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
 from weave.trace_server_bindings.http_utils import (
     _ENDPOINT_CACHE,
+    ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED,
     ROW_COUNT_CHUNKING_THRESHOLD,
 )
 from weave.trace_server_bindings.stainless_remote_http_trace_server import (
@@ -1699,6 +1701,76 @@ def test_parallel_chunk_probe_works_for_the_generated_client(client, monkeypatch
     assert config.use_chunking is True
     assert config.use_parallel_chunks is True
     assert [r.url.path for r in probed] == ["/table/create_from_digests"]
+
+
+def test_flush_drains_the_processor_installed_by_a_calls_complete_upgrade(monkeypatch):
+    """One flush() has to send calls that the upgrade moved to a new processor.
+
+    The client used to snapshot the processor in its constructor, so after an
+    upgrade it drained the retired one and reported no outstanding work.
+    """
+    monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", "false")
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/call/upsert_batch":
+            return httpx.Response(
+                400,
+                json={
+                    "error_code": ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED,
+                    "message": "Project requires calls_complete mode",
+                },
+                request=request,
+            )
+        return httpx.Response(200, json={}, request=request)
+
+    server = StainlessRemoteHTTPTraceServer("http://example.com", should_batch=True)
+    server._stainless_client = server._stainless_client.copy(
+        http_client=httpx.Client(transport=httpx.MockTransport(handle))
+    )
+    client = weave_client.WeaveClient(
+        "entity", "project", server, ensure_project_exists=False
+    )
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    started = tsi.StartedCallSchemaForInsert(
+        project_id="entity/project",
+        id="call-id",
+        trace_id="trace-id",
+        op_name="op",
+        started_at=now,
+        attributes={},
+        inputs={"a": 1},
+    )
+    ended = tsi.EndedCallSchemaForInsertWithStartedAt(
+        project_id="entity/project",
+        id="call-id",
+        trace_id="trace-id",
+        ended_at=now,
+        started_at=now,
+        summary={"result": "ok"},
+    )
+
+    legacy_processor = server.call_processor
+    try:
+        server.call_start(tsi.CallStartReq(start=started))
+        server.call_end(tsi.CallEndReq(end=ended))
+        client.flush()
+
+        assert isinstance(server.call_processor, CallBatchProcessor)
+        # The retired processor must stay retired and the live one must be usable.
+        assert legacy_processor.is_accepting_new_work() is False
+        assert server.call_processor.is_accepting_new_work() is True
+        complete = [
+            r for r in requests if r.url.path == "/v2/entity/project/calls/complete"
+        ]
+        assert len(complete) == 1
+        assert client.num_outstanding_jobs == 0
+    finally:
+        if server.call_processor and server.call_processor.is_accepting_new_work():
+            server.call_processor.stop_accepting_new_work_and_flush_queue()
+        if server.feedback_processor:
+            server.feedback_processor.stop_accepting_new_work_and_flush_queue()
 
 
 def test_summary_tokens_cost(client):

--- a/tests/trace_server_bindings/test_http_behavior_stainless.py
+++ b/tests/trace_server_bindings/test_http_behavior_stainless.py
@@ -6,8 +6,14 @@ status codes, and error handling specific to StainlessRemoteHTTPTraceServer.
 
 from __future__ import annotations
 
+import datetime
+import json
+import logging
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 import requests
 import tenacity
@@ -16,6 +22,17 @@ from pydantic import ValidationError
 from tests.trace_server_bindings.conftest import generate_id, generate_start
 from weave.trace.display.term import configure_logger
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
+from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
+from weave.trace_server_bindings.http_utils import (
+    ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED,
+    TRACE_ID_HEADER,
+)
+from weave.trace_server_bindings.models import (
+    CompleteBatchItem,
+    EndBatchItem,
+    StartBatchItem,
+)
 from weave.trace_server_bindings.stainless_remote_http_trace_server import (
     StainlessRemoteHTTPTraceServer,
 )
@@ -120,8 +137,9 @@ def test_invalid_no_retry(unbatched_server):
 
 
 @pytest.mark.disable_logging_error_check
-def test_timeout_retry_mechanism(success_response):
+def test_timeout_retry_mechanism(success_response, monkeypatch):
     """Test that timeouts trigger the retry mechanism."""
+    monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", "false")
     server = StainlessRemoteHTTPTraceServer("http://example.com", should_batch=True)
 
     # Mock _send_batch_to_server to raise errors twice, then succeed
@@ -149,8 +167,9 @@ def test_timeout_retry_mechanism(success_response):
 
 
 @pytest.fixture
-def fast_retrying_server():
+def fast_retrying_server(monkeypatch):
     """Create a StainlessRemoteHTTPTraceServer with fast retry settings for testing."""
+    monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", "false")
     server = StainlessRemoteHTTPTraceServer("http://example.com", should_batch=True)
     fast_retry = tenacity.retry(
         wait=tenacity.wait_fixed(0.1),
@@ -229,3 +248,267 @@ def test_post_timeout(success_response, fast_retrying_server, log_collector):
     response = new_server.call_start(start_req)
     assert response.id == "test_id"
     assert response.trace_id == "test_trace_id"
+
+
+# =============================================================================
+# calls_complete mode
+#
+# These tests drive the binding over an httpx.MockTransport so the vendored
+# client raises its own error type, which is the thing the binding recognises.
+# =============================================================================
+
+PROJECT = "entity/project"
+V2 = "/v2/entity/project"
+
+
+@contextmanager
+def _batching_server(
+    handle: Callable[[httpx.Request], httpx.Response],
+) -> Iterator[tuple[StainlessRemoteHTTPTraceServer, list[httpx.Request]]]:
+    """Yield a batching server whose generated client talks to `handle`."""
+    requests: list[httpx.Request] = []
+
+    def record(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return handle(request)
+
+    server = StainlessRemoteHTTPTraceServer("http://example.com", should_batch=True)
+    server._stainless_client = server._stainless_client.copy(
+        http_client=httpx.Client(transport=httpx.MockTransport(record))
+    )
+    try:
+        yield server, requests
+    finally:
+        if server.call_processor and server.call_processor.is_accepting_new_work():
+            server.call_processor.stop_accepting_new_work_and_flush_queue()
+        if server.feedback_processor:
+            server.feedback_processor.stop_accepting_new_work_and_flush_queue()
+
+
+def _ok(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(200, json={}, request=request)
+
+
+def _calls_complete_required(request: httpx.Request) -> httpx.Response:
+    if request.url.path == "/call/upsert_batch":
+        return httpx.Response(
+            400,
+            json={
+                "error_code": ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED,
+                "message": "Project requires calls_complete mode",
+            },
+            request=request,
+        )
+    return _ok(request)
+
+
+def _start_end_pair() -> tuple[StartBatchItem, EndBatchItem]:
+    ended_at = datetime.datetime.now(tz=datetime.timezone.utc)
+    start = generate_start("call-id", PROJECT)
+    # Distinct trace ids so the header assertions prove each request stamps its
+    # own item's trace_id rather than one shared value.
+    start.trace_id = "trace-eager-start"
+    end = tsi.EndedCallSchemaForInsertWithStartedAt(
+        project_id=PROJECT,
+        id="call-id",
+        trace_id="trace-eager-end",
+        ended_at=ended_at,
+        started_at=ended_at - datetime.timedelta(seconds=1),
+        summary={"result": "Test summary"},
+    )
+    return (
+        StartBatchItem(req=tsi.CallStartReq(start=start)),
+        EndBatchItem(req=tsi.CallEndReq(end=end)),
+    )
+
+
+@pytest.mark.parametrize(
+    ("setting", "expected_processor"),
+    [
+        (None, CallBatchProcessor),
+        ("true", CallBatchProcessor),
+        ("false", AsyncBatchProcessor),
+    ],
+)
+def test_calls_complete_setting_selects_the_processor(
+    setting, expected_processor, monkeypatch
+):
+    """The setting decides which processor the binding starts with; it defaults on."""
+    if setting is None:
+        monkeypatch.delenv("WEAVE_USE_CALLS_COMPLETE", raising=False)
+    else:
+        monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", setting)
+    with _batching_server(_ok) as (server, _):
+        assert server.use_calls_complete is (expected_processor is CallBatchProcessor)
+        assert type(server.call_processor) is expected_processor
+
+
+def test_calls_complete_batch_endpoint_and_payload(monkeypatch):
+    """Paired calls go to the v2 calls/complete route with the full payload."""
+    monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", "true")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    complete = tsi.CompletedCallSchemaForInsert(
+        project_id=PROJECT,
+        id="call-id",
+        trace_id="trace-id",
+        op_name="test_op",
+        started_at=now,
+        ended_at=now,
+        attributes={"a": 1},
+        inputs={"b": 2},
+        output={"c": 3},
+        summary={"result": "ok"},
+    )
+
+    with _batching_server(_ok) as (server, requests):
+        server._flush_calls_complete([CompleteBatchItem(req=complete)])
+
+        assert [r.url.path for r in requests] == [f"{V2}/calls/complete"]
+        payload = json.loads(requests[0].read().decode("utf-8"))
+        assert payload == tsi.CallsUpsertCompleteReq(batch=[complete]).model_dump(
+            mode="json"
+        )
+
+
+def test_eager_calls_use_v2_start_end_endpoints(monkeypatch):
+    """Unpaired calls go to the v2 single-call routes, one request each."""
+    monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", "true")
+    start_item, end_item = _start_end_pair()
+
+    with _batching_server(_ok) as (server, requests):
+        server._flush_calls_eager([start_item, end_item])
+
+        assert [r.url.path for r in requests] == [
+            f"{V2}/call/start",
+            f"{V2}/call/end",
+        ]
+        # The ingest sampler reads the trace id off the header, per request.
+        assert [r.headers.get(TRACE_ID_HEADER) for r in requests] == [
+            "trace-eager-start",
+            "trace-eager-end",
+        ]
+        start_body = json.loads(requests[0].read().decode("utf-8"))
+        end_body = json.loads(requests[1].read().decode("utf-8"))
+        assert start_body == tsi.CallStartV2Req(start=start_item.req.start).model_dump(
+            mode="json"
+        )
+        assert end_body == tsi.CallEndV2Req(end=end_item.req.end).model_dump(
+            mode="json"
+        )
+
+
+@pytest.mark.disable_logging_error_check
+def test_eager_failure_drops_one_item_and_continues(monkeypatch, caplog):
+    """A failed eager item is logged and dropped; the rest of the batch goes out."""
+    monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", "true")
+    start_item, end_item = _start_end_pair()
+
+    def fail_the_start(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/call/start"):
+            return httpx.Response(400, json={"detail": "no"}, request=request)
+        return _ok(request)
+
+    caplog.set_level(logging.ERROR)
+    with _batching_server(fail_the_start) as (server, requests):
+        server._flush_calls_eager([start_item, end_item])
+
+    assert [r.url.path for r in requests] == [f"{V2}/call/start", f"{V2}/call/end"]
+    # The third record is the vendor's own rendering of the error; only the two
+    # weave-owned lines are pinned so a vendor regen cannot turn this red.
+    assert [r.message for r in caplog.records[:2]] == [
+        "Error sending batch of 1 call events to server",
+        "dropped call start ids: ['call-id']",
+    ]
+    assert len(caplog.records) == 3
+
+
+@pytest.mark.disable_logging_error_check
+def test_auto_upgrade_to_calls_complete_on_error(monkeypatch):
+    """A 400 CALLS_COMPLETE_MODE_REQUIRED must not cost the batch."""
+    monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", "false")
+    start_item, end_item = _start_end_pair()
+
+    with _batching_server(_calls_complete_required) as (server, requests):
+        assert type(server.call_processor) is AsyncBatchProcessor
+        legacy_processor = server.call_processor
+
+        server.call_start(start_item.req)
+        server.call_end(end_item.req)
+        # The first drain hits the legacy route and upgrades the processor; the
+        # second drains the calls_complete processor the upgrade installed.
+        server.call_processor.stop_accepting_new_work_and_flush_queue()
+        server.call_processor.stop_accepting_new_work_and_flush_queue()
+
+        assert server.use_calls_complete is True
+        assert type(server.call_processor) is CallBatchProcessor
+        assert legacy_processor.stop_accepting_work_event.is_set()
+
+        complete = [r for r in requests if r.url.path == f"{V2}/calls/complete"]
+        assert len(complete) == 1
+        paired = tsi.CompletedCallSchemaForInsert(
+            project_id=PROJECT,
+            id="call-id",
+            trace_id=start_item.req.start.trace_id,
+            op_name=start_item.req.start.op_name,
+            parent_id=start_item.req.start.parent_id,
+            started_at=start_item.req.start.started_at,
+            attributes=start_item.req.start.attributes,
+            inputs=start_item.req.start.inputs,
+            ended_at=end_item.req.end.ended_at,
+            summary=end_item.req.end.summary,
+        )
+        assert json.loads(complete[0].read().decode("utf-8")) == (
+            tsi.CallsUpsertCompleteReq(batch=[paired]).model_dump(mode="json")
+        )
+
+
+@pytest.mark.disable_logging_error_check
+def test_a_second_rejected_batch_lands_on_the_upgraded_processor(monkeypatch):
+    """Items the retired processor was still holding must reach the new one."""
+    monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", "false")
+    first_start, first_end = _start_end_pair()
+    second_start, second_end = _start_end_pair()
+    second_start.req.start.id = "call-id-2"
+    second_end.req.end.id = "call-id-2"
+
+    with _batching_server(_calls_complete_required) as (server, requests):
+        # The first batch upgrades the processor; the second arrives after the swap
+        # and takes the already-upgraded path.
+        server._flush_calls([first_start, first_end])
+        server._flush_calls([second_start, second_end])
+        server.call_processor.stop_accepting_new_work_and_flush_queue()
+
+        sent = [
+            call["id"]
+            for r in requests
+            if r.url.path == f"{V2}/calls/complete"
+            for call in json.loads(r.read().decode("utf-8"))["batch"]
+        ]
+        assert sorted(sent) == ["call-id", "call-id-2"]
+
+
+@pytest.mark.disable_logging_error_check
+def test_other_400s_do_not_upgrade(monkeypatch):
+    """Only the calls_complete error code may switch the write path."""
+    monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", "false")
+    start_item, end_item = _start_end_pair()
+
+    def plain_400(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error_code": "NOPE"}, request=request)
+
+    with _batching_server(plain_400) as (server, requests):
+        server._flush_calls([start_item, end_item])
+
+        assert server.use_calls_complete is False
+        assert type(server.call_processor) is AsyncBatchProcessor
+        assert [r.url.path for r in requests] == ["/call/upsert_batch"]
+
+
+def test_calls_complete_needs_batching(monkeypatch):
+    """Without batching there is no processor to pair calls in."""
+    monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", "true")
+
+    server = StainlessRemoteHTTPTraceServer("http://example.com")
+
+    assert server.use_calls_complete is False
+    assert server.call_processor is None

--- a/tests/trace_server_bindings/test_trace_server_bindings.py
+++ b/tests/trace_server_bindings/test_trace_server_bindings.py
@@ -21,6 +21,7 @@ from tests.trace_server_bindings.conftest import (
     generate_end,
     generate_start,
 )
+from weave.trace_server import common_interface
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
 from weave.trace_server_bindings.models import (
@@ -279,3 +280,22 @@ def test_requeue_after_max_retries(server, server_class, caplog):
     assert len(caplog.records) == 1
     msg = caplog.records[0].message
     assert "batch failed after max retries, requeuing batch with" in msg
+
+
+def test_mixed_batch_parses_without_extra_field_warnings(caplog, monkeypatch):
+    """The generated client re-parses its own batch; ends must not look like starts."""
+    start, end = generate_call_start_end_pair()
+    encoded = (
+        Batch(batch=[StartBatchItem(req=start), EndBatchItem(req=end)])
+        .model_dump_json()
+        .encode("utf-8")
+    )
+    # The warning is emitted once per process, so an earlier test in the same
+    # session would otherwise make this assertion vacuous.
+    monkeypatch.setattr(common_interface, "_warned_field_sets", set())
+
+    caplog.set_level(logging.WARNING)
+    parsed = Batch.model_validate_json(encoded.decode("utf-8"))
+
+    assert [item.mode for item in parsed.batch] == ["start", "end"]
+    assert caplog.records == []

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -541,19 +541,14 @@ class WeaveClient:
             # Set Client project name with updated project name
             self.project = resp.project_name
 
-        self._server_call_processor: AsyncBatchProcessor | CallBatchProcessor | None = (
-            None
-        )
         self._server_feedback_processor: AsyncBatchProcessor | None = None
         # This is a short-term hack to get around the fact that we are reaching into
-        # the underlying implementation of the specific server to get the call processor.
-        # The `RemoteHTTPTraceServer` contains a call processor and we use that to control
+        # the underlying implementation of the specific server to get the feedback processor.
+        # The `RemoteHTTPTraceServer` contains a feedback processor and we use that to control
         # some client-side flushing mechanics. We should move this to the interface layer. However,
         # we don't really want the server-side implementations to need to define no-ops as that is
         # even uglier. So we are using this "hasattr" check to avoid forcing the server-side implementations
         # to define no-ops.
-        if hasattr(self.server, "get_call_processor"):
-            self._server_call_processor = self.server.get_call_processor()
         if hasattr(self.server, "get_feedback_processor"):
             self._server_feedback_processor = self.server.get_feedback_processor()
         self.send_file_cache = WeaveClientSendFileCache()
@@ -1616,7 +1611,7 @@ class WeaveClient:
         # Check if using CallBatchProcessor with non-eager mode (calls_complete path)
         # In this case, we delay printing the call link until finish_call
         uses_calls_complete_path = (
-            isinstance(self._server_call_processor, CallBatchProcessor)
+            isinstance(_get_call_processor(self.server), CallBatchProcessor)
             and not op.eager_call_start
         )
 
@@ -1841,7 +1836,7 @@ class WeaveClient:
         # after finish_call, when the complete call is queued to the batch processor.
         is_root_call = call.parent_id is None
         uses_calls_complete_path = isinstance(
-            self._server_call_processor, CallBatchProcessor
+            _get_call_processor(self.server), CallBatchProcessor
         ) and not (op is not None and op.eager_call_start)
 
         def on_end_complete(f: Future) -> None:
@@ -3352,8 +3347,8 @@ class WeaveClient:
             total += self.future_executor_fastlane.num_outstanding_futures
 
         # Add call batch uploads if available
-        if self._server_call_processor:
-            total += self._server_call_processor.num_outstanding_jobs
+        if call_processor := _get_call_processor(self.server):
+            total += call_processor.num_outstanding_jobs
         # Add feedback batch uploads if available
         if self._server_feedback_processor:
             total += self._server_feedback_processor.num_outstanding_jobs
@@ -3498,10 +3493,16 @@ class WeaveClient:
             self.future_executor.flush()
         if self.future_executor_fastlane:
             self.future_executor_fastlane.flush()
-        if self._server_call_processor:
-            self._server_call_processor.stop_accepting_new_work_and_flush_queue()
-            # Restart call processor processing thread after flushing
-            self._server_call_processor.accept_new_work()
+        # Draining can swap the call processor once, so drain the replacement too
+        # and restart only whichever one is still live.
+        call_processor = _get_call_processor(self.server)
+        while call_processor is not None:
+            call_processor.stop_accepting_new_work_and_flush_queue()
+            replacement = _get_call_processor(self.server)
+            if replacement is call_processor:
+                call_processor.accept_new_work()
+                break
+            call_processor = replacement
         if self._server_feedback_processor:
             self._server_feedback_processor.stop_accepting_new_work_and_flush_queue()
             # Restart feedback processor processing thread after flushing
@@ -3525,8 +3526,8 @@ class WeaveClient:
         if self.future_executor_fastlane:
             fastlane_jobs = self.future_executor_fastlane.num_outstanding_futures
         call_processor_jobs = 0
-        if self._server_call_processor:
-            call_processor_jobs = self._server_call_processor.num_outstanding_jobs
+        if call_processor := _get_call_processor(self.server):
+            call_processor_jobs = call_processor.num_outstanding_jobs
         feedback_processor_jobs = 0
         if self._server_feedback_processor:
             feedback_processor_jobs = (

--- a/weave/trace_server_bindings/models.py
+++ b/weave/trace_server_bindings/models.py
@@ -1,17 +1,17 @@
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from weave.trace_server import trace_server_interface as tsi
 
 
 class StartBatchItem(BaseModel):
-    mode: str = "start"
+    mode: Literal["start"] = "start"
     req: tsi.CallStartReq
 
 
 class EndBatchItem(BaseModel):
-    mode: str = "end"
+    mode: Literal["end"] = "end"
     req: tsi.CallEndReq
 
 
@@ -23,7 +23,8 @@ class CompleteBatchItem(BaseModel):
 
 
 class Batch(BaseModel):
-    batch: list[StartBatchItem | EndBatchItem]
+    # Discriminated: untagged, each item is tried against the wrong member and warns.
+    batch: list[Annotated[StartBatchItem | EndBatchItem, Field(discriminator="mode")]]
 
 
 class EntityProjectInfo(BaseModel):

--- a/weave/trace_server_bindings/stainless_remote_http_trace_server.py
+++ b/weave/trace_server_bindings/stainless_remote_http_trace_server.py
@@ -3,33 +3,43 @@ from __future__ import annotations
 import datetime
 import logging
 from collections.abc import Callable, Iterator
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, validate_call
 from typing_extensions import Self
 
 from weave.trace.env import weave_trace_server_url
-from weave.trace.settings import max_calls_queue_size, should_enable_disk_fallback
+from weave.trace.settings import (
+    max_calls_queue_size,
+    should_enable_disk_fallback,
+    should_use_calls_complete,
+)
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ids import generate_id
 from weave.trace_server.service_interface import ServerInfoRes
 from weave.trace_server.trace_server_interface import agent_types
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
+from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
 from weave.trace_server_bindings.client_interface import TraceServerClientInterface
 from weave.trace_server_bindings.http_utils import (
     REMOTE_REQUEST_BYTES_LIMIT,
+    TRACE_ID_HEADER,
+    CallsCompleteModeRequired,
+    is_calls_complete_mode_error,
     log_dropped_call_batch,
     log_dropped_feedback_batch,
     process_batch_with_retry,
 )
 from weave.trace_server_bindings.models import (
     Batch,
+    CompleteBatchItem,
     EndBatchItem,
     StartBatchItem,
 )
 from weave.utils.project_id import from_project_id
 from weave.utils.retry import get_current_retry_id, with_retry
+from weave.vendor.weave_server_sdk import APIStatusError
 from weave.vendor.weave_server_sdk import Client as StainlessClient
 from weave.wandb_interface import project_creator
 from weave.wandb_interface.auth import (
@@ -64,7 +74,8 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
     ):
         self.trace_server_url = trace_server_url.rstrip("/")
         self.should_batch = should_batch
-        self.call_processor: AsyncBatchProcessor | None = None
+        self.use_calls_complete = should_use_calls_complete() and should_batch
+        self.call_processor: AsyncBatchProcessor | CallBatchProcessor | None = None
         self.feedback_processor: AsyncBatchProcessor | None = None
         self.remote_request_bytes_limit = remote_request_bytes_limit
         self._extra_headers: dict[str, str] = extra_headers or {}
@@ -74,11 +85,19 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
         self._rebuild_client()
 
         if self.should_batch:
-            self.call_processor = AsyncBatchProcessor(
-                self._flush_calls,
-                max_queue_size=max_calls_queue_size(),
-                enable_disk_fallback=should_enable_disk_fallback(),
-            )
+            if self.use_calls_complete:
+                self.call_processor = CallBatchProcessor(
+                    complete_processor_fn=self._flush_calls_complete,
+                    eager_processor_fn=self._flush_calls_eager,
+                    max_queue_size=max_calls_queue_size(),
+                    enable_disk_fallback=should_enable_disk_fallback(),
+                )
+            else:
+                self.call_processor = AsyncBatchProcessor(
+                    self._flush_calls,
+                    max_queue_size=max_calls_queue_size(),
+                    enable_disk_fallback=should_enable_disk_fallback(),
+                )
             self.feedback_processor = AsyncBatchProcessor(
                 self._flush_feedback,
                 max_queue_size=max_calls_queue_size(),
@@ -112,12 +131,14 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
             default_headers=self._compose_headers(),
         )
 
-    def _compose_headers(self) -> dict[str, str]:
+    def _compose_headers(self, trace_id: str | None = None) -> dict[str, str]:
         headers = self._extra_headers.copy()
         if self._credentials is not None:
             headers["Authorization"] = self._credentials.authorization_header()
         if retry_id := get_current_retry_id():
             headers["X-Weave-Retry-Id"] = retry_id
+        if trace_id is not None:
+            headers[TRACE_ID_HEADER] = trace_id
         return headers
 
     def _update_client_headers(self) -> None:
@@ -208,7 +229,20 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
                         "req": item.req.model_dump(by_alias=True),
                     }
                 )
-        self._stainless_client.calls.upsert_batch(batch=stainless_batch)  # type: ignore[arg-type]
+        self._upsert_calls_batch(stainless_batch)
+
+    def _upsert_calls_batch(self, stainless_batch: list[Any]) -> Any:
+        """Send a legacy batch, mapping the calls_complete signal onto our own type.
+
+        The vendor client raises one generic type for every 4xx, so the signal has
+        to be recovered from the response body.
+        """
+        try:
+            return self._stainless_client.calls.upsert_batch(batch=stainless_batch)  # type: ignore[arg-type]
+        except APIStatusError as e:
+            if is_calls_complete_mode_error(e):
+                raise CallsCompleteModeRequired(str(e)) from e
+            raise
 
     def _flush_calls(
         self,
@@ -237,11 +271,159 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
             data = Batch(batch=batch).model_dump_json()
             return data.encode("utf-8")
 
+        try:
+            process_batch_with_retry(
+                batch_name="calls",
+                batch=batch,
+                remote_request_bytes_limit=self.remote_request_bytes_limit,
+                send_batch_fn=self._send_batch_to_server,
+                processor_obj=self.call_processor,
+                should_update_batch_size=_should_update_batch_size,
+                get_item_id_fn=get_item_id,
+                log_dropped_fn=log_dropped_call_batch,
+                encode_batch_fn=encode_batch,
+            )
+        except CallsCompleteModeRequired as e:
+            # Project requires calls_complete mode - upgrade and re-enqueue the batch
+            self._upgrade_to_calls_complete(batch, str(e))
+
+    def _upgrade_to_calls_complete(
+        self, batch: list[StartBatchItem | EndBatchItem], error_message: str
+    ) -> None:
+        """Upgrade from legacy AsyncBatchProcessor to CallBatchProcessor.
+
+        Called when the server says a project requires calls_complete mode. The
+        batch that was rejected is re-enqueued onto the replacement; anything still
+        queued on the retired processor arrives here again through its own thread
+        and takes the already-upgraded path below.
+
+        Args:
+            batch: The batch of items that failed to send (will be re-enqueued).
+            error_message: The error message from the server (for logging).
+        """
+        # Already upgraded? Just re-enqueue to the new processor
+        if self.use_calls_complete:
+            if isinstance(self.call_processor, CallBatchProcessor):
+                self.call_processor.enqueue(
+                    cast(list[StartBatchItem | EndBatchItem | CompleteBatchItem], batch)
+                )
+            return
+
+        logger.warning(
+            "Project has been previously written to with `use_calls_complete=True` and requires 'calls_complete' mode. Automatically upgrading SDK to use the more performant calls_complete processor. Server message: %s",
+            error_message,
+        )
+
+        old_processor = self.call_processor
+
+        self.use_calls_complete = True
+        self.call_processor = CallBatchProcessor(
+            complete_processor_fn=self._flush_calls_complete,
+            eager_processor_fn=self._flush_calls_eager,
+            max_queue_size=max_calls_queue_size(),
+            enable_disk_fallback=should_enable_disk_fallback(),
+        )
+
+        # Cast needed: list is invariant, but StartBatchItem | EndBatchItem is a valid subset of BatchItem
+        self.call_processor.enqueue(
+            cast(list[StartBatchItem | EndBatchItem | CompleteBatchItem], batch)
+        )
+
+        # Stop the old processor gracefully - any remaining items in its queue
+        # will be caught by _flush_calls which will re-enqueue them to the
+        # new processor via this same method (the "already upgraded" path above)
+        if old_processor is not None:
+            old_processor.stop_accepting_work_event.set()
+
+    def _flush_calls_eager(
+        self,
+        batch: list[StartBatchItem | EndBatchItem],
+        *,
+        _should_update_batch_size: bool = True,
+    ) -> None:
+        """Send eager start/end items one at a time via the v2 single endpoints.
+
+        Used by ops like Evaluation.evaluate whose start must be visible before
+        the call finishes, and for items still unpaired when the queue closes.
+        A failed item is logged and dropped; the rest of the batch continues.
+        """
+        for item in batch:
+            try:
+                if isinstance(item, StartBatchItem):
+                    self._send_call_start_v2(item.req.start)
+                elif isinstance(item, EndBatchItem):
+                    self._send_call_end_v2(item.req.end)
+            except Exception as e:
+                log_dropped_call_batch([item], e)
+
+    @with_retry
+    def _send_call_start_v2(self, start: tsi.StartedCallSchemaForInsert) -> None:
+        """Send a single call start to the v2 endpoint."""
+        entity, project = self._prepare_v2_request(start)
+        # The v2 single-call routes are hidden from the OpenAPI spec, so the
+        # generator emits no method for them.
+        self._stainless_client.post(
+            f"/v2/{entity}/{project}/call/start",
+            body=tsi.CallStartV2Req(start=start).model_dump(mode="json"),
+            cast_to=object,
+            options={"headers": self._compose_headers(trace_id=start.trace_id)},
+        )
+
+    @with_retry
+    def _send_call_end_v2(self, end: tsi.EndedCallSchemaForInsertWithStartedAt) -> None:
+        """Send a single call end to the v2 endpoint."""
+        entity, project = self._prepare_v2_request(end)
+        self._stainless_client.post(
+            f"/v2/{entity}/{project}/call/end",
+            body=tsi.CallEndV2Req(end=end).model_dump(mode="json"),
+            cast_to=object,
+            options={"headers": self._compose_headers(trace_id=end.trace_id)},
+        )
+
+    @with_retry
+    def _send_calls_complete_to_server(
+        self, entity: str, project: str, encoded_data: bytes
+    ) -> None:
+        """Send a batch of completed calls to the server with retry logic."""
+        # The generated method takes objects, not the bytes the batch splitter works in.
+        self._update_client_headers()
+        req = tsi.CallsUpsertCompleteReq.model_validate_json(
+            encoded_data.decode("utf-8")
+        )
+        self._stainless_client.v2_calls.complete(
+            project,
+            entity=entity,
+            batch=[item.model_dump(mode="json") for item in req.batch],  # type: ignore[misc]
+        )
+
+    def _flush_calls_complete(
+        self,
+        batch: list[CompleteBatchItem],
+        *,
+        _should_update_batch_size: bool = True,
+    ) -> None:
+        """Send a batch of paired calls to the calls_complete endpoint."""
+        assert self.call_processor is not None
+        if not batch:
+            return
+
+        entity, project = from_project_id(batch[0].req.project_id)
+
+        def get_item_id(item: CompleteBatchItem) -> str:
+            return f"{item.req.id}-complete"
+
+        def encode_batch(batch: list[CompleteBatchItem]) -> bytes:
+            api_batch = [item.req for item in batch]
+            req = tsi.CallsUpsertCompleteReq(batch=api_batch)
+            return req.model_dump_json().encode("utf-8")
+
         process_batch_with_retry(
-            batch_name="calls",
+            batch_name="calls_complete",
             batch=batch,
             remote_request_bytes_limit=self.remote_request_bytes_limit,
-            send_batch_fn=self._send_batch_to_server,
+            send_batch_fn=lambda data: self._send_calls_complete_to_server(
+                entity, project, data
+            ),
             processor_obj=self.call_processor,
             should_update_batch_size=_should_update_batch_size,
             get_item_id_fn=get_item_id,
@@ -249,11 +431,11 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
             encode_batch_fn=encode_batch,
         )
 
-    def get_call_processor(self) -> AsyncBatchProcessor | None:
+    def get_call_processor(self) -> AsyncBatchProcessor | CallBatchProcessor | None:
         """Get the call processor for batching.
 
         Returns:
-            AsyncBatchProcessor instance or None if batching is disabled.
+            AsyncBatchProcessor or CallBatchProcessor, or None if batching is disabled.
         """
         return self.call_processor
 
@@ -582,7 +764,7 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
                         "req": item.req.model_dump(by_alias=True),
                     }
                 )
-        response = self._stainless_client.calls.upsert_batch(batch=stainless_batch)  # type: ignore[arg-type]
+        response = self._upsert_calls_batch(stainless_batch)
         # Convert response back
         res_items = []
         for res_item in response.res:


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-39821

## Description

A project that already holds `calls_complete` rows rejects the legacy `/call/upsert_batch` route with a 400.

The hand-written client knows that error. It switches to the pairing processor and resends.

The generated client had no `calls_complete` support at all. Nothing caught the error, so the whole batch was dropped. On a local stack the ClickHouse row count did not move.

This is a port, not a new design. The TypeScript SDK already does the same thing in production (`sdks/node/src/weaveClient.ts`).

Four pieces. Start the pairing processor when the setting is on. Send paired calls through `v2_calls.complete`. Send unpaired ones through the v2 single-call routes, which are hidden from the spec, so we use raw `post`. Map the server's error code onto `CallsCompleteModeRequired`.

One more fix comes with it. The client no longer snapshots the call processor in its constructor. That snapshot left `flush()` restarting the retired processor after an upgrade. It fixes the hand-written client too.

Two notes before approving.

`WEAVE_USE_CALLS_COMPLETE` already defaults to true. So turning `WEAVE_USE_STAINLESS_SERVER` on also moves you to `calls_complete`. Non-eager call starts then stop appearing until the call finishes.

This is a faithful copy, so it keeps the hand-written client's existing weakness. A process that exits right after an upgrade without flushing can still lose in-flight calls.

Stacked on #7851.

## Testing

Eight new tests in `test_http_behavior_stainless.py` drive the vendored client over an `httpx.MockTransport`. Two more pin the batch re-parse and that `flush()` drains the live processor. Each fails on master.

Existing tests: one test and one fixture now pin `WEAVE_USE_CALLS_COMPLETE=false`. Four access-log tests lose two `get_call_processor` entries.

Locally: 1941 passed in `tests/trace/` and `tests/utils/`, 184 in `tests/trace_server_bindings/`, 178 with `--remote-http-trace-server=stainless`.
