### PR TITLE
fix(weave): skip duplicate output nesting in log_summary when auto_summarize=False

### DIFF
--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -1141,7 +1141,10 @@ class EvaluationLogger:
         final_summary = {}
         if summary_data:
             final_summary = summary_data
-        if summary is not None:
+        # Only nest the user-supplied summary under "output" when auto_summarize is True.
+        # When auto_summarize=False, summary_data IS summary, so adding it again would
+        # produce every key twice — once at the top level and once under "output".
+        if auto_summarize and summary is not None:
             final_summary = {**final_summary, "output": summary}
 
         # Call the summarize op


### PR DESCRIPTION
## Summary

When  is called, the user-supplied
 dict ends up duplicated in the logged output — every custom key appears
twice: once at the top level of  (from ,
where  is ) and once nested inside 
(from the unconditional `{**final_summary, "output": summary}`).

When `auto_summarize=True`, `summary_data` is the scorer-derived auto-summary and is
a distinct object from the user-supplied `summary`, so the `"output"` nesting correctly
distinguishes the two sources. The bug only occurs on the `auto_summarize=False` path.

## Fix

Guard the `"output"` nesting with `auto_summarize`:

```python
# before
if summary is not None:
    final_summary = {**final_summary, "output": summary}

# after
if auto_summarize and summary is not None:
    final_summary = {**final_summary, "output": summary}
```

## Test plan

- [ ] Verify `log_summary(summary={"avg_score": 0.9}, auto_summarize=False)` logs `{"avg_score": 0.9}` and not `{"avg_score": 0.9, "output": {"avg_score": 0.9}}`
- [ ] Verify `log_summary(summary={"avg_score": 0.9}, auto_summarize=True)` still logs the scorer-derived summary at the top level with the user-supplied dict nested under `"output"`
- [ ] Verify `log_summary(auto_summarize=True)` with no user-supplied summary is unaffected
- [ ] Verify `log_summary(auto_summarize=False)` with no user-supplied summary (`summary=None`/`{}`) is unaffected

Fixes #7741.