### PR TITLE
chore(weave): document the agent-turn status codes and show UNSET

### DIFF
--- a/examples/remote_scorer/README.md
+++ b/examples/remote_scorer/README.md
@@ -142,7 +142,10 @@ The `("agent_turn", 1)` payload describes one completed agent turn. See
   may be `null`.
 - `conversation`: `id` and `name`, each possibly `null`.
 - `agent`: `name`, `version`, and `description`, each possibly `null`.
-- `status`: `code`, `message`, and `error_type`, each possibly `null`.
+- `status`: `code`, `message`, and `error_type`. `code` is `"UNSET"`, `"OK"`,
+  or `"ERROR"`. A turn logged without an explicit status arrives as `"UNSET"`,
+  so treat `"UNSET"` as a normal completed turn and `"ERROR"` as the failure
+  signal. `message` and `error_type` may be `null`.
 - `messages`: `system_instructions` (a list of strings), `input`, and `output`.
   `input` and `output` are lists of messages with `role`, `content`, and
   `finish_reason`. `content` is plain text, or a JSON-encoded array of parts

--- a/examples/remote_scorer/sample_request_v2_agent_turn.json
+++ b/examples/remote_scorer/sample_request_v2_agent_turn.json
@@ -22,7 +22,7 @@
         "description": "Answers support questions"
       },
       "status": {
-        "code": "OK",
+        "code": "UNSET",
         "message": null,
         "error_type": null
       },


### PR DESCRIPTION
## Description

This is a review suggestion for wandb/weave#7868, not a change I intend to merge. It targets the frozen branch `mike/remote_scorer_docs_review_base`, a copy of the reviewed head `7320010`, so its diff stays readable after the reviewed branch moves.

An endpoint that treats `status.code == "OK"` as the success signal will misclassify every turn that `trigger_test_agent_turn.py` sends, because those turns arrive as `"UNSET"`. This change documents the three status values and makes the sample show the value the trigger script produces.

The agent-turn payload's `status.code` comes from the OpenTelemetry span status of the root turn span. The stored value is one of `"UNSET"`, `"OK"`, or `"ERROR"` (`StatusCodeLiteral` in `weave/trace_server/agents/schema.py`, default `"UNSET"`). `weave.conversation.log_turn` only sets a status when it records an error, so a successful turn logged through it keeps the OpenTelemetry default and arrives as `"UNSET"`. The README said each status field "may be null" and the sample showed `"OK"`, which together suggested that `"OK"` is what a good turn looks like.

The README now lists the three values, says that `"UNSET"` is a normal completed turn and `"ERROR"` is the failure signal, and keeps `message` and `error_type` as nullable. The agent-turn sample uses `"UNSET"` so it matches what the trigger script sends.

### Detail

- Verified from code: `StatusCodeLiteral` and its default in `weave/trace_server/agents/schema.py`; the only `set_status` call in `weave/conversation/conversation.py` is `StatusCode.ERROR`.
- Verified from code: the ingest path `weave/trace_server/opentelemetry/genai_extraction.py` stores `span.status.code.name`, and the OpenTelemetry default is `UNSET`. Not captured from a live run; to confirm, run the trigger script against a worker that points at the echo server in core (`src.tests.support.remote_scorer_server_echo`) and read `status.code` in the echoed body.

## Testing

- Posted the edited `sample_request_v2_agent_turn.json` to the sample app; it returned `200` with `schema_version: 2`.
- `uvx ruff@0.15.5 check examples/remote_scorer` and `uvx ruff@0.15.5 format --check examples/remote_scorer` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

