### PR TITLE
fix(weave): route the generated client through our own httpx client

### DIFF
--- a/tests/trace_server_bindings/test_http_behavior_stainless.py
+++ b/tests/trace_server_bindings/test_http_behavior_stainless.py
@@ -37,7 +37,7 @@ from weave.trace_server_bindings.stainless_remote_http_trace_server import (
     StainlessRemoteHTTPTraceServer,
 )
 from weave.utils.retry import with_retry
-from weave.vendor.weave_server_sdk import APIStatusError
+from weave.vendor.weave_server_sdk import APIStatusError, DefaultHttpxClient
 from weave.wandb_interface.auth import ApiKeyCredentials, WandbCredentials
 
 
@@ -512,3 +512,24 @@ def test_calls_complete_needs_batching(monkeypatch):
 
     assert server.use_calls_complete is False
     assert server.call_processor is None
+
+
+def test_generated_client_gets_our_ssl_and_timeout_settings(monkeypatch):
+    """The vendor client built its own httpx client, so both settings were lost."""
+    monkeypatch.setenv("WEAVE_INSECURE_DISABLE_SSL", "true")
+    monkeypatch.setenv("WEAVE_HTTP_TIMEOUT", "7")
+    captured: dict[str, object] = {}
+
+    def spy(**kwargs: object) -> httpx.Client:
+        captured.update(kwargs)
+        return DefaultHttpxClient(**kwargs)
+
+    monkeypatch.setattr(
+        "weave.trace_server_bindings.stainless_remote_http_trace_server.DefaultHttpxClient",
+        spy,
+    )
+
+    server = StainlessRemoteHTTPTraceServer("http://example.com")
+
+    assert captured == {"verify": False}
+    assert server._stainless_client.timeout == 7.0

--- a/weave/trace_server_bindings/stainless_remote_http_trace_server.py
+++ b/weave/trace_server_bindings/stainless_remote_http_trace_server.py
@@ -9,8 +9,9 @@ from zoneinfo import ZoneInfo
 from pydantic import BaseModel, validate_call
 from typing_extensions import Self
 
-from weave.trace.env import weave_trace_server_url
+from weave.trace.env import ssl_verify, weave_trace_server_url
 from weave.trace.settings import (
+    http_timeout,
     max_calls_queue_size,
     should_enable_disk_fallback,
     should_use_calls_complete,
@@ -39,7 +40,7 @@ from weave.trace_server_bindings.models import (
 )
 from weave.utils.project_id import from_project_id
 from weave.utils.retry import get_current_retry_id, with_retry
-from weave.vendor.weave_server_sdk import APIStatusError
+from weave.vendor.weave_server_sdk import APIStatusError, DefaultHttpxClient
 from weave.vendor.weave_server_sdk import Client as StainlessClient
 from weave.wandb_interface import project_creator
 from weave.wandb_interface.auth import (
@@ -129,6 +130,9 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
             username="",
             password="",
             default_headers=self._compose_headers(),
+            timeout=http_timeout(),
+            # DefaultHttpxClient keeps the vendor's own limits and redirect handling.
+            http_client=DefaultHttpxClient(verify=ssl_verify()),
         )
 
     def _compose_headers(self, trace_id: str | None = None) -> dict[str, str]:


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-39823

## Description

The generated client let the vendor SDK build its own httpx client. So `WEAVE_INSECURE_DISABLE_SSL` and our request timeout never reached it.

That blocks anyone on a self-signed or internally-issued certificate. The handshake fails, and `weave.init` reports it as the server not having Weave.

We now build the httpx client ourselves. It goes through the vendor's own `DefaultHttpxClient`, so connection limits and redirect handling are preserved.

Two consequences. Our timeout is a single number, so read and write go from 60s to 30s, and connect from 5s to 30s. That matches the hand-written client. Both settings are also read when the client is built, not per request.

Vendor retries stay on deliberately. Our `with_retry` covers only the write paths, so turning them off would take every other route from three attempts to one.

Stacked on #7852.

## Testing

New test: `verify=False` under `WEAVE_INSECURE_DISABLE_SSL=true`, and the client timeout comes from `WEAVE_HTTP_TIMEOUT`.

Locally: 1941 passed in `tests/trace/` and `tests/utils/`, 184 in `tests/trace_server_bindings/`, 179 with `--remote-http-trace-server=stainless`.
