### PR TITLE
chore(weave): say that internal refs are rewritten, not removed

### DIFF
--- a/examples/remote_scorer/README.md
+++ b/examples/remote_scorer/README.md
@@ -156,10 +156,12 @@ new top-level `schema_version` for envelope changes.
 
 ### Request content
 
-Weave removes internal references and rejects media before it sends a request.
-Payloads contain JSON text only, never images, audio, or video. Request and
-response bodies are each limited to 1 MiB. A target that cannot be represented
-within those rules fails to score and is not sent.
+Before it sends a request, Weave rewrites its internal object references to
+public `weave:///entity/project/...` refs. A request that still contains an
+internal reference, or that contains media, is not sent. Payloads contain JSON
+text only, never images, audio, or video. Request and response bodies are each
+limited to 1 MiB. A target that cannot be represented within those rules fails
+to score and is not sent.
 
 The request carries no W&B credential and no feedback identity. The bearer
 token authenticates Weave to your endpoint, not the reverse. Your endpoint


### PR DESCRIPTION
## Description

This is a review suggestion for wandb/weave#7868, not a change I intend to merge. It targets the frozen branch `mike/remote_scorer_docs_review_base`, a copy of the reviewed head `7320010`, so its diff stays readable after the reviewed branch moves.

The README says Weave "removes internal references" before it sends a request. An endpoint author would read that as the value being absent. The value is present and rewritten to a public ref. This change states the actual mechanics.

The worker converts every `weave-trace-internal://` reference in the outgoing body to a public `weave:///entity/project/...` ref, then fails closed if any internal reference survives. Media is rejected outright. The rewritten sentence says both.

### Detail

- Source: `universal_int_to_ext_ref_converter` and `assert_no_internal_customer_refs` in core `services/weave-trace/src/workers/remote_scorer/request_v2.py` and `request_helpers.py`.

## Testing

- `uvx ruff@0.15.5 check examples/remote_scorer` and `uvx ruff@0.15.5 format --check examples/remote_scorer` pass.
- No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
