### PR TITLE
fix(weave): return 400 for an illegal query argument, not 403

### DIFF
--- a/tests/trace/test_errors.py
+++ b/tests/trace/test_errors.py
@@ -1,6 +1,14 @@
 import httpx
+import pytest
 
 from weave.trace.errors import format_http_error, response_error_message
+from weave.trace_server.errors import (
+    BadQueryParameterError,
+    InvalidFieldError,
+    QueryIllegalTypeofArgumentError,
+    QueryNoCommonTypeError,
+    handle_server_exception,
+)
 
 
 def test_response_error_message_prefers_common_json_fields_and_falls_back_to_body():
@@ -50,3 +58,19 @@ def test_response_error_message_prefers_common_json_fields_and_falls_back_to_bod
         "weave:///test/test-project/object/frozen-dataset:abc123 "
         "(status 403): Project not found"
     )
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        QueryIllegalTypeofArgumentError("illegal type of argument"),
+        QueryNoCommonTypeError("no common type"),
+        BadQueryParameterError("bad query parameter"),
+        InvalidFieldError("field not allowed"),
+    ],
+)
+def test_rejected_queries_are_client_errors_not_authz_failures(exc):
+    """A query we reject is a 4xx about the request, never a 403."""
+    status_code = handle_server_exception(exc).status_code
+    assert 400 <= status_code < 500
+    assert status_code != 403

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -339,9 +339,7 @@ class ErrorRegistry:
         self.register(InvalidIdFormat, 400)
         # A malformed query value is a client request error, not an authz failure.
         self.register(BadQueryParameterError, 400)
-
-        # 403
-        self.register(QueryIllegalTypeofArgumentError, 403)
+        self.register(QueryIllegalTypeofArgumentError, 400)
 
         # 404
         self.register(NotFoundError, 404)


### PR DESCRIPTION
## Summary
- `QueryIllegalTypeofArgumentError` returned 403, so a caller comparing a JSON field against a numeric literal without `$convert` got `403 Forbidden` with a body explaining `$convert` — the status sends them to audit permissions, the message points at their query. Now 400.
- `QueryNoCommonTypeError` is raised two branches away in the same `handle_clickhouse_query_error`, carries the same `$convert` guidance, and was already 400. #7293 moved `BadQueryParameterError` to 400 as "a client request error, not an authz failure"; this is that case, missed then. The 403 came from #5565, a PR about message wording.
- 403 is now used only for `TransportQueryError`, which is genuine authz.
- Prod, Aug 28 – Sep 11: 6 traces, all `masterclass-ai` on `POST /calls/stream_query` from an authenticated read-scoped user ([Datadog](https://us5.datadoghq.com/apm/traces?query=env%3Aprod%20service%3Aweave-trace%20%40error.type%3AQueryIllegalTypeofArgumentError)). Surfaced while auditing prod error attribution, where non-4xx query rejections were counted as system failures.
- Response-code change on a public endpoint. Nothing in `wandb/weave` or `wandb/core` branches on 403 for this error.

## Testing
Parametrized registry test over the four query-rejection errors asserting each resolves to a 4xx that is not 403; fails against the old mapping (`assert 403 != 403`). `tests/trace/test_errors.py` and the `test_feedback.py` query tests pass, ruff check and format clean.