### PR TITLE
chore(weave): say which remote scorer requests are retried

### DIFF
--- a/examples/remote_scorer/README.md
+++ b/examples/remote_scorer/README.md
@@ -231,10 +231,16 @@ changes:
 ### Errors
 
 Weave treats a non-200 response as a scorer failure and records no feedback
-for that attempt. A `5xx`, `408`, or `429` response, or a timeout, is retried
-a limited number of times. Any other `4xx` is not retried, so return `4xx` for
-requests you will never accept and `5xx` for temporary problems. The response
-body of an error is for your logs; Weave does not parse it.
+for that attempt. Retries depend on the request version:
+
+- A V2 agent-turn request that gets a `5xx`, `408`, or `429` response, or
+  times out, is sent again with the same `Idempotency-Key`, up to three
+  attempts within about 30 seconds.
+- A V1 call request is sent once. No response or timeout is retried.
+
+In both versions, any other `4xx` is not retried, so return `4xx` for requests
+you will never accept and `5xx` for temporary problems. The response body of
+an error is for your logs; Weave does not parse it.
 
 ## Auth
 


### PR DESCRIPTION
## Description

This is a review suggestion for wandb/weave#7868, not a change I intend to merge. It targets the frozen branch `mike/remote_scorer_docs_review_base`, a copy of the reviewed head `7320010`, so its diff stays readable after the reviewed branch moves.

Endpoint authors who serve call monitors would read the current README and expect Weave to retry a `503`. It does not. Only agent-turn requests are retried. This change says which requests are retried and how many times.

Weave has two scoring workers that call a remote scorer. The agent scoring worker sends a `schema_version: 2` request for each completed agent turn. Since core#50385 it retries a transient failure (a `5xx`, `408`, or `429` response, or a timeout) up to three attempts within a 30 second budget, and every attempt carries the same `Idempotency-Key`. The call scoring worker sends a `schema_version: 1` request for each selected call and makes one attempt. A transient failure is recorded as a failed scorer attempt and nothing is retried.

The README's Errors section described the agent-worker behavior as if it applied to both versions. The rewrite lists the two cases separately and keeps the shared advice: return `4xx` for requests you will never accept and `5xx` for temporary problems.

### Detail

- Source for the agent-worker retry: `REMOTE_SCORER_RETRY_MAX_ATTEMPTS = 3` and `REMOTE_SCORER_RETRY_BUDGET_SECONDS = 30.0` in core `services/weave-trace/src/workers/agent_scoring_worker/agent_scoring_runner.py`, with `is_transient_remote_scorer_error` in `workers/remote_scorer/errors.py` deciding which failures qualify.
- Source for the call-worker behavior: `do_remote_scorer_score_call` in core `workers/remote_scorer/client.py` has no retry wrapper, and the only `@retry` in `scoring_worker.py` waits for the call row to appear in ClickHouse.
- The number of attempts is worker configuration, not contract. If it should stay out of the public README, replace the count with "a small number of attempts" and keep the version split.

## Testing

- `uvx ruff@0.15.5 check examples/remote_scorer` and `uvx ruff@0.15.5 format --check examples/remote_scorer` pass.
- No code changed. I did not run a worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
