### PR TITLE
chore(weave): omit thread_id from the V2 call sample

### DIFF
--- a/examples/remote_scorer/README.md
+++ b/examples/remote_scorer/README.md
@@ -128,8 +128,9 @@ for a pair you do not implement. The sample returns `400` with
 `unsupported_scoring_target_type` in the body.
 
 The `("call", 1)` payload is the same object V1 sends as `original_call`. See
-`sample_request_v2_call.json`. Weave does not send V2 for call monitors today,
-but the sample accepts it so the endpoint is ready when it does.
+`sample_request_v2_call.json`. Optional call fields such as `thread_id` are
+omitted when absent, not sent as `null`. Weave does not send V2 for call
+monitors today, but the sample accepts it so the endpoint is ready when it does.
 
 The `("agent_turn", 1)` payload describes one completed agent turn. See
 `sample_request_v2_agent_turn.json`. Its fields are:

--- a/examples/remote_scorer/sample_request_v2_call.json
+++ b/examples/remote_scorer/sample_request_v2_call.json
@@ -16,8 +16,7 @@
       "output": {
         "reply": "received: test message for scoring",
         "status": "ok"
-      },
-      "thread_id": null
+      }
     }
   },
   "scoring_call_id": "018f8d6c-8d5f-7000-8000-000000000003",


### PR DESCRIPTION
## Description

This is a review suggestion for wandb/weave#7868, not a change I intend to merge. It targets the frozen branch `mike/remote_scorer_docs_review_base`, a copy of the reviewed head `7320010`, so its diff stays readable after the reviewed branch moves.

The V2 call sample shows `"thread_id": null`, a shape Weave never sends. This change removes the line and says in the README that an absent optional call field is omitted.

The worker builds the call payload as a strict model and serializes it with unset fields excluded. The V1 builder only assigns `thread_id` when the call has one, so a call without a thread carries no `thread_id` key at all. The V1 sample in this directory already omits the key. The new V2 call sample carried it as `null`, so the two samples disagreed about the same payload.

### Detail

- Source: `RemoteScorerWireModel.to_wire` uses `exclude_unset=True` in core `services/weave-trace/src/workers/remote_scorer/contract.py`, and `request_v1.py` sets `original_call.thread_id` only when `call.thread_id is not None`. The golden test `test_remote_scorer_request_v2.py` deletes `thread_id` from the expected body for the no-thread case.
- Agent-turn fields behave differently: they are required and nullable, so a missing agent name arrives as `"name": null`. The README already says so for those fields.

## Testing

- The edited `sample_request_v2_call.json` parses as JSON and returns `200` from the sample app.
- `uvx ruff@0.15.5 check examples/remote_scorer` and `uvx ruff@0.15.5 format --check examples/remote_scorer` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
