### PR TITLE
chore(weave): lead SDK READMEs with agent tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,23 +127,49 @@ For a multi-turn loop with tools, see the [custom agents quickstart](https://doc
 
 ## Function tracing
 
-`@weave.op` still traces individual functions. Those traces land in the **Calls** tab, not the Agents tab. Use it for evaluations, scorers, and non-agent pipelines.
+`@weave.op` traces a function. Those traces land in the **Calls** tab, not the Agents tab. Use it for evaluations, scorers, and LLM calls that are not an agent loop.
+
+Plain `openai` is also auto-traced into the Calls tab after `weave.init()`. `@weave.op` wraps the call in a parent function, so the OpenAI request sits under `extract_fruit`.
+
+```bash
+pip install weave openai
+```
 
 ```python
+import json
 import weave
+from openai import OpenAI
 
 weave.init("<your-team>/<your-project-name>")
 
 
 @weave.op
-def greet(name: str) -> str:
-    return name
+def extract_fruit(sentence: str) -> dict:
+    client = OpenAI()
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You will be provided with unstructured data, and your task is to parse "
+                    "it into one JSON object with fruit, color and flavor as keys."
+                ),
+            },
+            {"role": "user", "content": sentence},
+        ],
+        temperature=0.7,
+        response_format={"type": "json_object"},
+    )
+    extracted = response.choices[0].message.content
+    return json.loads(extracted)
 
 
-greet("world")
+extract_fruit(
+    "There are many fruits that were found on the recently discovered planet Goocrux. "
+    "There are neoskizzles that grow there, which are purple and taste like candy."
+)
 ```
-
-Plain `openai` auto-traces into the **Calls** tab, not the Agents tab. For the Agents tab, wrap the call with `start_llm` as above.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,112 +7,143 @@
 )](https://github.com/wandb/weave)
 [![codecov](https://codecov.io/gh/wandb/weave/graph/badge.svg?token=YOUR_TOKEN)](https://codecov.io/gh/wandb/weave)
 
-Weave is a toolkit for developing Generative AI applications, built by [Weights & Biases](https://wandb.ai/).
-
----
+Weave is a toolkit for tracing and evaluating AI agents, built by [Weights & Biases](https://wandb.ai/).
 
 You can use Weave to:
 
-- **Log and debug** language model inputs, outputs, and traces
-- **Build rigorous, apples-to-apples evaluations** for language model use cases
-- **Organize all the information** generated across the LLM workflow, from experimentation to evaluations to production
-
-Our goal is to bring rigor, best-practices, and composability to the inherently experimental process of developing Generative AI software, without introducing cognitive overhead.
+- **Trace agents.** Conversations, turns, LLM calls, and tool calls show up in the Agents tab.
+- **Evaluate** agents and LLM applications.
+- **Trace functions** with `@weave.op` when you want the Calls tab, not the Agents tab.
 
 ## Documentation
 
 Our documentation site can be found [here](https://wandb.me/weave).
 
+Start here for agents:
+
+- [Choose an agent integration](https://docs.wandb.ai/weave/agent-integration-quickstart) — OpenAI Agents SDK, Claude Agent SDK, and Google ADK. `weave.init()` is enough for those SDKs.
+- [Custom agents](https://docs.wandb.ai/weave/custom-agents-quickstart) — wrap your own loop with `start_conversation`, `start_turn`, `start_llm`, and `start_tool`.
+
 ## Prerequisites
 
 - Python 3.10 or higher
 - A [Weights & Biases account](https://wandb.ai/signup) (free tier available)
+- A W&B API key from [https://wandb.ai/authorize](https://wandb.ai/authorize). Set `WANDB_API_KEY`, or run `wandb login`.
+- An [OpenAI API key](https://platform.openai.com/api-keys) in `OPENAI_API_KEY`, for the example below.
 
+## Quick start: trace an agent
 
-## Quick Start
+This example uses the [OpenAI Agents SDK](https://docs.wandb.ai/weave/guides/integrations/agents/openai-agents-sdk). The Python import is `agents`; the package name is `openai-agents`. Weave autopatches it after `weave.init()`. Traces land in the **Agents** tab, not the Calls tab.
 
-1. **Install Weave**:
-   ```bash
-   pip install weave
-   ```
-
-2. **Import and initialize**:
-   ```python
-   import weave
-   weave.init("my-project-name")
-   ```
-
-3. **Trace your functions**:
-   ```python
-   @weave.op
-   def my_function():
-       # Your tracked code!
-       pass
-   ```
-
-## Usage
-
-### Tracing
-You can trace any function using `weave.op` - from api calls to OpenAI, Anthropic, Google AI Studio etc to generation calls from Hugging Face and other open source models to any other validation functions or data transformations in your code you'd like to keep track of.
-
-Decorate all the functions you want to trace, this will generate a trace tree of the inputs and outputs of all your functions:
-
-```python
-import weave
-weave.init("weave-example")
-
-@weave.op
-def sum_nine(value_one: int):
-    return value_one + 9
-
-@weave.op
-def multiply_two(value_two: int):
-    return value_two * 2
-
-@weave.op
-def main():
-    output = sum_nine(3)
-    final_output = multiply_two(output)
-    return final_output
-
-main()
+```bash
+pip install weave openai-agents requests
 ```
 
-### Fuller Example 
-
 ```python
+import asyncio
+import requests
 import weave
-import json
-from openai import OpenAI
+from agents import Agent, Runner, function_tool
 
-@weave.op
-def extract_fruit(sentence: str) -> dict:
-    client = OpenAI()
+weave.init("<your-team>/<your-project-name>")
 
-    response = client.chat.completions.create(
-    model="gpt-3.5-turbo-1106",
-    messages=[
-        {
-            "role": "system",
-            "content": "You will be provided with unstructured data, and your task is to parse it one JSON dictionary with fruit, color and flavor as keys."
+
+@function_tool
+def wikipedia_search(query: str) -> str:
+    """Search Wikipedia for a topic and return its title and intro paragraph."""
+    r = requests.get(
+        "https://en.wikipedia.org/w/api.php",
+        params={
+            "action": "query",
+            "generator": "search",
+            "gsrsearch": query,
+            "gsrlimit": 1,
+            "prop": "extracts",
+            "exintro": True,
+            "explaintext": True,
+            "format": "json",
         },
-        {
-            "role": "user",
-            "content": sentence
-        }
-        ],
-        temperature=0.7,
-        response_format={ "type": "json_object" }
-    )
-    extracted = response.choices[0].message.content
-    return json.loads(extracted)
+        headers={"User-Agent": "weave-demo"},
+    ).json()
+    page = next(iter(r["query"]["pages"].values()))
+    return f"{page['title']}: {page['extract']}"
 
-weave.init('intro-example')
 
-sentence = "There are many fruits that were found on the recently discovered planet Goocrux. There are neoskizzles that grow there, which are purple and taste like candy."
+agent = Agent(
+    name="Research assistant",
+    instructions=(
+        "You are a research assistant. Use the wikipedia_search tool to look up "
+        "topics when needed, and cite the article titles you used."
+    ),
+    tools=[wikipedia_search],
+)
 
-extract_fruit(sentence)
+
+async def main():
+    history = []
+    for question in [
+        "Who founded Anthropic?",
+        "What is Claude (the AI assistant)?",
+        "Summarize what we discussed in one sentence.",
+    ]:
+        history.append({"role": "user", "content": question})
+        print(f"USER: {question}")
+        result = await Runner.run(agent, input=history)
+        print(f"AGENT: {result.final_output}\n")
+        history = result.to_input_list()
+
+
+asyncio.run(main())
 ```
+
+`weave.init()` prints a project URL. Open the **Agents** tab.
+
+Claude Agent SDK works the same way: install the framework, call `weave.init()`, run the agent. For Google ADK, import `google.adk` before `weave.init()`. See [Choose an agent integration](https://docs.wandb.ai/weave/agent-integration-quickstart).
+
+## Custom agents
+
+If you are not using a supported agent SDK, wrap your own loop. This is the Conversation SDK, not the `@weave.op` path.
+
+Use `start_conversation`, `start_turn`, and `start_llm`. In Python they are context managers and close on exceptions. `start_session` and `Session` still exist; they emit a `DeprecationWarning`. Do not use them in new code.
+
+```python
+import weave
+
+weave.init("<your-team>/<your-project-name>")
+
+with weave.start_conversation(agent_name="research-bot"):
+    with weave.start_turn(user_message="Who founded Anthropic?"):
+        with weave.start_llm(model="gpt-4o-mini", provider_name="openai") as llm:
+            llm.output("Anthropic was founded by former OpenAI researchers.")
+            llm.record(
+                usage=weave.Usage(input_tokens=12, output_tokens=9),
+                response_model="gpt-4o-mini",
+            )
+```
+
+Always pass `provider_name`. Weave does not infer it from the model name.
+
+For a multi-turn loop with tools, see the [custom agents quickstart](https://docs.wandb.ai/weave/custom-agents-quickstart).
+
+## Function tracing
+
+`@weave.op` still traces individual functions. Those traces land in the **Calls** tab, not the Agents tab. Use it for evaluations, scorers, and non-agent pipelines.
+
+```python
+import weave
+
+weave.init("<your-team>/<your-project-name>")
+
+
+@weave.op
+def greet(name: str) -> str:
+    return name
+
+
+greet("world")
+```
+
+Plain `openai` auto-traces into the **Calls** tab, not the Agents tab. For the Agents tab, wrap the call with `start_llm` as above.
 
 ## Contributing
 
@@ -123,4 +154,3 @@ We're in the process of 🧹 cleaning up 🧹. This codebase contains a large am
 The Weave Tracing code is mostly in: `weave/trace` and `weave/trace_server`.
 
 The Weave Evaluations code is mostly in `weave/flow`.
-

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -30,10 +30,10 @@ npm install weave @openai/agents zod
 
 Put this in a file called `main.mjs`:
 
-```javascript
+```typescript
 import { randomUUID } from "node:crypto";
 import * as weave from "weave";
-import { Agent, Runner, tool } from "@openai/agents";
+import { Agent, Runner, tool, type AgentInputItem } from "@openai/agents";
 import { z } from "zod";
 
 const wikipediaSearch = tool({
@@ -57,7 +57,7 @@ const wikipediaSearch = tool({
 
     const response = await fetch(url, { headers: { "User-Agent": "weave-demo" } });
     const data = await response.json();
-    const page = Object.values(data.query.pages)[0];
+    const page = Object.values(data.query.pages)[0] as { title: string; extract: string };
     return `${page.title}: ${page.extract}`;
   },
 });
@@ -81,7 +81,7 @@ async function main() {
     "Summarize what we discussed in one sentence.",
   ];
 
-  let history = [];
+  let history: AgentInputItem[] = [];
   for (const question of questions) {
     history.push({ role: "user", content: question });
     console.log(`USER: ${question}`);

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -1,6 +1,6 @@
 # Weave
 
-Weave is a library for tracing and monitoring AI applications.
+Weave is a library for tracing and monitoring AI agents.
 
 ## Installation
 
@@ -10,9 +10,7 @@ You can install Weave via npm:
 npm install weave
 ```
 
-Ensure you have a wandb API key in ~/.netrc.
-
-Like
+Put a wandb API key in `~/.netrc`, or set `WANDB_API_KEY`.
 
 ```
 machine api.wandb.ai
@@ -20,16 +18,22 @@ machine api.wandb.ai
   password <wandb-api-key>
 ```
 
-Get your wandb API key from [here](https://wandb.ai/authorize).
+Get your wandb API key from [here](https://wandb.ai/authorize). The example below also needs `OPENAI_API_KEY`.
 
 ## Quickstart
 
+This example uses the OpenAI Agents SDK. Weave autopatches it. Traces land in the **Agents** tab, not the Calls tab.
+
+```bash
+npm install weave @openai/agents zod
+```
+
 Put this in a file called `main.mjs`:
 
-```typescript
+```javascript
 import { randomUUID } from "node:crypto";
 import * as weave from "weave";
-import { Agent, Runner, tool, type AgentInputItem } from "@openai/agents";
+import { Agent, Runner, tool } from "@openai/agents";
 import { z } from "zod";
 
 const wikipediaSearch = tool({
@@ -53,7 +57,7 @@ const wikipediaSearch = tool({
 
     const response = await fetch(url, { headers: { "User-Agent": "weave-demo" } });
     const data = await response.json();
-    const page = Object.values(data.query.pages)[0] as { title: string; extract: string };
+    const page = Object.values(data.query.pages)[0];
     return `${page.title}: ${page.extract}`;
   },
 });
@@ -77,7 +81,7 @@ async function main() {
     "Summarize what we discussed in one sentence.",
   ];
 
-  let history: AgentInputItem[] = [];
+  let history = [];
   for (const question of questions) {
     history.push({ role: "user", content: question });
     console.log(`USER: ${question}`);
@@ -96,17 +100,19 @@ and then run
 node --import=weave/instrument main.mjs
 ```
 
+ESM needs that `--import=weave/instrument` flag. For CommonJS, `require('weave')` before requiring the agent SDK; no preload flag is needed.
+
 ## Usage
 
 ### Initializing a Project
 
-Before you can start tracing your agent or application, you need to initialize a project.
+Before you can start tracing your agent or application, you need to initialize a project. `init` is async. Await it before any traced work.
 
 ```typescript
 import {init} from 'weave';
 
 // Initialize your project with a unique project name
-init('my-awesome-ai-project');
+await init('my-awesome-ai-project');
 ```
 
 ### Integrations
@@ -117,11 +123,13 @@ Import the library, call `weave.init(...)`, and Weave picks it up. For ESM proje
 
 #### Agent SDKs
 
-- [OpenAI Agents SDK](https://docs.wandb.ai/weave/guides/integrations/openai_agents) (`@openai/agents`, `@openai/agents-realtime`)
-- [Google Agent Development Kit (ADK)](https://docs.wandb.ai/weave/guides/integrations/google_adk) (`@google/adk`)
-- [Claude Agent SDK](https://docs.wandb.ai/weave/guides/integrations/claude_agent_sdk) (`@anthropic-ai/claude-agent-sdk`)
+- [OpenAI Agents SDK](https://docs.wandb.ai/weave/guides/integrations/agents/openai-agents-sdk) (`@openai/agents`, `@openai/agents-realtime`)
+- [Google Agent Development Kit (ADK)](https://docs.wandb.ai/weave/guides/integrations/agents/google-adk) (`@google/adk`)
+- [Claude Agent SDK](https://docs.wandb.ai/weave/guides/integrations/agents/claude-agents-sdk) (`@anthropic-ai/claude-agent-sdk`)
 
 #### LLM providers
+
+These land in the **Calls** tab, not the Agents tab. For the Agents tab from a model SDK, use the Conversation SDK below.
 
 - [OpenAI](https://docs.wandb.ai/weave/guides/integrations/openai) (`openai`)
 - [Anthropic](https://docs.wandb.ai/weave/guides/integrations/anthropic) (`@anthropic-ai/sdk`)
@@ -129,8 +137,44 @@ Import the library, call `weave.init(...)`, and Weave picks it up. For ESM proje
 
 #### Custom agents and OpenTelemetry
 
-- [Quickstart: Manually instrument an agent](https://docs.wandb.ai/weave/agent-integration-quickstart#custom-agents-and-opentelemetry)
-- [Trace your agents](https://docs.wandb.ai/weave/guides/tracking/tracing)
+- [Quickstart: Manually instrument an agent](https://docs.wandb.ai/weave/custom-agents-quickstart)
+- [Trace your agents](https://docs.wandb.ai/weave/guides/tracking/trace-agents)
+
+### Custom agents
+
+If you are not using a supported agent SDK, wrap your own loop. Group turns with `startConversation`. Create spans with `startTurn`, `startLLM`, and `startTool`. The class names `Conversation`, `Turn`, `LLM`, and `Tool` are types only; there is no `new Turn()`. `startSession` is deprecated. Close every span in `finally`.
+
+```javascript
+import * as weave from 'weave';
+
+await weave.init('<your-team>/<your-project-name>');
+
+const conversation = weave.startConversation({agentName: 'research-bot'});
+try {
+  const turn = weave.startTurn({
+    model: 'gpt-4o-mini',
+    userMessage: 'Who founded Anthropic?',
+  });
+  try {
+    const llm = weave.startLLM({model: 'gpt-4o-mini', providerName: 'openai'});
+    try {
+      llm.output('Anthropic was founded by former OpenAI researchers.');
+      llm.record({
+        usage: {inputTokens: 12, outputTokens: 9},
+        responseModel: 'gpt-4o-mini',
+      });
+    } finally {
+      llm.end();
+    }
+  } finally {
+    turn.end();
+  }
+} finally {
+  conversation.end();
+}
+```
+
+`startLLM` throws if no turn is open. For a short-lived process, call `await weave.flushOTel()` before exit or the last spans may not export. A longer loop with tools is in the [custom agents quickstart](https://docs.wandb.ai/weave/custom-agents-quickstart).
 
 ### Evaluations
 
@@ -231,4 +275,3 @@ Get your wandb API key from [here](https://wandb.ai/authorize).
 ## License
 
 This project is licensed under the Apache2 License - see the [LICENSE](../../LICENSE) file for details.
-


### PR DESCRIPTION
## JIRA Issue(s)

https://coreweave.atlassian.net/browse/WB-39867

## Description

The Python README still opens on `@weave.op`. That path lands in the Calls tab.

Agent tracing has been the product surface since June. Autopatch of agent SDKs, plus the Conversation SDK (`start_conversation` / `start_turn` / `start_llm`), land in the Agents tab. GitHub and PyPI still teach the old path, so copy-paste and assistants keep generating `@weave.op`.

Python `README.md` now leads with the same OpenAI Agents Wikipedia example the docs already publish. `weave.init()` is enough. `@weave.op` stays lower down as the Calls-tab path, including the old `extract_fruit` OpenAI example on `gpt-4o-mini`.

The TypeScript README already led with OpenAI Agents (npm 0.16.2). This PR keeps that story and fixes the copy-paste:

- install line is `npm install weave @openai/agents zod`
- the hero is plain JavaScript in `main.mjs`, so `node --check` passes
- a short Conversation SDK snippet covers custom loops (`startConversation` / `startTurn` / `startLLM`)

Deprecated names (`start_session`, `startSession`, `turn.llm`) are not in the examples. Docs links point at the current `/agents/` pages.

## Out of scope

No version bump. `use_stainless_server` stays off. The `weave-instrument` skill is not edited.

GitHub updates on merge. PyPI still serves 0.53.9 until the next publish.

## Testing

Docs-only. Two files: `README.md` and `sdks/node/README.md`.

- Python snippets `py_compile`
- TypeScript hero `node --check` as `main.mjs`
- Docs URLs in the new text return 200
- Example names exist on `weave` / the TS SDK public surface
